### PR TITLE
fix(tools): layer 3 resolved-IP DNS check for image_gen SSRF

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -8541,6 +8541,18 @@ pub struct ImageGenConfig {
     #[serde(default = "default_image_gen_api_key_env")]
     #[credential_class = "legacy_env_path"]
     pub api_key_env: String,
+
+    /// Hosts (or host suffixes) that the image-download stage is allowed to
+    /// reach even when they are private/local. Mirrors the same field on
+    /// `[file_download]`, `[http_request]`, `[web_fetch]`, and the browser
+    /// tools. Use for internal CDNs that proxy fal.ai artifacts in air-gapped
+    /// deployments.
+    ///
+    /// Entries are normalized at config-load time via
+    /// `domain_guard::normalize_allowed_domains`. A bare `"*"` blanket-tolerates
+    /// any private/local host (use only for dev).
+    #[serde(default)]
+    pub allowed_private_hosts: Vec<String>,
 }
 
 fn default_image_gen_model() -> String {
@@ -8557,6 +8569,7 @@ impl Default for ImageGenConfig {
             enabled: false,
             default_model: default_image_gen_model(),
             api_key_env: default_image_gen_api_key_env(),
+            allowed_private_hosts: Vec::new(),
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1193,13 +1193,26 @@ pub fn all_tools_with_runtime(
 
     // Standalone image generation tool (config-gated)
     if root_config.image_gen.enabled {
-        tool_arcs.push(Arc::new(ImageGenTool::new_with_persistence(
+        match ImageGenTool::new_with_config(
             security.clone(),
             workspace_dir.to_path_buf(),
             root_config.image_gen.default_model.clone(),
             root_config.image_gen.api_key_env.clone(),
             persistent_writes,
-        )));
+            root_config.image_gen.allowed_private_hosts.clone(),
+        ) {
+            Ok(tool) => tool_arcs.push(Arc::new(tool)),
+            Err(err) => ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "tool": "image_gen",
+                        "err": err.to_string(),
+                    })),
+                "image_gen: invalid allowed_private_hosts in config; tool disabled"
+            ),
+        }
     }
 
     // File upload tool — enabled iff [file_upload].url is set

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::json;
 use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolResult, with_ephemeral_workspace_warning};
