### PR TITLE
fix(config): widen config-set alias auto-materialization past providers.*

### DIFF
--- a/crates/zeroclaw-config/src/traits.rs
+++ b/crates/zeroclaw-config/src/traits.rs
@@ -857,6 +857,15 @@ pub struct MapKeySection {
     /// `#[natural_key]` (legacy whole-array `ObjectArray` round-trip,
     /// no per-element addressing).
     pub natural_key: Option<&'static str>,
+    /// Whether this section's map key is a `#[resource_key]` — a value
+    /// drawn from another domain (a model id, tool name, …) that may
+    /// itself contain dots, rather than a short operator-chosen alias
+    /// validated by `validate_alias_key`. Consumers that split a dotted
+    /// prop path into "map key" + "field name" by first-dot-boundary
+    /// MUST exclude `resource_key` sections: naive splitting corrupts a
+    /// resource key like `gpt-4.1` into a bogus alias `gpt-4` plus a
+    /// nonsense tail `1`.
+    pub resource_key: bool,
 }
 
 /// Serializable wire representation of a config field for API consumers
@@ -1185,5 +1194,55 @@ mod secret_field_tests {
             msg.contains("mcp.servers.foo.headers.Authorization"),
             "error must include field path; got: {msg}"
         );
+    }
+}
+
+#[cfg(test)]
+mod resource_key_tests {
+    // Pins `MapKeySection::resource_key`, the discriminator that
+    // `ensure_map_key_for_prop_path` (in the `zeroclawlabs` binary crate)
+    // filters on: `true` for sections keyed by a value drawn from another
+    // domain (a model id, tool name, …) that may itself contain dots;
+    // `false` for sections keyed by a short operator-chosen alias.
+    use crate::schema::Config;
+
+    fn resource_key_of(path: &str) -> bool {
+        Config::map_key_sections()
+            .into_iter()
+            .find(|section| section.path == path)
+            .unwrap_or_else(|| panic!("no map_key_sections() entry for `{path}`"))
+            .resource_key
+    }
+
+    #[test]
+    fn cost_rate_sections_are_resource_keyed() {
+        for path in [
+            "cost.rates.tools",
+            "cost.rates.providers.models.openai",
+            "cost.rates.providers.tts.openai",
+            "cost.rates.providers.transcription.openai",
+        ] {
+            assert!(
+                resource_key_of(path),
+                "`{path}` prices a resource id (model/voice/tool name), \
+                 so its map key must be marked #[resource_key]"
+            );
+        }
+    }
+
+    #[test]
+    fn alias_keyed_sections_are_not_resource_keyed() {
+        for path in [
+            "risk_profiles",
+            "peer_groups",
+            "channels.telegram",
+            "providers.models.openai",
+        ] {
+            assert!(
+                !resource_key_of(path),
+                "`{path}` is keyed by an operator-chosen alias, not a \
+                 resource id, so it must not be marked #[resource_key]"
+            );
+        }
     }
 }

--- a/crates/zeroclaw-macros/src/lib.rs
+++ b/crates/zeroclaw-macros/src/lib.rs
@@ -779,6 +779,7 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                             // incremental writer needs no natural-key hint
                             // to descend through it.
                             natural_key: None,
+                            resource_key: #is_resource_key,
                         });
                     });
 
@@ -1065,6 +1066,7 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                             // HashMap arm above — the alias IS the TOML
                             // key, no natural-key hint needed.
                             natural_key: None,
+                            resource_key: #is_resource_key,
                         });
                     });
                     let validate_create = if is_resource_key {
@@ -1389,6 +1391,7 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
                         // `ObjectArray` round-trip and don't need
                         // per-element addressing.
                         natural_key: #vec_natural_key_token,
+                        resource_key: #is_resource_key,
                     });
                 });
                 // `create_map_key` on a Vec section. Two flavours:

