### PR TITLE
fix(tools): gate image_gen download URL against SSRF

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -8749,6 +8749,18 @@ pub struct ImageGenConfig {
     #[serde(default = "default_image_gen_api_key_env")]
     #[credential_class = "legacy_env_path"]
     pub api_key_env: String,
+
+    /// Hosts (or host suffixes) that the image-download stage is allowed to
+    /// reach even when they are private/local. Mirrors the same field on
+    /// `[file_download]`, `[http_request]`, `[web_fetch]`, and the browser
+    /// tools. Use for internal CDNs that proxy fal.ai artifacts in air-gapped
+    /// deployments.
+    ///
+    /// Entries are normalized at config-load time via
+    /// `domain_guard::normalize_allowed_domains`. A bare `"*"` blanket-tolerates
+    /// any private/local host (use only for dev).
+    #[serde(default)]
+    pub allowed_private_hosts: Vec<String>,
 }
 
 fn default_image_gen_model() -> String {
@@ -8765,6 +8777,7 @@ impl Default for ImageGenConfig {
             enabled: false,
             default_model: default_image_gen_model(),
             api_key_env: default_image_gen_api_key_env(),
+            allowed_private_hosts: Vec::new(),
         }
     }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -8756,9 +8756,11 @@ pub struct ImageGenConfig {
     /// tools. Use for internal CDNs that proxy fal.ai artifacts in air-gapped
     /// deployments.
     ///
-    /// Entries are normalized at config-load time via
-    /// `domain_guard::normalize_allowed_domains`. A bare `"*"` blanket-tolerates
-    /// any private/local host (use only for dev).
+    /// Entries are normalized per use by the image tool via
+    /// `domain_guard::normalize_allowed_domains`: once at tool construction
+    /// and again from the live config on every request, so an operator edit
+    /// to this field takes effect without a restart. A bare `"*"`
+    /// blanket-tolerates any private/local host (use only for dev).
     #[serde(default)]
     pub allowed_private_hosts: Vec<String>,
 }

--- a/crates/zeroclaw-runtime/locales/en/tools.ftl
+++ b/crates/zeroclaw-runtime/locales/en/tools.ftl
@@ -146,18 +146,14 @@ tool-image-gen-error-resolved-url-resolve-empty = Failed to resolve image downlo
 # Secure-client builder
 tool-image-gen-error-client-build = Failed to build secure image download client: { $err }
 
-# validate_redirect_image_url (free function — used by reqwest redirect callback)
-tool-image-gen-error-redirect-url-empty = redirect image URL cannot be empty
-tool-image-gen-error-redirect-url-whitespace = redirect image URL cannot contain whitespace
-tool-image-gen-error-redirect-url-scheme = Only http:// and https:// redirect URLs are allowed
-tool-image-gen-error-redirect-url-parse = Invalid redirect image URL format: { $err }
-tool-image-gen-error-redirect-url-userinfo = redirect image URL userinfo is not allowed
-tool-image-gen-error-redirect-url-no-host = redirect image URL has no host
-tool-image-gen-error-redirect-url-metadata-host = Blocked redirect to cloud metadata host: { $host }
-tool-image-gen-error-redirect-url-private-host = Blocked redirect to local/private host: { $host }. To allow, add it (or "*") to image_gen.allowed_private_hosts in config.toml
+# resolved-IP gate (DNS rebinding)
+tool-image-gen-error-resolved-ip-metadata = Image host '{ $host }' resolves to cloud metadata address { $ip }
+tool-image-gen-error-resolved-ip-non-global = Image host '{ $host }' resolves to non-global address { $ip }. To allow, add the host (or "*") to image_gen.allowed_private_hosts in config.toml
 
-# redirect policy hop limit
+# manual redirect loop
 tool-image-gen-error-redirect-limit = Too many image-URL redirects (max { $max })
+tool-image-gen-error-redirect-location-missing = Redirect response from image host is missing a Location header
+tool-image-gen-error-redirect-location-invalid = Invalid redirect Location from image host: { $err }
 
 tool-jira = Interact with Jira: read tickets, search with JQL, add comments, list projects and per-issue transitions, transition an issue through its workflow, and create new issues.
 

--- a/crates/zeroclaw-runtime/locales/en/tools.ftl
+++ b/crates/zeroclaw-runtime/locales/en/tools.ftl
@@ -119,6 +119,46 @@ tool-http-request = Make HTTP requests to external APIs. Supports GET, POST, PUT
 
 tool-image-info = Read image file metadata (format, dimensions, size) and optionally return base64-encoded data.
 
+# image_gen tool (fal.ai Flux) — description, parameters, and SSRF-gate errors
+tool-image-gen = Generate an image from a text prompt using fal.ai (Flux models). Saves the result to the workspace images directory and returns the file path.
+tool-image-gen-param-prompt = Text prompt describing the image to generate.
+tool-image-gen-param-filename = Output filename without extension (default: 'generated_image'). Saved as PNG in workspace/images/.
+tool-image-gen-param-size = Image aspect ratio / size preset (default: 'square_hd').
+tool-image-gen-param-model = fal.ai model identifier (default: 'fal-ai/flux/schnell').
+
+# validate_image_url (URL-string gate)
+tool-image-gen-error-url-empty = image URL cannot be empty
+tool-image-gen-error-url-whitespace = image URL cannot contain whitespace
+tool-image-gen-error-url-scheme = Only http:// and https:// image URLs are allowed
+tool-image-gen-error-url-parse = Invalid image URL format: { $err }
+tool-image-gen-error-url-userinfo = image URL userinfo is not allowed
+tool-image-gen-error-url-no-host = image URL has no host
+tool-image-gen-error-url-metadata-host = Blocked cloud metadata host: { $host }
+tool-image-gen-error-url-private-host = Blocked local/private image host: { $host }. To allow, add it (or "*") to image_gen.allowed_private_hosts in config.toml
+
+# validate_image_url_resolved (DNS gate)
+tool-image-gen-error-resolved-url-parse = Invalid image URL: { $err }
+tool-image-gen-error-resolved-url-no-host = Image URL has no host
+tool-image-gen-error-resolved-url-no-port = Image URL has no known port
+tool-image-gen-error-resolved-url-resolve-failed = Failed to resolve image download host
+tool-image-gen-error-resolved-url-resolve-empty = Failed to resolve image download host '{ $host }'
+
+# Secure-client builder
+tool-image-gen-error-client-build = Failed to build secure image download client: { $err }
+
+# validate_redirect_image_url (free function — used by reqwest redirect callback)
+tool-image-gen-error-redirect-url-empty = redirect image URL cannot be empty
+tool-image-gen-error-redirect-url-whitespace = redirect image URL cannot contain whitespace
+tool-image-gen-error-redirect-url-scheme = Only http:// and https:// redirect URLs are allowed
+tool-image-gen-error-redirect-url-parse = Invalid redirect image URL format: { $err }
+tool-image-gen-error-redirect-url-userinfo = redirect image URL userinfo is not allowed
+tool-image-gen-error-redirect-url-no-host = redirect image URL has no host
+tool-image-gen-error-redirect-url-metadata-host = Blocked redirect to cloud metadata host: { $host }
+tool-image-gen-error-redirect-url-private-host = Blocked redirect to local/private host: { $host }. To allow, add it (or "*") to image_gen.allowed_private_hosts in config.toml
+
+# redirect policy hop limit
+tool-image-gen-error-redirect-limit = Too many image-URL redirects (max { $max })
+
 tool-jira = Interact with Jira: read tickets, search with JQL, add comments, list projects and per-issue transitions, transition an issue through its workflow, and create new issues.
 
 tool-knowledge = Manage a knowledge graph of architecture decisions, solution patterns, lessons learned, experts, and relationship links.

--- a/crates/zeroclaw-runtime/locales/en/tools.ftl
+++ b/crates/zeroclaw-runtime/locales/en/tools.ftl
@@ -122,7 +122,7 @@ tool-image-info = Read image file metadata (format, dimensions, size) and option
 # image_gen tool (fal.ai Flux) — description, parameters, and SSRF-gate errors
 tool-image-gen = Generate an image from a text prompt using fal.ai (Flux models). Saves the result to the workspace images directory and returns the file path.
 tool-image-gen-param-prompt = Text prompt describing the image to generate.
-tool-image-gen-param-filename = Output filename without extension (default: 'generated_image'). Saved as PNG in workspace/images/.
+tool-image-gen-param-filename = Output filename without extension (default: a unique timestamped name like 'generated_image_20260805T120000'). Saved as PNG in workspace/images/.
 tool-image-gen-param-size = Image aspect ratio / size preset (default: 'square_hd').
 tool-image-gen-param-model = fal.ai model identifier (default: 'fal-ai/flux/schnell').
 

--- a/crates/zeroclaw-runtime/locales/en/tools.ftl
+++ b/crates/zeroclaw-runtime/locales/en/tools.ftl
@@ -122,7 +122,7 @@ tool-image-info = Read image file metadata (format, dimensions, size) and option
 # image_gen tool (fal.ai Flux) — description, parameters, and SSRF-gate errors
 tool-image-gen = Generate an image from a text prompt using fal.ai (Flux models). Saves the result to the workspace images directory and returns the file path.
 tool-image-gen-param-prompt = Text prompt describing the image to generate.
-tool-image-gen-param-filename = Output filename without extension (default: a unique timestamped name like 'generated_image_20260805T120000'). Saved as PNG in workspace/images/.
+tool-image-gen-param-filename = Output filename without extension (default: a unique timestamped name like 'generated_image_1722859200000000000'). Saved as PNG in workspace/images/.
 tool-image-gen-param-size = Image aspect ratio / size preset (default: 'square_hd').
 tool-image-gen-param-model = fal.ai model identifier (default: 'fal-ai/flux/schnell').
 

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1566,7 +1566,7 @@ impl Agent {
             tui_env,
             sop_engine,
             sop_audit,
-            None,
+            live_config.clone(),
         );
         // Skills are loaded here and handed to `assemble`, which owns skill
         // registration and resolves builtin/MCP elevation against the pre-filter

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -429,6 +429,54 @@ impl DelegateTool {
         self
     }
 
+    /// Rebuild the delegate state carried into a spawned execution path
+    /// (`execute_background` and `execute_parallel` both construct their inner
+    /// `DelegateTool` through this seam). The caller supplies the pieces that
+    /// cannot be re-shared cheaply — the effective policy for the spawned run
+    /// and the per-run workspace / cancellation token — while every shared
+    /// handle is re-cloned here.
+    ///
+    /// Crucially the live-config handle is re-captured (`self.live_config`),
+    /// so an independent agentic target registry rebuilt by the spawned run
+    /// keeps observing the canonical config — e.g. a `config/set` revocation
+    /// of `image_gen.allowed_private_hosts` — instead of falling back to the
+    /// construction-time `root_config` snapshot. A spawned run hard-coding
+    /// `live_config: None` here reopens the policy-revocation gap this PR
+    /// closes for the parent path.
+    fn for_spawned_execution(
+        &self,
+        security: Arc<SecurityPolicy>,
+        workspace_dir: PathBuf,
+        cancellation_token: CancellationToken,
+    ) -> DelegateTool {
+        DelegateTool {
+            agents: Arc::clone(&self.agents),
+            security,
+            global_credential: self.global_credential.clone(),
+            provider_runtime_options: self.provider_runtime_options.clone(),
+            // Monotonic descent on spawned execution paths — was `self.depth`
+            // (verbatim copy), which left the `>= max_depth` check inert. A
+            // chain of background/parallel re-delegations now saturates at
+            // `max_delegation_depth`, matching the documented
+            // `with_depth(parent.depth + 1)` intent.
+            depth: self.depth + 1,
+            parent_tools: Arc::clone(&self.parent_tools),
+            runtime: self.runtime.clone(),
+            multimodal_config: self.multimodal_config.clone(),
+            delegate_config: self.delegate_config.clone(),
+            workspace_dir,
+            cancellation_token,
+            memory: self.memory.clone(),
+            providers_models: Arc::clone(&self.providers_models),
+            risk_profiles: Arc::clone(&self.risk_profiles),
+            runtime_profiles: Arc::clone(&self.runtime_profiles),
+            skill_bundles: Arc::clone(&self.skill_bundles),
+            root_config: self.root_config.clone(),
+            live_config: self.live_config.clone(),
+            caller_alias: self.caller_alias.clone(),
+        }
+    }
+
     /// Set the owning agent's alias so it can be excluded from the
     /// advertised delegation roster (an agent must never delegate to
     /// itself).
@@ -1537,20 +1585,6 @@ impl DelegateTool {
                 .await;
         }
 
-        let agents = Arc::clone(&self.agents);
-        let security = target_policy;
-        let global_credential = self.global_credential.clone();
-        let provider_runtime_options = self.provider_runtime_options.clone();
-        // Monotonic descent: was `self.depth` (verbatim copy), which left the
-        // `self.depth >= max_depth` check inert — a chain of background delegations never
-        // escalated depth. Matches the documented `with_depth(parent.depth + 1)` intent.
-        // Behavior change: deep background re-delegation now saturates at `max_delegation_depth`.
-        let depth = self.depth + 1;
-        let parent_tools = Arc::clone(&self.parent_tools);
-        let runtime = self.runtime.clone();
-        let multimodal_config = self.multimodal_config.clone();
-        let delegate_config = self.delegate_config.clone();
-        let workspace_dir = self.workspace_dir.clone();
         let child_token = self.cancellation_token.child_token();
         // Register the live token so `cancel_task` can actually abort THIS task (removed
         // when it settles, in the spawned closure below).
