### PR TITLE
fix(channels): route startup tool assembly through the scoped seam

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -119,10 +119,9 @@ use zeroclaw_providers::reliable::{scope_provider_fallback, take_last_provider_f
 use zeroclaw_providers::{self, ChatMessage, ModelProvider, ProviderDispatch};
 use zeroclaw_runtime::agent::loop_::{
     LoopKnobs, ResolvedAgentExecution, ResolvedIo, ResolvedModelAccess, ResolvedRuntimeKnobs,
-    ToolLoop, apply_policy_tool_filter, apply_text_tool_prompt_policy,
-    build_tool_instructions_for_names, clear_model_switch_request, eager_mcp_tool_allowed,
-    get_model_switch_state, is_model_switch_requested, mcp_tool_access_policy,
-    register_eager_mcp_tool_if_allowed, run_tool_call_loop, scope_session_key, scope_thread_id,
+    ToolLoop, append_pinned_mcp_section, apply_text_tool_prompt_policy,
+    build_tool_instructions_for_names, clear_model_switch_request, get_model_switch_state,
+    is_model_switch_requested, run_tool_call_loop, scope_session_key, scope_thread_id,
     scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
@@ -9666,6 +9665,142 @@ fn build_owner_by_channel_key(
     owner_by_channel_key
 }
 
+/// The per-agent tool registry, prompt sections, and channel/deferred-MCP handles
+/// `start_channels` needs from [`assemble_channel_agent_tools`].
+struct ChannelAssembledTools {
+    tools: Vec<Box<dyn Tool>>,
+    deferred_section: String,
+    pinned_section: String,
+    ask_user_handle: Option<tools::PerToolChannelHandle>,
+    reaction_handle: tools::PerToolChannelHandle,
+    poll_handle: Option<tools::PerToolChannelHandle>,
+    escalate_handle: Option<tools::PerToolChannelHandle>,
+    channel_room_handle: Option<tools::PerToolChannelHandle>,
+    activated_handle: Option<Arc<std::sync::Mutex<tools::ActivatedToolSet>>>,
+}
+
+/// Route a channel agent's tool registry through the one gated seam
+/// (`ScopedToolRegistry::assemble`) - the same seam `run()`/`process_message()`/
+/// `Agent::from_config` use. Extracted from `start_channels` so the channel path's
+/// specific assembly knobs (below) are exercised directly by a unit test instead of
+/// only indirectly through `start_channels`'s much larger, harder-to-isolate flow.
+///
+/// Replaces the channel path's former hand-rolled peripheral wiring, built-in
+/// filter, MCP scoping, and skill registration - which had silently diverged from
+/// every other construction path in two ways this cutover closes: MCP
+/// resource/prompt capability tools and pinned MCP resources
+/// (`docs/book/src/tools/mcp.md` "Pinning resources into context", a documented
+/// general agent capability with no channel-specific exception) were never wired
+/// into the channel path at all.
+///
+/// - `connect_peripherals: true` - channel-driven sessions actuate hardware,
+///   mirroring the old unconditional `load_peripheral_tools` call.
+/// - `runtime` - the orchestrator's REAL configured `RuntimeAdapter`, threaded
+///   through skill execution. The old `register_skill_tools_with_context` call
+///   defaulted to `NativeRuntime` regardless of `[platform]`.
+/// - `connect_mcp: true`, `exclude_memory: false`, `caller_allowed: None` - match
+///   the channel path's pre-cutover behavior exactly (no allowlist narrowing beyond
+///   the agent's own policy; memory tools kept; MCP connected whenever
+///   `config.mcp.enabled`).
+///
+/// Test coverage: the `assemble_channel_agent_tools_*` tests below drive this
+/// function directly. They pin `exclude_memory: false` (memory tools survive),
+/// the built-in allow/deny and runtime-threading behavior, and -- via a mock MCP
+/// server granting a pinned resource -- that `connect_mcp: true` resolves MCP
+/// content into a `pinned_section` kept separate from the deferred tool-search
+/// listing. `connect_peripherals: true` is still only exercised as a literal
+/// value: `load_peripheral_tools` reads a process-global `OnceLock` that stays
+/// empty outside the real daemon binary, so peripheral-tool inclusion cannot be
+/// unit-tested here and a regression flipping that knob to `false` would still
+/// pass. Closing it needs a daemon-level peripheral harness; tracked as a
+/// residual, not silently skipped.
+async fn assemble_channel_agent_tools(
+    config: &Config,
+    agent_alias: &str,
+    security: &Arc<SecurityPolicy>,
+    built: tools::AllToolsResult,
+    skills: &[zeroclaw_runtime::skills::Skill],
+    runtime: Arc<dyn platform::RuntimeAdapter>,
+) -> ChannelAssembledTools {
+    let assembled = zeroclaw_runtime::tools::scoped::ScopedToolRegistry::assemble(
+        zeroclaw_runtime::tools::scoped::ScopedAssembly {
+            config,
+            agent_alias,
+            security,
+            built,
+            skills,
+            runtime,
+            caller_allowed: None,
+            connect_mcp: true,
+            connect_peripherals: true,
+            exclude_memory: false,
+            // Channel startup is an execution surface (the agent actually runs),
+            // so deferral behaves as normal; the dashboard-only per-spec listing
+            // is off, matching `run`/`process_message`.
+            list_deferred_mcp_specs: false,
+            emit_assembly_logs: true,
+        },
+    )
+    .await;
+    let deferred_section = assembled.deferred_section().to_string();
+    let pinned_section = assembled.pinned_section().to_string();
+    let zeroclaw_runtime::tools::scoped::ScopedAssembled {
+        registry,
+        // `assemble` threads the target's own `delegate_handle` into eager MCP
+        // registration internally (mirroring `run`/`process_message`, which also
+        // discard it here) - the channel path never separately needed it after
+        // that internal registration completes.
+        delegate_handle: _,
+        ask_user_handle,
+        reaction_handle,
+        poll_handle,
+        escalate_handle,
+        channel_room_handle,
+        activated_handle,
+        ..
+    } = assembled;
+    ChannelAssembledTools {
+        tools: registry.into_inner(),
+        deferred_section,
+        pinned_section,
+        ask_user_handle,
+        reaction_handle,
+        poll_handle,
+        escalate_handle,
+        channel_room_handle,
+        activated_handle,
+    }
+}
+
+/// Compose a channel agent's post-assembly MCP prompt sections in the order the
+/// system prompt requires: apply the strict text-tool suppression policy to ONLY
+/// the deferred/tool-search section, then append the pinned MCP resource section
+/// afterward. This keeps the two concerns separate so that a strict, non-native
+/// target (which clears the deferred tool-search listing) still starts with its
+/// granted pinned MCP resources intact. Returns whether the text-tool protocol
+/// should be exposed.
+///
+/// Single-sourced on purpose: `start_channels` and its regression test both call
+/// this exact step, so a future edit that reorders the policy/append pair (or
+/// applies suppression to a combined section) fails the test instead of silently
+/// dropping pinned resources.
+fn compose_channel_mcp_prompt_sections(
+    native_tools: bool,
+    strict_tool_parsing: bool,
+    tool_descs: &mut Vec<(&str, &str)>,
+    deferred_section: &mut String,
+    pinned_section: &str,
+) -> bool {
+    let expose_text_tool_protocol = apply_text_tool_prompt_policy(
+        native_tools,
+        strict_tool_parsing,
+        tool_descs,
+        deferred_section,
+    );
+    append_pinned_mcp_section(deferred_section, pinned_section);
+    expose_text_tool_protocol
+}
+
 /// Start all configured channels and route messages to the agent
 #[allow(clippy::too_many_lines)]
 pub async fn start_channels(
@@ -9866,198 +10001,29 @@ pub async fn start_channels(
             sop_audit.clone(),
             Some(Arc::clone(&config_arc)),
         );
-        let mut built_tools = all_tools_result_ch.tools;
-        let delegate_handle_ch = all_tools_result_ch.delegate_handle;
-
-        let peripheral_tools =
-            zeroclaw_runtime::agent::loop_::load_peripheral_tools(config.peripherals.clone()).await;
-        if !peripheral_tools.is_empty() {
-            ::zeroclaw_log::record!(
-                INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_attrs(::serde_json::json!({"count": peripheral_tools.len()})),
-                "Peripheral tools added (channels orchestrator)"
-            );
-            built_tools.extend(peripheral_tools);
-        }
-        let reaction_handle_ch = all_tools_result_ch.reaction_handle;
-        let ask_user_handle_ch = all_tools_result_ch.ask_user_handle;
-        let channel_room_handle_ch = all_tools_result_ch.channel_room_handle;
-        let poll_handle_ch = all_tools_result_ch.poll_handle;
-        let escalate_handle_ch = all_tools_result_ch.escalate_handle;
-
-        let before_policy_filter_ch = built_tools.len();
-        apply_policy_tool_filter(&mut built_tools, Some(security.as_ref()), None);
-        if built_tools.len() != before_policy_filter_ch {
-            ::zeroclaw_log::record!(
-                INFO,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_attrs(::serde_json::json!({
-                        "agent": agent_alias,
-                        "before": before_policy_filter_ch,
-                        "retained": built_tools.len(),
-                        "policy_allowed": security.allowed_tools.as_ref().map(|v| v.len()),
-                        "policy_excluded": security.excluded_tools.as_ref().map(|v| v.len()),
-                    })),
-                "Applied SecurityPolicy built-in tool filter (channel path)"
-            );
-        }
-
-        // Wire MCP tools into the per-agent registry before freezing —
-        // non-fatal. When `mcp.deferred_loading` is enabled, MCP tools are
-        // exposed via a `tool_search` built-in rather than added eagerly.
-        let mut deferred_section = String::new();
-        let mut ch_activated_handle: Option<
-            std::sync::Arc<std::sync::Mutex<zeroclaw_runtime::tools::ActivatedToolSet>>,
-        > = None;
-        // Resolution-only MCP wrappers for skill MCP elevation (kind = "mcp").
-        let mut ch_mcp_elevation_arcs: Vec<std::sync::Arc<dyn zeroclaw_runtime::tools::Tool>> =
-            Vec::new();
-        // Secure by default: an agent is granted only the MCP servers its
-        // `mcp_bundles` name (omission is not a grant). Connecting to the
-        // global server list here would let one agent's servers surface in a
-        // co-resident agent that was never granted them.
-        let agent_mcp_servers = if config.mcp.enabled {
-            config.mcp_servers_for_agent(agent_alias)
-        } else {
-            Vec::new()
-        };
-        if !agent_mcp_servers.is_empty() {
-            use ::zeroclaw_log::Instrument;
-            let mcp_model_provider = agent.model_provider.as_str().to_string();
-            let mcp_model = config
-                .model_provider_for_agent(agent_alias)
-                .and_then(|p| p.model.clone())
-                .unwrap_or_default();
-            let attribution_span = ::zeroclaw_log::attribution_span!(
-                &zeroclaw_runtime::agent::AgentAttribution(agent_alias)
-            );
-            ::zeroclaw_log::scope!(
-                model_provider: mcp_model_provider,
-                model: mcp_model,
-                =>
-                async {
-                    ::zeroclaw_log::record!(
-                        INFO,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-                        &format!(
-                            "Initializing MCP client - {} server(s) granted via mcp_bundles",
-                            agent_mcp_servers.len()
-                        )
-                    );
-                    match zeroclaw_runtime::tools::McpRegistry::connect_all(&agent_mcp_servers).await {
-                        Ok(registry) => {
-                            let registry = std::sync::Arc::new(registry);
-                            ch_mcp_elevation_arcs =
-                                zeroclaw_runtime::tools::collect_mcp_elevation_arcs(&registry).await;
-                            let mcp_policy = mcp_tool_access_policy(security.as_ref(), None);
-                            if config.mcp.deferred_loading {
-                                let deferred_set =
-                                    zeroclaw_runtime::tools::DeferredMcpToolSet::from_registry(
-                                        std::sync::Arc::clone(&registry),
-                                    )
-                                    .await;
-                                ::zeroclaw_log::record!(
-                                    INFO,
-                                    ::zeroclaw_log::Event::new(
-                                        module_path!(),
-                                        ::zeroclaw_log::Action::Note
-                                    ),
-                                    &format!(
-                                        "MCP deferred: {} tool stub(s) from {} server(s)",
-                                        deferred_set.len(),
-                                        registry.server_count()
-                                    )
-                                );
-                                deferred_section =
-                                    zeroclaw_runtime::tools::build_deferred_tools_section_filtered(
-                                        &deferred_set,
-                                        mcp_policy.as_ref(),
-                                    );
-                                let activated = std::sync::Arc::new(std::sync::Mutex::new(
-                                    zeroclaw_runtime::tools::ActivatedToolSet::new(),
-                                ));
-                                ch_activated_handle = Some(std::sync::Arc::clone(&activated));
-                                let mut tool_search =
-                                    zeroclaw_runtime::tools::ToolSearchTool::new(
-                                        deferred_set,
-                                        activated,
-                                    );
-                                if let Some(policy) = mcp_policy {
-                                    tool_search = tool_search.with_access_policy(policy);
-                                }
-                                built_tools.push(Box::new(tool_search));
-                            } else {
-                                let names = registry.tool_names();
-                                let mut registered = 0usize;
-                                let mut skipped = 0usize;
-                                for name in names {
-                                    if !eager_mcp_tool_allowed(&name, mcp_policy.as_ref()) {
-                                        skipped += 1;
-                                        continue;
-                                    }
-                                    if let Some(def) = registry.get_tool_def(&name).await {
-                                        let wrapper: std::sync::Arc<dyn Tool> = std::sync::Arc::new(
-                                            zeroclaw_runtime::tools::McpToolWrapper::new(
-                                                name,
-                                                def,
-                                                std::sync::Arc::clone(&registry),
-                                            ),
-                                        );
-                                        if register_eager_mcp_tool_if_allowed(
-                                            wrapper,
-                                            &mut built_tools,
-                                            delegate_handle_ch.as_ref(),
-                                            mcp_policy.as_ref(),
-                                        ) {
-                                            registered += 1;
-                                        }
-                                    }
-                                }
-                                ::zeroclaw_log::record!(
-                                    INFO,
-                                    ::zeroclaw_log::Event::new(
-                                        module_path!(),
-                                        ::zeroclaw_log::Action::Note
-                                    )
-                                    .with_attrs(::serde_json::json!({
-                                        "skipped": skipped,
-                                    })),
-                                    &format!(
-                                        "MCP: {} tool(s) registered from {} server(s)",
-                                        registered,
-                                        registry.server_count()
-                                    )
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            ::zeroclaw_log::record!(ERROR, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail).with_outcome(::zeroclaw_log::EventOutcome::Failure).with_attrs(::serde_json::json!({"error": format!("{}", e)})), "MCP registry failed to initialize");
-                        }
-                    }
-                }
-            )
-            .instrument(attribution_span)
-            .await;
-        }
-
-        // Skill tools share the workspace-loaded `skills` Vec but each
-        // agent gets its own `ToolBox` so per-agent security policies
-        // gate execution.
-        // Resolution registry = built-in arcs + resolution-only MCP wrappers.
-        let skill_resolution_registry: Vec<std::sync::Arc<dyn zeroclaw_runtime::tools::Tool>> =
-            all_tools_result_ch
-                .unfiltered_tool_arcs
-                .iter()
-                .cloned()
-                .chain(ch_mcp_elevation_arcs.iter().cloned())
-                .collect();
-        zeroclaw_runtime::tools::register_skill_tools_with_context(
-            &mut built_tools,
+        // Route the per-agent tool registry through the one gated seam - see
+        // `assemble_channel_agent_tools` for the knobs and why. `mut` because the
+        // text-tool prompt policy below may clear `deferred_section` for a
+        // non-native strict-tool-parsing target.
+        let ChannelAssembledTools {
+            tools: built_tools,
+            mut deferred_section,
+            pinned_section,
+            ask_user_handle: ask_user_handle_ch,
+            reaction_handle: reaction_handle_ch,
+            poll_handle: poll_handle_ch,
+            escalate_handle: escalate_handle_ch,
+            channel_room_handle: channel_room_handle_ch,
+            activated_handle: ch_activated_handle,
+        } = assemble_channel_agent_tools(
+            &config,
+            agent_alias,
+            &security,
+            all_tools_result_ch,
             &skills,
-            security.clone(),
-            &skill_resolution_registry,
-        );
+            Arc::clone(&runtime),
+        )
+        .await;
 
         let tool_specs: Vec<(String, String)> = built_tools
             .iter()
@@ -10162,11 +10128,12 @@ pub async fn start_channels(
             None
         };
         let native_tools = model_provider.supports_native_tools();
-        let expose_text_tool_protocol = apply_text_tool_prompt_policy(
+        let expose_text_tool_protocol = compose_channel_mcp_prompt_sections(
             native_tools,
             agent.resolved.strict_tool_parsing,
             &mut tool_descs,
             &mut deferred_section,
+            &pinned_section,
         );
         let mut system_prompt = build_system_prompt_with_mode_and_autonomy(
             &workspace,
@@ -11104,12 +11071,16 @@ fn concurrent_persist_lock_serialization() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Production code no longer calls this directly (the ScopedToolRegistry::assemble
+    // seam applies it internally now); two tests below still exercise it directly to
+    // pin the built-in filter's own behavior.
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tempfile::TempDir;
     use zeroclaw_memory::{Memory, MemoryCategory, SqliteMemory};
     use zeroclaw_providers::{ChatMessage, ModelProvider};
+    use zeroclaw_runtime::agent::loop_::apply_policy_tool_filter;
     use zeroclaw_runtime::agent::loop_::build_tool_instructions;
 
     #[test]
@@ -14691,6 +14662,401 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             names.contains(&"file_read"),
             "a non-excluded built-in must survive the filter; got {names:?}"
+        );
+    }
+
+    fn channel_all_tools_result(tools: Vec<Box<dyn Tool>>) -> tools::AllToolsResult {
+        tools::AllToolsResult {
+            tools,
+            delegate_handle: None,
+            ask_user_handle: None,
+            reaction_handle: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            poll_handle: None,
+            escalate_handle: None,
+            channel_room_handle: None,
+            unfiltered_tool_arcs: Vec::new(),
+        }
+    }
+
+    /// A mock HTTP MCP server that advertises `resources` support and serves one
+    /// readable resource (`file:///handbook.md`), so `assemble_channel_agent_tools`
+    /// resolves a real pinned-resource section instead of an empty one.
+    async fn mock_mcp_server_with_pinned_resource() -> wiremock::MockServer {
+        use wiremock::matchers::{body_partial_json, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(
+                serde_json::json!({"method": "initialize"}),
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("Mcp-Session-Id", "s")
+                    .set_body_json(serde_json::json!({
+                        "jsonrpc":"2.0","id":1,
+                        "result":{"capabilities":{"tools":{},"resources":{}}}
+                    })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(
+                serde_json::json!({"method":"notifications/initialized"}),
+            ))
+            .respond_with(ResponseTemplate::new(202))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(
+                serde_json::json!({"method":"tools/list"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc":"2.0","id":2,"result":{"tools":[
+                    {"name":"echo","description":"echo","inputSchema":{"type":"object"}}
+                ]}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(
+                serde_json::json!({"method":"resources/list"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc":"2.0","id":3,"result":{"resources":[
+                    {"uri":"file:///handbook.md","name":"handbook","mimeType":"text/plain"}
+                ]}
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(serde_json::json!({"method":"resources/read"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc":"2.0","id":4,"result":{"contents":[
+                    {"uri":"file:///handbook.md","mimeType":"text/plain","text":"Pinned handbook body"}
+                ]}
+            })))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    /// Drives the REAL `assemble_channel_agent_tools` against a mock MCP server
+    /// granting one pinned resource, then runs the exact post-assembly composition
+    /// `start_channels` performs (`compose_channel_mcp_prompt_sections`). It proves
+    /// the production boundary keeps the deferred tool-search listing and the pinned
+    /// MCP resource in SEPARATE sections, so strict text-tool suppression
+    /// (`native_tools = false`, `strict_tool_parsing = true`) clears the deferred
+    /// tool instructions while the pinned resource survives into the final prompt.
+    /// A regression that re-merges the two sections inside the assembly (or reorders
+    /// the suppress/append pair) fails here, unlike a test that hand-builds the
+    /// section strings and never calls the assembly.
+    #[tokio::test]
+    async fn assemble_channel_agent_tools_keeps_pinned_resources_after_strict_policy() {
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, McpBundleConfig, McpServerConfig, McpTransport, RiskProfileConfig,
+        };
+        let server = mock_mcp_server_with_pinned_resource().await;
+
+        let mut config = Config::default();
+        config.mcp.enabled = true;
+        config.mcp.deferred_loading = true;
+        config.mcp.servers = vec![McpServerConfig {
+            name: "docs".into(),
+            transport: McpTransport::Http,
+            url: Some(server.uri()),
+            pinned_resources: vec!["file:///handbook.md".into()],
+            ..Default::default()
+        }];
+        config.mcp_bundles.insert(
+            "docsbundle".into(),
+            McpBundleConfig {
+                servers: vec!["docs".into()],
+                exclude: Vec::new(),
+            },
+        );
+        config
+            .risk_profiles
+            .insert("test-profile".into(), RiskProfileConfig::default());
+        config.agents.insert(
+            "channel-agent".into(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: "openai.test-provider".into(),
+                risk_profile: "test-profile".into(),
+                mcp_bundles: vec!["docsbundle".into()],
+                ..Default::default()
+            },
+        );
+
+        let security = Arc::new(SecurityPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+        let assembled = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            assemble_channel_agent_tools(
+                &config,
+                "channel-agent",
+                &security,
+                channel_all_tools_result(Vec::new()),
+                &[],
+                Arc::new(platform::NativeRuntime::new()),
+            ),
+        )
+        .await
+        .expect("assemble must not hang");
+
+        // The production assembly must surface the pinned resource in its OWN
+        // section, distinct from the deferred/tool-search listing.
+        assert!(
+            assembled.pinned_section.contains("Pinned handbook body")
+                && assembled
+                    .pinned_section
+                    .contains("trust=\"untrusted-external\""),
+            "assemble_channel_agent_tools must expose the pinned MCP resource in \
+             pinned_section; got {:?}",
+            assembled.pinned_section
+        );
+        assert!(
+            !assembled.deferred_section.contains("Pinned handbook body"),
+            "pinned resource content must NOT be merged into the deferred section; got {:?}",
+            assembled.deferred_section
+        );
+        assert!(
+            assembled.deferred_section.contains("tool_search"),
+            "precondition: a deferred-loading MCP grant must yield a tool_search \
+             section to suppress; got {:?}",
+            assembled.deferred_section
+        );
+
+        // Run the exact composition start_channels performs for a strict,
+        // non-native target: suppress the deferred tool-search section, keep pinned.
+        let mut tool_descs: Vec<(&str, &str)> = vec![("shell", "Run commands")];
+        let mut deferred_section = assembled.deferred_section.clone();
+        let expose_text_protocol = compose_channel_mcp_prompt_sections(
+            false,
+            true,
+            &mut tool_descs,
+            &mut deferred_section,
+            &assembled.pinned_section,
+        );
+
+        assert!(!expose_text_protocol);
+        assert!(
+            !deferred_section.contains("tool_search"),
+            "strict policy must clear the deferred tool-search section; got {deferred_section:?}"
+        );
+        assert!(
+            deferred_section.contains("Pinned handbook body")
+                && deferred_section.contains("## Pinned MCP Resources"),
+            "pinned resource must survive strict suppression; got {deferred_section:?}"
+        );
+    }
+
+    /// The `channel_path_*` tests elsewhere pin the shared filter/registration
+    /// helpers directly, not `start_channels`'s actual assembly call - a bad edit
+    /// to `assemble_channel_agent_tools`'s knobs (flipping `exclude_memory`,
+    /// dropping `connect_mcp`, etc.) would compile and slip past them undetected.
+    /// This test drives the exact function `start_channels` calls, closing that
+    /// gap for the built-in allow/deny behavior. (Pinned-resource resolution
+    /// through this same path is covered by
+    /// `assemble_channel_agent_tools_keeps_pinned_resources_after_strict_policy`;
+    /// `scoped.rs`'s `assemble_grants_no_mcp_to_agent_without_bundles` and siblings
+    /// cover the assembly's own MCP-grant policy.)
+    #[tokio::test]
+    async fn assemble_channel_agent_tools_honors_allowed_and_excluded_tools() {
+        let config = Config::default();
+        let built = channel_all_tools_result(vec![
+            Box::new(NamedMockTool("shell")),
+            Box::new(NamedMockTool("file_write")),
+            Box::new(NamedMockTool("file_read")),
+        ]);
+        let security = Arc::new(SecurityPolicy {
+            allowed_tools: Some(vec!["file_read".to_string()]),
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+        let assembled = assemble_channel_agent_tools(
+            &config,
+            "test-agent",
+            &security,
+            built,
+            &[],
+            Arc::new(platform::NativeRuntime::new()),
+        )
+        .await;
+        let names: Vec<&str> = assembled.tools.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"shell") && !names.contains(&"file_write"),
+            "the real start_channels assembly path must drop non-allowlisted built-ins; got {names:?}"
+        );
+        assert!(
+            names.contains(&"file_read"),
+            "the real start_channels assembly path must keep the allowlisted built-in; got {names:?}"
+        );
+    }
+
+    /// Companion pin for `excluded_tools`, through the same real assembly path.
+    #[tokio::test]
+    async fn assemble_channel_agent_tools_drops_excluded_builtin() {
+        let config = Config::default();
+        let built = channel_all_tools_result(vec![
+            Box::new(NamedMockTool("shell")),
+            Box::new(NamedMockTool("file_read")),
+        ]);
+        let security = Arc::new(SecurityPolicy {
+            excluded_tools: Some(vec!["shell".to_string()]),
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+        let assembled = assemble_channel_agent_tools(
+            &config,
+            "test-agent",
+            &security,
+            built,
+            &[],
+            Arc::new(platform::NativeRuntime::new()),
+        )
+        .await;
+        let names: Vec<&str> = assembled.tools.iter().map(|t| t.name()).collect();
+        assert!(
+            !names.contains(&"shell"),
+            "the real start_channels assembly path must drop the excluded built-in; got {names:?}"
+        );
+        assert!(
+            names.contains(&"file_read"),
+            "the real start_channels assembly path must keep the non-excluded built-in; got {names:?}"
+        );
+    }
+
+    /// Pins the `exclude_memory: false` knob at `assemble_channel_agent_tools`'s
+    /// call site - a regression flipping it to `true` (the ACP-only divergence)
+    /// would silently strip memory tools from every channel agent, undetected by
+    /// the allow/deny-only tests. Feeds one of every canonical memory tool name
+    /// (`zeroclaw_tools::MEMORY_TOOL_NAMES`) through the real assembly path and
+    /// asserts all five survive.
+    #[tokio::test]
+    async fn assemble_channel_agent_tools_keeps_memory_tools() {
+        let config = Config::default();
+        let built = channel_all_tools_result(
+            zeroclaw_tools::MEMORY_TOOL_NAMES
+                .iter()
+                .map(|name| Box::new(NamedMockTool(name)) as Box<dyn Tool>)
+                .collect(),
+        );
+        let security = Arc::new(SecurityPolicy::default());
+        let assembled = assemble_channel_agent_tools(
+            &config,
+            "test-agent",
+            &security,
+            built,
+            &[],
+            Arc::new(platform::NativeRuntime::new()),
+        )
+        .await;
+        let names: Vec<&str> = assembled.tools.iter().map(|t| t.name()).collect();
+        for memory_tool in zeroclaw_tools::MEMORY_TOOL_NAMES {
+            assert!(
+                names.contains(memory_tool),
+                "the channel assembly path (exclude_memory: false) must keep memory tool \
+                 '{memory_tool}'; got {names:?}"
+            );
+        }
+    }
+
+    struct FingerprintRuntime;
+
+    impl platform::RuntimeAdapter for FingerprintRuntime {
+        fn name(&self) -> &str {
+            "fingerprint-test-runtime"
+        }
+        fn has_shell_access(&self) -> bool {
+            true
+        }
+        fn has_filesystem_access(&self) -> bool {
+            true
+        }
+        fn storage_path(&self) -> std::path::PathBuf {
+            std::env::temp_dir()
+        }
+        fn supports_long_running(&self) -> bool {
+            false
+        }
+        fn build_shell_command(
+            &self,
+            _command: &str,
+            _workspace_dir: &std::path::Path,
+        ) -> anyhow::Result<tokio::process::Command> {
+            // Deliberately fails with a distinguishable message instead of spawning a
+            // real process, so executing the resulting skill tool proves THIS runtime
+            // drove construction - not a default/native one, which would instead try
+            // to actually run the command.
+            anyhow::bail!("fingerprint-test-runtime: refusing to spawn a shell command")
+        }
+    }
+
+    /// Pins the fix for a channel-path divergence: `start_channels` previously
+    /// called `register_skill_tools_with_context`, which always defaulted to
+    /// `NativeRuntime` regardless of `[platform]`. `assemble_channel_agent_tools` now
+    /// threads the orchestrator's real `runtime` parameter into skill construction -
+    /// proven here by injecting a runtime whose `build_shell_command` refuses to spawn
+    /// a real process with a distinguishable error; executing the resulting shell-kind
+    /// skill tool surfaces exactly that error, which could only happen if the injected
+    /// runtime (not a default) drove construction.
+    #[tokio::test]
+    async fn assemble_channel_agent_tools_threads_the_given_runtime_to_skill_tools() {
+        let config = Config::default();
+        let built = channel_all_tools_result(Vec::new());
+        let security = Arc::new(SecurityPolicy::default());
+        let skills = vec![zeroclaw_runtime::skills::Skill {
+            name: "probe".into(),
+            description: "d".into(),
+            description_localizations: Default::default(),
+            version: "1.0.0".into(),
+            author: None,
+            tags: vec![],
+            tools: vec![zeroclaw_runtime::skills::SkillTool {
+                name: "run".into(),
+                description: "d".into(),
+                kind: "shell".into(),
+                command: "echo hi".into(),
+                args: HashMap::new(),
+                target: None,
+                locked_args: HashMap::new(),
+                timeout_secs: None,
+            }],
+            prompts: vec![],
+            slash_options: Vec::new(),
+            location: None,
+        }];
+        let assembled = assemble_channel_agent_tools(
+            &config,
+            "test-agent",
+            &security,
+            built,
+            &skills,
+            Arc::new(FingerprintRuntime),
+        )
+        .await;
+        let tool = assembled
+            .tools
+            .iter()
+            .find(|t| t.name() == "probe__run")
+            .expect("skill tool must be registered");
+        let result = tool.execute(serde_json::json!({})).await;
+        let failed_with_fingerprint = match &result {
+            Err(e) => e.to_string().contains("fingerprint-test-runtime"),
+            Ok(r) => {
+                !r.success
+                    && r.error
+                        .as_deref()
+                        .is_some_and(|e| e.contains("fingerprint-test-runtime"))
+            }
+        };
+        assert!(
+            failed_with_fingerprint,
+            "skill tool must execute via the INJECTED runtime, not a default one; got {result:?}"
         );
     }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9749,6 +9749,12 @@ async fn assemble_channel_agent_tools(
                         // is off, matching `run`/`process_message`.
                         list_deferred_mcp_specs: false,
                         emit_assembly_logs: true,
+                        // Channel tools are assembled once at daemon startup and
+                        // retain their registry-backed wrappers for the listener
+                        // lifetime, so there is no per-turn reconnect to avoid here.
+                        // The heartbeat worker remains the only caller that supplies
+                        // a pre-built registry for reuse across repeated assemblies.
+                        mcp_registry: None,
                     },
                 )
                 .await

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9717,30 +9717,46 @@ struct ChannelAssembledTools {
 async fn assemble_channel_agent_tools(
     config: &Config,
     agent_alias: &str,
+    model_provider: &str,
+    model: &str,
     security: &Arc<SecurityPolicy>,
     built: tools::AllToolsResult,
     skills: &[zeroclaw_runtime::skills::Skill],
     runtime: Arc<dyn platform::RuntimeAdapter>,
 ) -> ChannelAssembledTools {
-    let assembled = zeroclaw_runtime::tools::scoped::ScopedToolRegistry::assemble(
-        zeroclaw_runtime::tools::scoped::ScopedAssembly {
-            config,
-            agent_alias,
-            security,
-            built,
-            skills,
-            runtime,
-            caller_allowed: None,
-            connect_mcp: true,
-            connect_peripherals: true,
-            exclude_memory: false,
-            // Channel startup is an execution surface (the agent actually runs),
-            // so deferral behaves as normal; the dashboard-only per-spec listing
-            // is off, matching `run`/`process_message`.
-            list_deferred_mcp_specs: false,
-            emit_assembly_logs: true,
-        },
-    )
+    use zeroclaw_log::Instrument as _;
+
+    let agent_attribution = zeroclaw_runtime::agent::AgentAttribution(agent_alias);
+    let assembled = async {
+        zeroclaw_log::scope!(
+            model_provider: model_provider,
+            model: model,
+            => async {
+                zeroclaw_runtime::tools::scoped::ScopedToolRegistry::assemble(
+                    zeroclaw_runtime::tools::scoped::ScopedAssembly {
+                        config,
+                        agent_alias,
+                        security,
+                        built,
+                        skills,
+                        runtime,
+                        caller_allowed: None,
+                        connect_mcp: true,
+                        connect_peripherals: true,
+                        exclude_memory: false,
+                        // Channel startup is an execution surface (the agent actually runs),
+                        // so deferral behaves as normal; the dashboard-only per-spec listing
+                        // is off, matching `run`/`process_message`.
+                        list_deferred_mcp_specs: false,
+                        emit_assembly_logs: true,
+                    },
+                )
+                .await
+            }
+        )
+        .await
+    }
+    .instrument(zeroclaw_log::attribution_span!(&agent_attribution))
     .await;
     let deferred_section = assembled.deferred_section().to_string();
     let pinned_section = assembled.pinned_section().to_string();
@@ -10018,6 +10034,8 @@ pub async fn start_channels(
         } = assemble_channel_agent_tools(
             &config,
             agent_alias,
+            provider_name.as_str(),
+            model.as_str(),
             &security,
             all_tools_result_ch,
             &skills,
@@ -14798,6 +14816,8 @@ BTC is currently around $65,000 based on latest tool output."#
             assemble_channel_agent_tools(
                 &config,
                 "channel-agent",
+                "openai.test-provider",
+                "gpt-test",
                 &security,
                 channel_all_tools_result(Vec::new()),
                 &[],
@@ -14854,6 +14874,116 @@ BTC is currently around $65,000 based on latest tool output."#
         );
     }
 
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn assemble_channel_agent_tools_attributes_assembly_logs_to_agent_and_model() {
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, McpBundleConfig, McpServerConfig, McpTransport, RiskProfileConfig,
+        };
+
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let server = mock_mcp_server_with_pinned_resource().await;
+        let mut config = Config::default();
+        config.mcp.enabled = true;
+        config.mcp.deferred_loading = true;
+        config.mcp.servers = vec![McpServerConfig {
+            name: "docs".into(),
+            transport: McpTransport::Http,
+            url: Some(server.uri()),
+            pinned_resources: vec!["file:///handbook.md".into()],
+            ..Default::default()
+        }];
+        config.mcp_bundles.insert(
+            "docsbundle".into(),
+            McpBundleConfig {
+                servers: vec!["docs".into()],
+                exclude: Vec::new(),
+            },
+        );
+        config
+            .risk_profiles
+            .insert("test-profile".into(), RiskProfileConfig::default());
+        config.agents.insert(
+            "channel-agent".into(),
+            AliasedAgentConfig {
+                enabled: true,
+                model_provider: "openai.test-provider".into(),
+                risk_profile: "test-profile".into(),
+                mcp_bundles: vec!["docsbundle".into()],
+                ..Default::default()
+            },
+        );
+
+        let security = Arc::new(SecurityPolicy {
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+        let _assembled = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            assemble_channel_agent_tools(
+                &config,
+                "channel-agent",
+                "openai.test-provider",
+                "gpt-test",
+                &security,
+                channel_all_tools_result(Vec::new()),
+                &[],
+                Arc::new(platform::NativeRuntime::new()),
+            ),
+        )
+        .await
+        .expect("assemble must not hang");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut assembly_event = None;
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await {
+                Ok(Ok(value)) => {
+                    if value
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|m| m.starts_with("Initializing MCP client"))
+                    {
+                        assembly_event = Some(value);
+                        break;
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                Err(_) => {}
+            }
+        }
+
+        let value = assembly_event.expect("assembly log should be emitted");
+        assert_eq!(
+            value["zeroclaw"]["agent_alias"], "channel-agent",
+            "assembly log must inherit the channel agent attribution span, got: {value}"
+        );
+        assert_eq!(
+            value["zeroclaw"]["model_provider"], "openai.test-provider",
+            "assembly log must preserve the startup model_provider scope, got: {value}"
+        );
+        assert_eq!(
+            value["zeroclaw"]["model_provider_type"], "openai",
+            "assembly log must split the scoped provider family, got: {value}"
+        );
+        assert_eq!(
+            value["zeroclaw"]["model_provider_alias"], "test-provider",
+            "assembly log must split the scoped provider alias, got: {value}"
+        );
+        assert_eq!(
+            value["zeroclaw"]["model"], "gpt-test",
+            "assembly log must preserve the startup model scope, got: {value}"
+        );
+
+        zeroclaw_log::clear_broadcast_hook();
+    }
+
     /// The `channel_path_*` tests elsewhere pin the shared filter/registration
     /// helpers directly, not `start_channels`'s actual assembly call - a bad edit
     /// to `assemble_channel_agent_tools`'s knobs (flipping `exclude_memory`,
@@ -14880,6 +15010,8 @@ BTC is currently around $65,000 based on latest tool output."#
         let assembled = assemble_channel_agent_tools(
             &config,
             "test-agent",
+            "test-provider",
+            "test-model",
             &security,
             built,
             &[],
@@ -14913,6 +15045,8 @@ BTC is currently around $65,000 based on latest tool output."#
         let assembled = assemble_channel_agent_tools(
             &config,
             "test-agent",
+            "test-provider",
+            "test-model",
             &security,
             built,
             &[],
@@ -14949,6 +15083,8 @@ BTC is currently around $65,000 based on latest tool output."#
         let assembled = assemble_channel_agent_tools(
             &config,
             "test-agent",
+            "test-provider",
+            "test-model",
             &security,
             built,
             &[],
@@ -15033,6 +15169,8 @@ BTC is currently around $65,000 based on latest tool output."#
         let assembled = assemble_channel_agent_tools(
             &config,
             "test-agent",
+            "test-provider",
+            "test-model",
             &security,
             built,
             &skills,

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -302,7 +302,15 @@ pub(crate) fn mcp_allowed_tool_count<'a>(
         .count()
 }
 
-pub(crate) fn append_pinned_mcp_section(deferred_section: &mut String, pinned_section: &str) {
+/// Append a pre-rendered pinned-MCP-resources section onto the system-prompt
+/// MCP accumulator (`deferred_section`).
+///
+/// This MUST be called *after* the `deferred_loading` branch, which reassigns
+/// `deferred_section` with `=` (via `build_deferred_tools_section_filtered`)
+/// and would otherwise clobber any earlier-pushed pinned content. Centralizing
+/// the append keeps both `run()` and `process_message()` consistent and pins
+/// the ordering invariant in one testable place. No-op for an empty section.
+pub fn append_pinned_mcp_section(deferred_section: &mut String, pinned_section: &str) {
     if pinned_section.is_empty() {
         return;
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions; refreshed onto current `master`)
- **What changed and why:**
  - Route `start_channels` through `ScopedToolRegistry::assemble`, removing the last hand-rolled channel tool-assembly path and keeping built-in, MCP, skill, memory, and peripheral policy at the canonical scoped seam.
  - Preserve deferred MCP tool instructions and pinned MCP resources as separate sections so strict non-native parsing can suppress only the text-tool protocol while configured pinned context remains available.
  - Pass the channel daemon's configured `RuntimeAdapter` into skill tools instead of implicitly using `NativeRuntime`, and retain the deferred activation handle used by channel turns.
  - Restore agent, model-provider, and model attribution around the shared assembly boundary so multi-agent startup diagnostics remain identifiable.
  - Explicitly select `mcp_registry: None` for channel startup after the shared contract gained daemon heartbeat registry reuse: channel tools assemble once and retain their registry-backed wrappers for the listener lifetime, unlike the heartbeat worker's repeated assembly loop.
- **Scope boundary:** Does not change channel routing, per-message turn execution, configuration schema, MCP grants, or policy resolution. It only replaces channel startup assembly and composes the resulting MCP prompt sections correctly.
- **Blast radius:** Channel-agent startup and the public visibility of the existing pinned-section append helper. Agents with already-granted MCP servers may now receive the capability tools and pinned resources that the former channel-only assembly path omitted.
- **Linked issue(s):** Related #8812 and the `Agent Loop: Scoped Assembly & History Contract` milestone.
- **Labels:** `agent`, `bug`, `channel`, `runtime`, `channel:core`, `risk:high`, `size:L`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; a live smoke can verify the user-visible parity change beyond the mock-MCP regression.
- **Interface(s) exercised:** `channel`
- **Setup / preconditions:** Configure a channel agent with an admitted MCP bundle whose server advertises resources, set one `pinned_resources` URI, enable deferred MCP loading, and use a strict non-native provider.
- **Steps to run:** Start the channel daemon, send the agent a message that depends on the pinned resource, and inspect structured startup logs plus the response.
- **Expected on this branch (after):** Startup performs the configured `resources/read`; the pinned content remains in context after deferred text-tool suppression; assembly records carry the agent alias, provider reference, and model.
- **Prior behavior on `master` (before):** The channel-only assembly path does not resolve or inject pinned resources or MCP capability tools, and skill tools are built with `NativeRuntime` rather than the configured runtime.

### How I tested

```sh
cargo fmt --all -- --check
# clean

PATH=/Users/hollow/.rustup/toolchains/1.96.1-aarch64-apple-darwin/bin:$PATH \
  CARGO_TARGET_DIR=/private/tmp/zeroclaw-pr-8830-target \
  cargo test -p zeroclaw-channels assemble_channel_agent_tools --lib
# test result: ok. 6 passed; 0 failed; 0 ignored; 1268 filtered out

PATH=/Users/hollow/.rustup/toolchains/1.96.1-aarch64-apple-darwin/bin:$PATH \
  CARGO_TARGET_DIR=/private/tmp/zeroclaw-pr-8830-target \
  cargo test -p zeroclaw-channels --lib
# test result: ok. 1273 passed; 0 failed; 1 ignored

PATH=/Users/hollow/.rustup/toolchains/1.96.1-aarch64-apple-darwin/bin:$PATH \
  CARGO_TARGET_DIR=/private/tmp/zeroclaw-pr-8830-target \
  cargo test -p zeroclaw-runtime append_pinned_mcp_section --lib
# test result: ok. 1 passed; 0 failed; 0 ignored; 3302 filtered out

PATH=/Users/hollow/.rustup/toolchains/1.96.1-aarch64-apple-darwin/bin:$PATH \
  CARGO_TARGET_DIR=/private/tmp/zeroclaw-pr-8830-target \
  cargo clippy -p zeroclaw-channels --lib -- -D warnings
# Finished `dev` profile successfully
```

- **CI checks relied on and why they cover this change:** Fresh `Quality Gate` checks on the pushed exact head cover formatting, workspace lint/build/test, security, feature combinations, Linux, macOS, Windows, 32-bit, Nix, and benchmark compilation.
- **Known CI coverage gap, if any:** No daemon-level peripheral harness exists. `connect_peripherals: true` is preserved at the production call site, but the process-global peripheral loader is empty in library tests.
- **Commands run and tail output:** Included above.
- **Beyond CI, what did you manually verify?** Audited the exact integrated diff against the scoped-assembly, channel startup, MCP prompt, attribution, runtime-adapter, and policy contracts. The mock MCP test drives real initialize, tool-list, resource-list, and resource-read requests and proves pinned untrusted content survives strict deferred-tool suppression. I did not run a live external MCP server, physical peripheral, or messaging-channel smoke.
- **If any command was intentionally skipped, why:** Local all-target Clippy was not used as the acceptance signal because current `master` emits unrelated macOS test-only unused-import warnings in `login_probe.rs` and `login_relink.rs`; the changed library target passes with warnings denied, and fresh hosted required CI is required before approval.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes.** Channel agents now receive MCP resource/prompt capability tools and pinned context that their existing MCP grants already authorize but the duplicated startup path omitted. The same scoped security policy and per-agent MCP bundle remain the source of truth; no new grant is created.
- New external network calls? **Yes.** At startup, an admitted MCP server with configured pinned resources receives one `resources/read` request per pinned URI, matching the other agent execution paths. Destinations remain limited to servers already granted to that agent.
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **Yes.** Granted pinned MCP resource bodies now reach channel-agent context as intended and are marked `trust="untrusted-external"`; admission remains bounded by configured MCP bundles and the existing MCP access policy.
- If any `Yes`, describe the risk and mitigation: The effective behavior expands only within already-configured MCP grants. Policy gating, per-agent server scoping, untrusted-content marking, focused mock-MCP coverage, and a high-risk classification mitigate the change.

## Compatibility (required)

- Backward compatible? **Yes.** No surface or schema changes; the observable delta corrects channel behavior for operators who already opted into MCP capability tools or pinned resources.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's merge commit. No data or schema migration is involved.
- **Feature flags or config toggles:** None. As an operational mitigation, remove the affected agent's MCP bundle or pinned-resource entries before restarting channels.
- **Observable failure symptoms:** Channel startup failures or missing tools/context; inspect structured `ScopedToolRegistry` assembly records by `zeroclaw.agent_alias`, `model_provider`, and `model`, especially MCP initialization, policy-filter, capability-registration, and pinned-resource read failures.