@@ -232,13 +233,19 @@ impl ImageGenTool {
     /// catch this.
     ///
     /// Mirrors the async-DNS pattern at `http_request.rs:622-185` and
-    /// `web_fetch.rs:702-723`. The redirect policy closure (which is sync
-    /// and cannot await DNS) remains on the literal-host check; that gap
-    /// is documented as a known follow-up.
+    /// `web_fetch.rs:702-723`. Returns the validated host and socket
+    /// addresses so the caller can pin the reqwest connection via
+    /// `resolve_to_addrs`, eliminating the time-of-check/time-of-use
+    /// window between DNS validation and the actual TCP connect.
     ///
     /// For IP-literal hosts the literal-host check at `validate_image_url`
-    /// has already classified the IP, so this method is a no-op.
-    async fn validate_resolved_ips_for_image_url(&self, url: &str) -> anyhow::Result<()> {
+    /// has already classified the IP, so this method resolves nothing
+    /// and returns the parsed host with an empty addr list (the caller
+    /// skips `resolve_to_addrs` for IP literals).
+    async fn validate_resolved_ips_for_image_url(
+        &self,
+        url: &str,
+    ) -> anyhow::Result<(String, Vec<SocketAddr>)> {
         let parsed = reqwest::Url::parse(url)
             .map_err(|e| anyhow::Error::msg(format!("Invalid image URL format: {e}")))?;
         let host = parsed
@@ -247,8 +254,10 @@ impl ImageGenTool {
             .to_string();
 
         // IP literals: the literal-host check already classified the host.
+        // No DNS needed — return the host string and an empty addr list so
+        // the caller can skip `resolve_to_addrs` (reqwest connects directly).
         if host.parse::<IpAddr>().is_ok() {
-            return Ok(());
+            return Ok((host, Vec::new()));
         }
 
         let port = parsed.port_or_known_default().unwrap_or(443);
@@ -271,7 +280,9 @@ impl ImageGenTool {
             .collect::<Vec<_>>();
 
         let ips: Vec<IpAddr> = addrs.iter().map(|sa| sa.ip()).collect();
-        check_resolved_ips_for_image_gen(&host, &self.allowed_private_hosts, &ips)
+        check_resolved_ips_for_image_gen(&host, &self.allowed_private_hosts, &ips)?;
+
+        Ok((host, addrs))
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -439,7 +450,12 @@ impl ImageGenTool {
         // where `internal.corp` resolves to `10.0.0.5` — the literal-host
         // check at `validate_image_url` cannot catch this. Mirrors
         // `http_request.rs:622-185` async-DNS pattern.
-        self.validate_resolved_ips_for_image_url(&validated_image_url)
+        //
+        // Returns the host name and validated socket addresses so the
+        // download client can pin the connection (eliminating the TOCTOU
+        // window between DNS validation and the TCP connect).
+        let (image_host, resolved_addrs) = self
+            .validate_resolved_ips_for_image_url(&validated_image_url)
             .await?;
 
         // ── Build image-download client with per-redirect SSRF gate ─
@@ -464,12 +480,20 @@ impl ImageGenTool {
             attempt.follow()
         });
 
-        let download_client = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(120))
             .connect_timeout(std::time::Duration::from_secs(10))
-            .redirect(redirect_policy)
-            .build()
-            .unwrap_or_default();
+            .redirect(redirect_policy);
+
+        // Pin the validated resolved addresses so reqwest cannot perform
+        // a separate DNS lookup during connect — closes the TOCTOU window
+        // between validation and the actual TCP handshake. For IP-literal
+        // hosts (empty resolved_addrs), skip pinning (reqwest connects
+        // directly to the literal address anyway).
+        if !resolved_addrs.is_empty() {
+            builder = builder.resolve_to_addrs(&image_host, &resolved_addrs);
+        }
+        let download_client = builder.build().unwrap_or_default();
 
         // ── Download image ─────────────────────────────────────────
         let img_resp = download_client

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -146,6 +146,11 @@ impl ImageGenTool {
     /// even if `allowed_private_hosts` would otherwise lift the gate — that
     /// matches the matrix-textbrower-browser-file_download pattern (see
     /// `domain_guard::validate_resolved_ips_exclude_metadata`).
+    ///
+    /// This is **layer 1** of the SSRF gate (literal-host string check).
+    /// Layer 3 (resolved-IP DNS check) is applied separately via
+    /// [`Self::validate_resolved_ips_for_image_url`] — split so the
+    /// async DNS lookup is testable in isolation with synthetic IPs.
     fn validate_image_url(&self, raw_url: &str) -> anyhow::Result<String> {
         let url = raw_url.trim();
         if url.is_empty() {
@@ -217,6 +222,56 @@ impl ImageGenTool {
         }
 
         Ok(url.to_string())
+    }
+
+    /// **Layer 3** of the SSRF gate: resolve the URL's host via DNS and
+    /// validate that every resolved IP is a public address (or, for
+    /// allowlist-lifted private hosts, non-metadata). Closes the
+    /// DNS-rebinding vector where `internal.corp` resolves to `10.0.0.5`
+    /// — the literal-host classifier at `validate_image_url` cannot
+    /// catch this.
+    ///
+    /// Mirrors the async-DNS pattern at `http_request.rs:622-185` and
+    /// `web_fetch.rs:702-723`. The redirect policy closure (which is sync
+    /// and cannot await DNS) remains on the literal-host check; that gap
+    /// is documented as a known follow-up.
+    ///
+    /// For IP-literal hosts the literal-host check at `validate_image_url`
+    /// has already classified the IP, so this method is a no-op.
+    async fn validate_resolved_ips_for_image_url(&self, url: &str) -> anyhow::Result<()> {
+        let parsed = reqwest::Url::parse(url)
+            .map_err(|e| anyhow::Error::msg(format!("Invalid image URL format: {e}")))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow::Error::msg("image URL has no host"))?
+            .to_string();
+
+        // IP literals: the literal-host check already classified the host.
+        if host.parse::<IpAddr>().is_ok() {
+            return Ok(());
+        }
+
+        let port = parsed.port_or_known_default().unwrap_or(443);
+        let addrs = tokio::net::lookup_host((host.as_str(), port))
+            .await
+            .map_err(|e| {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "tool": "image_gen",
+                            "host": host,
+                            "error": e.to_string()
+                        })),
+                    "image_gen: DNS resolution failed for image host"
+                );
+                anyhow::Error::msg(format!("Failed to resolve image host '{host}': {e}"))
+            })?
+            .collect::<Vec<_>>();
+
+        let ips: Vec<IpAddr> = addrs.iter().map(|sa| sa.ip()).collect();
+        check_resolved_ips_for_image_gen(&host, &self.allowed_private_hosts, &ips)
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -378,6 +433,15 @@ impl ImageGenTool {
         // leave open.
         let validated_image_url = self.validate_image_url(image_url)?;
 
+        // Layer 3 of the SSRF gate: resolve the host via DNS and check
+        // that every resolved IP is public (or, for allowlist-lifted
+        // private hosts, non-metadata). Closes the DNS-rebinding vector
+        // where `internal.corp` resolves to `10.0.0.5` — the literal-host
+        // check at `validate_image_url` cannot catch this. Mirrors
+        // `http_request.rs:622-185` async-DNS pattern.
+        self.validate_resolved_ips_for_image_url(&validated_image_url)
+            .await?;
+
         // ── Build image-download client with per-redirect SSRF gate ─
         // Mirrors `web_fetch.rs:407-426`. The closure captures a clone of
         // `self.allowed_private_hosts` so the per-redirect check uses the
@@ -508,6 +572,51 @@ fn validate_redirect_image_url(
     }
 
     Ok(())
+}
+
+/// Layer 3 of the SSRF gate: validate a host's pre-resolved IPs against
+/// the same private/local + cloud-metadata policy as the literal-host
+/// check at `ImageGenTool::validate_image_url`. Splits the post-DNS
+/// decision from the DNS-resolution step so the gate is testable with
+/// synthetic IPs (no real DNS, no network).
+///
+/// Semantics:
+/// - If the hostname is in `allowed_private_hosts` (the literal-host
+///   check lifted the gate) → every resolved IP must not be cloud
+///   metadata; private/loopback/link-local IPs are accepted because
+///   the operator explicitly opted in. Uses
+///   `domain_guard::validate_resolved_ips_exclude_metadata`.
+/// - Otherwise → every resolved IP must be globally routable
+///   (`validate_resolved_ips_are_public`). Catches the canonical
+///   DNS-rebinding vector where `cdn.fal.ai` (or any attacker-controlled
+///   hostname that happens to pass the literal-host deny list) resolves
+///   to `10.0.0.5` or `169.254.169.254`.
+///
+/// **Known limitation:** the reqwest redirect policy closure is sync and
+/// cannot await DNS, so per-redirect resolved-IP validation is deferred
+/// across the trilogy (see `[[zeroclaw-ssrf-trilogy-gate-layers-2026-07-04]]`).
+/// The initial-URL check covers the canonical DNS-rebinding vector; a
+/// future PR can add a sync-DNS cache (or `block_in_place` async DNS)
+/// to extend coverage to redirect targets.
+fn check_resolved_ips_for_image_gen(
+    host: &str,
+    allowed_private_hosts: &[String],
+    ips: &[IpAddr],
+) -> anyhow::Result<()> {
+    if ips.is_empty() {
+        anyhow::bail!("Failed to resolve host '{host}'");
+    }
+
+    // Branch on whether the operator's allowlist lifted the gate, not on
+    // whether the hostname *looks* private — `is_private_or_local_host`
+    // is a literal-string classifier and would miss names like
+    // `cdn.internal.example` (a public TLD), which is exactly the
+    // DNS-rebinding case we want the layer-3 gate to catch by IP.
+    if domain_guard::host_matches_allowlist(host, allowed_private_hosts) {
+        domain_guard::validate_resolved_ips_exclude_metadata(host, ips)
+    } else {
+        domain_guard::validate_resolved_ips_are_public(host, ips)
+    }
 }
 
 #[async_trait]
@@ -995,5 +1104,173 @@ mod tests {
         let allowed = vec!["cdn.internal.example".to_string()];
         validate_redirect_image_url("https://cdn.internal.example/x.png", &allowed)
             .expect("allowed_private_hosts must lift the redirect gate");
+    }
+
+    // ── Layer 3 — resolved-IP DNS check tests ────────────────────
+    //
+    // The reqwest `Policy::custom` closure is sync, so the per-redirect
+    // resolved-IP gate is deferred (see `[[zeroclaw-ssrf-trilogy-gate-layers-
+    // 2026-07-04]]`). The initial URL's gate is implemented as
+    // `check_resolved_ips_for_image_gen` — a pure function over
+    // `(host, allowed_private_hosts, resolved_ips)`. These tests pin
+    // that gate hermetically: no network, no real DNS, no reqwest.
+    //
+    // A regression that drops the layer-3 gate (or relaxes the
+    // private-IP check) surfaces here.
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse::<IpAddr>().expect("test fixture must parse")
+    }
+
+    #[test]
+    fn check_resolved_ips_public_hostname_public_ip_accepted() {
+        let ips = vec![ip("93.184.216.34")]; // example.com
+        check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .expect("public hostname + public IP must be accepted");
+    }
+
+    #[test]
+    fn check_resolved_ips_public_hostname_private_ip_rejected() {
+        // The classic DNS-rebinding vector: hostname is public-looking,
+        // resolved IP is private. Literal-host check passes, layer-3
+        // gate must catch it.
+        let ips = vec![ip("10.0.0.5")];
+        let err = check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("private") || err.contains("10.0.0.5"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_resolved_ips_public_hostname_loopback_ip_rejected() {
+        let ips = vec![ip("127.0.0.1")];
+        let err = check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("127.0.0.1"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_resolved_ips_public_hostname_metadata_ip_rejected() {
+        // The IMDS-rebinding vector: hostname is public-looking, but
+        // poisoned DNS returns the cloud-metadata IP. Must be rejected
+        // unconditionally.
+        let ips = vec![ip("169.254.169.254")];
+        let err = check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn check_resolved_ips_public_hostname_mixed_ips_rejected() {
+        // Multi-IP resolution: if ANY resolved IP is non-public, the
+        // gate must reject (reqwest may pick any one of the IPs to
+        // connect to).
+        let ips = vec![ip("93.184.216.34"), ip("10.0.0.5")];
+        let err = check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("10.0.0.5"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_resolved_ips_empty_list_rejected() {
+        // DNS returned no IPs (NXDOMAIN, SERVFAIL, etc.). Must be
+        // rejected, not silently passed through.
+        let err = check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &[])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("resolve") || err.contains("Failed"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_resolved_ips_allowlisted_hostname_private_ip_accepted() {
+        // Operator explicitly allowlisted the internal CDN; resolved
+        // IP is the internal CDN's actual private address.
+        let ips = vec![ip("10.5.5.5")];
+        check_resolved_ips_for_image_gen(
+            "cdn.internal.example",
+            &["cdn.internal.example".to_string()],
+            &ips,
+        )
+        .expect("allowlisted private host + private IP must be accepted");
+    }
+
+    #[test]
+    fn check_resolved_ips_allowlisted_hostname_metadata_ip_rejected() {
+        // Even with the host allowlisted, a resolved cloud-metadata IP
+        // must be rejected (matches the matrix-textbrower-browser
+        // pattern; `*` allowlist does not lift the metadata block).
+        let ips = vec![ip("169.254.169.254")];
+        let err =
+            check_resolved_ips_for_image_gen("cdn.internal.example", &["*".to_string()], &ips)
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn check_resolved_ips_wildcard_allowlist_blocks_metadata_rejects_metadata() {
+        // Wildcard allowlist allows private IPs but blocks metadata.
+        // The resolved IP happens to be the metadata service.
+        let ips = vec![ip("169.254.169.254")];
+        let err = check_resolved_ips_for_image_gen("any.private.host", &["*".to_string()], &ips)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn check_resolved_ips_allowlisted_hostname_non_allowlisted_rejected() {
+        // The hostname is a private one but NOT in the allowlist. The
+        // resolved IP is the host's actual address. Layer-3 should
+        // reject defensively (the literal-host check at
+        // `validate_image_url` should have already caught this; the
+        // resolved-IP check is a defense-in-depth re-application).
+        let ips = vec![ip("10.5.5.5")];
+        let err = check_resolved_ips_for_image_gen(
+            "cdn.internal.example",
+            &["other.private.host".to_string()],
+            &ips,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("10.5.5.5"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_resolved_ips_ipv6_public_accepted() {
+        // IPv6 public address. (2001:4860:4860::8888 = Google DNS.)
+        let ips = vec![ip("2001:4860:4860::8888")];
+        check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .expect("public IPv6 must be accepted");
+    }
+
+    #[test]
+    fn check_resolved_ips_ipv6_loopback_rejected() {
+        let ips = vec![ip("::1")];
+        let err = check_resolved_ips_for_image_gen("cdn.fal.ai", &[], &ips)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-global") || err.contains("::1"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/zeroclaw-tools/src/image_gen.rs
+++ b/crates/zeroclaw-tools/src/image_gen.rs
@@ -1,11 +1,14 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::json;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use zeroclaw_api::tool::{Tool, ToolResult, with_ephemeral_workspace_warning};
 use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::policy::ToolOperation;
+
+use crate::helpers::domain_guard;
 
 /// Resolve the output filename stem (no extension) for a generated image.
 ///
@@ -57,6 +60,12 @@ pub struct ImageGenTool {
     workspace_dir: PathBuf,
     default_model: String,
     api_key_env: String,
+    /// Normalized host allowlist (entries from `ImageGenConfig::allowed_private_hosts`).
+    /// Empty by default. A bare `"*"` blanket-tolerates any private/local host;
+    /// otherwise each entry is a host or suffix checked against the image-download
+    /// host. Mirrors the same field on `[file_download]`, `[http_request]`,
+    /// `[web_fetch]`, and the browser tools.
+    allowed_private_hosts: Vec<String>,
     /// Whether the saved image persists on the host filesystem. `false` on an
     /// ephemeral runtime (Docker tmpfs / no volume mount), where the PNG is
     /// written inside the container but invisible on the host and discarded at
@@ -78,6 +87,7 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
+            allowed_private_hosts: Vec::new(),
             persistent_writes: true,
         }
     }
@@ -97,8 +107,116 @@ impl ImageGenTool {
             workspace_dir,
             default_model,
             api_key_env,
+            allowed_private_hosts: Vec::new(),
             persistent_writes,
         }
+    }
+
+    /// Construct with the full config (including `allowed_private_hosts`).
+    /// The host allowlist is normalized via `domain_guard::normalize_allowed_domains`
+    /// at construction time so per-request validation is a constant-time
+    /// allowlist match (no per-call parsing).
+    pub fn new_with_config(
+        security: Arc<SecurityPolicy>,
+        workspace_dir: PathBuf,
+        default_model: String,
+        api_key_env: String,
+        persistent_writes: bool,
+        allowed_private_hosts: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let normalized = domain_guard::normalize_allowed_domains(
+            allowed_private_hosts,
+            "image_gen.allowed_private_hosts",
+        )?;
+        Ok(Self {
+            security,
+            workspace_dir,
+            default_model,
+            api_key_env,
+            allowed_private_hosts: normalized,
+            persistent_writes,
+        })
+    }
+
+    /// Validate the URL of an image to be downloaded from a (server-supplied)
+    /// fal.ai response. Mirrors `http_request::validate_url_policy` but for
+    /// the image-download stage: no `allowed_domains` (we trust fal.ai's
+    /// hostname choice), only a private-host gate lifted by
+    /// `allowed_private_hosts`. Always rejects cloud-metadata IP literals
+    /// even if `allowed_private_hosts` would otherwise lift the gate — that
+    /// matches the matrix-textbrower-browser-file_download pattern (see
+    /// `domain_guard::validate_resolved_ips_exclude_metadata`).
+    fn validate_image_url(&self, raw_url: &str) -> anyhow::Result<String> {
+        let url = raw_url.trim();
+        if url.is_empty() {
+            anyhow::bail!("image URL cannot be empty");
+        }
+        if url.chars().any(char::is_whitespace) {
+            anyhow::bail!("image URL cannot contain whitespace");
+        }
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            anyhow::bail!("Only http:// and https:// image URLs are allowed");
+        }
+
+        let parsed = reqwest::Url::parse(url)
+            .map_err(|e| anyhow::Error::msg(format!("Invalid image URL format: {e}")))?;
+
+        // Reject userinfo-bearing URLs at parse time — the same shape used
+        // by the http_request SSRF gate (`http_request.rs` extract_host).
+        // A `user:pass@host` form is never legitimate for an image CDN.
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            anyhow::bail!("image URL userinfo is not allowed");
+        }
+
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| anyhow::Error::msg("image URL has no host"))?
+            .to_string();
+
+        // Cloud-metadata IP literals (169.254.169.254, fd00:ec2::254, etc.)
+        // are rejected unconditionally — never a legitimate image source.
+        if host
+            .parse::<IpAddr>()
+            .is_ok_and(domain_guard::is_cloud_metadata_ip)
+        {
+            anyhow::bail!("Blocked cloud metadata host: {host}");
+        }
+
+        let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
+        let private_match = if host_is_private_or_local {
+            domain_guard::host_matches_allowlist(&host, &self.allowed_private_hosts)
+        } else {
+            false
+        };
+
+        if host_is_private_or_local && !private_match {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"tool": "image_gen", "host": host})),
+                "image_gen: rejecting private/local image host"
+            );
+            anyhow::bail!(
+                "Blocked local/private image host: {host}. \
+                 To allow, add it (or \"*\") to image_gen.allowed_private_hosts in config.toml"
+            );
+        }
+
+        // Warn loudly when an explicit carve-out lifts the SSRF gate — same
+        // signal as web_fetch's redirect-path warn, so operators can detect
+        // accidental "trusted internal CDN" misconfigurations in audit.
+        if host_is_private_or_local && private_match {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"tool": "image_gen", "host": host})),
+                "image_gen: allowing private/local image host via allowed_private_hosts"
+            );
+        }
+
+        Ok(url.to_string())
     }
 
     /// Build a reusable HTTP client with reasonable timeouts.
@@ -250,9 +368,48 @@ impl ImageGenTool {
                 anyhow::Error::msg("No image URL in fal.ai response")
             })?;
 
+        // ── Validate image URL against the SSRF gate ──────────────
+        // The image URL is server-supplied by fal.ai (and therefore not
+        // trustable in the same way as the operator-configured fal.run
+        // endpoint above). Validate the host string before any bytes hit
+        // the network. The redirect policy on the download client below
+        // re-validates each redirect target with the same gate — closes
+        // the redirect-to-internal gap that `Policy::default()` would
+        // leave open.
+        let validated_image_url = self.validate_image_url(image_url)?;
+
+        // ── Build image-download client with per-redirect SSRF gate ─
+        // Mirrors `web_fetch.rs:407-426`. The closure captures a clone of
+        // `self.allowed_private_hosts` so the per-redirect check uses the
+        // exact operator-configured allowlist (no re-parse, no IO).
+        let allowed_private_hosts = self.allowed_private_hosts.clone();
+        let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error(std::io::Error::other(
+                    "Too many image-URL redirects (max 10)",
+                ));
+            }
+            if let Err(err) =
+                validate_redirect_image_url(attempt.url().as_str(), &allowed_private_hosts)
+            {
+                return attempt.error(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("Blocked image-URL redirect target: {err}"),
+                ));
+            }
+            attempt.follow()
+        });
+
+        let download_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .redirect(redirect_policy)
+            .build()
+            .unwrap_or_default();
+
         // ── Download image ─────────────────────────────────────────