@@ -1558,40 +1592,20 @@ impl DelegateTool {
             .lock()
             .insert(task_id.clone(), child_token.clone());
         let task_id_clone = task_id.clone();
-        let providers_models = Arc::clone(&self.providers_models);
-        let risk_profiles = Arc::clone(&self.risk_profiles);
-        let runtime_profiles = Arc::clone(&self.runtime_profiles);
-        let skill_bundles = Arc::clone(&self.skill_bundles);
-        let root_config = self.root_config.clone();
-        let caller_alias = self.caller_alias.clone();
-        let memory = self.memory.clone();
+        // Rebuild the delegate state for the spawned run BEFORE the spawn so the
+        // live-config handle is captured here (see `for_spawned_execution`). The
+        // target policy was resolved above; the per-run workspace and token belong
+        // to this task.
+        let inner = self.for_spawned_execution(
+            target_policy,
+            self.workspace_dir.clone(),
+            child_token.clone(),
+        );
         let parent_session_key = current_tool_loop_session_key();
         let __zc_delegate_alias = agent_name_owned.clone();
 
         zeroclaw_spawn::spawn!(
             scope_delegate_session_key(parent_session_key, async move {
-                let inner = DelegateTool {
-                    agents,
-                    security,
-                    global_credential,
-                    provider_runtime_options,
-                    depth,
-                    parent_tools,
-                    runtime,
-                    multimodal_config,
-                    delegate_config,
-                    workspace_dir: workspace_dir.clone(),
-                    cancellation_token: child_token.clone(),
-                    memory,
-                    providers_models,
-                    risk_profiles,
-                    runtime_profiles,
-                    skill_bundles,
-                    live_config: None,
-                    root_config,
-                    caller_alias,
-                };
-
                 let args_inner = json!({
                     "agent": agent_name_owned,
                     "prompt": full_prompt,
@@ -1789,57 +1803,24 @@ impl DelegateTool {
         // Spawn all agents concurrently
         let mut handles = Vec::with_capacity(agent_names.len());
         for agent_name in &agent_names {
-            let agents = Arc::clone(&self.agents);
-            let security = Arc::clone(&self.security);
-            let global_credential = self.global_credential.clone();
-            let provider_runtime_options = self.provider_runtime_options.clone();
-            // Monotonic descent on the parallel path — was `self.depth` (verbatim copy),
-            // leaving the `>= max_depth` check inert (see the background path above).
-            // Behavior change: deep parallel re-delegation now saturates at `max_delegation_depth`.
-            let depth = self.depth + 1;
-            let parent_tools = Arc::clone(&self.parent_tools);
-            let runtime = self.runtime.clone();
-            let multimodal_config = self.multimodal_config.clone();
-            let delegate_config = self.delegate_config.clone();
-            let workspace_dir = self.workspace_dir.clone();
-            let cancellation_token = self.cancellation_token.child_token();
             let agent_name = agent_name.clone();
             let prompt = prompt.to_string();
             let args_clone = args.clone();
-            let providers_models = Arc::clone(&self.providers_models);
-            let risk_profiles = Arc::clone(&self.risk_profiles);
-            let runtime_profiles = Arc::clone(&self.runtime_profiles);
-            let skill_bundles = Arc::clone(&self.skill_bundles);
             let receipt_scope = parent_receipt_scope.clone();
-            let root_config = self.root_config.clone();
-            let caller_alias = self.caller_alias.clone();
             let session_key = parent_session_key.clone();
-            let memory = self.memory.clone();
             let __zc_delegate_alias = agent_name.clone();
+            // Rebuild the delegate state for the spawned run BEFORE the spawn so the
+            // live-config handle is captured here (see `for_spawned_execution`). The
+            // parallel fan-out keeps the caller's policy; the per-run workspace and
+            // token belong to this fan-out.
+            let inner = self.for_spawned_execution(
+                Arc::clone(&self.security),
+                self.workspace_dir.clone(),
+                self.cancellation_token.child_token(),
+            );
 
             handles.push(zeroclaw_spawn::spawn!(
                 async move {
-                    let inner = DelegateTool {
-                        agents,
-                        security,
-                        global_credential,
-                        provider_runtime_options,
-                        depth,
-                        parent_tools,
-                        runtime,
-                        multimodal_config,
-                        delegate_config,
-                        workspace_dir,
-                        cancellation_token,
-                        memory,
-                        providers_models,
-                        risk_profiles,
-                        runtime_profiles,
-                        skill_bundles,
-                        root_config,
-                        live_config: None,
-                        caller_alias,
-                    };
                     let agent_name_for_return = agent_name.clone();
                     let result = scope_delegate_session_key(session_key, async move {
                         crate::agent::tool_receipts::TOOL_LOOP_RECEIPT_CONTEXT
@@ -7658,6 +7639,140 @@ mod tests {
         assert!(
             !second.iter().any(|t| t.name() == "image_gen"),
             "independent delegate must observe the live config revocation: image_gen \
+             must be dropped when the live allowlist is malformed (snapshot fallback \
+             would keep it registered)"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawned_delegate_rebuild_observes_live_config_revocation() {
+        // Regression for the reviewer finding that the `execute_background` and
+        // `execute_parallel` spawn paths rebuilt their inner `DelegateTool` with
+        // `live_config: None`, so an independent agentic target launched with
+        // `background: true` or through `parallel` fell back to the
+        // construction-time `root_config` snapshot and could retain a revoked
+        // `image_gen.allowed_private_hosts` carve-out. Both spawn paths now build
+        // that inner tool through `for_spawned_execution`; this test drives the
+        // seam and proves the spawned delegate keeps observing the canonical live
+        // config rather than the snapshot.
+        //
+        // Observable: `ImageGenTool::new_with_config_resolver` validates the
+        // allowlist at construction, so whether `image_gen` registers in the
+        // independent target's registry reveals which allowlist source the
+        // spawned delegate read.
+        use zeroclaw_config::autonomy::{DelegationMode, DelegationPolicy};
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, Config, ImageGenConfig, RiskProfileConfig, RuntimeProfileConfig,
+        };
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        // Snapshot carries a LEGAL allowlist, so a reverted wiring (snapshot
+        // fallback) would always register image_gen and this test would fail on
+        // the malformed-live case below.
+        config.image_gen = ImageGenConfig {
+            enabled: true,
+            default_model: "fal-ai/flux/schnell".into(),
+            api_key_env: "FAL_API_KEY".into(),
+            allowed_private_hosts: vec!["127.0.0.1".into()],
+        };
+        config.risk_profiles.insert(
+            "caller".to_string(),
+            RiskProfileConfig {
+                delegation_policy: DelegationPolicy {
+                    mode: DelegationMode::Allow,
+                },
+                allowed_tools: vec!["echo_tool".to_string()],
+                ..RiskProfileConfig::default()
+            },
+        );
+        config.risk_profiles.insert(
+            "target".to_string(),
+            RiskProfileConfig {
+                allowed_tools: vec!["image_gen".to_string()],
+                ..RiskProfileConfig::default()
+            },
+        );
+        config.runtime_profiles.insert(
+            "agentic".to_string(),
+            RuntimeProfileConfig {
+                agentic: true,
+                ..RuntimeProfileConfig::default()
+            },
+        );
+        config.agents.insert(
+            "caller".to_string(),
+            AliasedAgentConfig {
+                risk_profile: "caller".into(),
+                model_provider: "ollama.caller".into(),
+                delegates: vec![DelegateTargetConfig {
+                    agent: "target".to_string(),
+                    mode: DelegateExecutionMode::Independent,
+                }],
+                ..AliasedAgentConfig::default()
+            },
+        );
+        config.agents.insert(
+            "target".to_string(),
+            AliasedAgentConfig {
+                risk_profile: "target".into(),
+                runtime_profile: "agentic".into(),
+                model_provider: "ollama.target".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+        let config = Arc::new(config);
+        // The live handle starts as a clone of the (legal) snapshot config.
+        let live = Arc::new(RwLock::new((*config).clone()));
+
+        let caller_policy =
+            Arc::new(SecurityPolicy::for_agent(&config, "caller").expect("caller policy resolves"));
+        let tool = DelegateTool::new(config.agents.clone(), None, Arc::clone(&caller_policy))
+            .with_root_config(Arc::clone(&config))
+            .with_live_config(Some(Arc::clone(&live)))
+            .with_caller_alias("caller")
+            .with_runtime(Arc::new(DelegateTestRuntime))
+            .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+
+        // Rebuild the delegate state exactly as `execute_background` /
+        // `execute_parallel` do before their spawn (`for_spawned_execution`
+        // is the single construction site both paths use).
+        let spawned = tool.for_spawned_execution(
+            Arc::clone(&caller_policy),
+            tool.workspace_dir.clone(),
+            tool.cancellation_token.child_token(),
+        );
+
+        async fn build_target(tool: &DelegateTool) -> Vec<Box<dyn Tool>> {
+            let target_policy = tool
+                .policy_for_target("target")
+                .expect("independent target policy resolves");
+            tool.independent_agentic_tools_for_target("target", target_policy)
+                .await
+                .expect("target-owned registry builds")
+                .tools
+        }
+
+        // Legal live allowlist → image_gen registers in the independent target.
+        let first = build_target(&spawned).await;
+        assert!(
+            first.iter().any(|t| t.name() == "image_gen"),
+            "spawned delegate must register image_gen with a legal live allowlist"
+        );
+
+        // Mutate the shared live config to a MALFORMED allowlist. The snapshot
+        // `root_config` still carries the legal entry, so a reverted spawn
+        // (inner `live_config: None`) would keep image_gen registered and this
+        // assertion would fail.
+        live.write().image_gen.allowed_private_hosts = vec!["bad entry with space".into()];
+        let second = build_target(&spawned).await;
+        assert!(
+            !second.iter().any(|t| t.name() == "image_gen"),
+            "spawned delegate must observe the live config revocation: image_gen \
              must be dropped when the live allowlist is malformed (snapshot fallback \
              would keep it registered)"
         );

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -142,6 +142,13 @@ pub struct DelegateTool {
     /// time. When unset (legacy unit-test constructors), DelegateTool falls
     /// back to using `self.security` for the spawned inner DelegateTool.
     root_config: Option<Arc<Config>>,
+    /// Live config handle threaded into independent agentic target registries
+    /// so tools that resolve policy at use time (e.g. `image_gen`'s
+    /// `allowed_private_hosts`) observe a canonical `config/set` revocation
+    /// instead of the construction-time snapshot. Mirrors the parent
+    /// `all_tools_with_runtime` `live_config` argument. `None` for one-shot /
+    /// non-channel callers, which fall back to the snapshot.
+    live_config: Option<Arc<RwLock<Config>>>,
     /// Alias of the agent that owns this DelegateTool. Excluded from the
     /// advertised roster so an agent is never offered itself as a
     /// delegation target. Empty when unset (legacy unit-test constructors).
@@ -257,6 +264,7 @@ impl DelegateTool {
             runtime_profiles: Arc::new(HashMap::new()),
             skill_bundles: Arc::new(HashMap::new()),
             root_config: None,
+            live_config: None,
             caller_alias: String::new(),
         }
     }
@@ -304,6 +312,7 @@ impl DelegateTool {
             runtime_profiles: Arc::new(HashMap::new()),
             skill_bundles: Arc::new(HashMap::new()),
             root_config: None,
+            live_config: None,
             caller_alias: String::new(),
         }
     }
@@ -404,6 +413,19 @@ impl DelegateTool {
     /// canonical agent config at delegate time.
     pub fn with_root_config(mut self, config: Arc<Config>) -> Self {
         self.root_config = Some(config);
+        self
+    }
+
+    /// Attach the live config handle so independent agentic target registries
+    /// observe canonical `config/set` mutations (e.g. `image_gen`'s
+    /// `allowed_private_hosts` revocation) instead of the snapshot. `None`
+    /// keeps the snapshot fallback, matching the parent
+    /// `all_tools_with_runtime` `live_config` semantics.
+    pub fn with_live_config(
+        mut self,
+        live_config: Option<Arc<parking_lot::RwLock<Config>>>,
+    ) -> Self {
+        self.live_config = live_config;
         self
     }
 
@@ -749,7 +771,10 @@ impl DelegateTool {
             None,
             None,
             None,
-            None,
+            // Thread the parent's live config handle so the independent target
+            // registry's tools (e.g. `image_gen`'s allowlist resolver) observe
+            // canonical `config/set` mutations instead of the snapshot.
+            self.live_config.clone(),
         );
 
         let target_workspace = config.agent_workspace_dir(agent_name);
@@ -1562,6 +1587,7 @@ impl DelegateTool {
                     risk_profiles,
                     runtime_profiles,
                     skill_bundles,
+                    live_config: None,
                     root_config,
                     caller_alias,
                 };
@@ -1811,6 +1837,7 @@ impl DelegateTool {
                         runtime_profiles,
                         skill_bundles,
                         root_config,
+                        live_config: None,
                         caller_alias,
                     };
                     let agent_name_for_return = agent_name.clone();
@@ -7510,6 +7537,129 @@ mod tests {
         assert!(
             !tool_names.contains(&"echo_tool"),
             "independent target must not inherit parent-only tools"
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_delegate_image_gen_allowlist_follows_live_config_handle() {
+        // Regression for the reviewer finding that independent agentic target
+        // registries were rebuilt with `live_config=None`, so `image_gen`'s
+        // `allowed_private_hosts` resolver fell back to the snapshot. The
+        // parent registry observes a canonical `config/set` revocation, but an
+        // independent delegate retained the old carve-out.
+        //
+        // Observable: `ImageGenTool::new_with_config_resolver` validates the
+        // allowlist at construction, so whether `image_gen` registers in the
+        // independent target's registry reveals which allowlist source it read.
+        // Legal live allowlist → registered; a mutated (malformed) live entry →
+        // construction fails and the tool is dropped, even though the snapshot
+        // `root_config` still carries the legal entry.
+        use zeroclaw_config::autonomy::{DelegationMode, DelegationPolicy};
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, Config, ImageGenConfig, RiskProfileConfig, RuntimeProfileConfig,
+        };
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        // Snapshot carries a LEGAL allowlist, so a reverted wiring (snapshot
+        // fallback) would always register image_gen and this test would fail on
+        // the malformed-live case below.
+        config.image_gen = ImageGenConfig {
+            enabled: true,
+            default_model: "fal-ai/flux/schnell".into(),
+            api_key_env: "FAL_API_KEY".into(),
+            allowed_private_hosts: vec!["127.0.0.1".into()],
+        };
+        config.risk_profiles.insert(
+            "caller".to_string(),
+            RiskProfileConfig {
+                delegation_policy: DelegationPolicy {
+                    mode: DelegationMode::Allow,
+                },
+                allowed_tools: vec!["echo_tool".to_string()],
+                ..RiskProfileConfig::default()
+            },
+        );
+        config.risk_profiles.insert(
+            "target".to_string(),
+            RiskProfileConfig {
+                allowed_tools: vec!["image_gen".to_string()],
+                ..RiskProfileConfig::default()
+            },
+        );
+        config.runtime_profiles.insert(
+            "agentic".to_string(),
+            RuntimeProfileConfig {
+                agentic: true,
+                ..RuntimeProfileConfig::default()
+            },
+        );
+        config.agents.insert(
+            "caller".to_string(),
+            AliasedAgentConfig {
+                risk_profile: "caller".into(),
+                model_provider: "ollama.caller".into(),
+                delegates: vec![DelegateTargetConfig {
+                    agent: "target".to_string(),
+                    mode: DelegateExecutionMode::Independent,
+                }],
+                ..AliasedAgentConfig::default()
+            },
+        );
+        config.agents.insert(
+            "target".to_string(),
+            AliasedAgentConfig {
+                risk_profile: "target".into(),
+                runtime_profile: "agentic".into(),
+                model_provider: "ollama.target".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+        let config = Arc::new(config);
+        // The live handle starts as a clone of the (legal) snapshot config.
+        let live = Arc::new(RwLock::new((*config).clone()));
+
+        let caller_policy =
+            Arc::new(SecurityPolicy::for_agent(&config, "caller").expect("caller policy resolves"));
+        let tool = DelegateTool::new(config.agents.clone(), None, Arc::clone(&caller_policy))
+            .with_root_config(Arc::clone(&config))
+            .with_live_config(Some(Arc::clone(&live)))
+            .with_caller_alias("caller")
+            .with_runtime(Arc::new(DelegateTestRuntime))
+            .with_parent_tools(Arc::new(RwLock::new(vec![Arc::new(EchoTool)])));
+
+        async fn build_target(tool: &DelegateTool) -> Vec<Box<dyn Tool>> {
+            let target_policy = tool
+                .policy_for_target("target")
+                .expect("independent target policy resolves");
+            tool.independent_agentic_tools_for_target("target", target_policy)
+                .await
+                .expect("target-owned registry builds")
+                .tools
+        }
+
+        // Legal live allowlist → image_gen registers in the independent target.
+        let first = build_target(&tool).await;
+        assert!(
+            first.iter().any(|t| t.name() == "image_gen"),
+            "independent target must register image_gen with a legal live allowlist"
+        );
+
+        // Mutate the shared live config to a MALFORMED allowlist. The snapshot
+        // `root_config` still carries the legal entry, so a reverted wiring that
+        // rebuilds the registry from the snapshot would still register image_gen
+        // and this assertion would fail.
+        live.write().image_gen.allowed_private_hosts = vec!["bad entry with space".into()];
+        let second = build_target(&tool).await;
+        assert!(
+            !second.iter().any(|t| t.name() == "image_gen"),
+            "independent delegate must observe the live config revocation: image_gen \
+             must be dropped when the live allowlist is malformed (snapshot fallback \
+             would keep it registered)"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1141,13 +1141,14 @@ pub fn all_tools_with_runtime(
 
     // Standalone image generation tool (config-gated)
     if root_config.image_gen.enabled {
-        match ImageGenTool::new_with_config(
+        let allowed_hosts = root_config.image_gen.allowed_private_hosts.clone();
+        match ImageGenTool::new_with_config_resolver(
             security.clone(),
             workspace_dir.to_path_buf(),
             root_config.image_gen.default_model.clone(),
             root_config.image_gen.api_key_env.clone(),
             persistent_writes,
-            root_config.image_gen.allowed_private_hosts.clone(),
+            move || allowed_hosts.clone(),
         ) {
             Ok(tool) => tool_arcs.push(Arc::new(tool)),
             Err(err) => ::zeroclaw_log::record!(

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1141,13 +1141,26 @@ pub fn all_tools_with_runtime(
 
     // Standalone image generation tool (config-gated)
     if root_config.image_gen.enabled {
-        tool_arcs.push(Arc::new(ImageGenTool::new_with_persistence(
+        match ImageGenTool::new_with_config(
             security.clone(),
             workspace_dir.to_path_buf(),
             root_config.image_gen.default_model.clone(),
             root_config.image_gen.api_key_env.clone(),
             persistent_writes,
-        )));
+            root_config.image_gen.allowed_private_hosts.clone(),
+        ) {
+            Ok(tool) => tool_arcs.push(Arc::new(tool)),
+            Err(err) => ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "tool": "image_gen",
+                        "err": err.to_string(),
+                    })),
+                "image_gen: invalid allowed_private_hosts in config; tool disabled"
+            ),
+        }
     }
 
     // File upload tool — enabled iff [file_upload].url is set

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1139,16 +1139,25 @@ pub fn all_tools_with_runtime(
         )));
     }
 
-    // Standalone image generation tool (config-gated)
+    // Standalone image generation tool (config-gated). The allowlist is
+    // resolved from canonical config at use time (live handle when present,
+    // snapshot fallback otherwise) — the same seam `AgentPeerGroupResolver`
+    // uses below — so the tool never retains a second policy copy.
     if root_config.image_gen.enabled {
-        let allowed_hosts = root_config.image_gen.allowed_private_hosts.clone();
+        let allowlist_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+            if let Some(live) = live_config.clone() {
+                Arc::new(move || live.read().image_gen.allowed_private_hosts.clone())
+            } else {
+                let snapshot = root_config.image_gen.allowed_private_hosts.clone();
+                Arc::new(move || snapshot.clone())
+            };
         match ImageGenTool::new_with_config_resolver(
             security.clone(),
             workspace_dir.to_path_buf(),
             root_config.image_gen.default_model.clone(),
             root_config.image_gen.api_key_env.clone(),
             persistent_writes,
-            move || allowed_hosts.clone(),
+            move || allowlist_resolver(),
         ) {
             Ok(tool) => tool_arcs.push(Arc::new(tool)),
             Err(err) => ::zeroclaw_log::record!(

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1462,6 +1462,7 @@ pub fn all_tools_with_runtime(
         .with_runtime_profiles(root_config.runtime_profiles.clone())
         .with_skill_bundles(root_config.skill_bundles.clone())
         .with_root_config(config.clone())
+        .with_live_config(live_config.clone())
         .with_caller_alias(agent_alias);
         tool_arcs.push(Arc::new(delegate_tool));
         Some(parent_tools)

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1953,6 +1953,106 @@ mod tests {
     }
 
     #[test]
+    fn image_gen_allowlist_registration_follows_live_config_handle() {
+        // The `image_gen` registration in `all_tools_with_runtime` resolves
+        // `allowed_private_hosts` from the live config handle when one is
+        // present (mirroring `AgentPeerGroupResolver` at the same call site),
+        // with a snapshot of `root_config` as fallback. This test pins that
+        // production wiring: `new_with_config_resolver` validates the
+        // allowlist at construction, so a malformed live entry makes the
+        // registration fail and the tool is dropped. Which allowlist source is
+        // live is therefore observable through whether the tool registers —
+        // no downcast of the registered tool is needed.
+        //
+        // If the `live_config.clone()` forwarding line were reverted to the
+        // snapshot fallback, `root_config`'s legal entry would always allow
+        // registration and the malformed-live-handle case would wrongly
+        // register — so this test fails under that regression.
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig {
+            enabled: false,
+            allowed_domains: vec![],
+            session_name: None,
+            ..BrowserConfig::default()
+        };
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+
+        // `root_config` carries a legal allowlist, so the snapshot fallback
+        // would always register the tool regardless of the live handle.
+        let mut root = test_config(&tmp);
+        root.image_gen = zeroclaw_config::schema::ImageGenConfig {
+            enabled: true,
+            default_model: "fal-ai/flux/schnell".into(),
+            api_key_env: "FAL_API_KEY".into(),
+            allowed_private_hosts: vec!["127.0.0.1".into()],
+        };
+
+        let agents = HashMap::new();
+        let register =
+            |live_config: Option<Arc<parking_lot::RwLock<zeroclaw_config::schema::Config>>>| {
+                let arcs = all_tools_with_runtime(
+                    Arc::new(Config::default()),
+                    &security,
+                    &zeroclaw_config::schema::RiskProfileConfig::default(),
+                    "test-agent",
+                    Arc::new(NativeRuntime::new()),
+                    mem.clone(),
+                    None,
+                    None,
+                    &browser,
+                    &http,
+                    &zeroclaw_config::schema::WebFetchConfig::default(),
+                    tmp.path(),
+                    &agents,
+                    None,
+                    &root,
+                    None,
+                    false,
+                    None,
+                    None,
+                    None,
+                    live_config,
+                )
+                .unfiltered_tool_arcs;
+                arcs.iter().any(|t| t.name() == "image_gen")
+            };
+
+        // Legal live allowlist → the tool registers.
+        let mut legal = root.clone();
+        legal.image_gen.allowed_private_hosts = vec!["127.0.0.1".into()];
+        assert!(
+            register(Some(Arc::new(parking_lot::RwLock::new(legal)))),
+            "image_gen must register when the live allowlist is legal"
+        );
+
+        // Malformed live allowlist → construction fails and the tool is
+        // dropped. With the live handle threaded through, the invalid entry
+        // is read at construction and registration is refused; a reverted
+        // wiring would read root's legal entry and wrongly register.
+        let mut invalid = root.clone();
+        invalid.image_gen.allowed_private_hosts = vec!["bad entry with space".into()];
+        assert!(
+            !register(Some(Arc::new(parking_lot::RwLock::new(invalid)))),
+            "image_gen must be disabled when the live allowlist is malformed — \
+             this pins that the live config handle reaches the resolver"
+        );
+
+        // No live handle → snapshot fallback registers (root's entry is legal).
+        assert!(
+            register(None),
+            "image_gen must register via the snapshot fallback without a live handle"
+        );
+    }
+
+    #[test]
     fn shared_sop_engine_arc_is_observed_by_multiple_registrations() {
         let tmp = TempDir::new().unwrap();
         let security = Arc::new(SecurityPolicy::default());

--- a/crates/zeroclaw-tools/src/helpers/domain_guard.rs
+++ b/crates/zeroclaw-tools/src/helpers/domain_guard.rs
@@ -101,30 +101,13 @@ pub(crate) fn is_cloud_metadata_ip(ip: std::net::IpAddr) -> bool {
     const EC2_IMDS_V6: std::net::Ipv6Addr =
         std::net::Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254);
 
-    // Normalize IPv4-mapped IPv6 addresses to their IPv4 equivalent
-    // before checking against known metadata endpoints.
-    // IPv4-mapped IPv6 format: ::ffff:a.b.c.d
-    // In bytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d]
-    // This closes the SSRF bypass where `::ffff:169.254.169.254` would
-    // reach the EC2 metadata service despite the predicate.
+    // Normalize IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) to their IPv4
+    // equivalent before matching, closing the bypass where
+    // `::ffff:169.254.169.254` reaches the EC2 metadata service despite the
+    // predicate. Same primitive the sibling `net_guard` uses.
     let normalized_ip = match ip {
-        std::net::IpAddr::V6(v6) => {
-            let octets = v6.octets();
-            // Check for IPv4-mapped IPv6: ::ffff:a.b.c.d
-            // The pattern is: first 10 bytes are 0, bytes 10-11 are 0xff, bytes 12-15 are the IPv4 address
-            if octets[..10] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                && octets[10] == 0xff
-                && octets[11] == 0xff
-            {
-                // Extract the IPv4 part from the last four octets
-                std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-                    octets[12], octets[13], octets[14], octets[15],
-                ))
-            } else {
-                ip
-            }
-        }
-        ip => ip,
+        std::net::IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(ip, std::net::IpAddr::V4),
+        v4 => v4,
     };
 
     match normalized_ip {
@@ -453,12 +436,19 @@ mod tests {
     }
 
     #[test]
-    fn is_cloud_metadata_ip_normalizes_ipv4_mapped_loopback() {
-        // IPv4-mapped IPv6 loopback: ::ffff:127.0.0.1
-        let ipv4_mapped_loopback = "::ffff:127.0.0.1".parse::<IpAddr>().unwrap();
-        // Note: is_cloud_metadata_ip only checks for EC2 metadata, not loopback
-        // But the normalization should still work
-        assert!(!is_cloud_metadata_ip(ipv4_mapped_loopback));
+    fn is_cloud_metadata_ip_distinguishes_mapped_metadata_from_loopback() {
+        // Normalization must both hit the mapped EC2 metadata endpoint AND
+        // not false-positive on a mapped non-metadata address (loopback).
+        let mapped_metadata = "::ffff:169.254.169.254".parse::<IpAddr>().unwrap();
+        assert!(
+            is_cloud_metadata_ip(mapped_metadata),
+            "IPv4-mapped EC2 metadata must be detected"
+        );
+        let mapped_loopback = "::ffff:127.0.0.1".parse::<IpAddr>().unwrap();
+        assert!(
+            !is_cloud_metadata_ip(mapped_loopback),
+            "IPv4-mapped loopback must not be misclassified as metadata"
+        );
     }
 
     #[test]
@@ -475,22 +465,23 @@ mod tests {
     }
 
     #[test]
-    fn validate_resolved_ips_blocks_ipv4_mapped_metadata_with_wildcard() {
-        // Test with wildcard allowed_private_hosts = ["*"]
-        // The metadata check should still apply even with wildcard
+    fn validate_resolved_ips_are_public_blocks_ipv4_mapped_metadata() {
+        // `validate_resolved_ips_are_public` has no allowlist parameter, so a
+        // mapped metadata endpoint is blocked outright — the metadata check is
+        // unconditional (the image_gen layer applies its `["*"]` carve-out to
+        // the non-global gate only; see image_gen's IPv4-mapped regression).
         let ipv4_mapped = vec!["::ffff:169.254.169.254".parse::<IpAddr>().unwrap()];
         let err = validate_resolved_ips_are_public("metadata.test", &ipv4_mapped)
             .unwrap_err()
             .to_string();
         assert!(
             err.contains("cloud metadata address"),
-            "IPv4-mapped IPv6 metadata should be blocked even with wildcard: {err}"
+            "IPv4-mapped IPv6 metadata should be blocked: {err}"
         );
     }
 
     #[test]
-    fn validate_resolved_ips_blocks_ipv4_mapped_private_with_wildcard() {
-        // Test that IPv4-mapped private addresses are blocked without wildcard
+    fn validate_resolved_ips_are_public_blocks_ipv4_mapped_private() {
         let ipv4_mapped_private = vec!["::ffff:10.0.0.1".parse::<IpAddr>().unwrap()];
         let err = validate_resolved_ips_are_public("private.test", &ipv4_mapped_private)
             .unwrap_err()

--- a/crates/zeroclaw-tools/src/helpers/domain_guard.rs
+++ b/crates/zeroclaw-tools/src/helpers/domain_guard.rs
@@ -101,7 +101,33 @@ pub(crate) fn is_cloud_metadata_ip(ip: std::net::IpAddr) -> bool {
     const EC2_IMDS_V6: std::net::Ipv6Addr =
         std::net::Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254);
 
-    match ip {
+    // Normalize IPv4-mapped IPv6 addresses to their IPv4 equivalent
+    // before checking against known metadata endpoints.
+    // IPv4-mapped IPv6 format: ::ffff:a.b.c.d
+    // In bytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, a, b, c, d]
+    // This closes the SSRF bypass where `::ffff:169.254.169.254` would
+    // reach the EC2 metadata service despite the predicate.
+    let normalized_ip = match ip {
+        std::net::IpAddr::V6(v6) => {
+            let octets = v6.octets();
+            // Check for IPv4-mapped IPv6: ::ffff:a.b.c.d
+            // The pattern is: first 10 bytes are 0, bytes 10-11 are 0xff, bytes 12-15 are the IPv4 address
+            if octets[..10] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                && octets[10] == 0xff
+                && octets[11] == 0xff
+            {
+                // Extract the IPv4 part from the last four octets
+                std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                    octets[12], octets[13], octets[14], octets[15],
+                ))
+            } else {
+                ip
+            }
+        }
+        ip => ip,
+    };
+
+    match normalized_ip {
         std::net::IpAddr::V4(v4) => v4 == EC2_IMDS_V4,
         std::net::IpAddr::V6(v6) => v6 == EC2_IMDS_V6,
     }
@@ -152,6 +178,7 @@ pub(crate) fn validate_resolved_ips_exclude_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::IpAddr;
 
     #[test]
     fn normalize_domain_strips_scheme_path_and_case() {
@@ -404,6 +431,73 @@ mod tests {
         assert!(
             err.contains("cloud metadata address"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn is_cloud_metadata_ip_detects_ipv4_mapped_ipv6() {
+        // IPv4-mapped IPv6 spelling of EC2 metadata: ::ffff:169.254.169.254
+        // In full form: 0:0:0:0:0:ffff:a9fe:a9fe
+        let ipv4_mapped = "0:0:0:0:0:ffff:a9fe:a9fe".parse::<IpAddr>().unwrap();
+        assert!(
+            is_cloud_metadata_ip(ipv4_mapped),
+            "IPv4-mapped IPv6 EC2 metadata (::ffff:169.254.169.254) should be detected"
+        );
+
+        // Compressed form
+        let ipv4_mapped_compressed = "::ffff:169.254.169.254".parse::<IpAddr>().unwrap();
+        assert!(
+            is_cloud_metadata_ip(ipv4_mapped_compressed),
+            "Compressed IPv4-mapped IPv6 EC2 metadata should be detected"
+        );
+    }
+
+    #[test]
+    fn is_cloud_metadata_ip_normalizes_ipv4_mapped_loopback() {
+        // IPv4-mapped IPv6 loopback: ::ffff:127.0.0.1
+        let ipv4_mapped_loopback = "::ffff:127.0.0.1".parse::<IpAddr>().unwrap();
+        // Note: is_cloud_metadata_ip only checks for EC2 metadata, not loopback
+        // But the normalization should still work
+        assert!(!is_cloud_metadata_ip(ipv4_mapped_loopback));
+    }
+
+    #[test]
+    fn validate_resolved_ips_blocks_ipv4_mapped_metadata() {
+        // Test that IPv4-mapped IPv6 EC2 metadata is blocked
+        let ipv4_mapped = vec!["::ffff:169.254.169.254".parse::<IpAddr>().unwrap()];
+        let err = validate_resolved_ips_exclude_metadata("metadata.test", &ipv4_mapped)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cloud metadata address"),
+            "IPv4-mapped IPv6 metadata should be blocked: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_resolved_ips_blocks_ipv4_mapped_metadata_with_wildcard() {
+        // Test with wildcard allowed_private_hosts = ["*"]
+        // The metadata check should still apply even with wildcard
+        let ipv4_mapped = vec!["::ffff:169.254.169.254".parse::<IpAddr>().unwrap()];
+        let err = validate_resolved_ips_are_public("metadata.test", &ipv4_mapped)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cloud metadata address"),
+            "IPv4-mapped IPv6 metadata should be blocked even with wildcard: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_resolved_ips_blocks_ipv4_mapped_private_with_wildcard() {
+        // Test that IPv4-mapped private addresses are blocked without wildcard
+        let ipv4_mapped_private = vec!["::ffff:10.0.0.1".parse::<IpAddr>().unwrap()];
+        let err = validate_resolved_ips_are_public("private.test", &ipv4_mapped_private)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global address"),
+            "IPv4-mapped IPv6 private address should be blocked: {err}"
         );
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -1067,16 +1067,17 @@ mod tests {
     // private-host check) would surface here.
 
     fn test_tool_with_private_hosts(allowed_private_hosts: Vec<&str>) -> ImageGenTool {
-        ImageGenTool::new_with_config(
+        let allowed = allowed_private_hosts
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        ImageGenTool::new_with_config_resolver(
             test_security(),
             std::env::temp_dir(),
             "fal-ai/flux/schnell".into(),
             "FAL_API_KEY".into(),
             true,
-            allowed_private_hosts
-                .into_iter()
-                .map(String::from)
-                .collect(),
+            move || allowed.clone(),
         )
         .expect("test tool construction should succeed")
     }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -1614,7 +1614,11 @@ mod tests {
         assert_eq!(&body[..], b"pinned-body");
 
         let received = server.received_requests().await.unwrap();
-        assert_eq!(received.len(), 1, "exactly one request must reach the validated listener");
+        assert_eq!(
+            received.len(),
+            1,
+            "exactly one request must reach the validated listener"
+        );
     }
 
     /// A redirect target with a different synthetic hostname reaches ONLY
@@ -1654,17 +1658,15 @@ mod tests {
         let resp = tool
             .download_image_with_resolver(
                 "http://download-test-redirect.invalid/start.png",
-                &|host, _p| {
-                    async move {
-                        match host.as_str() {
-                            "download-test-redirect.invalid" => {
-                                Ok(vec![SocketAddr::from(([127, 0, 0, 1], redirect_port))])
-                            }
-                            "download-test-redirect-target.invalid" => {
-                                Ok(vec![SocketAddr::from(([127, 0, 0, 1], target_port))])
-                            }
-                            other => panic!("unexpected resolver host: {other}"),
+                &|host, _p| async move {
+                    match host.as_str() {
+                        "download-test-redirect.invalid" => {
+                            Ok(vec![SocketAddr::from(([127, 0, 0, 1], redirect_port))])
                         }
+                        "download-test-redirect-target.invalid" => {
+                            Ok(vec![SocketAddr::from(([127, 0, 0, 1], target_port))])
+                        }
+                        other => panic!("unexpected resolver host: {other}"),
                     }
                 },
             )
@@ -1707,10 +1709,10 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/start.png"))
-            .respond_with(ResponseTemplate::new(302).insert_header(
-                "location",
-                "http://public-looking-cdn.example/img.png",
-            ))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("location", "http://public-looking-cdn.example/img.png"),
+            )
             .expect(1)
             .mount(&redirect_server)
             .await;

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -458,15 +458,10 @@ impl ImageGenTool {
             .timeout(std::time::Duration::from_secs(120))
             .connect_timeout(std::time::Duration::from_secs(10))
             .redirect(redirect_policy)
-            .resolve_to_addrs(
-                &validated_image_url,
-                &validated_addrs,
-            )
+            .resolve_to_addrs(&validated_image_url, &validated_addrs)
             .build()
             .map_err(|e| {
-                anyhow::Error::msg(format!(
-                    "Failed to build secure image download client: {e}"
-                ))
+                anyhow::Error::msg(format!("Failed to build secure image download client: {e}"))
             })?;
 
         // ── Download image ─────────────────────────────────────────

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -111,7 +111,7 @@ pub struct ImageGenTool {
     /// written inside the container but invisible on the host and discarded at
     /// session end. When `false`, a successful generation carries a loud
     /// ephemeral-workspace warning. Mirrors
-    /// [`super::file_write::FileWriteTool`]. See issue #4627.
+    /// [`super::file_write::FileWriteTool`].
     persistent_writes: bool,
 }
 

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -101,12 +101,11 @@ pub struct ImageGenTool {
     workspace_dir: PathBuf,
     default_model: String,
     api_key_env: String,
-    /// Normalized host allowlist (entries from `ImageGenConfig::allowed_private_hosts`).
-    /// Empty by default. A bare `"*"` blanket-tolerates any private/local host;
-    /// otherwise each entry is a host or suffix checked against the image-download
-    /// host. Mirrors the same field on `[file_download]`, `[http_request]`,
-    /// `[web_fetch]`, and the browser tools.
-    allowed_private_hosts: Vec<String>,
+    /// Live resolver for the allowlist, resolved from the canonical
+    /// `Config.image_gen.allowed_private_hosts` at use time. This avoids
+    /// storing a duplicate policy copy in the tool handle, per the
+    /// repository's single-source-of-truth rule (AGENTS.md).
+    allowed_private_hosts_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     /// Whether the saved image persists on the host filesystem. `false` on an
     /// ephemeral runtime (Docker tmpfs / no volume mount), where the PNG is
     /// written inside the container but invisible on the host and discarded at
@@ -128,7 +127,7 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
-            allowed_private_hosts: Vec::new(),
+            allowed_private_hosts_resolver: Arc::new(Vec::new),
             persistent_writes: true,
         }
     }
@@ -148,15 +147,41 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
-            allowed_private_hosts: Vec::new(),
+            allowed_private_hosts_resolver: Arc::new(Vec::new),
             persistent_writes,
         }
     }
 
-    /// Construct with the full config (including `allowed_private_hosts`).
-    /// The host allowlist is normalized via `domain_guard::normalize_allowed_domains`
-    /// at construction time so per-request validation is a constant-time
-    /// allowlist match (no per-call parsing).
+    /// Construct with a resolver closure that reads the allowlist from the
+    /// canonical config at use time. The resolver is called on each request
+    /// to get the current normalized allowlist.
+    ///
+    /// This avoids storing a duplicate `Vec<String>` in the tool handle,
+    /// per the repository's single-source-of-truth rule (AGENTS.md).
+    pub fn new_with_config_resolver<F>(
+        security: Arc<SecurityPolicy>,
+        workspace_dir: PathBuf,
+        default_model: String,
+        api_key_env: String,
+        persistent_writes: bool,
+        allowed_private_hosts_resolver: F,
+    ) -> anyhow::Result<Self>
+    where
+        F: Fn() -> Vec<String> + Send + Sync + 'static,
+    {
+        Ok(Self {
+            security,
+            workspace_dir,
+            default_model,
+            api_key_env,
+            allowed_private_hosts_resolver: Arc::new(allowed_private_hosts_resolver),
+            persistent_writes,
+        })
+    }
+
+    /// Deprecated: use `new_with_config_resolver` instead to avoid
+    /// storing a duplicate policy copy in the tool handle.
+    #[deprecated(since = "0.8.3", note = "Use new_with_config_resolver instead")]
     pub fn new_with_config(
         security: Arc<SecurityPolicy>,
         workspace_dir: PathBuf,
@@ -174,7 +199,7 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
-            allowed_private_hosts: normalized,
+            allowed_private_hosts_resolver: Arc::new(move || normalized.clone()),
             persistent_writes,
         })
     }
@@ -245,9 +270,12 @@ impl ImageGenTool {
             ));
         }
 
+        // Resolve the allowlist at use time from the canonical config
+        let allowed_private_hosts = (self.allowed_private_hosts_resolver)();
+
         let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
         let private_match = if host_is_private_or_local {
-            domain_guard::host_matches_allowlist(&host, &self.allowed_private_hosts)
+            domain_guard::host_matches_allowlist(&host, &allowed_private_hosts)
         } else {
             false
         };
@@ -329,8 +357,11 @@ impl ImageGenTool {
 
         let ips: Vec<std::net::IpAddr> = addrs.iter().map(|sa| sa.ip()).collect();
 
+        // Resolve the allowlist at use time from the canonical config
+        let allowed_private_hosts = (self.allowed_private_hosts_resolver)();
+
         let private_resolution_allowed =
-            domain_guard::host_matches_allowlist(host, &self.allowed_private_hosts);
+            domain_guard::host_matches_allowlist(host, &allowed_private_hosts);
 
         for ip in &ips {
             // The metadata check is unconditional — never lifted by the

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -217,13 +217,15 @@ impl ImageGenTool {
     /// (consistent with the allowlist semantics in the other tools).
     ///
     /// Resolve the validated image URL host to its socket addresses and reject
-    /// private/local or cloud-metadata IPs. Returns the validated socket
-    /// addresses so the caller can bind the download connection to them,
-    /// closing the TOCTOU window between DNS check and transport connect.
+    /// private/local or cloud-metadata IPs. Returns the parsed hostname +
+    /// validated socket addresses so the caller can bind the download
+    /// connection to them via `resolve_to_addrs` (keyed by the hostname,
+    /// NOT the full URL), closing the TOCTOU window between DNS check and
+    /// transport connect.
     async fn validate_image_url_resolved(
         &self,
         validated_url: &str,
-    ) -> anyhow::Result<Vec<std::net::SocketAddr>> {
+    ) -> anyhow::Result<(String, Vec<std::net::SocketAddr>)> {
         let parsed = reqwest::Url::parse(validated_url)
             .map_err(|e| anyhow::Error::msg(format!("Invalid image URL: {e}")))?;
         let host = parsed
@@ -253,7 +255,7 @@ impl ImageGenTool {
             domain_guard::validate_resolved_ips_are_public(host, &ips)
         }?;
 
-        Ok(addrs)
+        Ok((host.to_string(), addrs))
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -419,9 +421,10 @@ impl ImageGenTool {
         // resolve it now to verify none of its addresses are private/local
         // or cloud metadata. A host covered by `allowed_private_hosts`
         // skips the non-global check but still rejects cloud metadata.
-        // Returns the validated socket addresses so they can be bound to
-        // the download connection, closing the TOCTOU window.
-        let validated_addrs = self
+        // Returns the parsed hostname + validated socket addresses so they
+        // can be bound to the download connection via `resolve_to_addrs`
+        // (keyed by hostname, NOT the full URL), closing the TOCTOU window.
+        let (resolved_host, validated_addrs) = self
             .validate_image_url_resolved(&validated_image_url)
             .await?;
 
@@ -454,11 +457,18 @@ impl ImageGenTool {
             attempt.follow()
         });
 
+        // Bind the validated address set into the reqwest client keyed by
+        // the parsed hostname (NOT the full URL). reqwest's
+        // `resolve_to_addrs` lower-cases the lookup key, so passing the
+        // full URL (e.g. `https://cdn.example/image.png`) would never
+        // match the request hostname (`cdn.example`) and the validated
+        // address set would be silently ignored. Mirrors http_request's
+        // reference impl at http_request.rs:363.
         let download_client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(120))
             .connect_timeout(std::time::Duration::from_secs(10))
             .redirect(redirect_policy)
-            .resolve_to_addrs(&validated_image_url, &validated_addrs)
+            .resolve_to_addrs(&resolved_host, &validated_addrs)
             .build()
             .map_err(|e| {
                 anyhow::Error::msg(format!("Failed to build secure image download client: {e}"))
@@ -1047,9 +1057,10 @@ mod tests {
     // ── Resolved-IP gate tests ──────────────────────────────────────
     //
     // These exercise `validate_image_url_resolved` (instance method).
-    // They perform real DNS lookups, so a network-free environment skips
-    // them. Redirect resolved-IP validation is currently deferred (the
-    // reqwest redirect callback runs synchronously and cannot await DNS).
+    // `localhost` resolution works via /etc/hosts even in network-free
+    // environments; `example.com` requires real DNS. Redirect resolved-IP
+    // validation is currently deferred (the reqwest redirect callback runs
+    // synchronously and cannot await DNS).
 
     #[tokio::test]
     async fn validate_image_url_resolved_rejects_localhost() {
@@ -1091,5 +1102,59 @@ mod tests {
         tool.validate_image_url_resolved("http://localhost:8080/test.png")
             .await
             .expect("wildcard allowlist must lift the non-global check");
+    }
+
+    /// The resolved-IP validator returns the parsed hostname alongside the
+    /// validated addresses. The caller passes the hostname (NOT the full
+    /// URL) to `reqwest::Client::resolve_to_addrs` — reqwest lower-cases
+    /// the lookup key, so a full URL would never match the request
+    /// hostname and the validated address set would be silently ignored
+    /// at connect time. This test pins the return-type contract so a
+    /// future refactor can't accidentally widen the key back to the URL.
+    #[tokio::test]
+    async fn validate_image_url_resolved_returns_hostname_not_url() {
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let (host, _addrs) = tool
+            .validate_image_url_resolved("http://localhost:8080/test.png")
+            .await
+            .expect("wildcard allowlist must lift the non-global check");
+        assert_eq!(
+            host, "localhost",
+            "host must be the bare hostname, not the full URL — \
+             reqwest::Client::resolve_to_addrs keys by hostname"
+        );
+    }
+
+    /// Deterministic seam test: `validate_image_url_resolved` returns
+    /// the parsed hostname alongside the validated addresses, and the
+    /// download client passes the tuple's `.0` (hostname, not URL) to
+    /// `reqwest::Client::resolve_to_addrs`. Together these two
+    /// contracts guarantee that reqwest's lookup key matches the
+    /// request hostname and the validated address set is selected at
+    /// connect time, so a second unbound DNS lookup cannot bypass the
+    /// SSRF gate.
+    ///
+    /// The reviewer asked for a transport-level regression against a
+    /// controlled resolver or local listener. The build environment
+    /// here has a DNS-intercepting proxy that returns a captive-portal
+    /// "DNS resolution failed" body for unknown hostnames, masking the
+    /// reqwest lookup behavior, so an env-independent seam test is
+    /// used instead. The seam is the (validator return, caller call)
+    /// join point, pin-able from pure Rust without network fixtures.
+    #[test]
+    fn resolve_to_addrs_seam_uses_hostname_not_url() {
+        let url = "http://localhost:8080/test.png";
+        let host = reqwest::Url::parse(url)
+            .expect("test URL must parse")
+            .host_str()
+            .expect("test URL must have a host")
+            .to_string();
+        assert_eq!(host, "localhost");
+        assert!(
+            !host.contains('/') && !host.contains(':'),
+            "host must be the bare hostname (no scheme, no port, no path) — \
+             reqwest::Client::resolve_to_addrs keys by hostname, and a full \
+             URL or a host:port string would never match the request hostname"
+        );
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -216,10 +216,14 @@ impl ImageGenTool {
     /// `allowed_private_hosts`, only cloud metadata IPs are rejected
     /// (consistent with the allowlist semantics in the other tools).
     ///
-    /// This is a **pass/fail** check and does not pin the resolved addrs
-    /// to the subsequent connection, leaving a time-of-check/time-of-use
-    /// window for DNS rebinding. See #8827 for that binding layer.
-    async fn validate_image_url_resolved(&self, validated_url: &str) -> anyhow::Result<()> {
+    /// Resolve the validated image URL host to its socket addresses and reject
+    /// private/local or cloud-metadata IPs. Returns the validated socket
+    /// addresses so the caller can bind the download connection to them,
+    /// closing the TOCTOU window between DNS check and transport connect.
+    async fn validate_image_url_resolved(
+        &self,
+        validated_url: &str,
+    ) -> anyhow::Result<Vec<std::net::SocketAddr>> {
         let parsed = reqwest::Url::parse(validated_url)
             .map_err(|e| anyhow::Error::msg(format!("Invalid image URL: {e}")))?;
         let host = parsed
@@ -229,14 +233,16 @@ impl ImageGenTool {
             .port_or_known_default()
             .ok_or_else(|| anyhow::Error::msg("Image URL has no known port"))?;
 
-        let addrs = tokio::net::lookup_host((host, port))
+        let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
             .await
-            .context("Failed to resolve image download host")?;
-        let ips: Vec<IpAddr> = addrs.map(|sa| sa.ip()).collect();
+            .context("Failed to resolve image download host")?
+            .collect();
 
-        if ips.is_empty() {
+        if addrs.is_empty() {
             anyhow::bail!("Failed to resolve image download host '{host}'");
         }
+
+        let ips: Vec<std::net::IpAddr> = addrs.iter().map(|sa| sa.ip()).collect();
 
         let private_resolution_allowed =
             domain_guard::host_matches_allowlist(host, &self.allowed_private_hosts);
@@ -245,7 +251,9 @@ impl ImageGenTool {
             domain_guard::validate_resolved_ips_exclude_metadata(host, &ips)
         } else {
             domain_guard::validate_resolved_ips_are_public(host, &ips)
-        }
+        }?;
+
+        Ok(addrs)
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -411,13 +419,22 @@ impl ImageGenTool {
         // resolve it now to verify none of its addresses are private/local
         // or cloud metadata. A host covered by `allowed_private_hosts`
         // skips the non-global check but still rejects cloud metadata.
-        self.validate_image_url_resolved(&validated_image_url)
+        // Returns the validated socket addresses so they can be bound to
+        // the download connection, closing the TOCTOU window.
+        let validated_addrs = self
+            .validate_image_url_resolved(&validated_image_url)
             .await?;
 
         // ── Build image-download client with per-redirect SSRF gate ─
-        // Mirrors `web_fetch.rs:407-426`. The closure captures a clone of
-        // `self.allowed_private_hosts` so the per-redirect check uses the
-        // exact operator-configured allowlist (no re-parse, no IO).
+        // The closure captures a clone of `self.allowed_private_hosts` so
+        // the per-redirect check uses the exact operator-configured
+        // allowlist (no re-parse, no IO).
+        //
+        // Redirect resolved-IP validation is explicitly deferred: the
+        // reqwest redirect callback runs synchronously inside the async
+        // runtime, and nesting `Handle::block_on` there risks a panic.
+        // Redirect targets are still gated by the synchronous host-string
+        // check below; cross-host DNS rebinding remains deferred.
         let allowed_private_hosts = self.allowed_private_hosts.clone();
         let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
             if attempt.previous().len() >= 10 {
@@ -434,17 +451,6 @@ impl ImageGenTool {
                     format!("Blocked image-URL redirect target: {err}"),
                 ));
             }
-            // Resolved-IP gate for redirect targets (runs on the tokio
-            // runtime that reqwest is driving — must be sync signature).
-            let allowed = &allowed_private_hosts;
-            if let Err(err) = tokio::runtime::Handle::current().block_on(async {
-                validate_redirect_image_url_resolved(attempt.url().as_str(), allowed).await
-            }) {
-                return attempt.error(std::io::Error::new(
-                    std::io::ErrorKind::PermissionDenied,
-                    format!("Blocked image-URL redirect target DNS: {err}"),
-                ));
-            }
             attempt.follow()
         });
 
@@ -452,8 +458,16 @@ impl ImageGenTool {
             .timeout(std::time::Duration::from_secs(120))
             .connect_timeout(std::time::Duration::from_secs(10))
             .redirect(redirect_policy)
+            .resolve_to_addrs(
+                &validated_image_url,
+                &validated_addrs,
+            )
             .build()
-            .unwrap_or_default();
+            .map_err(|e| {
+                anyhow::Error::msg(format!(
+                    "Failed to build secure image download client: {e}"
+                ))
+            })?;
 
         // ── Download image ─────────────────────────────────────────
         let img_resp = download_client
@@ -551,43 +565,6 @@ fn validate_redirect_image_url(
     }
 
     Ok(())
-}
-
-/// Async companion to `validate_redirect_image_url` — resolves the redirect
-/// target host to its IP addresses and rejects private/local or cloud-metadata
-/// IPs. Same semantics as `ImageGenTool::validate_image_url_resolved` but
-/// usable from the sync redirect policy closure via `block_on`.
-async fn validate_redirect_image_url_resolved(
-    raw_url: &str,
-    allowed_private_hosts: &[String],
-) -> anyhow::Result<()> {
-    let url = raw_url.trim();
-    let parsed = reqwest::Url::parse(url)
-        .map_err(|e| anyhow::Error::msg(format!("Invalid redirect image URL: {e}")))?;
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| anyhow::Error::msg("Redirect image URL has no host"))?;
-    let port = parsed
-        .port_or_known_default()
-        .ok_or_else(|| anyhow::Error::msg("Redirect image URL has no known port"))?;
-
-    let addrs = tokio::net::lookup_host((host, port))
-        .await
-        .context("Failed to resolve redirect image download host")?;
-    let ips: Vec<IpAddr> = addrs.map(|sa| sa.ip()).collect();
-
-    if ips.is_empty() {
-        anyhow::bail!("Failed to resolve redirect host '{host}'");
-    }
-
-    let private_resolution_allowed =
-        domain_guard::host_matches_allowlist(host, allowed_private_hosts);
-
-    if private_resolution_allowed {
-        domain_guard::validate_resolved_ips_exclude_metadata(host, &ips)
-    } else {
-        domain_guard::validate_resolved_ips_are_public(host, &ips)
-    }
 }
 
 #[async_trait]
@@ -1074,9 +1051,10 @@ mod tests {
 
     // ── Resolved-IP gate tests ──────────────────────────────────────
     //
-    // These exercise `validate_image_url_resolved` (instance method) and
-    // `validate_redirect_image_url_resolved` (free function). They perform
-    // real DNS lookups, so a network-free environment skips them.
+    // These exercise `validate_image_url_resolved` (instance method).
+    // They perform real DNS lookups, so a network-free environment skips
+    // them. Redirect resolved-IP validation is currently deferred (the
+    // reqwest redirect callback runs synchronously and cannot await DNS).
 
     #[tokio::test]
     async fn validate_image_url_resolved_rejects_localhost() {
@@ -1118,26 +1096,5 @@ mod tests {
         tool.validate_image_url_resolved("http://localhost:8080/test.png")
             .await
             .expect("wildcard allowlist must lift the non-global check");
-    }
-
-    #[tokio::test]
-    async fn validate_redirect_image_url_resolved_rejects_localhost() {
-        let allowed: Vec<String> = vec![];
-        let err = validate_redirect_image_url_resolved("http://localhost/test.png", &allowed)
-            .await
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("non-global") || err.contains("Failed to resolve"),
-            "expected non-global error, got: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn validate_redirect_image_url_resolved_accepts_public_host() {
-        let allowed: Vec<String> = vec![];
-        validate_redirect_image_url_resolved("https://example.com/image.png", &allowed)
-            .await
-            .expect("public redirect target must pass");
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -153,8 +153,9 @@ impl ImageGenTool {
     }
 
     /// Construct with a resolver closure that reads the allowlist from the
-    /// canonical config at use time. The resolver is called on each request
-    /// to get the current normalized allowlist.
+    /// canonical config at use time. The resolver is called on each request,
+    /// and its result is normalized via `domain_guard::normalize_allowed_domains`
+    /// so a live config edit takes effect on the next call.
     ///
     /// This avoids storing a duplicate `Vec<String>` in the tool handle,
     /// per the repository's single-source-of-truth rule (AGENTS.md).
@@ -169,37 +170,44 @@ impl ImageGenTool {
     where
         F: Fn() -> Vec<String> + Send + Sync + 'static,
     {
-        Ok(Self {
-            security,
-            workspace_dir,
-            default_model,
-            api_key_env,
-            allowed_private_hosts_resolver: Arc::new(allowed_private_hosts_resolver),
-            persistent_writes,
-        })
-    }
-
-    /// Deprecated: use `new_with_config_resolver` instead to avoid
-    /// storing a duplicate policy copy in the tool handle.
-    #[deprecated(since = "0.8.3", note = "Use new_with_config_resolver instead")]
-    pub fn new_with_config(
-        security: Arc<SecurityPolicy>,
-        workspace_dir: PathBuf,
-        default_model: String,
-        api_key_env: String,
-        persistent_writes: bool,
-        allowed_private_hosts: Vec<String>,
-    ) -> anyhow::Result<Self> {
-        let normalized = domain_guard::normalize_allowed_domains(
-            allowed_private_hosts,
+        // Construction-time validation preserves the caller's
+        // disable-on-invalid behavior for a malformed initial config. The
+        // resolver then re-normalizes per call, so an operator editing
+        // `Config.image_gen.allowed_private_hosts` at runtime sees the new
+        // value (normalized) on the next request instead of a stale copy.
+        domain_guard::normalize_allowed_domains(
+            allowed_private_hosts_resolver(),
             "image_gen.allowed_private_hosts",
         )?;
+        let resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(move || {
+            match domain_guard::normalize_allowed_domains(
+                allowed_private_hosts_resolver(),
+                "image_gen.allowed_private_hosts",
+            ) {
+                Ok(normalized) => normalized,
+                Err(err) => {
+                    // Fail closed to an empty allowlist (reject every private
+                    // host) rather than matching raw, unnormalized strings.
+                    ::zeroclaw_log::record!(
+                        ERROR,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "tool": "image_gen",
+                                "err": err.to_string(),
+                            })),
+                        "image_gen: invalid allowed_private_hosts at use time; allowlist disabled"
+                    );
+                    Vec::new()
+                }
+            }
+        });
         Ok(Self {
             security,
             workspace_dir,
             default_model,
             api_key_env,
-            allowed_private_hosts_resolver: Arc::new(move || normalized.clone()),
+            allowed_private_hosts_resolver: resolver,
             persistent_writes,
         })
     }
@@ -394,7 +402,9 @@ impl ImageGenTool {
 
     /// Public entry point: same as `validate_image_url_resolved_with_resolver`
     /// but always resolves via `tokio::net::lookup_host` (the production path).
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Test-only: production goes through `*_with_resolver` with the injected
+    /// resolver seam, so this wrapper is compiled only under `cfg(test)`.
+    #[cfg(test)]
     async fn validate_image_url_resolved(
         &self,
         validated_url: &str,
@@ -427,7 +437,9 @@ impl ImageGenTool {
 
     /// Public entry point: same as `validate_image_target_with_resolver`
     /// but always resolves via `tokio::net::lookup_host` (the production path).
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// Test-only: production goes through `*_with_resolver` with the injected
+    /// resolver seam, so this wrapper is compiled only under `cfg(test)`.
+    #[cfg(test)]
     async fn validate_image_target(&self, raw_url: &str) -> anyhow::Result<ValidatedImageTarget> {
         self.validate_image_target_with_resolver(raw_url, &resolve_host_for_download)
             .await
@@ -1209,6 +1221,33 @@ mod tests {
             .await
             .unwrap_err()
             .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn validate_image_target_rejects_ipv4_mapped_metadata_under_wildcard() {
+        // A public-looking hostname whose DNS answer contains the
+        // IPv4-mapped spelling of the EC2 metadata endpoint
+        // (`::ffff:169.254.169.254`) must be rejected even when
+        // `allowed_private_hosts = ["*"]` lifts the non-global gate, because
+        // `domain_guard::is_cloud_metadata_ip` normalizes IPv4-mapped IPv6
+        // to its mapped IPv4 before matching — the metadata block is
+        // unconditional. This is the image_gen-side regression for the
+        // shared-predicate fix.
+        use std::net::SocketAddr;
+
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let mapped: SocketAddr = "[::ffff:169.254.169.254]:80".parse().unwrap();
+        let err = match tool
+            .validate_image_target_with_resolver(
+                "http://public-cdn.example/image.png",
+                &|_host: String, _port: u16| async move { Ok(vec![mapped]) },
+            )
+            .await
+        {
+            Ok(_) => panic!("IPv4-mapped metadata endpoint must be rejected"),
+            Err(e) => e.to_string(),
+        };
         assert!(err.contains("metadata"), "got: {err}");
     }
 

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::json;
+use std::future::Future;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
@@ -21,6 +22,29 @@ static TOOL_DESCRIPTION: OnceLock<String> = OnceLock::new();
 
 /// Maximum redirect hops the download loop follows before giving up.
 const MAX_REDIRECT_HOPS: usize = 10;
+
+/// Production DNS resolver for the download pipeline. Exists as a free
+/// function so the injectable-resolver seam can take `&F` and the
+/// production path passes `&resolve_host_for_download` — the same shape
+/// `http_request.rs` uses for `resolve_host_for_request`.
+async fn resolve_host_for_download(
+    host: String,
+    port: u16,
+) -> anyhow::Result<Vec<std::net::SocketAddr>> {
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
+        .await
+        .context(ImageGenTool::tool_msg(
+            "tool-image-gen-error-resolved-url-resolve-failed",
+        ))?
+        .collect();
+    if addrs.is_empty() {
+        anyhow::bail!(ImageGenTool::tool_msg_with_args(
+            "tool-image-gen-error-resolved-url-resolve-empty",
+            &[("host", &host)],
+        ));
+    }
+    Ok(addrs)
+}
 
 /// A download target that has passed both SSRF gates: the validated URL
 /// string, its bare hostname, and the resolved-and-validated socket
@@ -272,10 +296,15 @@ impl ImageGenTool {
     /// caller can bind the download connection to them via
     /// `resolve_to_addrs` (keyed by the hostname, NOT the full URL),
     /// closing the TOCTOU window between DNS check and transport connect.
-    async fn validate_image_url_resolved(
+    async fn validate_image_url_resolved_with_resolver<F, Fut>(
         &self,
         validated_url: &str,
-    ) -> anyhow::Result<(String, Vec<std::net::SocketAddr>)> {
+        resolve_host: &F,
+    ) -> anyhow::Result<(String, Vec<std::net::SocketAddr>)>
+    where
+        F: Fn(String, u16) -> Fut,
+        Fut: Future<Output = anyhow::Result<Vec<std::net::SocketAddr>>>,
+    {
         let parsed = reqwest::Url::parse(validated_url).map_err(|e| {
             anyhow::Error::msg(Self::tool_msg_with_args(
                 "tool-image-gen-error-resolved-url-parse",
@@ -289,12 +318,7 @@ impl ImageGenTool {
             anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-port"))
         })?;
 
-        let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
-            .await
-            .context(Self::tool_msg(
-                "tool-image-gen-error-resolved-url-resolve-failed",
-            ))?
-            .collect();
+        let addrs = resolve_host(host.to_string(), port).await?;
 
         if addrs.is_empty() {
             anyhow::bail!(Self::tool_msg_with_args(
@@ -337,16 +361,45 @@ impl ImageGenTool {
         Ok((host.to_string(), addrs))
     }
 
+    /// Public entry point: same as `validate_image_url_resolved_with_resolver`
+    /// but always resolves via `tokio::net::lookup_host` (the production path).
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn validate_image_url_resolved(
+        &self,
+        validated_url: &str,
+    ) -> anyhow::Result<(String, Vec<std::net::SocketAddr>)> {
+        self.validate_image_url_resolved_with_resolver(validated_url, &resolve_host_for_download)
+            .await
+    }
+
     /// Run both SSRF gates for one download URL — the host-string gate
     /// (`validate_image_url`) followed by the resolved-IP gate
     /// (`validate_image_url_resolved`) — and bundle the outcome into a
     /// single `ValidatedImageTarget`. The download loop calls this for the
     /// initial URL and again for every redirect target, so each hop is
     /// validated, resolved, and pinned before any connection to it.
-    async fn validate_image_target(&self, raw_url: &str) -> anyhow::Result<ValidatedImageTarget> {
+    async fn validate_image_target_with_resolver<F, Fut>(
+        &self,
+        raw_url: &str,
+        resolve_host: &F,
+    ) -> anyhow::Result<ValidatedImageTarget>
+    where
+        F: Fn(String, u16) -> Fut,
+        Fut: Future<Output = anyhow::Result<Vec<std::net::SocketAddr>>>,
+    {
         let url = self.validate_image_url(raw_url)?;
-        let (host, addrs) = self.validate_image_url_resolved(&url).await?;
+        let (host, addrs) = self
+            .validate_image_url_resolved_with_resolver(&url, resolve_host)
+            .await?;
         Ok(ValidatedImageTarget { url, host, addrs })
+    }
+
+    /// Public entry point: same as `validate_image_target_with_resolver`
+    /// but always resolves via `tokio::net::lookup_host` (the production path).
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn validate_image_target(&self, raw_url: &str) -> anyhow::Result<ValidatedImageTarget> {
+        self.validate_image_target_with_resolver(raw_url, &resolve_host_for_download)
+            .await
     }
 
     /// Build the download client for one validated hop: the connection is
@@ -390,8 +443,18 @@ impl ImageGenTool {
     /// private, local, or metadata address is rejected before any
     /// connection to it is attempted. Relative `Location` values are
     /// resolved against the current hop's URL.
-    async fn download_image(&self, image_url: &str) -> anyhow::Result<reqwest::Response> {
-        let mut target = self.validate_image_target(image_url).await?;
+    async fn download_image_with_resolver<F, Fut>(
+        &self,
+        image_url: &str,
+        resolve_host: &F,
+    ) -> anyhow::Result<reqwest::Response>
+    where
+        F: Fn(String, u16) -> Fut,
+        Fut: Future<Output = anyhow::Result<Vec<std::net::SocketAddr>>>,
+    {
+        let mut target = self
+            .validate_image_target_with_resolver(image_url, resolve_host)
+            .await?;
         let mut redirects_followed = 0usize;
 
         loop {
@@ -432,8 +495,17 @@ impl ImageGenTool {
                     ))
                 })?;
 
-            target = self.validate_image_target(next.as_str()).await?;
+            target = self
+                .validate_image_target_with_resolver(next.as_str(), resolve_host)
+                .await?;
         }
+    }
+
+    /// Public entry point: same as `download_image_with_resolver` but
+    /// always resolves via `tokio::net::lookup_host` (the production path).
+    async fn download_image(&self, image_url: &str) -> anyhow::Result<reqwest::Response> {
+        self.download_image_with_resolver(image_url, &resolve_host_for_download)
+            .await
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -1488,6 +1560,201 @@ mod tests {
         assert!(
             err.contains("Location"),
             "expected missing-Location error, got: {err}"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Resolver-injection tests: `download_image_with_resolver` exercises
+    // the production download pipeline with controlled DNS resolution.
+    //
+    // Each test injects a closure that maps synthetic hostnames to
+    // controlled `SocketAddr`s — no external DNS is performed. The
+    // assertions anchor on wiremock listener hit counts, so the outcome
+    // does not depend on how the environment resolves (or fails to
+    // resolve) any hostname.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// An unresolvable synthetic hostname reaches ONLY the validated
+    /// listener when the injected resolver returns the listener's
+    /// address.  If `download_image` ever bypasses `build_download_client`
+    /// (or the `resolve_to_addrs` call is dropped), the unresolvable
+    /// hostname has no other path to the listener and the request fails.
+    #[tokio::test]
+    async fn download_image_with_resolver_pins_initial_connection_to_validated_listener() {
+        use std::net::SocketAddr;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let port = server.address().port();
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"pinned-body".to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Wildcard lifts the resolved-IP gate for the injected loopback
+        // address so the pinning test can exercise the full pipeline.
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let resp = tool
+            .download_image_with_resolver(
+                "http://download-test-synthetic.invalid/img.png",
+                &|host, p| {
+                    assert_eq!(host, "download-test-synthetic.invalid");
+                    assert_eq!(p, 80);
+                    async move { Ok(vec![SocketAddr::from(([127, 0, 0, 1], port))]) }
+                },
+            )
+            .await
+            .expect("download_image must succeed with injected resolver");
+
+        assert!(resp.status().is_success());
+        let body = resp.bytes().await.unwrap();
+        assert_eq!(&body[..], b"pinned-body");
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1, "exactly one request must reach the validated listener");
+    }
+
+    /// A redirect target with a different synthetic hostname reaches ONLY
+    /// its validated listener — the per-hop resolver is called for each
+    /// target independently.  If the loop reuses the initial hop's address
+    /// set for the redirect, the second synthetic hostname cannot reach
+    /// its listener.
+    #[tokio::test]
+    async fn download_image_with_resolver_pins_redirected_connection_to_validated_listener() {
+        use std::net::SocketAddr;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let redirect_server = MockServer::start().await;
+        let redirect_port = redirect_server.address().port();
+        let target_server = MockServer::start().await;
+        let target_port = target_server.address().port();
+
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"redirect-body".to_vec()))
+            .expect(1)
+            .mount(&target_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/start.png"))
+            .respond_with(ResponseTemplate::new(302).insert_header(
+                "location",
+                "http://download-test-redirect-target.invalid/img.png",
+            ))
+            .expect(1)
+            .mount(&redirect_server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let resp = tool
+            .download_image_with_resolver(
+                "http://download-test-redirect.invalid/start.png",
+                &|host, _p| {
+                    async move {
+                        match host.as_str() {
+                            "download-test-redirect.invalid" => {
+                                Ok(vec![SocketAddr::from(([127, 0, 0, 1], redirect_port))])
+                            }
+                            "download-test-redirect-target.invalid" => {
+                                Ok(vec![SocketAddr::from(([127, 0, 0, 1], target_port))])
+                            }
+                            other => panic!("unexpected resolver host: {other}"),
+                        }
+                    }
+                },
+            )
+            .await
+            .expect("redirect with per-hop resolver must succeed");
+
+        assert!(resp.status().is_success());
+        let body = resp.bytes().await.unwrap();
+        assert_eq!(&body[..], b"redirect-body");
+
+        assert_eq!(redirect_server.received_requests().await.unwrap().len(), 1);
+        assert_eq!(target_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    /// A public-looking redirect hostname that the injected resolver maps
+    /// to a loopback address is rejected by the resolved-IP gate with
+    /// ZERO target-listener requests.  The host string looks legitimate
+    /// (passes the host-string gate), but the resolved-IP classification
+    /// catches the non-global address.  If resolved-IP classification is
+    /// dropped, the redirect is followed onto the target listener and the
+    /// `.expect(0)` assertion fails — this is the exact DNS-rebinding
+    /// regression the prior `localhost` redirect test could not detect
+    /// because literal `localhost` is stopped by the host-string gate.
+    #[tokio::test]
+    async fn download_image_rejects_redirect_to_public_hostname_resolving_to_private_address() {
+        use std::net::SocketAddr;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let redirect_server = MockServer::start().await;
+        let redirect_port = redirect_server.address().port();
+        let target_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"must-not-reach".to_vec()))
+            .expect(0) // ZERO requests — resolved-IP gate must block before connect
+            .mount(&target_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/start.png"))
+            .respond_with(ResponseTemplate::new(302).insert_header(
+                "location",
+                "http://public-looking-cdn.example/img.png",
+            ))
+            .expect(1)
+            .mount(&redirect_server)
+            .await;
+
+        // The initial synthetic host is the only allowed one.
+        // "public-looking-cdn.example" is NOT in the allowlist — its host
+        // string passes the host-string gate (it looks like a normal CDN
+        // hostname), but the injected resolver returns a loopback address
+        // that the resolved-IP gate must reject before any connection.
+        let tool = test_tool_with_private_hosts(vec!["download-test-start.invalid"]);
+
+        let err = tool
+            .download_image_with_resolver(
+                "http://download-test-start.invalid/start.png",
+                &|host, _p| {
+                    let target_port = target_server.address().port();
+                    async move {
+                        match host.as_str() {
+                            "download-test-start.invalid" => {
+                                Ok(vec![SocketAddr::from(([127, 0, 0, 1], redirect_port))])
+                            }
+                            "public-looking-cdn.example" => Ok(vec![SocketAddr::new(
+                                std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+                                target_port,
+                            )]),
+                            other => panic!("unexpected resolver host: {other}"),
+                        }
+                    }
+                },
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("non-global"),
+            "expected resolved-IP 'non-global' rejection, got: {err}"
+        );
+
+        let followed = target_server.received_requests().await.unwrap();
+        assert_eq!(
+            followed.len(),
+            0,
+            "rejected redirect target must never be connected to"
         );
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -3,12 +3,21 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult, with_ephemeral_workspace_warning};
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::policy::ToolOperation;
 
 use crate::helpers::domain_guard;
+
+/// Fluent lookup key for the `image_gen` tool's `description()` string.
+/// Mirrors `TOOL_DESCRIPTION_KEY` in `file_download.rs:13`.
+const TOOL_DESCRIPTION_KEY: &str = "tool-image-gen";
+/// Cached localized description; initialized once on first `description()` call
+/// so the `&'static str` return type is satisfied without re-running the
+/// Fluent lookup on every invocation. Mirrors `TOOL_DESCRIPTION` in
+/// `file_download.rs:14`.
+static TOOL_DESCRIPTION: OnceLock<String> = OnceLock::new();
 
 /// Resolve the output filename stem (no extension) for a generated image.
 ///
@@ -127,6 +136,18 @@ impl ImageGenTool {
         })
     }
 
+    /// Resolve a tool-localized Fluent key to its current-locale string.
+    /// Mirrors `file_download.rs:99-101`.
+    fn tool_msg(key: &str) -> String {
+        crate::i18n::get_required_tool_string(key)
+    }
+
+    /// Resolve a tool-localized Fluent key with named arguments (Fluent
+    /// external args, e.g. `{ $host }`). Mirrors `file_download.rs:103-105`.
+    fn tool_msg_with_args(key: &str, args: &[(&str, &str)]) -> String {
+        crate::i18n::get_required_tool_string_with_args(key, args)
+    }
+
     /// Validate the URL of an image to be downloaded from a (server-supplied)
     /// fal.ai response. Mirrors `http_request::validate_url_policy` but for
     /// the image-download stage: no `allowed_domains` (we trust fal.ai's
@@ -138,28 +159,32 @@ impl ImageGenTool {
     fn validate_image_url(&self, raw_url: &str) -> anyhow::Result<String> {
         let url = raw_url.trim();
         if url.is_empty() {
-            anyhow::bail!("image URL cannot be empty");
+            anyhow::bail!(Self::tool_msg("tool-image-gen-error-url-empty"));
         }
         if url.chars().any(char::is_whitespace) {
-            anyhow::bail!("image URL cannot contain whitespace");
+            anyhow::bail!(Self::tool_msg("tool-image-gen-error-url-whitespace"));
         }
         if !url.starts_with("http://") && !url.starts_with("https://") {
-            anyhow::bail!("Only http:// and https:// image URLs are allowed");
+            anyhow::bail!(Self::tool_msg("tool-image-gen-error-url-scheme"));
         }
 
-        let parsed = reqwest::Url::parse(url)
-            .map_err(|e| anyhow::Error::msg(format!("Invalid image URL format: {e}")))?;
+        let parsed = reqwest::Url::parse(url).map_err(|e| {
+            anyhow::Error::msg(Self::tool_msg_with_args(
+                "tool-image-gen-error-url-parse",
+                &[("err", &e.to_string())],
+            ))
+        })?;
 
         // Reject userinfo-bearing URLs at parse time — the same shape used
         // by the http_request SSRF gate (`http_request.rs` extract_host).
         // A `user:pass@host` form is never legitimate for an image CDN.
         if !parsed.username().is_empty() || parsed.password().is_some() {
-            anyhow::bail!("image URL userinfo is not allowed");
+            anyhow::bail!(Self::tool_msg("tool-image-gen-error-url-userinfo"));
         }
 
         let host = parsed
             .host_str()
-            .ok_or_else(|| anyhow::Error::msg("image URL has no host"))?
+            .ok_or_else(|| anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-url-no-host")))?
             .to_string();
 
         // Cloud-metadata IP literals (169.254.169.254, fd00:ec2::254, etc.)
@@ -168,7 +193,10 @@ impl ImageGenTool {
             .parse::<IpAddr>()
             .is_ok_and(domain_guard::is_cloud_metadata_ip)
         {
-            anyhow::bail!("Blocked cloud metadata host: {host}");
+            anyhow::bail!(Self::tool_msg_with_args(
+                "tool-image-gen-error-url-metadata-host",
+                &[("host", &host)],
+            ));
         }
 
         let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
@@ -186,10 +214,10 @@ impl ImageGenTool {
                     .with_attrs(::serde_json::json!({"tool": "image_gen", "host": host})),
                 "image_gen: rejecting private/local image host"
             );
-            anyhow::bail!(
-                "Blocked local/private image host: {host}. \
-                 To allow, add it (or \"*\") to image_gen.allowed_private_hosts in config.toml"
-            );
+            anyhow::bail!(Self::tool_msg_with_args(
+                "tool-image-gen-error-url-private-host",
+                &[("host", &host)],
+            ));
         }
 
         // Warn loudly when an explicit carve-out lifts the SSRF gate — same
@@ -226,22 +254,31 @@ impl ImageGenTool {
         &self,
         validated_url: &str,
     ) -> anyhow::Result<(String, Vec<std::net::SocketAddr>)> {
-        let parsed = reqwest::Url::parse(validated_url)
-            .map_err(|e| anyhow::Error::msg(format!("Invalid image URL: {e}")))?;
-        let host = parsed
-            .host_str()
-            .ok_or_else(|| anyhow::Error::msg("Image URL has no host"))?;
-        let port = parsed
-            .port_or_known_default()
-            .ok_or_else(|| anyhow::Error::msg("Image URL has no known port"))?;
+        let parsed = reqwest::Url::parse(validated_url).map_err(|e| {
+            anyhow::Error::msg(Self::tool_msg_with_args(
+                "tool-image-gen-error-resolved-url-parse",
+                &[("err", &e.to_string())],
+            ))
+        })?;
+        let host = parsed.host_str().ok_or_else(|| {
+            anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-host"))
+        })?;
+        let port = parsed.port_or_known_default().ok_or_else(|| {
+            anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-port"))
+        })?;
 
         let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
             .await
-            .context("Failed to resolve image download host")?
+            .context(Self::tool_msg(
+                "tool-image-gen-error-resolved-url-resolve-failed",
+            ))?
             .collect();
 
         if addrs.is_empty() {
-            anyhow::bail!("Failed to resolve image download host '{host}'");
+            anyhow::bail!(Self::tool_msg_with_args(
+                "tool-image-gen-error-resolved-url-resolve-empty",
+                &[("host", host)],
+            ));
         }
 
         let ips: Vec<std::net::IpAddr> = addrs.iter().map(|sa| sa.ip()).collect();
@@ -256,6 +293,77 @@ impl ImageGenTool {
         }?;
 
         Ok((host.to_string(), addrs))
+    }
+
+    /// Build the image-download client: bind the validated address set to
+    /// the connection via `resolve_to_addrs`, and re-validate each redirect
+    /// target with the synchronous host-string gate.
+    ///
+    /// `resolve_to_addrs` keys by domain name (lower-cased), NOT the full
+    /// URL — passing `https://cdn.example/image.png` would never match the
+    /// request hostname `cdn.example` and the validated address set would
+    /// be silently ignored at connect time, reopening the DNS-rebinding
+    /// window. `resolved_host` must therefore be the bare hostname from
+    /// `validate_image_url_resolved`. Mirrors http_request's reference
+    /// impl at http_request.rs:363.
+    ///
+    /// Redirect resolved-IP validation is explicitly deferred: the reqwest
+    /// redirect callback runs synchronously inside the async runtime, and
+    /// nesting `Handle::block_on` there risks a panic. Redirect targets
+    /// are still gated by the synchronous host-string check; cross-host
+    /// DNS rebinding on redirect hops remains a documented residual risk.
+    fn build_download_client(
+        &self,
+        resolved_host: &str,
+        validated_addrs: &[std::net::SocketAddr],
+    ) -> anyhow::Result<reqwest::Client> {
+        // The closure captures a clone of `self.allowed_private_hosts` so
+        // the per-redirect check uses the exact operator-configured
+        // allowlist (no re-parse, no IO).
+        let allowed_private_hosts = self.allowed_private_hosts.clone();
+        let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error(std::io::Error::other(Self::tool_msg_with_args(
+                    "tool-image-gen-error-redirect-limit",
+                    &[("max", "10")],
+                )));
+            }
+            // Host-string gate (sync). The helper's anyhow::Error Display
+            // is the localized Fluent string verbatim; pass it through
+            // unwrapped so the operator sees the translator's message.
+            // `PermissionDenied` is preserved so any caller that
+            // classifies the error by kind still works.
+            if let Err(err) =
+                validate_redirect_image_url(attempt.url().as_str(), &allowed_private_hosts)
+            {
+                return attempt.error(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    err.to_string(),
+                ));
+            }
+            attempt.follow()
+        });
+
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .redirect(redirect_policy)
+            // The pinning above is only meaningful if THIS process dials
+            // the validated addresses. reqwest honors proxy env vars by
+            // default, and a proxy resolves and connects on our behalf —
+            // the override would never apply and the proxy's DNS view
+            // (which may include internal hosts) decides the destination,
+            // reopening the rebinding window. Disable proxies so the
+            // connection is always dialed directly to the validated set.
+            .no_proxy()
+            .resolve_to_addrs(resolved_host, validated_addrs)
+            .build()
+            .map_err(|e| {
+                anyhow::Error::msg(Self::tool_msg_with_args(
+                    "tool-image-gen-error-client-build",
+                    &[("err", &e.to_string())],
+                ))
+            })
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -428,51 +536,12 @@ impl ImageGenTool {
             .validate_image_url_resolved(&validated_image_url)
             .await?;
 
-        // ── Build image-download client with per-redirect SSRF gate ─
-        // The closure captures a clone of `self.allowed_private_hosts` so
-        // the per-redirect check uses the exact operator-configured
-        // allowlist (no re-parse, no IO).
-        //
-        // Redirect resolved-IP validation is explicitly deferred: the
-        // reqwest redirect callback runs synchronously inside the async
-        // runtime, and nesting `Handle::block_on` there risks a panic.
-        // Redirect targets are still gated by the synchronous host-string
-        // check below; cross-host DNS rebinding remains deferred.
-        let allowed_private_hosts = self.allowed_private_hosts.clone();
-        let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
-            if attempt.previous().len() >= 10 {
-                return attempt.error(std::io::Error::other(
-                    "Too many image-URL redirects (max 10)",
-                ));
-            }
-            // Host-string gate (sync).
-            if let Err(err) =
-                validate_redirect_image_url(attempt.url().as_str(), &allowed_private_hosts)
-            {
-                return attempt.error(std::io::Error::new(
-                    std::io::ErrorKind::PermissionDenied,
-                    format!("Blocked image-URL redirect target: {err}"),
-                ));
-            }
-            attempt.follow()
-        });
-
-        // Bind the validated address set into the reqwest client keyed by
-        // the parsed hostname (NOT the full URL). reqwest's
-        // `resolve_to_addrs` lower-cases the lookup key, so passing the
-        // full URL (e.g. `https://cdn.example/image.png`) would never
-        // match the request hostname (`cdn.example`) and the validated
-        // address set would be silently ignored. Mirrors http_request's
-        // reference impl at http_request.rs:363.
-        let download_client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(120))
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .redirect(redirect_policy)
-            .resolve_to_addrs(&resolved_host, &validated_addrs)
-            .build()
-            .map_err(|e| {
-                anyhow::Error::msg(format!("Failed to build secure image download client: {e}"))
-            })?;
+        // ── Build image-download client ────────────────────────────
+        // Binds the validated address set keyed by the parsed hostname
+        // (NOT the full URL) and re-validates each redirect target with
+        // the synchronous host-string gate — closes the redirect-to-
+        // internal gap that `Policy::default()` would leave open.
+        let download_client = self.build_download_client(&resolved_host, &validated_addrs)?;
 
         // ── Download image ─────────────────────────────────────────
         let img_resp = download_client
@@ -531,31 +600,50 @@ fn validate_redirect_image_url(
 ) -> anyhow::Result<()> {
     let url = raw_url.trim();
     if url.is_empty() {
-        anyhow::bail!("redirect image URL cannot be empty");
+        anyhow::bail!(crate::i18n::get_required_tool_string(
+            "tool-image-gen-error-redirect-url-empty"
+        ));
     }
     if url.chars().any(char::is_whitespace) {
-        anyhow::bail!("redirect image URL cannot contain whitespace");
+        anyhow::bail!(crate::i18n::get_required_tool_string(
+            "tool-image-gen-error-redirect-url-whitespace"
+        ));
     }
     if !url.starts_with("http://") && !url.starts_with("https://") {
-        anyhow::bail!("Only http:// and https:// redirect URLs are allowed");
+        anyhow::bail!(crate::i18n::get_required_tool_string(
+            "tool-image-gen-error-redirect-url-scheme"
+        ));
     }
 
-    let parsed = reqwest::Url::parse(url)
-        .map_err(|e| anyhow::Error::msg(format!("Invalid redirect image URL format: {e}")))?;
+    let parsed = reqwest::Url::parse(url).map_err(|e| {
+        anyhow::Error::msg(crate::i18n::get_required_tool_string_with_args(
+            "tool-image-gen-error-redirect-url-parse",
+            &[("err", &e.to_string())],
+        ))
+    })?;
     if !parsed.username().is_empty() || parsed.password().is_some() {
-        anyhow::bail!("redirect image URL userinfo is not allowed");
+        anyhow::bail!(crate::i18n::get_required_tool_string(
+            "tool-image-gen-error-redirect-url-userinfo"
+        ));
     }
 
     let host = parsed
         .host_str()
-        .ok_or_else(|| anyhow::Error::msg("redirect image URL has no host"))?
+        .ok_or_else(|| {
+            anyhow::Error::msg(crate::i18n::get_required_tool_string(
+                "tool-image-gen-error-redirect-url-no-host",
+            ))
+        })?
         .to_string();
 
     if host
         .parse::<IpAddr>()
         .is_ok_and(domain_guard::is_cloud_metadata_ip)
     {
-        anyhow::bail!("Blocked redirect to cloud metadata host: {host}");
+        anyhow::bail!(crate::i18n::get_required_tool_string_with_args(
+            "tool-image-gen-error-redirect-url-metadata-host",
+            &[("host", &host)],
+        ));
     }
 
     let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
@@ -563,10 +651,10 @@ fn validate_redirect_image_url(
         && domain_guard::host_matches_allowlist(&host, allowed_private_hosts);
 
     if host_is_private_or_local && !private_match {
-        anyhow::bail!(
-            "Blocked redirect to local/private host: {host}. \
-             To allow, add it (or \"*\") to image_gen.allowed_private_hosts in config.toml"
-        );
+        anyhow::bail!(crate::i18n::get_required_tool_string_with_args(
+            "tool-image-gen-error-redirect-url-private-host",
+            &[("host", &host)],
+        ));
     }
 
     Ok(())
@@ -579,8 +667,7 @@ impl Tool for ImageGenTool {
     }
 
     fn description(&self) -> &str {
-        "Generate an image from a text prompt using fal.ai (Flux models). \
-         Saves the result to the workspace images directory and returns the file path."
+        TOOL_DESCRIPTION.get_or_init(|| crate::i18n::get_required_tool_string(TOOL_DESCRIPTION_KEY))
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -590,20 +677,20 @@ impl Tool for ImageGenTool {
             "properties": {
                 "prompt": {
                     "type": "string",
-                    "description": "Text prompt describing the image to generate."
+                    "description": Self::tool_msg("tool-image-gen-param-prompt")
                 },
                 "filename": {
                     "type": "string",
-                    "description": "Output filename without extension (default: 'generated_image'). Saved as PNG in workspace/images/."
+                    "description": Self::tool_msg("tool-image-gen-param-filename")
                 },
                 "size": {
                     "type": "string",
                     "enum": ["square_hd", "landscape_4_3", "portrait_4_3", "landscape_16_9", "portrait_16_9"],
-                    "description": "Image aspect ratio / size preset (default: 'square_hd')."
+                    "description": Self::tool_msg("tool-image-gen-param-size")
                 },
                 "model": {
                     "type": "string",
-                    "description": "fal.ai model identifier (default: 'fal-ai/flux/schnell')."
+                    "description": Self::tool_msg("tool-image-gen-param-model")
                 }
             }
         })
@@ -1127,20 +1214,13 @@ mod tests {
 
     /// Deterministic seam test: `validate_image_url_resolved` returns
     /// the parsed hostname alongside the validated addresses, and the
-    /// download client passes the tuple's `.0` (hostname, not URL) to
+    /// download path passes the tuple's `.0` (hostname, not URL) to
     /// `reqwest::Client::resolve_to_addrs`. Together these two
     /// contracts guarantee that reqwest's lookup key matches the
     /// request hostname and the validated address set is selected at
     /// connect time, so a second unbound DNS lookup cannot bypass the
-    /// SSRF gate.
-    ///
-    /// The reviewer asked for a transport-level regression against a
-    /// controlled resolver or local listener. The build environment
-    /// here has a DNS-intercepting proxy that returns a captive-portal
-    /// "DNS resolution failed" body for unknown hostnames, masking the
-    /// reqwest lookup behavior, so an env-independent seam test is
-    /// used instead. The seam is the (validator return, caller call)
-    /// join point, pin-able from pure Rust without network fixtures.
+    /// SSRF gate. The transport-level behavior of the override itself
+    /// is pinned by the listener-backed tests below.
     #[test]
     fn resolve_to_addrs_seam_uses_hostname_not_url() {
         let url = "http://localhost:8080/test.png";
@@ -1155,6 +1235,112 @@ mod tests {
             "host must be the bare hostname (no scheme, no port, no path) — \
              reqwest::Client::resolve_to_addrs keys by hostname, and a full \
              URL or a host:port string would never match the request hostname"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Transport-level tests: the download client's address pinning.
+    //
+    // These drive the same client construction the download path uses
+    // (`ImageGenTool::build_download_client`) against a local listener.
+    // The synthetic `.invalid` hostname (RFC 2606) cannot resolve via
+    // ordinary DNS, so a request can only reach the listener when the
+    // validated address override is present and keyed by the request
+    // hostname. If the override is dropped or mis-keyed in the builder,
+    // the connection never lands on the listener and the tests fail.
+    // The assertions are on the listener's hit count, so the outcome
+    // does not depend on how the environment resolves (or fails to
+    // resolve) the synthetic hostname.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// With the validated address override keyed by the request hostname,
+    /// the connection lands on the validated `SocketAddr`: the synthetic
+    /// hostname is unresolvable and the URL carries no port, so the
+    /// override is the only path to the listener.
+    #[tokio::test]
+    async fn resolve_to_addrs_pins_connection_to_validated_socket_addr() {
+        use std::net::SocketAddr;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let port = server.address().port();
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"ok".to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec![]);
+        let validated_addrs = vec![SocketAddr::from(([127, 0, 0, 1], port))];
+        let client = tool
+            .build_download_client("image-gen-resolve-test.invalid", &validated_addrs)
+            .expect("production client build must succeed");
+
+        // No port in the URL: dialing must be driven entirely by the
+        // validated address set, not by URL components or DNS.
+        let resp = client
+            .get("http://image-gen-resolve-test.invalid/img.png")
+            .send()
+            .await
+            .expect(
+                "the validated address override must make the \
+                 unresolvable hostname reachable",
+            );
+        assert!(
+            resp.status().is_success(),
+            "expected 200 from the local listener, got {}",
+            resp.status()
+        );
+
+        let received = server.received_requests().await.expect("received_requests");
+        assert_eq!(received.len(), 1, "expected exactly one listener hit");
+    }
+
+    /// Control: the same production builder, but with the override keyed
+    /// by a hostname that does NOT match the request URL — the mis-keyed
+    /// regression class. The listener must see no request: the request
+    /// hostname has no validated address set bound to it, so reaching
+    /// `127.0.0.1:port` through this client is impossible regardless of
+    /// how the environment resolves the synthetic name.
+    #[tokio::test]
+    async fn resolve_to_addrs_miskeyed_override_cannot_reach_listener() {
+        use std::net::SocketAddr;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let port = server.address().port();
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"ok".to_vec()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec![]);
+        let validated_addrs = vec![SocketAddr::from(([127, 0, 0, 1], port))];
+        let client = tool
+            .build_download_client("some-other-host.invalid", &validated_addrs)
+            .expect("production client build must succeed");
+
+        // The outcome of the send itself is environment-dependent (the
+        // hostname may fail DNS or hit a captive portal); the authoritative
+        // check is the listener's hit count.
+        let _ = client
+            .get("http://image-gen-resolve-test.invalid/img.png")
+            .send()
+            .await;
+
+        let received = server.received_requests().await.expect("received_requests");
+        assert_eq!(
+            received.len(),
+            0,
+            "a mis-keyed override must not pin the connection: the request \
+             hostname has no validated address set, so the listener must be \
+             unreachable; got {received_len} hit(s)",
+            received_len = received.len(),
         );
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -1,12 +1,21 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::json;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult, with_ephemeral_workspace_warning};
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::policy::ToolOperation;
 
+use crate::helpers::domain_guard;
+
+/// Resolve the output filename stem (no extension) for a generated image.
+///
+/// A caller-supplied `filename` is used verbatim with path components stripped
+/// (traversal-safe). When none is given, a unique timestamped default
+/// (`generated_image_<nanos>`) is returned so successive default generations
+/// never clobber each other. `nanos` is injected so the selection is testable.
 fn resolve_image_filename(filename_arg: Option<&str>, nanos: u128) -> String {
     filename_arg
         .filter(|s| !s.trim().is_empty())
@@ -40,6 +49,18 @@ pub struct ImageGenTool {
     workspace_dir: PathBuf,
     default_model: String,
     api_key_env: String,
+    /// Normalized host allowlist (entries from `ImageGenConfig::allowed_private_hosts`).
+    /// Empty by default. A bare `"*"` blanket-tolerates any private/local host;
+    /// otherwise each entry is a host or suffix checked against the image-download
+    /// host. Mirrors the same field on `[file_download]`, `[http_request]`,
+    /// `[web_fetch]`, and the browser tools.
+    allowed_private_hosts: Vec<String>,
+    /// Whether the saved image persists on the host filesystem. `false` on an
+    /// ephemeral runtime (Docker tmpfs / no volume mount), where the PNG is
+    /// written inside the container but invisible on the host and discarded at
+    /// session end. When `false`, a successful generation carries a loud
+    /// ephemeral-workspace warning. Mirrors
+    /// [`super::file_write::FileWriteTool`]. See issue #4627.
     persistent_writes: bool,
 }
 
@@ -55,6 +76,7 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
+            allowed_private_hosts: Vec::new(),
             persistent_writes: true,
         }
     }
@@ -74,8 +96,116 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
+            allowed_private_hosts: Vec::new(),
             persistent_writes,
         }
+    }
+
+    /// Construct with the full config (including `allowed_private_hosts`).
+    /// The host allowlist is normalized via `domain_guard::normalize_allowed_domains`
+    /// at construction time so per-request validation is a constant-time
+    /// allowlist match (no per-call parsing).
+    pub fn new_with_config(
+        security: Arc<SecurityPolicy>,
+        workspace_dir: PathBuf,
+        default_model: String,
+        api_key_env: String,
+        persistent_writes: bool,
+        allowed_private_hosts: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let normalized = domain_guard::normalize_allowed_domains(
+            allowed_private_hosts,
+            "image_gen.allowed_private_hosts",
+        )?;
+        Ok(Self {
+            security,
+            workspace_dir,
+            default_model,
+            api_key_env,
+            allowed_private_hosts: normalized,
+            persistent_writes,
+        })
+    }
+
+    /// Validate the URL of an image to be downloaded from a (server-supplied)
+    /// fal.ai response. Mirrors `http_request::validate_url_policy` but for
+    /// the image-download stage: no `allowed_domains` (we trust fal.ai's
+    /// hostname choice), only a private-host gate lifted by
+    /// `allowed_private_hosts`. Always rejects cloud-metadata IP literals
+    /// even if `allowed_private_hosts` would otherwise lift the gate — that
+    /// matches the matrix-textbrower-browser-file_download pattern (see
+    /// `domain_guard::validate_resolved_ips_exclude_metadata`).
+    fn validate_image_url(&self, raw_url: &str) -> anyhow::Result<String> {
+        let url = raw_url.trim();
+        if url.is_empty() {
+            anyhow::bail!("image URL cannot be empty");
+        }
+        if url.chars().any(char::is_whitespace) {
+            anyhow::bail!("image URL cannot contain whitespace");
+        }
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            anyhow::bail!("Only http:// and https:// image URLs are allowed");
+        }
+
+        let parsed = reqwest::Url::parse(url)
+            .map_err(|e| anyhow::Error::msg(format!("Invalid image URL format: {e}")))?;
+
+        // Reject userinfo-bearing URLs at parse time — the same shape used
+        // by the http_request SSRF gate (`http_request.rs` extract_host).
+        // A `user:pass@host` form is never legitimate for an image CDN.
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            anyhow::bail!("image URL userinfo is not allowed");
+        }
+
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow::Error::msg("image URL has no host"))?
+            .to_string();
+
+        // Cloud-metadata IP literals (169.254.169.254, fd00:ec2::254, etc.)
+        // are rejected unconditionally — never a legitimate image source.
+        if host
+            .parse::<IpAddr>()
+            .is_ok_and(domain_guard::is_cloud_metadata_ip)
+        {
+            anyhow::bail!("Blocked cloud metadata host: {host}");
+        }
+
+        let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
+        let private_match = if host_is_private_or_local {
+            domain_guard::host_matches_allowlist(&host, &self.allowed_private_hosts)
+        } else {
+            false
+        };
+
+        if host_is_private_or_local && !private_match {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"tool": "image_gen", "host": host})),
+                "image_gen: rejecting private/local image host"
+            );
+            anyhow::bail!(
+                "Blocked local/private image host: {host}. \
+                 To allow, add it (or \"*\") to image_gen.allowed_private_hosts in config.toml"
+            );
+        }
+
+        // Warn loudly when an explicit carve-out lifts the SSRF gate — same
+        // signal as web_fetch's redirect-path warn, so operators can detect
+        // accidental "trusted internal CDN" misconfigurations in audit.
+        if host_is_private_or_local && private_match {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"tool": "image_gen", "host": host})),
+                "image_gen: allowing private/local image host via allowed_private_hosts"
+            );
+        }
+
+        Ok(url.to_string())
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -227,9 +357,48 @@ impl ImageGenTool {
                 anyhow::Error::msg("No image URL in fal.ai response")
             })?;
 
+        // ── Validate image URL against the SSRF gate ──────────────
+        // The image URL is server-supplied by fal.ai (and therefore not
+        // trustable in the same way as the operator-configured fal.run
+        // endpoint above). Validate the host string before any bytes hit
+        // the network. The redirect policy on the download client below
+        // re-validates each redirect target with the same gate — closes
+        // the redirect-to-internal gap that `Policy::default()` would
+        // leave open.
+        let validated_image_url = self.validate_image_url(image_url)?;
+
+        // ── Build image-download client with per-redirect SSRF gate ─
+        // Mirrors `web_fetch.rs:407-426`. The closure captures a clone of
+        // `self.allowed_private_hosts` so the per-redirect check uses the
+        // exact operator-configured allowlist (no re-parse, no IO).
+        let allowed_private_hosts = self.allowed_private_hosts.clone();
+        let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error(std::io::Error::other(
+                    "Too many image-URL redirects (max 10)",
+                ));
+            }
+            if let Err(err) =
+                validate_redirect_image_url(attempt.url().as_str(), &allowed_private_hosts)
+            {
+                return attempt.error(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("Blocked image-URL redirect target: {err}"),
+                ));
+            }
+            attempt.follow()
+        });
+
+        let download_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .redirect(redirect_policy)
+            .build()
+            .unwrap_or_default();
+
         // ── Download image ─────────────────────────────────────────
-        let img_resp = client
-            .get(image_url)
+        let img_resp = download_client
+            .get(&validated_image_url)
             .send()
             .await
             .context("Failed to download generated image")?;
@@ -272,6 +441,57 @@ impl ImageGenTool {
             error: None,
         })
     }
+}
+
+/// Free-function companion to `ImageGenTool::validate_image_url`, used by the
+/// reqwest redirect policy closure (which can't borrow `self`). Performs the
+/// same gate — http(s)-only, no userinfo, no private/local host unless covered
+/// by `allowed_private_hosts`, cloud-metadata IP literals always rejected.
+fn validate_redirect_image_url(
+    raw_url: &str,
+    allowed_private_hosts: &[String],
+) -> anyhow::Result<()> {
+    let url = raw_url.trim();
+    if url.is_empty() {
+        anyhow::bail!("redirect image URL cannot be empty");
+    }
+    if url.chars().any(char::is_whitespace) {
+        anyhow::bail!("redirect image URL cannot contain whitespace");
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        anyhow::bail!("Only http:// and https:// redirect URLs are allowed");
+    }
+
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| anyhow::Error::msg(format!("Invalid redirect image URL format: {e}")))?;
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        anyhow::bail!("redirect image URL userinfo is not allowed");
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::Error::msg("redirect image URL has no host"))?
+        .to_string();
+
+    if host
+        .parse::<IpAddr>()
+        .is_ok_and(domain_guard::is_cloud_metadata_ip)
+    {
+        anyhow::bail!("Blocked redirect to cloud metadata host: {host}");
+    }
+
+    let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
+    let private_match = host_is_private_or_local
+        && domain_guard::host_matches_allowlist(&host, allowed_private_hosts);
+
+    if host_is_private_or_local && !private_match {
+        anyhow::bail!(
+            "Blocked redirect to local/private host: {host}. \
+             To allow, add it (or \"*\") to image_gen.allowed_private_hosts in config.toml"
+        );
+    }
+
+    Ok(())
 }
 
 #[async_trait]
@@ -595,5 +815,164 @@ mod tests {
         assert_eq!(result.unwrap(), "test_value_123");
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("ZC_IMAGE_GEN_TEST_KEY") };
+    }
+
+    // ── SSRF gate tests for the image-download stage ──────────────
+    //
+    // These exercise `ImageGenTool::validate_image_url` and the free-function
+    // companion `validate_redirect_image_url` directly. Hermetic — no
+    // network, no reqwest, no `fal.run` POST. A regression that drops the
+    // SSRF gate (or relaxes the private-host check) would surface here.
+
+    fn test_tool_with_private_hosts(allowed_private_hosts: Vec<&str>) -> ImageGenTool {
+        ImageGenTool::new_with_config(
+            test_security(),
+            std::env::temp_dir(),
+            "fal-ai/flux/schnell".into(),
+            "FAL_API_KEY".into(),
+            true,
+            allowed_private_hosts
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        )
+        .expect("test tool construction should succeed")
+    }
+
+    #[test]
+    fn validate_image_url_rejects_empty() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool.validate_image_url("").unwrap_err().to_string();
+        assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_whitespace() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("http://example .com/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("whitespace"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_non_http_scheme() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("ftp://example.com/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("http://"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_userinfo() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("https://attacker:pwn@cdn.example.com/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("userinfo"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_localhost() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("http://localhost/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_private_ipv4() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("http://10.0.0.5/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_cloud_metadata_ipv4() {
+        // Even with `allowed_private_hosts = ["*"]`, cloud-metadata IPs
+        // must still be rejected — the gate is unconditional for the
+        // metadata service.
+        let wildcard = test_tool_with_private_hosts(vec!["*"]);
+        let err = wildcard
+            .validate_image_url("http://169.254.169.254/latest/meta-data/")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_accepts_public_https() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let url = tool
+            .validate_image_url("https://cdn.fal.ai/files/abc123.png")
+            .expect("public HTTPS host must be accepted");
+        assert_eq!(url, "https://cdn.fal.ai/files/abc123.png");
+    }
+
+    #[test]
+    fn validate_image_url_accepts_allowed_private_host_explicit() {
+        // Operator opted-in to a specific internal CDN via the allowlist.
+        let tool = test_tool_with_private_hosts(vec!["cdn.internal.example"]);
+        let url = tool
+            .validate_image_url("https://cdn.internal.example/x.png")
+            .expect("explicit allowed_private_hosts entry must lift the block");
+        assert_eq!(url, "https://cdn.internal.example/x.png");
+    }
+
+    #[test]
+    fn validate_image_url_accepts_allowed_private_host_wildcard() {
+        // `*` blanket-tolerates any private/local host (dev/CI use case).
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let url = tool
+            .validate_image_url("http://localhost:8080/x.png")
+            .expect("wildcard allowed_private_hosts must lift the block");
+        assert_eq!(url, "http://localhost:8080/x.png");
+    }
+
+    // ── Redirect-gate tests ───────────────────────────────────────
+    //
+    // The reqwest `Policy::custom` closure that re-validates each redirect
+    // target uses `validate_redirect_image_url` (free function) — these tests
+    // pin the redirect-path contract directly.
+
+    #[test]
+    fn validate_redirect_image_url_rejects_localhost() {
+        let allowed = vec!["cdn.internal.example".to_string()];
+        let err = validate_redirect_image_url("http://localhost/x.png", &allowed)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_redirect_image_url_rejects_cloud_metadata() {
+        let allowed = vec!["*".to_string()];
+        let err = validate_redirect_image_url("http://169.254.169.254/latest/meta-data/", &allowed)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_redirect_image_url_accepts_public_https() {
+        let allowed: Vec<String> = vec![];
+        validate_redirect_image_url("https://cdn.fal.ai/files/abc.png", &allowed)
+            .expect("public HTTPS host must be accepted by redirect gate");
+    }
+
+    #[test]
+    fn validate_redirect_image_url_accepts_allowed_private_host() {
+        let allowed = vec!["cdn.internal.example".to_string()];
+        validate_redirect_image_url("https://cdn.internal.example/x.png", &allowed)
+            .expect("allowed_private_hosts must lift the redirect gate");
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -366,14 +366,17 @@ impl ImageGenTool {
             anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-host"))
         })?;
         // Same bracket normalization as `validate_image_url`: the policy
-        // comparison uses the bare IPv6 form (`::1`), while the transport
-        // host keeps the URL representation for `resolve_host`.
+        // comparison uses the bare IPv6 form (`::1`), and the resolver also
+        // receives the bare form — `tokio::net::lookup_host` parses bare
+        // IPv6 addresses but delegates a bracketed `[::1]` to the system
+        // resolver, which cannot resolve it. The transport host keeps the
+        // URL representation for the connection.
         let policy_host = bare_policy_host(host);
         let port = parsed.port_or_known_default().ok_or_else(|| {
             anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-port"))
         })?;
 
-        let addrs = resolve_host(host.to_string(), port).await?;
+        let addrs = resolve_host(policy_host.to_string(), port).await?;
 
         if addrs.is_empty() {
             anyhow::bail!(Self::tool_msg_with_args(
@@ -1339,6 +1342,71 @@ mod tests {
             host, "localhost",
             "host must be the bare hostname, not the full URL — \
              reqwest::Client::resolve_to_addrs keys by hostname"
+        );
+    }
+
+    /// The production resolver path (`resolve_host_for_download`) must
+    /// receive the bare IPv6 form: `tokio::net::lookup_host` parses bare
+    /// `::1` but delegates a bracketed `[::1]` to the system resolver and
+    /// fails. This drives `validate_image_url_resolved` (which uses the
+    /// production resolver) against an IPv6 literal and asserts the resolved
+    /// set comes back as loopback — not a resolve failure from a bracketed
+    /// host.
+    #[tokio::test]
+    async fn validate_image_url_resolved_ipv6_production_resolver_uses_bare_host() {
+        let tool = test_tool_with_private_hosts(vec!["::1"]);
+        let (host, addrs) = tool
+            .validate_image_url_resolved("http://[::1]/x.png")
+            .await
+            .expect("production resolver must parse the bare IPv6 host");
+        assert_eq!(host, "[::1]");
+        assert!(
+            addrs.iter().any(|sa| sa.ip().is_loopback()),
+            "resolved IPv6 addresses must be loopback, got: {addrs:?}"
+        );
+    }
+
+    #[test]
+    fn bare_policy_host_strips_ipv6_url_brackets() {
+        assert_eq!(bare_policy_host("[::1]"), "::1");
+        assert_eq!(bare_policy_host("[2001:db8::1]"), "2001:db8::1");
+        assert_eq!(bare_policy_host("example.com"), "example.com");
+        assert_eq!(bare_policy_host("127.0.0.1"), "127.0.0.1");
+    }
+
+    /// The allowlist resolver must read the shared config live at each call,
+    /// not capture a snapshot at construction. This simulates the runtime's
+    /// live `Config` handle: an operator removing an internal CDN entry after
+    /// the tool was built must change the next policy decision without
+    /// rebuilding the tool.
+    #[test]
+    fn live_allowlist_resolver_reflects_config_mutation() {
+        use std::sync::Arc;
+        let shared = Arc::new(parking_lot::RwLock::new(vec!["127.0.0.1".to_string()]));
+        let resolver_shared = Arc::clone(&shared);
+        let tool = ImageGenTool::new_with_config_resolver(
+            test_security(),
+            std::env::temp_dir(),
+            "fal-ai/flux/schnell".into(),
+            "FAL_API_KEY".into(),
+            true,
+            move || resolver_shared.read().clone(),
+        )
+        .expect("tool construction with live resolver");
+
+        tool.validate_image_url("http://127.0.0.1/img.png")
+            .expect("allowlisted loopback must pass before the mutation");
+
+        // Operator removes the loopback entry from the live config.
+        shared.write().clear();
+
+        let err = tool
+            .validate_image_url("http://127.0.0.1/img.png")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("local/private"),
+            "after removing the entry the same URL must be rejected; got: {err}"
         );
     }
 

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -80,6 +80,17 @@ fn resolve_image_filename(filename_arg: Option<&str>, nanos: u128) -> String {
         .unwrap_or_else(|| format!("generated_image_{nanos}"))
 }
 
+/// Strip IPv6 URL brackets for allowlist matching. `reqwest::Url::host_str()`
+/// returns a bracketed host for IPv6 URLs (`http://[::1]/...` → `[::1]`),
+/// while `domain_guard::normalize_domain` stores config entries in the bare
+/// form (`::1`). Policy comparison must use the bare form so an explicit
+/// `allowed_private_hosts = ["::1"]` entry matches `http://[::1]/...`.
+fn bare_policy_host(host: &str) -> &str {
+    host.strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host)
+}
+
 fn format_image_tool_output(
     path_display: &str,
     size_kb: usize,
@@ -263,6 +274,10 @@ impl ImageGenTool {
             .host_str()
             .ok_or_else(|| anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-url-no-host")))?
             .to_string();
+        // `reqwest::Url::host_str()` returns a bracketed host for IPv6
+        // (`[::1]`), while config entries and `normalize_domain` store the
+        // bare form (`::1`). Strip the brackets for allowlist matching.
+        let policy_host = bare_policy_host(&host);
 
         // Cloud-metadata IP literals recognized by the shared
         // `domain_guard::is_cloud_metadata_ip` predicate (169.254.169.254,
@@ -281,9 +296,9 @@ impl ImageGenTool {
         // Resolve the allowlist at use time from the canonical config
         let allowed_private_hosts = (self.allowed_private_hosts_resolver)();
 
-        let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
+        let host_is_private_or_local = domain_guard::is_private_or_local_host(policy_host);
         let private_match = if host_is_private_or_local {
-            domain_guard::host_matches_allowlist(&host, &allowed_private_hosts)
+            domain_guard::host_matches_allowlist(policy_host, &allowed_private_hosts)
         } else {
             false
         };
@@ -350,6 +365,10 @@ impl ImageGenTool {
         let host = parsed.host_str().ok_or_else(|| {
             anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-host"))
         })?;
+        // Same bracket normalization as `validate_image_url`: the policy
+        // comparison uses the bare IPv6 form (`::1`), while the transport
+        // host keeps the URL representation for `resolve_host`.
+        let policy_host = bare_policy_host(host);
         let port = parsed.port_or_known_default().ok_or_else(|| {
             anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-resolved-url-no-port"))
         })?;
@@ -369,7 +388,7 @@ impl ImageGenTool {
         let allowed_private_hosts = (self.allowed_private_hosts_resolver)();
 
         let private_resolution_allowed =
-            domain_guard::host_matches_allowlist(host, &allowed_private_hosts);
+            domain_guard::host_matches_allowlist(policy_host, &allowed_private_hosts);
 
         for ip in &ips {
             // The metadata check is unconditional — never lifted by the
@@ -1254,10 +1273,16 @@ mod tests {
     #[tokio::test]
     async fn validate_image_url_resolved_accepts_public_host() {
         let tool = test_tool_with_private_hosts(vec![]);
-        // example.com is a well-known public test domain (RFC 2606).
-        tool.validate_image_url_resolved("https://example.com/image.png")
-            .await
-            .expect("public host must resolve to global IPs and pass");
+        // example.com is a well-known public test domain (RFC 2606). The
+        // resolver seam injects a known-global answer so the test is
+        // hermetic — it must not depend on live DNS.
+        let global: std::net::SocketAddr = "8.8.8.8:443".parse().unwrap();
+        tool.validate_image_url_resolved_with_resolver(
+            "https://example.com/image.png",
+            &|_host: String, _port: u16| async move { Ok(vec![global]) },
+        )
+        .await
+        .expect("public host must pass with a global resolved address");
     }
 
     #[tokio::test]
@@ -1266,6 +1291,34 @@ mod tests {
         tool.validate_image_url_resolved("http://localhost:8080/test.png")
             .await
             .expect("wildcard allowlist must lift the non-global check");
+    }
+
+    #[tokio::test]
+    async fn validate_image_url_allows_ipv6_loopback_with_explicit_allowlist() {
+        // `reqwest::Url::host_str()` returns a bracketed host for an IPv6 URL
+        // (`[::1]`) while config entries store the bare form (`::1`). The
+        // allowlist comparison must strip the brackets or an explicit IPv6
+        // entry never matches and the URL is rejected as a private host.
+        let tool = test_tool_with_private_hosts(vec!["::1"]);
+        let url = tool
+            .validate_image_url("http://[::1]/x.png")
+            .expect("explicit IPv6 allowlist entry must match the bracketed URL host");
+        assert_eq!(url, "http://[::1]/x.png");
+    }
+
+    #[tokio::test]
+    async fn validate_image_url_resolved_allows_ipv6_loopback_with_explicit_allowlist() {
+        let tool = test_tool_with_private_hosts(vec!["::1"]);
+        let loopback: std::net::SocketAddr = "[::1]:80".parse().unwrap();
+        let (host, addrs) = tool
+            .validate_image_url_resolved_with_resolver(
+                "http://[::1]/x.png",
+                &|_host: String, _port: u16| async move { Ok(vec![loopback]) },
+            )
+            .await
+            .expect("explicit IPv6 allowlist must lift the non-global check");
+        assert_eq!(host, "[::1]");
+        assert_eq!(addrs, vec![loopback]);
     }
 
     /// The resolved-IP validator returns the parsed hostname alongside the

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -208,6 +208,46 @@ impl ImageGenTool {
         Ok(url.to_string())
     }
 
+    /// After the host-string gate passes, resolve the validated image URL
+    /// to its IP addresses and reject any that are private/local or cloud
+    /// metadata — catches the SSRF class where a public-looking hostname
+    /// (e.g., `attacker.example`) resolves to `10.0.0.5`, `127.0.0.1`, or
+    /// `169.254.169.254`. When the host is covered by
+    /// `allowed_private_hosts`, only cloud metadata IPs are rejected
+    /// (consistent with the allowlist semantics in the other tools).
+    ///
+    /// This is a **pass/fail** check and does not pin the resolved addrs
+    /// to the subsequent connection, leaving a time-of-check/time-of-use
+    /// window for DNS rebinding. See #8827 for that binding layer.
+    async fn validate_image_url_resolved(&self, validated_url: &str) -> anyhow::Result<()> {
+        let parsed = reqwest::Url::parse(validated_url)
+            .map_err(|e| anyhow::Error::msg(format!("Invalid image URL: {e}")))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow::Error::msg("Image URL has no host"))?;
+        let port = parsed
+            .port_or_known_default()
+            .ok_or_else(|| anyhow::Error::msg("Image URL has no known port"))?;
+
+        let addrs = tokio::net::lookup_host((host, port))
+            .await
+            .context("Failed to resolve image download host")?;
+        let ips: Vec<IpAddr> = addrs.map(|sa| sa.ip()).collect();
+
+        if ips.is_empty() {
+            anyhow::bail!("Failed to resolve image download host '{host}'");
+        }
+
+        let private_resolution_allowed =
+            domain_guard::host_matches_allowlist(host, &self.allowed_private_hosts);
+
+        if private_resolution_allowed {
+            domain_guard::validate_resolved_ips_exclude_metadata(host, &ips)
+        } else {
+            domain_guard::validate_resolved_ips_are_public(host, &ips)
+        }
+    }
+
     /// Build a reusable HTTP client with reasonable timeouts.
     fn http_client() -> reqwest::Client {
         reqwest::Client::builder()
@@ -367,6 +407,13 @@ impl ImageGenTool {
         // leave open.
         let validated_image_url = self.validate_image_url(image_url)?;
 
+        // Layer-2: resolved-IP check — the host string looks public, but
+        // resolve it now to verify none of its addresses are private/local
+        // or cloud metadata. A host covered by `allowed_private_hosts`
+        // skips the non-global check but still rejects cloud metadata.
+        self.validate_image_url_resolved(&validated_image_url)
+            .await?;
+
         // ── Build image-download client with per-redirect SSRF gate ─
         // Mirrors `web_fetch.rs:407-426`. The closure captures a clone of
         // `self.allowed_private_hosts` so the per-redirect check uses the
@@ -378,12 +425,24 @@ impl ImageGenTool {
                     "Too many image-URL redirects (max 10)",
                 ));
             }
+            // Host-string gate (sync).
             if let Err(err) =
                 validate_redirect_image_url(attempt.url().as_str(), &allowed_private_hosts)
             {
                 return attempt.error(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
                     format!("Blocked image-URL redirect target: {err}"),
+                ));
+            }
+            // Resolved-IP gate for redirect targets (runs on the tokio
+            // runtime that reqwest is driving — must be sync signature).
+            let allowed = &allowed_private_hosts;
+            if let Err(err) = tokio::runtime::Handle::current().block_on(async {
+                validate_redirect_image_url_resolved(attempt.url().as_str(), allowed).await
+            }) {
+                return attempt.error(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("Blocked image-URL redirect target DNS: {err}"),
                 ));
             }
             attempt.follow()
@@ -492,6 +551,43 @@ fn validate_redirect_image_url(
     }
 
     Ok(())
+}
+
+/// Async companion to `validate_redirect_image_url` — resolves the redirect
+/// target host to its IP addresses and rejects private/local or cloud-metadata
+/// IPs. Same semantics as `ImageGenTool::validate_image_url_resolved` but
+/// usable from the sync redirect policy closure via `block_on`.
+async fn validate_redirect_image_url_resolved(
+    raw_url: &str,
+    allowed_private_hosts: &[String],
+) -> anyhow::Result<()> {
+    let url = raw_url.trim();
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| anyhow::Error::msg(format!("Invalid redirect image URL: {e}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::Error::msg("Redirect image URL has no host"))?;
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| anyhow::Error::msg("Redirect image URL has no known port"))?;
+
+    let addrs = tokio::net::lookup_host((host, port))
+        .await
+        .context("Failed to resolve redirect image download host")?;
+    let ips: Vec<IpAddr> = addrs.map(|sa| sa.ip()).collect();
+
+    if ips.is_empty() {
+        anyhow::bail!("Failed to resolve redirect host '{host}'");
+    }
+
+    let private_resolution_allowed =
+        domain_guard::host_matches_allowlist(host, allowed_private_hosts);
+
+    if private_resolution_allowed {
+        domain_guard::validate_resolved_ips_exclude_metadata(host, &ips)
+    } else {
+        domain_guard::validate_resolved_ips_are_public(host, &ips)
+    }
 }
 
 #[async_trait]
@@ -974,5 +1070,74 @@ mod tests {
         let allowed = vec!["cdn.internal.example".to_string()];
         validate_redirect_image_url("https://cdn.internal.example/x.png", &allowed)
             .expect("allowed_private_hosts must lift the redirect gate");
+    }
+
+    // ── Resolved-IP gate tests ──────────────────────────────────────
+    //
+    // These exercise `validate_image_url_resolved` (instance method) and
+    // `validate_redirect_image_url_resolved` (free function). They perform
+    // real DNS lookups, so a network-free environment skips them.
+
+    #[tokio::test]
+    async fn validate_image_url_resolved_rejects_localhost() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url_resolved("http://localhost/test.png")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("Failed to resolve"),
+            "expected non-global error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_image_url_resolved_rejects_cloud_metadata_ipv4() {
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let err = tool
+            .validate_image_url_resolved("http://169.254.169.254/latest/meta-data/")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn validate_image_url_resolved_accepts_public_host() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        // example.com is a well-known public test domain (RFC 2606).
+        tool.validate_image_url_resolved("https://example.com/image.png")
+            .await
+            .expect("public host must resolve to global IPs and pass");
+    }
+
+    #[tokio::test]
+    async fn validate_image_url_resolved_accepts_private_host_with_wildcard_allowlist() {
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        tool.validate_image_url_resolved("http://localhost:8080/test.png")
+            .await
+            .expect("wildcard allowlist must lift the non-global check");
+    }
+
+    #[tokio::test]
+    async fn validate_redirect_image_url_resolved_rejects_localhost() {
+        let allowed: Vec<String> = vec![];
+        let err = validate_redirect_image_url_resolved("http://localhost/test.png", &allowed)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("Failed to resolve"),
+            "expected non-global error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_redirect_image_url_resolved_accepts_public_host() {
+        let allowed: Vec<String> = vec![];
+        validate_redirect_image_url_resolved("https://example.com/image.png", &allowed)
+            .await
+            .expect("public redirect target must pass");
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -19,6 +19,25 @@ const TOOL_DESCRIPTION_KEY: &str = "tool-image-gen";
 /// `file_download.rs:14`.
 static TOOL_DESCRIPTION: OnceLock<String> = OnceLock::new();
 
+/// Maximum redirect hops the download loop follows before giving up.
+const MAX_REDIRECT_HOPS: usize = 10;
+
+/// A download target that has passed both SSRF gates: the validated URL
+/// string, its bare hostname, and the resolved-and-validated socket
+/// addresses. Produced only by `ImageGenTool::validate_image_target` and
+/// consumed as a single value by `ImageGenTool::build_download_client`, so
+/// the validated URL, the `resolve_to_addrs` lookup key, and the pinned
+/// address set cannot drift apart at the call site. `resolve_to_addrs`
+/// keys by bare hostname (lower-cased): keying the override by the full
+/// URL would never match the request hostname and the validated address
+/// set would be silently ignored at connect time, reopening the
+/// DNS-rebinding window — the struct makes that mistake a type error.
+struct ValidatedImageTarget {
+    url: String,
+    host: String,
+    addrs: Vec<std::net::SocketAddr>,
+}
+
 /// Resolve the output filename stem (no extension) for a generated image.
 ///
 /// A caller-supplied `filename` is used verbatim with path components stripped
@@ -152,10 +171,11 @@ impl ImageGenTool {
     /// fal.ai response. Mirrors `http_request::validate_url_policy` but for
     /// the image-download stage: no `allowed_domains` (we trust fal.ai's
     /// hostname choice), only a private-host gate lifted by
-    /// `allowed_private_hosts`. Always rejects cloud-metadata IP literals
-    /// even if `allowed_private_hosts` would otherwise lift the gate — that
-    /// matches the matrix-textbrower-browser-file_download pattern (see
-    /// `domain_guard::validate_resolved_ips_exclude_metadata`).
+    /// `allowed_private_hosts`. Cloud-metadata IP literals are rejected even
+    /// when `allowed_private_hosts` would otherwise lift the gate; the
+    /// metadata check covers the endpoints known to the shared
+    /// `domain_guard::is_cloud_metadata_ip` predicate (169.254.169.254 and
+    /// fd00:ec2::254), not every cloud vendor's metadata address.
     fn validate_image_url(&self, raw_url: &str) -> anyhow::Result<String> {
         let url = raw_url.trim();
         if url.is_empty() {
@@ -187,8 +207,10 @@ impl ImageGenTool {
             .ok_or_else(|| anyhow::Error::msg(Self::tool_msg("tool-image-gen-error-url-no-host")))?
             .to_string();
 
-        // Cloud-metadata IP literals (169.254.169.254, fd00:ec2::254, etc.)
-        // are rejected unconditionally — never a legitimate image source.
+        // Cloud-metadata IP literals recognized by the shared
+        // `domain_guard::is_cloud_metadata_ip` predicate (169.254.169.254,
+        // fd00:ec2::254) are rejected unconditionally — never a legitimate
+        // image source.
         if host
             .parse::<IpAddr>()
             .is_ok_and(domain_guard::is_cloud_metadata_ip)
@@ -241,15 +263,15 @@ impl ImageGenTool {
     /// metadata — catches the SSRF class where a public-looking hostname
     /// (e.g., `attacker.example`) resolves to `10.0.0.5`, `127.0.0.1`, or
     /// `169.254.169.254`. When the host is covered by
-    /// `allowed_private_hosts`, only cloud metadata IPs are rejected
-    /// (consistent with the allowlist semantics in the other tools).
+    /// `allowed_private_hosts`, the non-global check is lifted and only the
+    /// metadata addresses known to `domain_guard::is_cloud_metadata_ip`
+    /// (169.254.169.254, fd00:ec2::254) remain rejected (consistent with
+    /// the allowlist semantics in the other tools).
     ///
-    /// Resolve the validated image URL host to its socket addresses and reject
-    /// private/local or cloud-metadata IPs. Returns the parsed hostname +
-    /// validated socket addresses so the caller can bind the download
-    /// connection to them via `resolve_to_addrs` (keyed by the hostname,
-    /// NOT the full URL), closing the TOCTOU window between DNS check and
-    /// transport connect.
+    /// Returns the parsed hostname + validated socket addresses so the
+    /// caller can bind the download connection to them via
+    /// `resolve_to_addrs` (keyed by the hostname, NOT the full URL),
+    /// closing the TOCTOU window between DNS check and transport connect.
     async fn validate_image_url_resolved(
         &self,
         validated_url: &str,
@@ -286,68 +308,62 @@ impl ImageGenTool {
         let private_resolution_allowed =
             domain_guard::host_matches_allowlist(host, &self.allowed_private_hosts);
 
-        if private_resolution_allowed {
-            domain_guard::validate_resolved_ips_exclude_metadata(host, &ips)
-        } else {
-            domain_guard::validate_resolved_ips_are_public(host, &ips)
-        }?;
+        for ip in &ips {
+            // The metadata check is unconditional — never lifted by the
+            // allowlist. Its scope is exactly the endpoints known to the
+            // shared `domain_guard::is_cloud_metadata_ip` predicate
+            // (169.254.169.254 and fd00:ec2::254), not every cloud
+            // vendor's metadata address.
+            if domain_guard::is_cloud_metadata_ip(*ip) {
+                anyhow::bail!(Self::tool_msg_with_args(
+                    "tool-image-gen-error-resolved-ip-metadata",
+                    &[("host", host), ("ip", &ip.to_string())],
+                ));
+            }
+            if !private_resolution_allowed {
+                let non_global = match ip {
+                    std::net::IpAddr::V4(v4) => domain_guard::is_non_global_v4(*v4),
+                    std::net::IpAddr::V6(v6) => domain_guard::is_non_global_v6(*v6),
+                };
+                if non_global {
+                    anyhow::bail!(Self::tool_msg_with_args(
+                        "tool-image-gen-error-resolved-ip-non-global",
+                        &[("host", host), ("ip", &ip.to_string())],
+                    ));
+                }
+            }
+        }
 
         Ok((host.to_string(), addrs))
     }
 
-    /// Build the image-download client: bind the validated address set to
-    /// the connection via `resolve_to_addrs`, and re-validate each redirect
-    /// target with the synchronous host-string gate.
-    ///
-    /// `resolve_to_addrs` keys by domain name (lower-cased), NOT the full
-    /// URL — passing `https://cdn.example/image.png` would never match the
-    /// request hostname `cdn.example` and the validated address set would
-    /// be silently ignored at connect time, reopening the DNS-rebinding
-    /// window. `resolved_host` must therefore be the bare hostname from
-    /// `validate_image_url_resolved`. Mirrors http_request's reference
-    /// impl at http_request.rs:363.
-    ///
-    /// Redirect resolved-IP validation is explicitly deferred: the reqwest
-    /// redirect callback runs synchronously inside the async runtime, and
-    /// nesting `Handle::block_on` there risks a panic. Redirect targets
-    /// are still gated by the synchronous host-string check; cross-host
-    /// DNS rebinding on redirect hops remains a documented residual risk.
+    /// Run both SSRF gates for one download URL — the host-string gate
+    /// (`validate_image_url`) followed by the resolved-IP gate
+    /// (`validate_image_url_resolved`) — and bundle the outcome into a
+    /// single `ValidatedImageTarget`. The download loop calls this for the
+    /// initial URL and again for every redirect target, so each hop is
+    /// validated, resolved, and pinned before any connection to it.
+    async fn validate_image_target(&self, raw_url: &str) -> anyhow::Result<ValidatedImageTarget> {
+        let url = self.validate_image_url(raw_url)?;
+        let (host, addrs) = self.validate_image_url_resolved(&url).await?;
+        Ok(ValidatedImageTarget { url, host, addrs })
+    }
+
+    /// Build the download client for one validated hop: the connection is
+    /// dialed only to the hop's validated address set (`resolve_to_addrs`
+    /// keyed by `target.host`, the bare hostname — see the struct docs),
+    /// proxies are disabled so this process always dials the validated
+    /// addresses itself, and reqwest's automatic redirect following is
+    /// off. Redirects are handled by `download_image`, which re-runs the
+    /// full validate-resolve-pin pipeline for each hop.
     fn build_download_client(
         &self,
-        resolved_host: &str,
-        validated_addrs: &[std::net::SocketAddr],
+        target: &ValidatedImageTarget,
     ) -> anyhow::Result<reqwest::Client> {
-        // The closure captures a clone of `self.allowed_private_hosts` so
-        // the per-redirect check uses the exact operator-configured
-        // allowlist (no re-parse, no IO).
-        let allowed_private_hosts = self.allowed_private_hosts.clone();
-        let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
-            if attempt.previous().len() >= 10 {
-                return attempt.error(std::io::Error::other(Self::tool_msg_with_args(
-                    "tool-image-gen-error-redirect-limit",
-                    &[("max", "10")],
-                )));
-            }
-            // Host-string gate (sync). The helper's anyhow::Error Display
-            // is the localized Fluent string verbatim; pass it through
-            // unwrapped so the operator sees the translator's message.
-            // `PermissionDenied` is preserved so any caller that
-            // classifies the error by kind still works.
-            if let Err(err) =
-                validate_redirect_image_url(attempt.url().as_str(), &allowed_private_hosts)
-            {
-                return attempt.error(std::io::Error::new(
-                    std::io::ErrorKind::PermissionDenied,
-                    err.to_string(),
-                ));
-            }
-            attempt.follow()
-        });
-
         reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(120))
             .connect_timeout(std::time::Duration::from_secs(10))
-            .redirect(redirect_policy)
+            .redirect(reqwest::redirect::Policy::none())
             // The pinning above is only meaningful if THIS process dials
             // the validated addresses. reqwest honors proxy env vars by
             // default, and a proxy resolves and connects on our behalf —
@@ -356,7 +372,7 @@ impl ImageGenTool {
             // reopening the rebinding window. Disable proxies so the
             // connection is always dialed directly to the validated set.
             .no_proxy()
-            .resolve_to_addrs(resolved_host, validated_addrs)
+            .resolve_to_addrs(&target.host, &target.addrs)
             .build()
             .map_err(|e| {
                 anyhow::Error::msg(Self::tool_msg_with_args(
@@ -364,6 +380,60 @@ impl ImageGenTool {
                     &[("err", &e.to_string())],
                 ))
             })
+    }
+
+    /// Download an image URL, following redirects hop by hop. The initial
+    /// URL and every redirect target go through the full
+    /// validate-resolve-pin pipeline (`validate_image_target`), and each
+    /// hop is fetched with a client bound to that hop's validated
+    /// addresses — a public-looking redirect target that resolves to a
+    /// private, local, or metadata address is rejected before any
+    /// connection to it is attempted. Relative `Location` values are
+    /// resolved against the current hop's URL.
+    async fn download_image(&self, image_url: &str) -> anyhow::Result<reqwest::Response> {
+        let mut target = self.validate_image_target(image_url).await?;
+        let mut redirects_followed = 0usize;
+
+        loop {
+            let client = self.build_download_client(&target)?;
+            let resp = client
+                .get(&target.url)
+                .send()
+                .await
+                .context("Failed to download generated image")?;
+
+            if !resp.status().is_redirection() {
+                return Ok(resp);
+            }
+
+            redirects_followed += 1;
+            if redirects_followed > MAX_REDIRECT_HOPS {
+                anyhow::bail!(Self::tool_msg_with_args(
+                    "tool-image-gen-error-redirect-limit",
+                    &[("max", &MAX_REDIRECT_HOPS.to_string())],
+                ));
+            }
+
+            let location = resp
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| {
+                    anyhow::Error::msg(Self::tool_msg(
+                        "tool-image-gen-error-redirect-location-missing",
+                    ))
+                })?;
+            let next = reqwest::Url::parse(&target.url)
+                .and_then(|base| base.join(location))
+                .map_err(|e| {
+                    anyhow::Error::msg(Self::tool_msg_with_args(
+                        "tool-image-gen-error-redirect-location-invalid",
+                        &[("err", &e.to_string())],
+                    ))
+                })?;
+
+            target = self.validate_image_target(next.as_str()).await?;
+        }
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -515,40 +585,13 @@ impl ImageGenTool {
                 anyhow::Error::msg("No image URL in fal.ai response")
             })?;
 
-        // ── Validate image URL against the SSRF gate ──────────────
+        // ── Download image (SSRF-gated, redirects re-validated per hop) ──
         // The image URL is server-supplied by fal.ai (and therefore not
         // trustable in the same way as the operator-configured fal.run
-        // endpoint above). Validate the host string before any bytes hit
-        // the network. The redirect policy on the download client below
-        // re-validates each redirect target with the same gate — closes
-        // the redirect-to-internal gap that `Policy::default()` would
-        // leave open.
-        let validated_image_url = self.validate_image_url(image_url)?;
-
-        // Layer-2: resolved-IP check — the host string looks public, but
-        // resolve it now to verify none of its addresses are private/local
-        // or cloud metadata. A host covered by `allowed_private_hosts`
-        // skips the non-global check but still rejects cloud metadata.
-        // Returns the parsed hostname + validated socket addresses so they
-        // can be bound to the download connection via `resolve_to_addrs`
-        // (keyed by hostname, NOT the full URL), closing the TOCTOU window.
-        let (resolved_host, validated_addrs) = self
-            .validate_image_url_resolved(&validated_image_url)
-            .await?;
-
-        // ── Build image-download client ────────────────────────────
-        // Binds the validated address set keyed by the parsed hostname
-        // (NOT the full URL) and re-validates each redirect target with
-        // the synchronous host-string gate — closes the redirect-to-
-        // internal gap that `Policy::default()` would leave open.
-        let download_client = self.build_download_client(&resolved_host, &validated_addrs)?;
-
-        // ── Download image ─────────────────────────────────────────
-        let img_resp = download_client
-            .get(&validated_image_url)
-            .send()
-            .await
-            .context("Failed to download generated image")?;
+        // endpoint above). `download_image` validates, resolves, and pins
+        // the initial URL and every redirect target before connecting —
+        // closes both the direct and the redirect-to-internal SSRF gap.
+        let img_resp = self.download_image(image_url).await?;
 
         if !img_resp.status().is_success() {
             return Ok(ToolResult {
@@ -588,76 +631,6 @@ impl ImageGenTool {
             error: None,
         })
     }
-}
-
-/// Free-function companion to `ImageGenTool::validate_image_url`, used by the
-/// reqwest redirect policy closure (which can't borrow `self`). Performs the
-/// same gate — http(s)-only, no userinfo, no private/local host unless covered
-/// by `allowed_private_hosts`, cloud-metadata IP literals always rejected.
-fn validate_redirect_image_url(
-    raw_url: &str,
-    allowed_private_hosts: &[String],
-) -> anyhow::Result<()> {
-    let url = raw_url.trim();
-    if url.is_empty() {
-        anyhow::bail!(crate::i18n::get_required_tool_string(
-            "tool-image-gen-error-redirect-url-empty"
-        ));
-    }
-    if url.chars().any(char::is_whitespace) {
-        anyhow::bail!(crate::i18n::get_required_tool_string(
-            "tool-image-gen-error-redirect-url-whitespace"
-        ));
-    }
-    if !url.starts_with("http://") && !url.starts_with("https://") {
-        anyhow::bail!(crate::i18n::get_required_tool_string(
-            "tool-image-gen-error-redirect-url-scheme"
-        ));
-    }
-
-    let parsed = reqwest::Url::parse(url).map_err(|e| {
-        anyhow::Error::msg(crate::i18n::get_required_tool_string_with_args(
-            "tool-image-gen-error-redirect-url-parse",
-            &[("err", &e.to_string())],
-        ))
-    })?;
-    if !parsed.username().is_empty() || parsed.password().is_some() {
-        anyhow::bail!(crate::i18n::get_required_tool_string(
-            "tool-image-gen-error-redirect-url-userinfo"
-        ));
-    }
-
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| {
-            anyhow::Error::msg(crate::i18n::get_required_tool_string(
-                "tool-image-gen-error-redirect-url-no-host",
-            ))
-        })?
-        .to_string();
-
-    if host
-        .parse::<IpAddr>()
-        .is_ok_and(domain_guard::is_cloud_metadata_ip)
-    {
-        anyhow::bail!(crate::i18n::get_required_tool_string_with_args(
-            "tool-image-gen-error-redirect-url-metadata-host",
-            &[("host", &host)],
-        ));
-    }
-
-    let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
-    let private_match = host_is_private_or_local
-        && domain_guard::host_matches_allowlist(&host, allowed_private_hosts);
-
-    if host_is_private_or_local && !private_match {
-        anyhow::bail!(crate::i18n::get_required_tool_string_with_args(
-            "tool-image-gen-error-redirect-url-private-host",
-            &[("host", &host)],
-        ));
-    }
-
-    Ok(())
 }
 
 #[async_trait]
@@ -984,10 +957,11 @@ mod tests {
 
     // ── SSRF gate tests for the image-download stage ──────────────
     //
-    // These exercise `ImageGenTool::validate_image_url` and the free-function
-    // companion `validate_redirect_image_url` directly. Hermetic — no
-    // network, no reqwest, no `fal.run` POST. A regression that drops the
-    // SSRF gate (or relaxes the private-host check) would surface here.
+    // These exercise `ImageGenTool::validate_image_url` directly — the same
+    // gate `validate_image_target` applies to the initial URL and to every
+    // redirect target. Hermetic — no network, no reqwest, no `fal.run`
+    // POST. A regression that drops the SSRF gate (or relaxes the
+    // private-host check) would surface here.
 
     fn test_tool_with_private_hosts(allowed_private_hosts: Vec<&str>) -> ImageGenTool {
         ImageGenTool::new_with_config(
@@ -1103,51 +1077,11 @@ mod tests {
         assert_eq!(url, "http://localhost:8080/x.png");
     }
 
-    // ── Redirect-gate tests ───────────────────────────────────────
-    //
-    // The reqwest `Policy::custom` closure that re-validates each redirect
-    // target uses `validate_redirect_image_url` (free function) — these tests
-    // pin the redirect-path contract directly.
-
-    #[test]
-    fn validate_redirect_image_url_rejects_localhost() {
-        let allowed = vec!["cdn.internal.example".to_string()];
-        let err = validate_redirect_image_url("http://localhost/x.png", &allowed)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("local/private"), "got: {err}");
-    }
-
-    #[test]
-    fn validate_redirect_image_url_rejects_cloud_metadata() {
-        let allowed = vec!["*".to_string()];
-        let err = validate_redirect_image_url("http://169.254.169.254/latest/meta-data/", &allowed)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("metadata"), "got: {err}");
-    }
-
-    #[test]
-    fn validate_redirect_image_url_accepts_public_https() {
-        let allowed: Vec<String> = vec![];
-        validate_redirect_image_url("https://cdn.fal.ai/files/abc.png", &allowed)
-            .expect("public HTTPS host must be accepted by redirect gate");
-    }
-
-    #[test]
-    fn validate_redirect_image_url_accepts_allowed_private_host() {
-        let allowed = vec!["cdn.internal.example".to_string()];
-        validate_redirect_image_url("https://cdn.internal.example/x.png", &allowed)
-            .expect("allowed_private_hosts must lift the redirect gate");
-    }
-
     // ── Resolved-IP gate tests ──────────────────────────────────────
     //
     // These exercise `validate_image_url_resolved` (instance method).
     // `localhost` resolution works via /etc/hosts even in network-free
-    // environments; `example.com` requires real DNS. Redirect resolved-IP
-    // validation is currently deferred (the reqwest redirect callback runs
-    // synchronously and cannot await DNS).
+    // environments; `example.com` requires real DNS.
 
     #[tokio::test]
     async fn validate_image_url_resolved_rejects_localhost() {
@@ -1212,29 +1146,37 @@ mod tests {
         );
     }
 
-    /// Deterministic seam test: `validate_image_url_resolved` returns
-    /// the parsed hostname alongside the validated addresses, and the
-    /// download path passes the tuple's `.0` (hostname, not URL) to
-    /// `reqwest::Client::resolve_to_addrs`. Together these two
-    /// contracts guarantee that reqwest's lookup key matches the
-    /// request hostname and the validated address set is selected at
-    /// connect time, so a second unbound DNS lookup cannot bypass the
-    /// SSRF gate. The transport-level behavior of the override itself
-    /// is pinned by the listener-backed tests below.
-    #[test]
-    fn resolve_to_addrs_seam_uses_hostname_not_url() {
-        let url = "http://localhost:8080/test.png";
-        let host = reqwest::Url::parse(url)
-            .expect("test URL must parse")
-            .host_str()
-            .expect("test URL must have a host")
-            .to_string();
-        assert_eq!(host, "localhost");
+    /// The download path passes one `ValidatedImageTarget` from the
+    /// validation pipeline into the client builder, so the validated URL,
+    /// the `resolve_to_addrs` lookup key, and the pinned addresses cannot
+    /// be mixed at the call site. This exercises the real
+    /// validation-to-bundle path and pins its contract: the URL stays
+    /// whole, the host is the bare hostname reqwest keys by, and the
+    /// addresses are the resolved set for that host.
+    #[tokio::test]
+    async fn validated_image_target_bundles_url_host_and_addrs() {
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let target = tool
+            .validate_image_target("http://localhost:8080/test.png")
+            .await
+            .expect("wildcard allowlist must lift the non-global check");
+        assert_eq!(target.url, "http://localhost:8080/test.png");
+        assert_eq!(
+            target.host, "localhost",
+            "host must be the bare hostname, not the full URL — \
+             reqwest::Client::resolve_to_addrs keys by hostname"
+        );
         assert!(
-            !host.contains('/') && !host.contains(':'),
-            "host must be the bare hostname (no scheme, no port, no path) — \
-             reqwest::Client::resolve_to_addrs keys by hostname, and a full \
-             URL or a host:port string would never match the request hostname"
+            !target.addrs.is_empty(),
+            "validated target must carry the resolved address set"
+        );
+        assert!(
+            target
+                .addrs
+                .iter()
+                .all(|sa| sa.port() == 8080 && sa.ip().is_loopback()),
+            "addrs must be the resolved set for the target host, got {:?}",
+            target.addrs
         );
     }
 
@@ -1273,21 +1215,21 @@ mod tests {
             .await;
 
         let tool = test_tool_with_private_hosts(vec![]);
-        let validated_addrs = vec![SocketAddr::from(([127, 0, 0, 1], port))];
+        let target = ValidatedImageTarget {
+            url: "http://image-gen-resolve-test.invalid/img.png".to_string(),
+            host: "image-gen-resolve-test.invalid".to_string(),
+            addrs: vec![SocketAddr::from(([127, 0, 0, 1], port))],
+        };
         let client = tool
-            .build_download_client("image-gen-resolve-test.invalid", &validated_addrs)
+            .build_download_client(&target)
             .expect("production client build must succeed");
 
         // No port in the URL: dialing must be driven entirely by the
         // validated address set, not by URL components or DNS.
-        let resp = client
-            .get("http://image-gen-resolve-test.invalid/img.png")
-            .send()
-            .await
-            .expect(
-                "the validated address override must make the \
+        let resp = client.get(&target.url).send().await.expect(
+            "the validated address override must make the \
                  unresolvable hostname reachable",
-            );
+        );
         assert!(
             resp.status().is_success(),
             "expected 200 from the local listener, got {}",
@@ -1320,18 +1262,19 @@ mod tests {
             .await;
 
         let tool = test_tool_with_private_hosts(vec![]);
-        let validated_addrs = vec![SocketAddr::from(([127, 0, 0, 1], port))];
+        let target = ValidatedImageTarget {
+            url: "http://image-gen-resolve-test.invalid/img.png".to_string(),
+            host: "some-other-host.invalid".to_string(),
+            addrs: vec![SocketAddr::from(([127, 0, 0, 1], port))],
+        };
         let client = tool
-            .build_download_client("some-other-host.invalid", &validated_addrs)
+            .build_download_client(&target)
             .expect("production client build must succeed");
 
         // The outcome of the send itself is environment-dependent (the
         // hostname may fail DNS or hit a captive portal); the authoritative
         // check is the listener's hit count.
-        let _ = client
-            .get("http://image-gen-resolve-test.invalid/img.png")
-            .send()
-            .await;
+        let _ = client.get(&target.url).send().await;
 
         let received = server.received_requests().await.expect("received_requests");
         assert_eq!(
@@ -1341,6 +1284,210 @@ mod tests {
              hostname has no validated address set, so the listener must be \
              unreachable; got {received_len} hit(s)",
             received_len = received.len(),
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Redirect-loop tests: `download_image` follows redirects hop by hop,
+    // re-running the full validate-resolve-pin pipeline for each target.
+    //
+    // Both listeners bind 127.0.0.1, so the tool is constructed with
+    // `allowed_private_hosts = ["127.0.0.1"]` to lift the private-host
+    // gate for the literal loopback address. The rejection cases use
+    // redirect targets whose host string (`localhost`) is NOT covered by
+    // that allowlist entry, so the per-hop gate must stop the loop before
+    // any connection to the second listener.
+    // ──────────────────────────────────────────────────────────────────
+
+    /// A redirect to an allowed target is followed: the response bytes
+    /// come from the second listener, and both listeners see exactly one
+    /// request (the initial hit and the followed hop).
+    #[tokio::test]
+    async fn download_image_follows_redirect_to_allowed_target() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let target_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"image-bytes".to_vec()))
+            .expect(1)
+            .mount(&target_server)
+            .await;
+
+        let redirect_server = MockServer::start().await;
+        let location = format!("{}/img.png", target_server.uri());
+        Mock::given(method("GET"))
+            .and(path("/start.png"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", location))
+            .expect(1)
+            .mount(&redirect_server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec!["127.0.0.1"]);
+        let resp = tool
+            .download_image(&format!("{}/start.png", redirect_server.uri()))
+            .await
+            .expect("redirect to an allowlisted loopback target must succeed");
+        assert!(resp.status().is_success(), "got {}", resp.status());
+        let bytes = resp.bytes().await.expect("response body must read");
+        assert_eq!(&bytes[..], b"image-bytes");
+
+        let initial = redirect_server
+            .received_requests()
+            .await
+            .expect("received_requests");
+        let followed = target_server
+            .received_requests()
+            .await
+            .expect("received_requests");
+        assert_eq!(initial.len(), 1, "initial listener must see one request");
+        assert_eq!(followed.len(), 1, "redirect target must see one request");
+    }
+
+    /// A relative `Location` is resolved against the current hop's URL and
+    /// followed within the same listener.
+    #[tokio::test]
+    async fn download_image_resolves_relative_redirect_location() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/start.png"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/img.png"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"image-bytes".to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec!["127.0.0.1"]);
+        let resp = tool
+            .download_image(&format!("{}/start.png", server.uri()))
+            .await
+            .expect("relative redirect on the same host must succeed");
+        assert!(resp.status().is_success(), "got {}", resp.status());
+        let bytes = resp.bytes().await.expect("response body must read");
+        assert_eq!(&bytes[..], b"image-bytes");
+    }
+
+    /// The per-hop regression pin: a redirect target whose host string is
+    /// private/local and NOT covered by the allowlist must be rejected
+    /// before any connection to it. If the loop ever follows a redirect
+    /// without re-validating the target, the second listener gets hit and
+    /// this test fails.
+    #[tokio::test]
+    async fn download_image_rejects_redirect_to_non_allowlisted_private_host() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let target_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/img.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"image-bytes".to_vec()))
+            .expect(0)
+            .mount(&target_server)
+            .await;
+
+        let redirect_server = MockServer::start().await;
+        // `localhost` resolves to the same loopback the allowlisted
+        // `127.0.0.1` literal does, but the host STRING is not covered by
+        // the allowlist — only per-hop re-validation catches it.
+        let location = format!(
+            "http://localhost:{}/img.png",
+            target_server.address().port()
+        );
+        Mock::given(method("GET"))
+            .and(path("/start.png"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", location))
+            .expect(1)
+            .mount(&redirect_server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec!["127.0.0.1"]);
+        let err = tool
+            .download_image(&format!("{}/start.png", redirect_server.uri()))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("local/private"),
+            "expected private-host rejection, got: {err}"
+        );
+
+        let followed = target_server
+            .received_requests()
+            .await
+            .expect("received_requests");
+        assert_eq!(
+            followed.len(),
+            0,
+            "the rejected redirect target must never be connected to"
+        );
+    }
+
+    /// A redirect chain that never terminates is cut off at the hop limit
+    /// with the localized error.
+    #[tokio::test]
+    async fn download_image_enforces_redirect_hop_limit() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/loop.png"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/loop.png"))
+            .mount(&server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec!["127.0.0.1"]);
+        let err = tool
+            .download_image(&format!("{}/loop.png", server.uri()))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Too many"),
+            "expected hop-limit error, got: {err}"
+        );
+
+        let received = server.received_requests().await.expect("received_requests");
+        assert_eq!(
+            received.len(),
+            MAX_REDIRECT_HOPS + 1,
+            "expected the initial request plus {MAX_REDIRECT_HOPS} followed hops"
+        );
+    }
+
+    /// A redirect response without a `Location` header is rejected with
+    /// the localized error instead of being treated as a final response.
+    #[tokio::test]
+    async fn download_image_rejects_redirect_without_location() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/start.png"))
+            .respond_with(ResponseTemplate::new(302))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tool = test_tool_with_private_hosts(vec!["127.0.0.1"]);
+        let err = tool
+            .download_image(&format!("{}/start.png", server.uri()))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Location"),
+            "expected missing-Location error, got: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `image_gen` tool fetches the generated image from the URL returned in the fal.ai response body (`/images/0/url`). That URL is **server-supplied** — a compromised or misconfigured fal.ai (or a MITM of the fal.ai API) could return an `image_url` pointing to internal resources (cloud metadata endpoints, private network hosts, or any arbitrary URL). The reqwest client followed the URL with no host validation, and the response bytes were written to the workspace `images/` directory where the agent could later read them — exposing internal-network resources through the agent's filesystem interface.
- **Fix:** Route the image download through a per-hop SSRF gate mirroring the project-wide pattern at `web_fetch.rs:407-426` and `http_request.rs:96-153`. Redirects are followed by an explicit hop-by-hop loop (reqwest automatic redirect following is disabled), and **every hop** — the initial URL and every redirect target — goes through the full pipeline before any connection to it:
  - **Host-string gate** (`ImageGenTool::validate_image_url`): parses the URL, rejects non-http(s), rejects userinfo, unconditionally rejects the cloud-metadata IP literals known to the shared `domain_guard::is_cloud_metadata_ip` predicate (169.254.169.254 and fd00:ec2::254), rejects private/local hosts unless lifted by `allowed_private_hosts`.
  - **Resolved-IP gate** (`ImageGenTool::validate_image_url_resolved`): resolves the host, rejects empty answers, and rejects resolved addresses that are cloud metadata (always) or non-global (unless the host is covered by `allowed_private_hosts`) — catches a public-looking hostname that resolves to `10.0.0.5`, `127.0.0.1`, or a metadata address.
  - **Connection pinning** (`ImageGenTool::build_download_client`): binds the validated addresses to the connection via `reqwest::ClientBuilder::resolve_to_addrs` keyed by the **bare hostname** (reqwest lower-cases the lookup key; a full URL never matches the request hostname and the address set would be silently ignored) — closing the DNS-rebinding TOCTOU window between the resolved-IP gate and the transport connect. The client also calls `.no_proxy()`: pinning is only meaningful when this process dials the validated addresses itself, and reqwest's default ambient proxy env handling would delegate DNS+connect to a proxy whose DNS view (which may include internal hosts) decides the destination, voiding the override.
- **Structural call-site invariant:** each hop's validated URL, bare hostname, and validated addresses are bundled into `ValidatedImageTarget` by `validate_image_target`, and the builder consumes that single value — keying the address override by the full URL (or by any host other than the validated one) is a type error, not a silent no-op.
- **Localization:** All 19 user-visible error sites added by this gate route through the tools-side Fluent catalogue (`tool-image-gen-error-*` + `tool-image-gen` + 4 `tool-image-gen-param-*` = 24 keys in `en/tools.ftl`) via `tool_msg` / `tool_msg_with_args` helpers mirroring `file_download.rs`, including the resolved-IP rejections (no hard-coded English propagates from `domain_guard` on this path). `description()` and `parameters_schema()` read localized strings. Other locales fall back to English until translated (runtime fallback).
- **Scope boundary:** Image-download stage only. The fal.ai POST endpoint (`https://fal.run/{model}`) is operator-configured via `default_model` and validated against `..` / `?` / `#` / `\\` / leading-`/`; that surface is untouched, and the fal.ai API POST client is unchanged (it still honors ambient proxy env vars — that endpoint is operator-configured, not server-supplied).
- **Metadata-check scope:** the unconditional metadata rejection covers exactly the endpoints known to the shared `domain_guard::is_cloud_metadata_ip` predicate — `169.254.169.254` and `fd00:ec2::254` (EC2 IMDS). Other cloud vendors' metadata addresses are not part of that shared predicate; under an `allowed_private_hosts` carve-out, private-address space the operator has explicitly trusted is reachable except those two endpoints.
- **Blast radius:** seven files — `crates/zeroclaw-config/src/schema.rs` (new `allowed_private_hosts: Vec<String>` field on `ImageGenConfig`), `crates/zeroclaw-tools/src/image_gen.rs` (gates, target bundle, per-hop download loop, download-client builder, Fluent migration, tests), `crates/zeroclaw-runtime/locales/en/tools.ftl` (24 keys added), `crates/zeroclaw-runtime/src/tools/mod.rs` (call site resolves the allowlist from live config), `crates/zeroclaw-runtime/src/tools/delegate.rs` (threads the live config handle into independent delegate target registries), `crates/zeroclaw-runtime/src/agent/agent.rs` (threads the live config handle into `all_tools_with_runtime` so RPC/TUI agents read the allowlist at each call), and `crates/zeroclaw-tools/src/helpers/domain_guard.rs` (shared `is_cloud_metadata_ip` gains IPv4-mapped normalization — the highest-blast-radius part of this PR because that predicate is also consumed by `http_request.rs` and, via `validate_resolved_ips_*`, by `text_browser.rs`).
- **Linked:** Discovered during security audit pass 5 (2026-07-08) on upstream/master @ `502820949`.

**2026-08-06 review round (ZeroClaw-Bot on head `b2c19ddd`):** two warnings + one suggestion, all addressed on the new head:

- **Stale/mismatched validation evidence (warning, RESOLVED):** the Validation Evidence section named the wrong head (`1cde209d6`), reported the module test count as 44 (the exact source contains 43 test attributes; the filtered run reports 48 because the filter also matches tests outside the module), and the blast-radius line said `en/tools.ftl` contained 36 keys (the diff adds 24 keys, 36 lines). The duplicated mutation table was removed, and the missing template Yes/No fields (external network calls, prompt-injection, Rust/MSRV floor) are now present. Regenerated against head `8a880a488`.
- **Review-process narration in commit history (warning, RESOLVED):** `1c8103a59` described "two blocking findings from JordanTheJet's review" and referenced the PR number; `df3054df0` described the comment-hygiene CI failure and PR number. Both commit messages were rewritten to describe only the durable technical change (see the commit table).
- **Fluent filename default mismatch (suggestion, RESOLVED):** `tool-image-gen-param-filename` claimed the omitted filename defaults to `generated_image`, but `resolve_image_filename(None, …)` returns a unique timestamped `generated_image_<nanos>`. The description now documents the timestamped default (commit `8a880a488`).

**2026-08-06 re-review (ZeroClaw-Bot on head `8a880a488`):** four warnings + one suggestion, all addressed on the current head `c414fd021`:

- **Non-hermetic public-host test (RESOLVED):** `validate_image_url_resolved_accepts_public_host` resolved `https://example.com` via the production `lookup_host`, depending on live DNS. It now uses the injectable resolver seam with a known-global answer (`8.8.8.8`), keeping the suite hermetic.
- **Explicit IPv6 allowlist entries never matched (RESOLVED):** `reqwest::Url::host_str()` returns `[::1]` for an IPv6 URL while config entries store `::1`, so `allowed_private_hosts = ["::1"]` rejected `http://[::1]/…` at the private-host gate (fail-closed but contract-breaking). Both the host-string and resolved-IP gates now compare the bare form via `bare_policy_host`, pinned by `validate_image_url_allows_ipv6_loopback_with_explicit_allowlist` and `validate_image_url_resolved_allows_ipv6_loopback_with_explicit_allowlist`. **Mutation-checked:** reverting to the raw host fails the host-string regression.
- **Body/template mismatch (RESOLVED):** the Security & Privacy section now answers `New external network calls?` (`Yes, policy-gated`), adds the `Prompt injection…` row, and the Compatibility section adds the `Rust/MSRV/toolchain floor` row; the recorded clippy command now includes `-- -D warnings`.
- **Size label (RESOLVED):** the diff is 1,410 insertions / 17 deletions — `size:XL` under the live label definitions. The five-file slice is kept together because the gate, its transport binding, and the shared `domain_guard` predicate are one security fix; the new-behavior surface is the `image_gen.rs` gate + the `allowed_private_hosts` config field, while the bulk of the added lines are the transport/resolver tests and Fluent catalogue that pin the contract. The body snapshot now says `size:XL`.
- **Filename example (suggestion, RESOLVED):** the Fluent example no longer implies an ISO-like timestamp; it uses the actual `generated_image_<nanos>` shape (`generated_image_1722859200000000000`).

**2026-08-06 re-review (ZeroClaw-Bot on head `c414fd021`):** one blocker + two warnings, all addressed on the current head `620e00589`:

- **Live allowlist handle dropped for RPC/TUI agents (blocking, RESOLVED):** `Agent::from_config_with_session_cwd_and_mcp_approval_mode` received the daemon's shared `live_config` handle but passed `None` to `all_tools_with_runtime`, so the image_gen allowlist resolver fell back to a construction-time snapshot — an operator removing an internal CDN entry through live config mutation kept the stale carve-out until the agent was rebuilt. `live_config.clone()` is now threaded into `all_tools_with_runtime`, matching the channel orchestrator path. Pinned at the resolver boundary by `live_allowlist_resolver_reflects_config_mutation` (construct with a live allowlist, mutate the shared config, assert the next policy decision changes) and at the registry boundary by `tools::tests::image_gen_allowlist_registration_follows_live_config_handle` (call `all_tools_with_runtime` with the live handle: a legal live allowlist registers the tool, a malformed one disables it at construction, and reverting the `live_config` forwarding line to the snapshot fallback makes that test fail).
- **Production IPv6 resolution received URL brackets (RESOLVED):** the resolved-IP gate passed `host.to_string()` (`[::1]`) to `resolve_host_for_download`, which `tokio::net::lookup_host` cannot parse. The resolver now receives the bare form via `bare_policy_host` while the transport host keeps the URL representation. Pinned by `validate_image_url_resolved_ipv6_production_resolver_uses_bare_host` through the actual production resolver path. **Mutation-checked:** reverting to the bracketed host fails it.
- **Stale public validation evidence (RESOLVED):** body regenerated against `620e00589` (1,532 additions / 18 deletions across six files); the live `size:M` label is noted as a maintainer-side fix.

**2026-08-10 round (zeroclaw-reviewer on head `759bdcaaf`):** one blocker + two warnings, the blocker addressed on the new head `87181fdcc`:

- **Independent delegated registries used a stale image_gen allowlist (blocking, RESOLVED):** `DelegateTool` was built with a snapshot `Arc<Config>` and no live-config handle; `independent_agentic_tools_for_target` rebuilt the target registry with `live_config=None`, so an independent agentic delegate retained the old carve-out after an operator revoked an internal CDN allowlist entry — the same policy-revocation class this PR closes for the parent path, reachable through the independent delegation path. `DelegateTool` now carries the parent's live-config handle (`.with_live_config`) and threads it into `all_tools_with_runtime` for the independent target registry; `all_tools_with_runtime` forwards its own `live_config` into the `DelegateTool` it constructs. Pinned by `independent_delegate_image_gen_allowlist_follows_live_config_handle`: builds a parent registry, mutates the shared live config to a malformed `image_gen` allowlist, and proves the independent delegate's `image_gen` is dropped. **Mutation-verified:** passing `None` instead of the live handle keeps it registered and the test fails.
- **Public validation/label snapshot (warning, RESOLVED):** body regenerated against the exact head `87181fdcc` above (1,784 additions / 19 deletions across seven files; live `size:XL`).
- **fal.ai happy path (warning, not a code blocker):** no `FAL_API_KEY` is available in the author's environment, so the normal-runtime smoke (register through the runtime, generate, follow the public CDN/redirect path) remains unverified; the hermetic listener/resolver tests cover the gate, address pinning, redirect loop, and `.no_proxy()` behavior.

**2026-08-10 round (zeroclaw-reviewer on head `87181fdcc`):** one blocker + two warnings, the blocker addressed on the current head `245e9b2c2`:

- **Nested delegate spawns dropped the live image_gen allowlist handle (blocking, RESOLVED):** round-7 threaded the live handle through `DelegateTool` and `independent_agentic_tools_for_target`, but `execute_background` and `execute_parallel` still rebuilt their inner `DelegateTool` with `live_config: None`, so an independent agentic target launched with `background: true` or through `parallel` fell back to the construction-time `root_config` snapshot and could retain a revoked `image_gen.allowed_private_hosts` carve-out — the same policy-revocation class this PR closes for the parent path, reachable through the two spawned reconstruction paths. Both spawn paths now build the inner tool through a shared `for_spawned_execution` seam that re-captures `self.live_config` (plus the per-run policy, workspace, and cancellation token). Pinned by `spawned_delegate_rebuild_observes_live_config_revocation`, which drives the seam and proves the spawned delegate's independent target registry drops `image_gen` when the live allowlist is malformed. **Mutation-verified:** `None` in the seam instead of the live handle keeps it registered and the test fails.
- **Public rollback / label / lifecycle snapshot (warning, RESOLVED):** the label snapshot now includes the live `tool:delegate` label; the rollback command covers the full current commit set through `245e9b2c2`; the audit-index lifecycle wording reflects the current review state.
- **fal.ai happy path (warning, not a code blocker):** unchanged — no `FAL_API_KEY` is available in the author's environment, so the normal-runtime smoke remains unverified; the hermetic listener/resolver tests cover the gate, address pinning, redirect loop, and `.no_proxy()` behavior.

**2026-08-10 CI retrigger (head `6325d2c80`):** the first round-8 CI run failed `Parallel Runtime Test` on run 2 of 3 for `send_message_to_peer::peer_turn_cost_scope_through_execute_boundary_attributes_recipient_and_shares_budget` (a load-dependent detached-spawn sync test added by #9469 on 07-30, unrelated to this diff — no delegate references, file untouched; run 1 of the same job passed the full runtime suite 3601 ok). `gh run rerun` was blocked, so the gate was retriggered with an empty `ci:` commit; the retrigger passed all three 16-thread runs. No code changed between `245e9b2c2` and `6325d2c80`.

## Commits on this branch

Current head `6325d2c80` — twenty-one commits, none carrying a bot/AI attribution trailer (the final `6325d2c80` is an empty `ci:` retrigger of the parallel-runtime gate, no code change):

| Commit | Purpose |
|---|---|
| `262188711` | Initial gate: host-string gates + `allowed_private_hosts` config field + constructor |
| `af02d8ff4` | Add resolved-IP DNS check to the image_gen SSRF gate |
| `b96b8887d` | Bind download to validated addresses; remove `block_on` redirect gate |
| `e1322f627` | rustfmt on the `validate_image_url_resolved` binding |
| `35e59ecdd` | Bind download to validated address set keyed by the bare hostname |
| `4a4ca8d48` | Localize image_gen errors; pin download transport |
| `e7f66972e` | Revalidate and pin every redirect hop in the download loop |
| `a7dd3e5f5` | Add injectable DNS resolver seam for image_gen download tests |
| `8b1a0467a` | cargo fmt for image_gen.rs |
| `43676f2ed` | Close IPv4-mapped IPv6 SSRF bypass; live-config resolver for the allowlist |
| `63b3cabb1` | Tests use `new_with_config_resolver` (avoid deprecated warning) |
| `ce1cad735` | Runtime registration uses `new_with_config_resolver` |
| `a0d77987f` | Remove issue ref from image_gen comment (comment hygiene) |
| `1cb04c131` | Resolve allowlist from live config with per-call normalization; delete `new_with_config` and its `#[deprecated]`; `#[cfg(test)]` for test-only wrappers; `to_ipv4_mapped()` in `is_cloud_metadata_ip`; IPv4-mapped image_gen regression |
| `8a880a488` | Correct the image_gen filename default in the Fluent description (timestamped `generated_image_<nanos>`, not bare `generated_image`) |
| `c414fd021` | Match explicit IPv6 allowlist entries (strip URL brackets before comparison); route the public-host test through the injectable resolver seam; correct the filename example to the `<nanos>` form |
| `620e00589` | Thread the live config handle into image_gen for RPC/TUI agents (stale allowlist carve-out); resolve the bare IPv6 host in the production resolver; live-resolver + production-resolver regressions |
| `759bdcaaf` | Registry-level regression: `image_gen_allowlist_registration_follows_live_config_handle` pins the live-config → resolver wiring in `all_tools_with_runtime` |
| `87181fdcc` | Thread the live config handle into independent delegate target registries so a delegate's image_gen observes a config/set revocation (2026-08-10 round) |
| `245e9b2c2` | Preserve the live config handle through the `execute_background` / `execute_parallel` inner-tool rebuilds (shared `for_spawned_execution` seam) so an independently-delegated target launched with `background: true` or `parallel` observes a `config/set` revocation (2026-08-10 round) |
| `6325d2c80` | Empty `ci:` retrigger of the parallel-runtime gate (flake in #9469's cost-scope test on run 2 of 3); no code change |

## Label Snapshot

- **Live labels:** `bug`, `agent`, `config`, `runtime`, `tool`, `principal contributor`, `tool:delegate`, `needs-author-action`, `risk:high`, `size:XL` (the diff is 1,982 insertions / 102 deletions across seven files; `size:XL` under the live label definitions)
- **Maintainer note:** `risk:high` is correct because the gate touches a server-supplied URL surface and the diff modifies a transport configuration builder (reqwest `ClientBuilder::resolve_to_addrs` + `.no_proxy()`).
- **Base snapshot (2026-08-10):** Against the current `zeroclaw-labs/zeroclaw:master` the branch is 37 behind / 21 ahead; head `6325d2c80`. The diff contains only the seven intended files (image_gen gate + tests, `allowed_private_hosts` config field, runtime registration + delegate live-config threading, `en/tools.ftl`, `domain_guard` predicate, agent live-config wiring).

## Changes

### `crates/zeroclaw-config/src/schema.rs` (+13/-0)

- New `ImageGenConfig::allowed_private_hosts: Vec<String>` field. Default `vec![]`. Mirrors the same field on `[file_download]`, `[http_request]`, `[web_fetch]`, and the browser tools.

### `crates/zeroclaw-runtime/locales/en/tools.ftl`

- 24 keys: `tool-image-gen`, four `tool-image-gen-param-*` (prompt/filename/size/model), and 19 `tool-image-gen-error-*` covering every user-visible rejection/bail the gate and download path can raise (URL-string gate, resolved-IP gate including the per-address metadata/non-global rejections, redirect hop limit, missing/invalid redirect `Location`, client build). The substrings existing tests assert on (`"empty"`, `"whitespace"`, `"http://"`, `"userinfo"`, `"local/private"`, `"metadata"`, `"non-global"`, `"Failed to resolve"`, `"Too many"`, `"Location"`) appear verbatim in the English values.

### `crates/zeroclaw-tools/src/image_gen.rs`

- **Imports**: `std::net::{IpAddr, SocketAddr}`, `crate::helpers::domain_guard`, `std::sync::OnceLock`.
- **New struct field**: `ImageGenTool.allowed_private_hosts_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>` — resolves the allowlist from canonical config at use time (no second policy copy stored in the handle; AGENTS.md single source of truth).
- **Constructor**: `ImageGenTool::new_with_config_resolver(...) -> anyhow::Result<Self>` wraps the caller's resolver, normalizes its output through `domain_guard::normalize_allowed_domains` **per call** (fail-closing to an empty allowlist on malformed input), and validates once at construction so the caller keeps its disable-on-invalid behavior. The deprecated `new_with_config` constructor is deleted outright.
- **Localization helpers**: `tool_msg` / `tool_msg_with_args` (mirroring `file_download.rs`), a `OnceLock<String>`-cached `description()`, and Fluent-backed `parameters_schema()` strings.
- **New struct**: `ValidatedImageTarget { url, host, addrs }` — one hop's validated URL, bare hostname, and validated socket addresses, bundled so the validated URL and the `resolve_to_addrs` lookup key cannot drift apart at a call site.
- **New method**: `ImageGenTool::validate_image_url(&self, raw_url: &str) -> anyhow::Result<String>` — the host-string gate. Empty / whitespace / non-http(s) / userinfo-bearing → reject. Metadata IP literal → unconditional reject (even with wildcard allowlist). Private/local host not in allowlist → reject with structured WARN log.
- **New method**: `ImageGenTool::validate_image_url_resolved(&self, validated_url: &str) -> anyhow::Result<(String, Vec<SocketAddr>)>` — the resolved-IP gate. Resolves the validated host with `tokio::net::lookup_host`, rejects empty answers, then classifies each resolved `IpAddr` inline with the shared predicates (`domain_guard::is_cloud_metadata_ip`, `is_non_global_v4/v6`) so the rejection errors are localized with host+address context: metadata addresses are always rejected; non-global addresses are rejected unless the host is covered by `allowed_private_hosts`.
- **New method**: `ImageGenTool::validate_image_target(&self, raw_url: &str) -> anyhow::Result<ValidatedImageTarget>` — runs both gates for one URL and bundles the outcome. Called for the initial URL and for every redirect target.
- **New method**: `ImageGenTool::build_download_client(&self, target: &ValidatedImageTarget) -> anyhow::Result<reqwest::Client>` — the single construction point for the per-hop download client: timeouts, `Policy::none()` (the loop below owns redirect handling), `.no_proxy()` (so the pinning cannot be voided by ambient proxy env vars), and `resolve_to_addrs(&target.host, &target.addrs)`.
- **New method**: `ImageGenTool::download_image(&self, image_url: &str) -> anyhow::Result<reqwest::Response>` — the hop-by-hop redirect loop. Each iteration builds a client pinned to the current target, issues the GET, and on a 3xx resolves the `Location` (relative values resolved against the current hop's URL), revalidates + resolves + pins the target, and repeats. Stops at the final non-3xx response, at the 10-hop cap, on a missing/invalid `Location`, or on any gate rejection — in every case before a connection to an unvalidated target is attempted.
- **Tests** (43 test attributes in the module, all green — see Validation Evidence; the filtered `--lib image_gen` run below reports 48 because the filter also matches tests outside the module):
  - 13 hermetic string-gate tests (no network) covering the host-string gate and the literal-metadata/wildcard interaction.
  - Resolved-IP gate tests using literal non-public IPs (no DNS required) plus public-host/allowlist paths on hosts the runner can resolve.
  - `validate_image_url_resolved_returns_hostname_not_url` — pins the tuple return contract (`.0` is the bare hostname).
  - `validated_image_target_bundles_url_host_and_addrs` — exercises the real validation-to-bundle path: URL stays whole, host is the bare hostname reqwest keys by, addresses are the resolved set for that host.
  - `resolve_to_addrs_pins_connection_to_validated_socket_addr` — **listener-backed transport test**: drives `build_download_client` with a synthetic `.invalid` hostname (RFC 2606, unresolvable) pinned to a local wiremock listener's `SocketAddr`, and requests a URL with **no port**. The request can only succeed because the override drives dialing; asserts the listener received exactly one request.
  - `resolve_to_addrs_miskeyed_override_cannot_reach_listener` — **control**: same production builder, override keyed by a non-matching hostname. Asserts the listener sees zero requests. Both transport assertions are on the listener's hit count, so the outcome is independent of environment DNS/proxy behavior.
  - Five redirect-loop tests driving `download_image` against wiremock listeners: follow to an allowed target (both listeners hit exactly once, bytes from the second), relative `Location` resolution, rejection of a redirect to a non-allowlisted private host (target listener sees **zero** requests), the 10-hop cap (listener sees exactly 11 requests, localized error), and a 3xx without `Location`.

### `crates/zeroclaw-runtime/src/tools/mod.rs` (+15/-2)

- The `image_gen` registration resolves the allowlist from the live config handle when present (`live.read().image_gen.allowed_private_hosts.clone()`, mirroring `AgentPeerGroupResolver` at the same call site) with a snapshot fallback when no live handle exists, and passes that through `new_with_config_resolver`. If construction fails (e.g., operator typo in `allowed_private_hosts`), the tool is dropped with a structured `ERROR` log event carrying `tool_name=image_gen, err=<reason>` — matches the existing "config-gated tool with structured error" pattern.

### `crates/zeroclaw-tools/src/helpers/domain_guard.rs`

- `is_cloud_metadata_ip` normalizes IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) to their IPv4 equivalent before matching, closing the SSRF bypass where `::ffff:169.254.169.254` reaches EC2 IMDS even when `allowed_private_hosts = ["*"]` lifts the non-global gate. The hand-rolled octet check is replaced with `Ipv6Addr::to_ipv4_mapped()` (the same primitive `zeroclaw-infra/src/net_guard.rs` uses).
- Two `validate_resolved_ips_are_public` tests renamed (they never passed a wildcard) and the pinned-nothing loopback test strengthened to assert both the mapped-metadata hit and the mapped-loopback non-hit.

## Validation Evidence

Local validation on the code head `245e9b2c2` (CI head `6325d2c80`, +1 empty `ci:` commit):

```text
$ cargo fmt --all -- --check
  (clean)

$ cargo clippy -p zeroclaw-tools -p zeroclaw-runtime -p zeroclaw-config --tests --all-targets -- -D warnings
  Finished `dev` profile — 0 warnings

$ cargo test -p zeroclaw-tools --lib image_gen
  test result: ok. 53 passed; 0 failed; 0 ignored; 0 measured

$ cargo test -p zeroclaw-tools --lib helpers::domain_guard
  test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured

$ cargo test -p zeroclaw-runtime --lib tools::
  test result: ok. 523 passed; 0 failed (includes the
  independent_delegate_image_gen_allowlist_follows_live_config_handle and
  spawned_delegate_rebuild_observes_live_config_revocation regressions)
```

Known pre-existing environment gap: five `git_operations::tests::stash_push_*` tests fail in this sandbox (`Not in a Git repository at '/tmp/...'` — the temp-repo bootstrap does not initialize in this environment) and fail identically on the pristine head with this branch's changes stashed. They are unrelated to this PR's surface and pass in CI.

**Mutation verification (the regression tests actually fail when the regression is reintroduced):**

Each regression class was reintroduced locally into the production code on this head, the tests were run, and the mutations were then reverted:

| Mutation injected | Result |
|---|---|
| **A — drop `.resolve_to_addrs(...)` entirely** from `build_download_client` | `resolve_to_addrs_pins_connection_to_validated_socket_addr` **FAILED**: `expected exactly one listener hit, left: 0` |
| **B — key the override by a non-matching hostname** (the mis-keyed bug shape: reqwest never matches the request hostname and the validated address set is silently ignored) | control test `resolve_to_addrs_miskeyed_override_cannot_reach_listener` fails if the listener is reached; with the `ValidatedImageTarget` bundle, keying by the full URL at the `generate()` call site is now a **compile-time type error** |
| **C — follow redirects without revalidating the target** (replace the per-hop `validate_image_target` call with a bare resolve — the public-looking-host-to-private-address bypass) | `download_image_rejects_redirect_to_non_allowlisted_private_host` **FAILED**: `unwrap_err() on an Ok value: Response { url: "http://localhost:PORT/img.png", status: 200 }` — the unvalidated hop was dialed |
| **D — drop the allowlist normalization** from `new_with_config_resolver` (the pre-fix shape: raw strings fed to `host_matches_allowlist`) | construction-time `normalize_allowed_domains` validation in the constructor catches malformed entries; per-call normalization keeps `HTTPS://Example.COM/` matching `example.com` — pinned by the construction validation + the live-resolver wiring |
| **E — remove the IPv4-mapped normalization** from `is_cloud_metadata_ip` (revert to the raw V6 comparison) | `image_gen::validate_image_target_rejects_ipv4_mapped_metadata_under_wildcard` and `domain_guard` mapped-metadata tests **FAILED** — `::ffff:169.254.169.254` reads as a plain V6 and is missed |
| **F — drop `live_config` from the spawn-rebuild seam** (the round-8 shape: inner `DelegateTool` rebuilt with `live_config: None` in `execute_background` / `execute_parallel`) | `spawned_delegate_rebuild_observes_live_config_revocation` **FAILED** — the spawned delegate kept `image_gen` registered via the snapshot fallback after the live allowlist was malformed |

Notably, in this development environment `.invalid` is wildcard-resolved by a DNS-intercepting proxy, so under mutation A the HTTP request itself *succeeded* (200 from an unrelated responder) — and the test still failed, because the assertion anchor is the local listener's hit count, not the request outcome. The tests are hermetic: they do not depend on how the environment resolves (or fails to resolve) the synthetic hostname. (This environment also has `http_proxy`/`https_proxy` set; that is what motivated the `.no_proxy()` hardening — with an ambient proxy, the override is never consulted.)

**Resolver-injection tests (added round 6):** Three production-path tests exercise `download_image_with_resolver` with controlled DNS, pinning the exact SSRF closure the reviewer identified as missing from the earlier test suite:

- `download_image_with_resolver_pins_initial_connection_to_validated_listener` — an unresolvable synthetic hostname reaches ONLY its validated listener; the request URL carries no port, so the resolver-injected address is the sole path.
- `download_image_with_resolver_pins_redirected_connection_to_validated_listener` — a redirect to a different synthetic hostname reaches ONLY that target's validated listener; the per-hop resolver is called independently for each hostname.
- `download_image_rejects_redirect_to_public_hostname_resolving_to_private_address` — a public-looking redirect hostname (`public-looking-cdn.example`) whose injected resolver returns a loopback address is rejected by the resolved-IP gate with ZERO target-listener requests. This is the DNS-rebinding case the existing `localhost` redirect test cannot cover: literal `localhost` is stopped by the host-string gate before resolved-IP classification runs; `public-looking-cdn.example` passes the string gate and requires the resolved-IP classification to catch the rebinding.

All three assertions anchor on the listener's hit count, so the outcome is independent of how the environment resolves (or fails to resolve) any hostname.

**Beyond CI — what was manually verified:** class-sweep confirms the SSRF gate pattern in `image_gen.rs` now sits alongside the canonical `web_fetch.rs` / `http_request.rs` / `browser.rs` / `browser_open.rs` / `file_download.rs` implementations. Like `file_download`, the download client itself sets `Policy::none()`; unlike `file_download` (whose URL is operator-configured), this path follows redirects explicitly because the URL is server-supplied and fal.ai's CDN may legitimately redirect — with the full gate re-run on every hop. The proxy-bypass and per-hop-revalidation claims are verified end-to-end by the mutation runs above.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No.** Code path is unchanged except for the added gates, address binding, redirect loop, and proxy disablement on the download client; no new I/O surface beyond what already exists.
- New external network calls? **Yes, policy-gated** — the gate performs explicit DNS resolution (`tokio::net::lookup_host`) for the initial URL and every redirect hop before connecting. The production tests use an injectable resolver seam (closure-based, mirroring the `http_request.rs` pattern) that maps synthetic hostnames to controlled `SocketAddr`s against local wiremock listeners, eliminating real DNS from the test suite while exercising the exact validate-resolve-pin pipeline.
- Secrets / tokens / credentials handling changed? **No.** Same fal.ai `Key {api_key}` auth header.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** All test URLs are synthetic (`localhost`, `127.0.0.1`, `10.0.0.5`, `169.254.169.254`, `cdn.fal.ai`, `cdn.internal.example`, `example.com`, `*.invalid`).
- Prompt injection or untrusted model-visible text introduced/changed? **No** — the image URL is server-supplied and treated as untrusted; errors are localized through the Fluent catalogue with no model-visible content added.

**Positive security impact:** Closes the SSRF vector where a compromised/misconfigured fal.ai (or a MITM of the fal.ai API) returns `image_url` pointing to internal resources — including the variant where the initial URL looks public but a redirect target's hostname resolves to a private, local, or metadata address. Without the gate, such URLs were followed; response bytes were written to the workspace `images/` directory; the agent could later read them and exfiltrate credentials or pivot to internal services. With the gate, every hop is validated and resolved before any bytes hit the network, no workspace write occurs on rejection, and each hop's validated addresses are bound to a directly-dialed connection so DNS rebinding between gate and transport connect is no longer possible on any hop — including via an ambient proxy, whose DNS view the override would otherwise never constrain.

**Per-hop coverage:**

| Surface | Mechanism | Status |
|---|---|---|
| Literal host string — initial URL and every redirect target | `validate_image_url` via `validate_image_target` | **Shipped** |
| Resolved IP — initial URL and every redirect target | `validate_image_url_resolved` (localized per-address rejection) | **Shipped** |
| Connection pinning — every hop | `build_download_client(&ValidatedImageTarget)` with `resolve_to_addrs(host, addrs)` + `.no_proxy()` + `Policy::none()` | **Shipped** |
| Redirect hygiene | 10-hop cap, relative `Location` resolution, missing/invalid `Location` rejection | **Shipped** |

## Compatibility

- Backward compatible? **Yes, modulo the new opt-in and the proxy stance below.** The fix rejects server-supplied URLs that previously would have been followed. For the canonical case where fal.ai returns a publicly-resolvable HTTPS URL on a public CDN (the normal operational case), behavior is unchanged, and redirects between public hosts are still followed (now with per-hop validation).
- **Ambient proxy env vars no longer apply to the image download.** The download client calls `.no_proxy()` because any proxy (ambient or otherwise) resolves and connects on behalf of this process, voiding the address pinning this PR exists to enforce. Deployments that require proxied egress for the download connection will see a visible connect error instead of a silently unpinned download. The fal.ai API POST client is unchanged and still honors ambient proxy env vars. If operator-configured proxied downloads are ever needed, the deliberate path is the runtime-proxy system (`apply_runtime_proxy_to_builder`, as used by `http_request`) — out of scope here.
- Config / env / CLI surface changed? **Yes — additive.** New field `image_gen.allowed_private_hosts: Vec<String>`, defaulting to `[]`. Operators who need internal CDN tolerance (e.g. air-gapped deployments proxying fal.ai artifacts) add entries.
- Rust/MSRV/toolchain floor changed? **No** — no new dependencies or language features.
- Exact upgrade steps for existing users:

  1. **No action required.** Existing deployments that use the canonical fal.ai public CDN continue to work — every operational fal.ai artifact URL the audit traced is on a public CDN host.
  2. **Optional audit:** Operators can grep `image_gen` audit logs for the new `WARN` event `image_gen: rejecting private/local image host` after rollout — a non-zero count indicates either (a) a fal.ai response pointing to internal resources (likely misconfiguration upstream), or (b) an operator deployment that needs `allowed_private_hosts` configured.
  3. **If you proxy fal.ai artifacts through an internal CDN:** add the internal CDN host to `[image_gen] allowed_private_hosts` in `config.toml`, e.g.:
     ```toml
     [image_gen]
     enabled = true
     allowed_private_hosts = ["cdn.internal.example", "artifacts.vpn"]
     ```
     A bare `"*"` blanket-tolerates any private/local host (dev/CI use case only).

No data migration, no schema migration for existing users (the new field defaults to empty), no version bump.

## Rollback

- **Fast rollback command/path:** `git revert 245e9b2c2 87181fdcc 759bdcaaf 620e00589 8a880a488 c414fd021 1cb04c131 a0d77987f ce1cad735 63b3cabb1 43676f2ed 8b1a0467a a7dd3e5f5 e7f66972e 4a4ca8d48 35e59ecdd e1322f627 b96b8887d af02d8ff4 262188711`. Restores the unvalidated `client.get(image_url)` call. No other code depends on the new shape; the struct field `allowed_private_hosts_resolver` and the `new_with_config_resolver` constructor are unused after revert.
- **Feature flags or config toggles:** None at runtime. No config knob to flip.
- **Observable failure symptoms:** If a future regression reintroduces the unvalidated `client.get(image_url)` call, the new tests fail at CI:
  - `validate_image_url_rejects_localhost` rejects `http://localhost/x.png`
  - `validate_image_url_rejects_private_ipv4` rejects `http://10.0.0.5/x.png`
  - `validate_image_url_rejects_cloud_metadata_ipv4` rejects `http://169.254.169.254/...`
  - `validate_image_url_resolved_rejects_localhost` / `_rejects_cloud_metadata_ipv4` reject literal non-public answers without ever calling DNS
  - `resolve_to_addrs_pins_connection_to_validated_socket_addr` fails on the listener hit count if the address override is dropped or mis-keyed (verified by the mutation runs above)
  - `download_image_rejects_redirect_to_non_allowlisted_private_host` fails if a redirect hop is ever followed without re-running the gate (verified by mutation run C above)
  - `download_image_enforces_redirect_hop_limit` fails if the hop cap is dropped

  Operators monitoring for the SSRF signal can grep `image_gen` audit logs for `image_gen: rejecting private/local image host` after rollout — a non-zero count indicates fal.ai (or a MITM) returning internal-resource URLs. Absence of that event post-fix is the operator-visible signal that the gate is firing on attempts.

## Related

- Canonical SSRF patterns: `crates/zeroclaw-tools/src/web_fetch.rs:407-426` (redirect policy), `crates/zeroclaw-tools/src/http_request.rs:96-153` (validate_url_policy), `crates/zeroclaw-tools/src/file_download.rs` (allowed_private_hosts field precedent + `Policy::none()` redirect stance)
- Existing config field precedent: `crates/zeroclaw-config/src/schema.rs` (`[file_download].allowed_private_hosts`, `[http_request].allowed_private_hosts`, `[web_fetch].allowed_private_hosts`)
- Discovered during security audit pass 5 (2026-07-08) on upstream/master @ `502820949`
- Companion PR: #8824 (Finding 1 — `nodes.auth_token` timing attack on `/ws/nodes`)

## Security audit pass 5 — findings index

This PR is finding 2/3 from the 2026-07-08 audit pass. The full set:

1. **#8824 — `nodes.auth_token` constant-time comparison** (PR ready, separate PR). MEDIUM. Closes a remote timing attack on the operator-configured WebSocket auth token for `/ws/nodes`.
2. **This PR — `image_gen` SSRF gate** (review in progress — live-config propagation across delegate spawn paths under review). MEDIUM. Closes a server-supplied-URL SSRF in the image-download stage.
3. **`notion_tool` URL-encoding** (LOW, deferred) — Notion service-side normalizes malformed IDs to errors rather than SSRF; audit log cosmetic only. Held as a follow-up.
