### PR TITLE
fix(config): auto-materialize new map aliases in config patch, matching HTTP PATCH

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5773,6 +5773,26 @@ async fn main() -> Result<()> {
                     } else {
                         raw_path.to_string()
                     };
+                    // Mirror `PATCH /api/config`'s alias auto-materialization
+                    // (`handle_patch` in crates/zeroclaw-gateway/src/api_config.rs):
+                    // `add`/`replace` against a leaf under a not-yet-existing map-keyed
+                    // alias (e.g. a brand-new `channels.telegram.<alias>.<field>`)
+                    // creates the alias first. `remove`/`test`/`comment` intentionally
+                    // do not materialize — nothing to remove/test on an alias that
+                    // doesn't exist yet.
+                    if matches!(op_name, "add" | "replace") && config.ensure_map_key_for_path(&path)
+                    {
+                        let err = ConfigApiError::new(
+                            ConfigApiCode::ValidationFailed,
+                            "alias `default` is reserved and cannot be created",
+                        )
+                        .with_path(&path)
+                        .with_op_index(idx);
+                        let human = format!(
+                            "op[{idx}] `{op_name}` on `{path}`: alias `default` is reserved and cannot be created"
+                        );
+                        config_patch_fail_json_or_human(json, err, human)?;
+                    }
                     let comment = match object.get("comment") {
                         Some(value) => match value.as_str() {
                             Some(comment) => Some(comment),
@@ -5816,11 +5836,17 @@ async fn main() -> Result<()> {
                                 ))
                             })?;
                             let value_str = json_value_to_setprop_string(value, &config, &path)?;