-        let img_resp = client
-            .get(image_url)
+        let img_resp = download_client
+            .get(&validated_image_url)
             .send()
             .await
             .context("Failed to download generated image")?;
@@ -300,6 +457,57 @@ impl ImageGenTool {
             error: None,
         })
     }
+}
+
+/// Free-function companion to `ImageGenTool::validate_image_url`, used by the
+/// reqwest redirect policy closure (which can't borrow `self`). Performs the
+/// same gate — http(s)-only, no userinfo, no private/local host unless covered
+/// by `allowed_private_hosts`, cloud-metadata IP literals always rejected.
+fn validate_redirect_image_url(
+    raw_url: &str,
+    allowed_private_hosts: &[String],
+) -> anyhow::Result<()> {
+    let url = raw_url.trim();
+    if url.is_empty() {
+        anyhow::bail!("redirect image URL cannot be empty");
+    }
+    if url.chars().any(char::is_whitespace) {
+        anyhow::bail!("redirect image URL cannot contain whitespace");
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        anyhow::bail!("Only http:// and https:// redirect URLs are allowed");
+    }
+
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| anyhow::Error::msg(format!("Invalid redirect image URL format: {e}")))?;
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        anyhow::bail!("redirect image URL userinfo is not allowed");
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| anyhow::Error::msg("redirect image URL has no host"))?
+        .to_string();
+
+    if host
+        .parse::<IpAddr>()
+        .is_ok_and(domain_guard::is_cloud_metadata_ip)
+    {
+        anyhow::bail!("Blocked redirect to cloud metadata host: {host}");
+    }
+
+    let host_is_private_or_local = domain_guard::is_private_or_local_host(&host);
+    let private_match = host_is_private_or_local
+        && domain_guard::host_matches_allowlist(&host, allowed_private_hosts);
+
+    if host_is_private_or_local && !private_match {
+        anyhow::bail!(
+            "Blocked redirect to local/private host: {host}. \
+             To allow, add it (or \"*\") to image_gen.allowed_private_hosts in config.toml"
+        );
+    }
+
+    Ok(())
 }
 
 #[async_trait]