--- a/src/main.rs
+++ b/src/main.rs
@@ -2485,8 +2485,8 @@ fn map_key_for_prop_path<'a>(section_path: &str, prop_path: &'a str) -> Option<&
 fn ensure_map_key_for_prop_path(config: &mut Config, prop_path: &str) -> Result<bool> {
     let Some((section_path, key)) = Config::map_key_sections()
         .into_iter()
-        .filter(|section| section.path.starts_with("providers."))
         .filter(|section| section.kind == zeroclaw_config::traits::MapKeyKind::Map)
+        .filter(|section| !section.resource_key)
         .filter_map(|section| {
             let key = map_key_for_prop_path(section.path, prop_path)?;
             Some((section.path, key))
@@ -2500,6 +2500,23 @@ fn ensure_map_key_for_prop_path(config: &mut Config, prop_path: &str) -> Result<
         .create_map_key(section_path, key)
         .map_err(anyhow::Error::msg)?;
     if created {
+        // The section matched and the alias was newly materialized, but the
+        // requested prop path might still not resolve (typo'd trailing field
+        // name, or belt-and-suspenders against a resource-key path that
+        // slipped past the `!resource_key` filter above). Roll back rather
+        // than leave a phantom alias, falling through to the normal
+        // "Unknown property" error exactly as before this alias existed.
+        //
+        // IMPORTANT: this probe/rollback must stay strictly inside the
+        // `if created` branch. `create_map_key` returns `Ok(false)` when the
+        // alias already existed (idempotent case) — never run this rollback
+        // when `created == false`, or a bogus tail-field on an
+        // ALREADY-EXISTING alias would delete a legitimate, pre-existing
+        // config entry that has nothing to do with this call.
+        if config.get_prop(prop_path).is_err() {
+            let _ = config.delete_map_key(section_path, key);
+            return Ok(false);
+        }
         config.mark_dirty(&format!("{section_path}.{key}"));
     }
     Ok(created)
@@ -8728,11 +8745,58 @@ mod tests {
             &mut config,
             "cost.rates.providers.models.openai.gpt-4.1.input_per_mtok",
         )
-        .expect("non-provider map paths should be ignored, not rejected");
+        .expect("resource-key map paths should be ignored, not rejected");
 
         assert!(
             !created,
-            "auto-materialization must stay scoped to typed provider aliases"
+            "auto-materialization must stay scoped to alias-keyed sections, excluding #[resource_key] sections"
+        );
+        assert!(
+            config.cost.rates.providers.models.openai.is_empty(),
+            "no bogus model-id key should have been materialized under cost.rates",
+        );
+    }
+
+    #[test]
+    fn ensure_map_key_materializes_non_provider_alias_sections() {
+        for (path, value) in [
+            ("risk_profiles.newprofile.level", "supervised"),
+            ("channels.telegram.main.enabled", "true"),
+            ("channels.telegram.main.bot_token", "tok"),
+            ("peer_groups.pi400_owner.channel", "telegram.main"),
+        ] {
+            let mut config = Config::default();
+            assert!(
+                config.set_prop(path, value).is_err(),
+                "precondition: {path} should be unknown on a fresh config"
+            );
+            let created = ensure_map_key_for_prop_path(&mut config, path)
+                .expect("newly-widened alias sections should materialize");
+            assert!(created, "{path}'s alias should be created");
+            assert!(
+                config.set_prop(path, value).is_ok(),
+                "{path} must be settable after map-key materialization"
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_map_key_rolls_back_alias_on_unknown_tail_field() {
+        let mut config = Config::default();
+        let path = "risk_profiles.newprofile.not_a_real_field";
+
+        let created = ensure_map_key_for_prop_path(&mut config, path)
+            .expect("section resolves; only the tail field is bogus");
+        assert!(
+            !created,
+            "must not report success when the tail field doesn't resolve"
+        );
+        assert!(
+            config
+                .get_map_keys("risk_profiles")
+                .unwrap_or_default()
+                .is_empty(),
+            "the tentatively-created alias must be rolled back, not left dangling",
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2496,9 +2496,19 @@ fn ensure_map_key_for_prop_path(config: &mut Config, prop_path: &str) -> Result<
         return Ok(false);
     };
 
-    let created = config
-        .create_map_key(section_path, key)
-        .map_err(anyhow::Error::msg)?;
+    // Route through the shared `create_map_key_checked` (not raw
+    // `create_map_key`) so this CLI path inherits the reserved `default`
+    // agent guard from the one place it's defined, rather than re-deriving
+    // `section == "agents" && is_reserved_agent_alias(key)` here too. Without
+    // this, widening past `providers.*` would let `config set
+    // agents.default.enabled ...` auto-create the reserved runtime-fallback
+    // agent alias, which the rename guard then refuses to ever rename.
+    let created =
+        match zeroclaw_config::alias_refs::create_map_key_checked(config, section_path, key) {
+            Ok(created) => created,
+            Err(zeroclaw_config::alias_refs::CreateError::Reserved(_)) => return Ok(false),
+            Err(e) => return Err(anyhow::Error::msg(e.to_string())),
+        };
     if created {
         // The section matched and the alias was newly materialized, but the
         // requested prop path might still not resolve (typo'd trailing field
@@ -8778,6 +8788,33 @@ mod tests {
                 "{path} must be settable after map-key materialization"
             );
         }
+    }
+
+    #[test]
+    fn ensure_map_key_for_prop_path_refuses_reserved_default_agent() {
+        let mut config = Config::default();
+
+        let created = ensure_map_key_for_prop_path(&mut config, "agents.default.enabled")
+            .expect("agents is a known map-keyed section; refusal is not an error");
+        assert!(
+            !created,
+            "must refuse to auto-create the reserved `default` agent alias"
+        );
+        assert!(
+            config.agents.is_empty(),
+            "no `agents.default` entry should have been left behind by the refused create"
+        );
+
+        let created = ensure_map_key_for_prop_path(&mut config, "agents.researcher.enabled")
+            .expect("non-reserved agent aliases should still materialize");
+        assert!(
+            created,
+            "agents.<non-default> must still auto-materialize like every other widened section"
+        );
+        assert!(
+            config.agents.contains_key("researcher"),
+            "researcher alias should have been created"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Related #8834.

`config set` could auto-create a new map-key alias for `providers.*`
sections (e.g. `config set providers.models.zai.default.model glm-5.2` auto-creates
the `default` alias), but errored `Unknown property` for every other dynamic-map
section instead of auto-creating the alias — `risk_profiles.*`, `peer_groups.*`,
`channels.telegram.*` and its channel siblings.

```
$ zeroclaw config set risk_profiles.default.level supervised
Error: Unknown property 'risk_profiles.default.level'
$ zeroclaw config set channels.telegram.main.enabled true
Error: Unknown property 'channels.telegram.main.enabled'
```

This is the unfinished half of #6053: #7028 implemented auto-materialization but
deliberately scoped it to `providers.models/tts/transcription.<alias>` only (per
that PR's own description). The underlying machinery
(`Config::map_key_sections()`, `create_map_key`) was already fully generic — it
just needed the right filter, since the real discriminator is whether a section's
map key is operator-chosen (safe to auto-materialize) vs. a `#[resource_key]` (a
value drawn from another domain that may itself contain dots, e.g. a model id like
`gpt-4.1` under `cost.rates.providers.models.<type>` — naive splitting on such a
path would create a bogus alias).

Related but distinct: #8505 (Telegram alias binding at quickstart-time) — different
bug, not touched by this PR.

## Changes

- `crates/zeroclaw-config/src/traits.rs`: added a `resource_key: bool` field to
  `MapKeySection`, so the discriminator is structural rather than string-matched
  against a path prefix.
- `crates/zeroclaw-macros/src/lib.rs`: threaded the already-computed
  `is_resource_key` (used elsewhere for `create_map_key`/`rename_map_key`
  validation) into all 3 `MapKeySection { .. }` construction sites.
- `src/main.rs`: `ensure_map_key_for_prop_path` now filters on `!resource_key`
  instead of `starts_with("providers.")`, and rolls back a tentatively-created
  alias (via `delete_map_key`) if the requested prop path still doesn't resolve
  after materialization — so a typo'd trailing field name can't leave a phantom
  alias behind. Rollback is scoped strictly to the newly-created case; an
  already-existing alias is never touched. Materialization is routed through the
  shared `create_map_key_checked` helper so this CLI path inherits the reserved
  `agents.default` alias guard from its one definition instead of re-deriving it.
- Strengthened the existing regression-guard test
  (`config_set_does_not_materialize_non_provider_map_keys`) with an assertion that
  no bogus key is left behind, and added coverage for the newly-supported sections,
  the rollback path, and the reserved `agents.default` refusal.

## Validation

Targeted tests (workspace has no `default-members`, so scoped with `-p`):
```
cargo test --locked -p zeroclaw-config resource_key                                → 2 passed
cargo test --locked -p zeroclawlabs --bin zeroclaw ensure_map_key                  → 4 passed
cargo test --locked -p zeroclawlabs --bin zeroclaw config_set_materializes         → 3 passed
cargo test --locked -p zeroclawlabs --bin zeroclaw config_set_does_not_materialize → 1 passed
```
`cargo fmt --all -- --check` and `cargo clippy --locked --all-targets -- -D
clippy::correctness` both clean, plus an additional
`cargo clippy -p zeroclawlabs --bin zeroclaw --all-targets -- -D warnings` clean.

`scripts/ci/rust_quality_gate.sh`'s final "provider dispatch gate" step doesn't
finish cleanly in my environment, but I confirmed it fails identically on
unmodified `master` (i.e. it's pre-existing and unrelated to this diff) — the
output includes files this PR never touches, and even files the script's own
allowlist should exempt (e.g. `crates/zeroclaw-providers/tests/dispatch_integration.rs`),
which suggests a path-separator mismatch specific to running the script on
Windows rather than an actual violation. Flagging in case it's useful, happy to
dig further if maintainers want.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No — this only
  changes which subsections of the already-read-and-written `config.toml` a
  `config set` invocation is allowed to auto-create; it doesn't add a new file,
  directory, or permission the CLI didn't already have.
- New external network calls? No — pure local config CRUD logic in
  `zeroclaw-config`/`src/main.rs`.
- Secrets / tokens / credentials handling changed? No — the CLI still writes
  whatever value the operator passes (e.g. `channels.telegram.main.bot_token`);
  this PR doesn't change how secrets are read, stored, or masked.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No —
  the new test aliases (`newprofile`, `main`, `pi400_owner`, `researcher`) are all
  synthetic placeholders; no real usernames, tokens, or identities.

## Compatibility

- Backward compatible? Yes — commands that already worked (`providers.*`
  aliasing) are untouched; this only makes previously-erroring
  `config set <section>.<alias>.<field>` calls succeed for `risk_profiles.*`,
  `peer_groups.*`, and `channels.*` sections instead of returning
  `Unknown property`.
- Config / env / CLI surface changed? Yes — `config set` now accepts and
  auto-creates aliases for additional dynamic-map sections it previously
  rejected. Purely additive; no existing flag, subcommand, or config key was
  renamed or removed.
- Upgrade steps: None. Existing configs and scripts keep working unchanged;
  users who previously worked around this by hand-editing `config.toml` (per
  #8834) can now use `config set` directly instead.

## Rollback

- **Fast rollback command/path:** `git revert <merge-commit-sha>` once merged —
  the change is confined to `ensure_map_key_for_prop_path`'s filter plus the new
  `resource_key` field/tests; no data migration or schema change to unwind.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A regression would show up as either (a) an
  unwanted `[section.alias]` table appearing in a user's `config.toml` under a
  section that should stay resource-key-protected (e.g. `cost.rates.*`) after a
  `config set` on a dotted resource id, or (b) `config set providers.*` aliasing
  that used to work now erroring `Unknown property` again. Grep CLI output/logs
  for `Unknown property` regressions on `providers.*` paths, or diff a user's
  `config.toml` for unexpected new `[risk_profiles.*]`/`[peer_groups.*]`/
  `[channels.*]` tables after a failed `config set`.

Out of scope for this PR (documented for anyone picking these up):
- Extending `config init <section>.<alias>` to also create map aliases
  (`init_defaults` currently has no code path touching `HashMap<String, T>`
  sections at all — separate, smaller feature). This is the part of #8834 this
  PR leaves open, hence `Related #8834` above rather than a closing reference.
- `Config::ensure_map_key_for_path` (`crates/zeroclaw-config/src/schema.rs`), the
  gateway/RPC-facing twin used by `PATCH /api/config` and RPC `config/set`, has
  the same missing resource-key exclusion and is unguarded by any regression test
  today — this PR intentionally doesn't touch it to keep blast radius to the CLI
  only, but it's a real latent bug worth a follow-up.