-                            config
-                                .set_prop_persistent(&path, &value_str)
-                                .with_context(|| {
-                                    format!("op[{idx}] `{op_name}` on `{path}` failed")
-                                })?;
+                            match config.set_prop_persistent(&path, &value_str) {
+                                Ok(()) => {}
+                                Err(err) => {
+                                    let api_err = config_patch_map_prop_error(err, &path, idx);
+                                    let human = format!(
+                                        "op[{idx}] `{op_name}` on `{path}` failed: {}",
+                                        api_err.message
+                                    );
+                                    config_patch_fail_json_or_human(json, api_err, human)?;
+                                }
+                            }
                             if is_secret {
                                 serde_json::json!({
                                     "op": op_name,
@@ -5836,9 +5862,17 @@ async fn main() -> Result<()> {
                             }
                         }
                         "remove" => {
-                            config.set_prop_persistent(&path, "").with_context(|| {
-                                format!("op[{idx}] `remove` on `{path}` failed")
-                            })?;
+                            match config.set_prop_persistent(&path, "") {
+                                Ok(()) => {}
+                                Err(err) => {
+                                    let api_err = config_patch_map_prop_error(err, &path, idx);
+                                    let human = format!(
+                                        "op[{idx}] `remove` on `{path}` failed: {}",
+                                        api_err.message
+                                    );
+                                    config_patch_fail_json_or_human(json, api_err, human)?;
+                                }
+                            }
                             if is_secret {
                                 serde_json::json!({
                                     "op": "remove",
@@ -5946,9 +5980,14 @@ async fn main() -> Result<()> {
                     results.push(result_entry);
                 }
 
-                config
-                    .validate()
-                    .context("validation failed after applying patch \u{2014} no changes saved")?;
+                if let Err(err) = config.validate() {
+                    let api_err = ConfigApiError::from_validation(err);
+                    let human = format!(
+                        "validation failed after applying patch \u{2014} no changes saved: {}",
+                        api_err.message
+                    );
+                    config_patch_fail_json_or_human(json, api_err, human)?;
+                }
                 Box::pin(config.save_dirty()).await?;
 
                 if json {

--- a/tests/component/config_patch_cli.rs
+++ b/tests/component/config_patch_cli.rs
@@ -1,22 +1,24 @@
 //! Regression coverage for `zeroclaw config patch --json` output.
 
 use axum::{Router, routing::patch};
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::process::{Command, Output, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 use tower::ServiceExt;
 use zeroclaw::gateway::{self, AppState};
-use zeroclaw::providers::Provider;
+use zeroclaw_api::attribution::Attributable;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::NoneMemory;
+use zeroclaw_providers::ModelProvider;
 use zeroclaw_runtime::security::PairingGuard;
 
-struct MockProvider;
+#[derive(Default)]
+struct MockModelProvider;
 
 #[async_trait::async_trait]
-impl Provider for MockProvider {
+impl ModelProvider for MockModelProvider {
     async fn chat_with_system(
         &self,
         _system_prompt: Option<&str>,
@@ -28,13 +30,34 @@ impl Provider for MockProvider {
     }
 }
 
+impl Attributable for MockModelProvider {
+    fn role(&self) -> zeroclaw_api::attribution::Role {
+        zeroclaw_api::attribution::Role::Provider(zeroclaw_api::attribution::ProviderKind::Model(
+            zeroclaw_api::attribution::ModelProviderKind::Custom,
+        ))
+    }
+
+    fn alias(&self) -> &str {
+        "MockModelProvider"
+    }
+}
+
 fn test_state(config: Config) -> AppState {
+    let memory: Arc<dyn zeroclaw_memory::Memory> =
+        Arc::new(NoneMemory::new("config-patch-cli-test"));
     AppState {
-        config: Arc::new(Mutex::new(config)),
-        provider: Arc::new(MockProvider),
+        config: Arc::new(RwLock::new(config)),
+        model_provider: Arc::new(MockModelProvider),
         model: "test-model".into(),
-        temperature: 0.0,
-        mem: Arc::new(NoneMemory::new()),
+        temperature: None,
+        mem: memory.clone(),
+        memory_strategy: Arc::new(
+            zeroclaw_runtime::agent::memory_strategy::DefaultMemoryStrategy::with_config(
+                memory,
+                zeroclaw_config::schema::MemoryConfig::default(),
+                std::path::PathBuf::new(),
+            ),
+        ),
         auto_save: false,
         webhook_secret_hash: None,
         pairing: Arc::new(PairingGuard::new(false, &[])),
@@ -45,16 +68,25 @@ fn test_state(config: Config) -> AppState {
             Duration::from_secs(300),
             1000,
         )),
-        whatsapp: None,
-        whatsapp_app_secret: None,
+        #[cfg(feature = "channel-whatsapp-cloud")]
+        whatsapp: HashMap::new(),
+        #[cfg(feature = "channel-whatsapp-cloud")]
+        whatsapp_app_secret: HashMap::new(),
+        #[cfg(feature = "channel-linq")]
         linq: HashMap::new(),
+        #[cfg(feature = "channel-linq")]
         linq_signing_secrets: HashMap::new(),
-        nextcloud_talk: None,
-        nextcloud_talk_webhook_secret: None,
-        wati: None,
+        #[cfg(feature = "channel-nextcloud")]
+        nextcloud_talk: HashMap::new(),
+        #[cfg(feature = "channel-nextcloud")]
+        nextcloud_talk_webhook_secret: HashMap::new(),
+        #[cfg(feature = "channel-wati")]
+        wati: HashMap::new(),
+        #[cfg(feature = "channel-email")]
         gmail_push: None,
         observer: Arc::new(zeroclaw_runtime::observability::NoopObserver),
         tools_registry: Arc::new(Vec::new()),
+        tools_registry_by_agent: Arc::new(HashMap::new()),
         cost_tracker: None,
         event_tx: tokio::sync::broadcast::channel(16).0,
         event_buffer: Arc::new(gateway::sse::EventBuffer::new(16)),
@@ -71,6 +103,10 @@ fn test_state(config: Config) -> AppState {
         #[cfg(feature = "webauthn")]
         webauthn: None,
         cancel_tokens: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        pending_reload: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tui_registry: None,
+        sop_engine: None,
+        sop_audit: None,
     }
 }
 
@@ -237,5 +273,233 @@ fn config_patch_json_post_apply_validation_emits_structured_error_envelope() {
             .expect("message")
             .contains("gateway.host must not be empty"),
         "message should describe validation failure: {envelope}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alias auto-materialization (mirrors `PATCH /api/config`'s
+// `ensure_map_key_for_path` guard in `handle_patch`, api_config.rs:2040-2051)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `add` on a leaf under a not-yet-existing map-keyed alias (a brand-new
+/// `channels.telegram.<alias>`) now materializes the alias first instead of
+/// failing `Unknown property`, and the materialized alias is actually
+/// persisted to disk. A second op sets `bot_token` too — `TelegramConfig`'s
+/// `bot_token` field has no `#[serde(default)]`, so a section missing it
+/// fails to deserialize on the next load and gets salvaged back to defaults
+/// by the migration layer, which would make the round-trip assertion below
+/// meaningless.
+#[test]
+fn config_patch_add_materializes_new_map_alias_and_persists() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    let envelope = run_cli_patch_success(
+        config_dir.path(),
+        br#"[
+            {"op":"add","path":"/channels/telegram/newbot/enabled","value":true},
+            {"op":"add","path":"/channels/telegram/newbot/bot_token","value":"dummy-token"}
+        ]"#,
+    );
+
+    assert_eq!(envelope["saved"], true);
+    assert_eq!(envelope["results"][0]["op"], "add");
+    assert_eq!(
+        envelope["results"][0]["path"],
+        "channels.telegram.newbot.enabled"
+    );
+    assert_eq!(envelope["results"][0]["value"], "true");
+
+    let saved =
+        std::fs::read_to_string(config_dir.path().join("config.toml")).expect("read saved config");
+    let parsed: Config = toml::from_str(&saved).expect("saved config should parse");
+    let newbot = parsed
+        .channels
+        .telegram
+        .get("newbot")
+        .expect("new alias should be persisted to disk");
+    assert!(
+        newbot.enabled,
+        "materialized alias should carry the patched value"
+    );
+}
+
+/// HTTP's guard covers both `add` and `replace` identically (same
+/// `matches!(op.op.as_str(), "add" | "replace")` in `handle_patch`) — prove
+/// the CLI's does too.
+#[test]
+fn config_patch_replace_materializes_new_map_alias_and_persists() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    let envelope = run_cli_patch_success(
+        config_dir.path(),
+        br#"[
+            {"op":"replace","path":"/channels/telegram/anotherbot/enabled","value":true},
+            {"op":"replace","path":"/channels/telegram/anotherbot/bot_token","value":"dummy-token"}
+        ]"#,
+    );
+
+    assert_eq!(envelope["saved"], true);
+    assert_eq!(envelope["results"][0]["op"], "replace");
+    assert_eq!(
+        envelope["results"][0]["path"],
+        "channels.telegram.anotherbot.enabled"
+    );
+
+    let saved =
+        std::fs::read_to_string(config_dir.path().join("config.toml")).expect("read saved config");
+    let parsed: Config = toml::from_str(&saved).expect("saved config should parse");
+    let bot = parsed
+        .channels
+        .telegram
+        .get("anotherbot")
+        .expect("new alias should be persisted to disk via `replace` too");
+    assert!(bot.enabled);
+}
+
+/// `replace` on an EXISTING alias's leaf must still succeed, and must not
+/// re-touch the map-keyed section's alias set — guards against the new
+/// materialization guard accidentally re-creating (or disturbing) an alias
+/// that already exists.
+#[test]
+fn config_patch_replace_on_existing_alias_does_not_recreate_it() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+
+    // Establish the alias first.
+    run_cli_patch_success(
+        config_dir.path(),
+        br#"[
+            {"op":"add","path":"/channels/telegram/existingbot/enabled","value":true},
+            {"op":"add","path":"/channels/telegram/existingbot/bot_token","value":"dummy-token"}
+        ]"#,
+    );
+    let saved_before = std::fs::read_to_string(config_dir.path().join("config.toml"))
+        .expect("read config after setup");
+    let before: Config = toml::from_str(&saved_before).expect("config should parse");
+    let mut keys_before = before
+        .get_map_keys("channels.telegram")
+        .expect("channels.telegram should be a map-keyed section");
+    keys_before.sort();
+
+    let envelope = run_cli_patch_success(
+        config_dir.path(),
+        br#"[{"op":"replace","path":"/channels/telegram/existingbot/enabled","value":false}]"#,
+    );
+    assert_eq!(envelope["results"][0]["value"], "false");
+
+    let saved_after = std::fs::read_to_string(config_dir.path().join("config.toml"))
+        .expect("read config after replace");
+    let after: Config = toml::from_str(&saved_after).expect("config should parse");
+    let mut keys_after = after
+        .get_map_keys("channels.telegram")
+        .expect("channels.telegram should be a map-keyed section");
+    keys_after.sort();
+
+    assert_eq!(
+        keys_before, keys_after,
+        "replace on an existing alias must not add or remove aliases"
+    );
+    assert!(!after.channels.telegram["existingbot"].enabled);
+}
+
+/// `remove`/`test` intentionally do NOT materialize (the new guard is
+/// `matches!(op_name, "add" | "replace")` only) — a nonexistent alias path
+/// via either op must still fail with the same `path_not_found` error as
+/// before this change, and must not create the alias as a side effect.
+#[test]
+fn config_patch_remove_and_test_do_not_materialize_unknown_alias() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    // Establish a config.toml on disk first via a benign, unrelated op.
+    run_cli_patch_success(
+        config_dir.path(),
+        br#"[{"op":"replace","path":"/gateway/host","value":"127.0.0.4"}]"#,
+    );
+
+    let remove_envelope = run_cli_patch(
+        config_dir.path(),
+        br#"[{"op":"remove","path":"/channels/telegram/ghostbot/enabled"}]"#,
+    );
+    assert_eq!(remove_envelope["code"], "path_not_found");
+    assert_eq!(
+        remove_envelope["path"],
+        "channels.telegram.ghostbot.enabled"
+    );
+
+    let test_envelope = run_cli_patch(
+        config_dir.path(),
+        br#"[{"op":"test","path":"/channels/telegram/ghostbot/enabled","value":true}]"#,
+    );
+    assert_eq!(test_envelope["code"], "path_not_found");
+    assert_eq!(test_envelope["path"], "channels.telegram.ghostbot.enabled");
+
+    let saved =
+        std::fs::read_to_string(config_dir.path().join("config.toml")).expect("read saved config");
+    let cfg: Config = toml::from_str(&saved).expect("saved config should parse");
+    assert!(
+        !cfg.channels.telegram.contains_key("ghostbot"),
+        "remove/test must not materialize an unknown alias: {saved}"
+    );
+}
+
+/// `add` on `/agents/default/<field>` is refused with `ValidationFailed` and
+/// a message naming the reserved alias, mirroring the schema-level
+/// `ensure_map_key_for_path_refuses_reserved_default_agent`
+/// (`crates/zeroclaw-config/src/alias_refs.rs`) and HTTP's identical guard.
+#[test]
+fn config_patch_add_on_reserved_default_agent_is_refused() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    // Establish a config.toml on disk first via a benign, unrelated op.
+    run_cli_patch_success(
+        config_dir.path(),
+        br#"[{"op":"replace","path":"/gateway/host","value":"127.0.0.5"}]"#,
+    );
+
+    let envelope = run_cli_patch(
+        config_dir.path(),
+        br#"[{"op":"add","path":"/agents/default/enabled","value":true}]"#,
+    );
+
+    assert_eq!(envelope["code"], "validation_failed");
+    assert_eq!(envelope["path"], "agents.default.enabled");
+    assert_eq!(envelope["op_index"], 0);
+    assert!(
+        envelope["message"]
+            .as_str()
+            .expect("message")
+            .contains("alias `default` is reserved"),
+        "message should name the reserved alias: {envelope}"
+    );
+
+    let saved =
+        std::fs::read_to_string(config_dir.path().join("config.toml")).expect("read saved config");
+    let cfg: Config = toml::from_str(&saved).expect("saved config should parse");
+    assert!(
+        !cfg.agents.contains_key("default"),
+        "reserved alias must not be materialized"
+    );
+}
+
+/// The genuinely new risk: a patch document where `add` targets a brand-new
+/// alias's leaf, the alias gets materialized in-memory, but the op itself
+/// (or a later op in the same document) then fails post-apply
+/// `Config::validate()`. `config.save_dirty()` only runs after the whole op
+/// loop succeeds, so the phantom alias must never reach disk.
+#[test]
+fn config_patch_add_failure_after_materialization_does_not_persist_phantom_alias() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+
+    let envelope = run_cli_patch(
+        config_dir.path(),
+        br#"[{"op":"add","path":"/channels/telegram/phantombot/reply_min_interval_secs","value":99999}]"#,
+    );
+    assert_eq!(envelope["code"], "invalid_numeric_range");
+    assert_eq!(
+        envelope["path"],
+        "channels.telegram.phantombot.reply_min_interval_secs"
+    );
+
+    let saved =
+        std::fs::read_to_string(config_dir.path().join("config.toml")).expect("read saved config");
+    let cfg: Config = toml::from_str(&saved).expect("saved config should parse");
+    assert!(
+        !cfg.channels.telegram.contains_key("phantombot"),
+        "a failed op must not leave a phantom alias on disk: {saved}"
     );
 }

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -1,3 +1,4 @@
+mod config_patch_cli;
 mod config_persistence;
 mod config_schema;
 mod dockerignore_test;


### PR DESCRIPTION
## Summary

Fixes #8841.

`config patch`'s `add`/`replace` ops never auto-materialized a not-yet-existing
dynamic-map alias, even though `config patch` is documented to mirror HTTP
`PATCH /api/config`, which already does this via `Config::ensure_map_key_for_path`.

```
$ echo '[{"op":"add","path":"/channels/telegram/newbot/enabled","value":true}]' | zeroclaw config patch
Error: op[0] `add` on `channels.telegram.newbot.enabled` failed
Caused by: Unknown property 'channels.telegram.newbot.enabled'
```

Note: the originally-reported repro (a bare `remove` on a leaf-less alias path,
`/channels/telegram/retry`) turned out not to be a patch-specific bug on
investigation — `config get` fails identically on the same bare path, since the
shared dotted-path resolver can't address a whole map entry as one unit on any
surface. Not fixed here (would need a materially different mechanism); see #8841
for detail.

## Changes

- `src/main.rs`: added the missing `Config::ensure_map_key_for_path` guard to
  the `ConfigCommands::Patch` handler for `add`/`replace` ops, mirroring
  `handle_patch`'s existing guard in `crates/zeroclaw-gateway/src/api_config.rs`
  word-for-word — including its reserved-`agents.default`-alias refusal.
- `src/main.rs`: found while verifying pre-existing test coverage — 3 other
  `config patch` error paths (the op-apply branches and the post-loop
  `Config::validate()` call) bypassed the structured `ConfigApiError` JSON
  envelope entirely, unlike HTTP's equivalents and unlike this handler's own
  `test` op. Routed them through the same `config_patch_map_prop_error`/
  `ConfigApiError::from_validation` helpers already used elsewhere in this
  handler — mechanical consistency fix, no new machinery.
- `tests/component/config_patch_cli.rs` / `tests/component/mod.rs`: this file
  (added for #6252, 4 tests) has been silently unregistered from the test suite
  since an unrelated commit dropped its `mod` line — confirmed via
  `cargo test -p zeroclawlabs --test component config_patch -- --list` showing
  0 tests before this PR. Its `test_state()`/mock-provider helpers had also
  drifted from the current `AppState`/`ModelProvider` shape and would not have
  compiled if naively re-registered; rewrote them to match current types,
  confirmed the original 4 tests pass, re-registered the module, then added 6
  new tests covering: new-alias materialization via `add` and `replace`,
  no-op-on-existing-alias, `remove`/`test` correctly still refusing unknown
  paths (guard is `add`/`replace`-only), the reserved-`agents.default` refusal,
  and that a patch which materializes an alias but then fails its own
  value/validation step doesn't leave anything persisted to disk.

## Validation

```
cargo build -p zeroclawlabs --bin zeroclaw                          → clean
cargo build -p zeroclaw-gateway                                     → clean
cargo test  -p zeroclaw-config ensure_map_key_for_path               → 3/3 passed
cargo test  -p zeroclawlabs --test component config_patch_cli        → 10/10 passed (incl. all 4 original)
cargo test  -p zeroclawlabs --test component                         → 199/199 passed (was 189 before re-registration)
```
`cargo fmt --all -- --check` and `cargo clippy --locked --all-targets -- -D
clippy::correctness` (plus `-D warnings` on touched crates) both clean.

`scripts/ci/rust_quality_gate.sh`'s "provider dispatch gate" step fails for the
same pre-existing, unrelated reason flagged in #8833/#8836 — confirmed the
flagged file list doesn't include anything this PR touches.

Manually re-verified the full repro table against a fresh scratch config:
`add /channels/telegram/newbot/enabled true` now succeeds and persists; the
bare-alias-path case is unchanged (still fails identically to `config get` on
the same path, as expected — not part of this fix).

Branched from `8485b5d6` (the commit immediately before `e7b9d960`/#8703, which
currently leaves `origin/master`'s tip unable to compile — see #8703 — rather
than off the broken tip). Happy to rebase once that's resolved.