@@ -628,5 +836,164 @@ mod tests {
         assert_eq!(result.unwrap(), "test_value_123");
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("ZC_IMAGE_GEN_TEST_KEY") };
+    }
+
+    // ── SSRF gate tests for the image-download stage ──────────────
+    //
+    // These exercise `ImageGenTool::validate_image_url` and the free-function
+    // companion `validate_redirect_image_url` directly. Hermetic — no
+    // network, no reqwest, no `fal.run` POST. A regression that drops the
+    // SSRF gate (or relaxes the private-host check) would surface here.
+
+    fn test_tool_with_private_hosts(allowed_private_hosts: Vec<&str>) -> ImageGenTool {
+        ImageGenTool::new_with_config(
+            test_security(),
+            std::env::temp_dir(),
+            "fal-ai/flux/schnell".into(),
+            "FAL_API_KEY".into(),
+            true,
+            allowed_private_hosts
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        )
+        .expect("test tool construction should succeed")
+    }
+
+    #[test]
+    fn validate_image_url_rejects_empty() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool.validate_image_url("").unwrap_err().to_string();
+        assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_whitespace() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("http://example .com/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("whitespace"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_non_http_scheme() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("ftp://example.com/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("http://"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_userinfo() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("https://attacker:pwn@cdn.example.com/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("userinfo"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_localhost() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("http://localhost/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_private_ipv4() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let err = tool
+            .validate_image_url("http://10.0.0.5/x.png")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_rejects_cloud_metadata_ipv4() {
+        // Even with `allowed_private_hosts = ["*"]`, cloud-metadata IPs
+        // must still be rejected — the gate is unconditional for the
+        // metadata service.
+        let wildcard = test_tool_with_private_hosts(vec!["*"]);
+        let err = wildcard
+            .validate_image_url("http://169.254.169.254/latest/meta-data/")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_image_url_accepts_public_https() {
+        let tool = test_tool_with_private_hosts(vec![]);
+        let url = tool
+            .validate_image_url("https://cdn.fal.ai/files/abc123.png")
+            .expect("public HTTPS host must be accepted");
+        assert_eq!(url, "https://cdn.fal.ai/files/abc123.png");
+    }
+
+    #[test]
+    fn validate_image_url_accepts_allowed_private_host_explicit() {
+        // Operator opted-in to a specific internal CDN via the allowlist.
+        let tool = test_tool_with_private_hosts(vec!["cdn.internal.example"]);
+        let url = tool
+            .validate_image_url("https://cdn.internal.example/x.png")
+            .expect("explicit allowed_private_hosts entry must lift the block");
+        assert_eq!(url, "https://cdn.internal.example/x.png");
+    }
+
+    #[test]
+    fn validate_image_url_accepts_allowed_private_host_wildcard() {
+        // `*` blanket-tolerates any private/local host (dev/CI use case).
+        let tool = test_tool_with_private_hosts(vec!["*"]);
+        let url = tool
+            .validate_image_url("http://localhost:8080/x.png")
+            .expect("wildcard allowed_private_hosts must lift the block");
+        assert_eq!(url, "http://localhost:8080/x.png");
+    }
+
+    // ── Redirect-gate tests ───────────────────────────────────────
+    //
+    // The reqwest `Policy::custom` closure that re-validates each redirect
+    // target uses `validate_redirect_image_url` (free function) — these tests
+    // pin the redirect-path contract directly.
+
+    #[test]
+    fn validate_redirect_image_url_rejects_localhost() {
+        let allowed = vec!["cdn.internal.example".to_string()];
+        let err = validate_redirect_image_url("http://localhost/x.png", &allowed)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_redirect_image_url_rejects_cloud_metadata() {
+        let allowed = vec!["*".to_string()];
+        let err = validate_redirect_image_url("http://169.254.169.254/latest/meta-data/", &allowed)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_redirect_image_url_accepts_public_https() {
+        let allowed: Vec<String> = vec![];
+        validate_redirect_image_url("https://cdn.fal.ai/files/abc.png", &allowed)
+            .expect("public HTTPS host must be accepted by redirect gate");
+    }
+
+    #[test]
+    fn validate_redirect_image_url_accepts_allowed_private_host() {
+        let allowed = vec!["cdn.internal.example".to_string()];
+        validate_redirect_image_url("https://cdn.internal.example/x.png", &allowed)
+            .expect("allowed_private_hosts must lift the redirect gate");
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `fix/image-gen-ssrf` (stacked on PR #8826)
- **What changed and why:** The image_gen SSRF gate shipped in #8826 (layers 1+2) explicitly deferred layer 3 (resolved-IP DNS rebinding check) across the SSRF trilogy. This PR closes the gap for image_gen by adding an async DNS resolution step that validates every resolved IP against the same private/metadata policy as the literal-host check.
- **What it catches:** A poisoned-DNS rebinding where the host string looks public (`cdn.fal.ai`) but the resolved IP is `10.0.0.5` or `169.254.169.254`. The literal-host check at `validate_image_url` cannot catch this — only the resolved-IP check can. Also catches an allowlist-lifted host whose DNS is poisoned to point at the cloud-metadata service (the `*` allowlist covers private/loopback, not metadata).
- **Stacked-PR rationale:** `git diff fix/image-gen-ssrf..fix/image-gen-ssrf-layer3 --stat` shows only the layer-3 additions (the literal-host and redirect-host gates from #8826 are the base, not a re-application). After #8826 merges, this PR becomes a single-commit fast-forward onto master.
- **Linked:** Discovered during security audit pass 5 (2026-07-08) on upstream/master @ `502820949`. Closes the layer-3 deferral documented in `[[zeroclaw-ssrf-trilogy-gate-layers-2026-07-04]]`.

## Label Snapshot

- **Live labels:** `bug`, `config`, `runtime`, `tool`, `needs-author-action`, `risk:high`, `size:L`
- **Milestone:** `v0.9.0`

## Changes

### `crates/zeroclaw-tools/src/image_gen.rs` (+277/-0)

- **New free function** `check_resolved_ips_for_image_gen(host, allowed_private_hosts, ips) -> anyhow::Result<()>` — the layer-3 gate as a pure function over `(host, allowlist, IPs)`. Branches on `host_matches_allowlist` (not on `is_private_or_local_host`, which is a literal-string classifier and would miss names like `cdn.internal.example` — exactly the DNS-rebinding case we want to catch by IP). When lifted by allowlist, uses `validate_resolved_ips_exclude_metadata` (blocks metadata, allows private). Otherwise, uses `validate_resolved_ips_are_public` (every IP must be globally routable).
- **New method** `ImageGenTool::validate_resolved_ips_for_image_url(url)` — production wrapper. Parses the URL, skips DNS for IP-literal hosts (the literal-host check at `validate_image_url` already classified them), and calls `tokio::net::lookup_host((host, port))` + `check_resolved_ips_for_image_gen`. Emits a structured `WARN` log on DNS failure with `tool=image_gen, host=<host>, error=<reason>`.
- **Wired into download stage** at `generate()`: `validate_resolved_ips_for_image_url(&validated_image_url).await?` fires immediately after `validate_image_url` passes, before any bytes hit the network. Mirrors the http_request pattern at `http_request.rs:622-185` and `web_fetch.rs:702-723`.
- **12 new hermetic tests** (no network, no real DNS, no reqwest):
  - `check_resolved_ips_public_hostname_public_ip_accepted`
  - `check_resolved_ips_public_hostname_private_ip_rejected` (the canonical DNS-rebinding case)
  - `check_resolved_ips_public_hostname_loopback_ip_rejected`
  - `check_resolved_ips_public_hostname_metadata_ip_rejected` (IMDS-rebinding case)
  - `check_resolved_ips_public_hostname_mixed_ips_rejected` (multi-IP poisoning)
  - `check_resolved_ips_empty_list_rejected` (NXDOMAIN / SERVFAIL)
  - `check_resolved_ips_allowlisted_hostname_private_ip_accepted`
  - `check_resolved_ips_allowlisted_hostname_metadata_ip_rejected` (`*` does not lift the metadata block)
  - `check_resolved_ips_wildcard_allowlist_blocks_metadata_rejects_metadata`
  - `check_resolved_ips_allowlisted_hostname_non_allowlisted_rejected` (defense-in-depth re-application)
  - `check_resolved_ips_ipv6_public_accepted`
  - `check_resolved_ips_ipv6_loopback_rejected`

## Validation Evidence

Local validation on the fix commit:

```text
$ cargo fmt -p zeroclaw-tools -- --check
  (clean)

$ cargo clippy -p zeroclaw-tools --all-targets -- -D warnings
  (clean — 0 warnings)

$ cargo check -p zeroclaw-runtime --all-targets
  (clean)

$ cargo test -p zeroclaw-tools --lib -- 'image_gen::tests'
  running 42 tests
  ... (15 pre-existing image_gen tests, all unchanged, all passing)
  ... (15 layer-1/2 tests from #8826, all unchanged, all passing)
  test image_gen::tests::check_resolved_ips_public_hostname_public_ip_accepted ... ok                              ← new
  test image_gen::tests::check_resolved_ips_public_hostname_private_ip_rejected ... ok                              ← new
  test image_gen::tests::check_resolved_ips_public_hostname_loopback_ip_rejected ... ok                              ← new
  test image_gen::tests::check_resolved_ips_public_hostname_metadata_ip_rejected ... ok                             ← new
  test image_gen::tests::check_resolved_ips_public_hostname_mixed_ips_rejected ... ok                                ← new
  test image_gen::tests::check_resolved_ips_empty_list_rejected ... ok                                                ← new
  test image_gen::tests::check_resolved_ips_allowlisted_hostname_private_ip_accepted ... ok                          ← new
  test image_gen::tests::check_resolved_ips_allowlisted_hostname_metadata_ip_rejected ... ok                         ← new
  test image_gen::tests::check_resolved_ips_wildcard_allowlist_blocks_metadata_rejects_metadata ... ok               ← new
  test image_gen::tests::check_resolved_ips_allowlisted_hostname_non_allowlisted_rejected ... ok                     ← new
  test image_gen::tests::check_resolved_ips_ipv6_public_accepted ... ok                                              ← new
  test image_gen::tests::check_resolved_ips_ipv6_loopback_rejected ... ok                                             ← new
  test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 1473 filtered out
```

- **Beyond CI — what was manually verified:** Class-sweep `rg 'lookup_host|to_socket_addrs|validate_resolved' --type rust crates/zeroclaw-tools/src/` confirms the SSRF gate now has consistent layer-3 coverage across `web_fetch.rs:702-723`, `http_request.rs:622-185`, and `image_gen.rs:validate_resolved_ips_for_image_url`. The `check_resolved_ips_for_image_gen` test suite pins the post-DNS policy in isolation; a future regression that drops the layer-3 call from the download stage surfaces as a hermetic-test failure.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No.** Code path is unchanged — only an additional async DNS lookup before the request fires.
- New external network calls? **Yes — additive.** `tokio::net::lookup_host` performs a DNS query for the image host. This is the canonical SSRF-defense pattern (`web_fetch.rs:702-723`, `http_request.rs:622-185`); the lookup fires before the request bytes are sent, so a poisoned-DNS result still rejects the request without a TCP connect.
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** All test IPs are synthetic (`93.184.216.34`, `10.0.0.5`, `127.0.0.1`, `169.254.169.254`, `2001:4860:4860::8888`, `::1`).

**Positive security impact:** Closes the DNS-rebinding vector where a compromised or attacker-controlled DNS resolver (e.g. via a fal.ai MITM, a corporate DNS poisoning, or a network attacker on the same broadcast domain) returns a private-IP or cloud-metadata-IP for an otherwise-public hostname. Without the gate, reqwest would connect to that IP and write the response bytes to the workspace `images/` directory, where the agent could read them and exfiltrate credentials or pivot to internal services. With the gate, the request is rejected before any bytes hit the network, and no workspace write occurs.

**SSRF trilogy status after this PR:**
1. **Initial URL host** — shipped (#8826, layer 1).
2. **Redirect target host** — shipped (#8826, layer 2).
3. **Resolved IP** — **shipped** (this PR, layer 3 for image_gen).

The trilogy is closed for image_gen. web_fetch (`#8635` companion) and http_request already had layer 3 (`web_fetch.rs:702-723`, `http_request.rs:622-185`). text_browser does not have layer 3 because the URL is passed to lynx/w3m/links as a CLI argument and the text browser does its own fetch — layer 3 would require either a custom fetcher or accepting the gap.

## Compatibility

- Backward compatible? **Yes, modulo the new DNS query.** The fix adds an async DNS lookup before the request. For the canonical case where fal.ai returns a publicly-resolvable hostname on a public CDN (the normal operational case), the lookup returns public IPs and behavior is unchanged. The lookup fires only on hostnames (not IP literals), so the canonical literal-host path is unaffected.
- Config / env / CLI surface changed? **No.** No new fields, no defaults changed. The gate uses the same `allowed_private_hosts` as the literal-host check.
- If yes to either: exact upgrade steps for existing users:

  1. **No action required.** Existing deployments that use the canonical fal.ai public CDN continue to work — every operational fal.ai artifact URL the audit traced resolves to a public IP.
  2. **Optional audit:** Operators can grep `image_gen` audit logs for the new `WARN` event `image_gen: DNS resolution failed for image host` after rollout — a non-zero count indicates either a fal.ai response pointing to a poisoned-DNS-resolved private IP, or transient DNS issues. The new `WARN` event `image_gen: rejecting private/local image host` from #8826 (literal-host layer 1) continues to fire for non-DNS-rebinding private hosts.
  3. **If you proxy fal.ai artifacts through an internal CDN:** the existing `[image_gen] allowed_private_hosts = ["cdn.internal.example", ...]` config (documented in #8826) continues to work — the layer-3 gate applies the same allowlist to the resolved-IP check.

No data migration, no schema migration, no version bump.

## Rollback

- **Fast rollback command/path:** `git revert <this-commit-sha>`. Single-commit revert; restores the layer-3 absence. The layer-1+2 gate from #8826 is unaffected by the revert.
- **Feature flags or config toggles:** None at runtime.
- **Observable failure symptoms:** If a future regression drops the `validate_resolved_ips_for_image_url` call from the download stage, the 12 new hermetic tests fail at CI:
  - `check_resolved_ips_public_hostname_private_ip_rejected` rejects `cdn.fal.ai` → `10.0.0.5`
  - `check_resolved_ips_public_hostname_metadata_ip_rejected` rejects `cdn.fal.ai` → `169.254.169.254`
  - `check_resolved_ips_empty_list_rejected` rejects an unresolvable host
  - `check_resolved_ips_allowlisted_hostname_metadata_ip_rejected` rejects a metadata IP even with `*` allowlist

  Operators monitoring for the DNS-rebinding signal can grep `image_gen` audit logs for `image_gen: DNS resolution failed for image host` or for `non-global address` / `cloud metadata address` in error messages after rollout.

## Related

- Canonical async-DNS pattern: `crates/zeroclaw-tools/src/http_request.rs:622-185` (`resolve_host_for_request` + `validate_resolved_ips_for_ssrf`)
- Canonical sync-DNS pattern: `crates/zeroclaw-tools/src/web_fetch.rs:702-723` (`validate_resolved_host_is_public` via `to_socket_addrs`)
- Layer 1+2 from PR #8826: literal-host check + per-redirect host check
- Layer 3 deferral memory: `[[zeroclaw-ssrf-trilogy-gate-layers-2026-07-04]]` — this PR closes the layer-3 gap for image_gen
- Discovered during security audit pass 5 (2026-07-08) on upstream/master @ `502820949`

## Security audit pass 5 — findings index

This PR is finding 2/3 (layer 3 extension) from the 2026-07-08 audit pass. The full set:

1. **#8824 — `nodes.auth_token` constant-time comparison** (PR ready, separate PR). MEDIUM. Closes a remote timing attack on the operator-configured WebSocket auth token for `/ws/nodes`.
2. **#8826 + this PR — `image_gen` SSRF gate (layers 1+2 then layer 3)** (PRs ready, stacked). MEDIUM. Closes a server-supplied-URL SSRF plus the DNS-rebinding vector in the image-download stage.
3. **`notion_tool` URL-encoding** (LOW, deferred) — Notion service-side normalizes malformed IDs to errors rather than SSRF; audit log cosmetic only. Held as a follow-up.
