### PR TITLE
docs(labels): document refactor type label

### DIFF
--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -75,6 +75,7 @@ New or manual applications should use the canonical no-space labels below when t
 | `type:dependencies` | Dependency or lockfile maintenance |
 | `type:docs` | Documentation-only or docs-primary work |
 | `type:rfc` | RFC issue or proposal; protected from stale closure while active |
+| `type:refactor` | Code-structure cleanup or internal reorganization intended to preserve user-visible behavior |
 | `type:test` | Test-only or test-primary work |
 | `type:tracker` | Active parent coordination issue for a release, roadmap, RFC/design thread, implementation batch, cleanup, or audit. Issue-only marker; does not by itself create stale protection, assignment, acceptance, or contributor-ready scope. |
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds `type:refactor` to the maintainer label guide's type-label table.
  - Documents the live `type:refactor` label currently used by explicit `refactor(...)` PRs.
  - Keeps the definition narrow so it does not become a broad `chore` replacement.
- **Scope boundary:** This PR only updates checked-in maintainer documentation. It does not create labels, mutate PR labels, update automation, or change stale/status/contributor/default label policy.
- **Blast radius:** Maintainer docs only.
- **Linked issue(s):** Related #6808.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```text
$ git diff --check
<no output>

$ DOCS_FILES=docs/book/src/maintainers/labels.md scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.

$ scripts/check-pr-title.sh "docs(labels): document refactor type label"
<no output>
```

- **Beyond CI — what did you manually verify?** Confirmed the live `type:refactor` label exists and that this PR documents the same narrow purpose.
- **If any command was intentionally skipped, why:** `scripts/ci/docs_quality_gate.sh` did not detect the unstaged local docs edit. A direct local markdownlint run would require fetching and executing `markdownlint-cli2` through `npx`; I left that check to CI instead of adding a local npm execution step for this one-line docs change.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? No
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR.
