### PR TITLE
fix(lark): unify channel routing identity for Feishu endpoints

### DIFF
--- a/crates/zeroclaw-channels/src/lark.rs
+++ b/crates/zeroclaw-channels/src/lark.rs
@@ -81,10 +81,10 @@ impl LarkPlatform {
     }
 
     fn channel_name(self) -> &'static str {
-        match self {
-            Self::Lark => "lark",
-            Self::Feishu => "feishu",
-        }
+        // Always "lark" for routing identity. `use_feishu` only selects
+        // the API endpoint and display name — the config schema, agent
+        // bindings, and peer groups all use `lark.<alias>`.
+        "lark"
     }
 }
 
@@ -4885,7 +4885,7 @@ mod tests {
 
         assert_eq!(ch.api_base(), FEISHU_BASE_URL);
         assert_eq!(ch.ws_base(), FEISHU_WS_BASE_URL);
-        assert_eq!(ch.name(), "feishu");
+        assert_eq!(ch.name(), "lark");
     }
 
     #[test]
@@ -6114,9 +6114,9 @@ mod tests {
 
         assert_eq!(
             ch.name(),
-            "feishu",
-            "use_feishu=true must surface the channel identity as 'feishu' \
-             (registry key alignment — see orchestrator::deliver_announcement)"
+            "lark",
+            "use_feishu=true still uses 'lark' as routing identity — \
+             use_feishu only selects the API endpoint"
         );
 
         let message = SendMessage::new("hi from cron", "oc_test_chat_id");


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `LarkPlatform::channel_name()` returned `"feishu"` when `use_feishu = true`, but every other surface (config schema, agent bindings, peer groups) uses `"lark.<alias>"`. The router built composite keys like `"feishu.<alias>"` that did not match the owner map, causing authorized senders to be rejected and messages dropped. Fixed by making `channel_name()` always return `"lark"` -- `use_feishu` only selects the API endpoint and display name.
- **Scope boundary:** This PR does not change the config schema, orchestrator routing logic, validator, or any channel other than Lark. No new config syntax is introduced.
- **Blast radius:** Lark/Feishu channel routing only. Other channels are unaffected. Existing `[channels.lark.<alias>]` configs with `use_feishu = true` will start routing correctly without any config changes.
- **Linked issue(s):** Fixes #4873. Related #7986 (closed unmerged, same root cause, different approach).

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
(no output -- clean)

$ cargo test -p zeroclaw-channels --features channel-lark -- lark 2>&1 | tail -5
test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 1167 filtered out; finished in 0.71s

$ cargo test -p zeroclaw-config 2>&1 | tail -3
test result: ok. 1057 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.41s

$ cargo test 2>&1 | tail -3
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

- **Beyond CI -- what did you manually verify?**
  - Cross-compiled for `aarch64-unknown-linux-musl` with `--features channels-full,channel-wechat,whatsapp-web,channel-nostr,channel-line` and deployed to an OpenWrt router running ZeroClaw.
  - Config used: `[channels.lark.alice]` with `use_feishu = true`, agent binding `channels = ["lark.alice"]`, peer group `channel = "lark.alice"` with `external_peers = ["*"]`.
  - Sent a message from Feishu. Confirmed in `/tmp/zeroclaw.log`:
    - `[lark.alice] WS connected (service_id=)` -- WebSocket connected
    - `activated_bindings: ["wechat.admin","whatsapp.admin","lark.alice"]` -- channel activated
    - No `"dropping inbound message"` or `"not in peer group"` errors
    - Message routed to `alice_main` agent and response delivered back to Feishu
  - Previously (before fix): same config produced `"WS: ignoring (not in peer group)"` and `"dropping inbound message: no agent owns this channel"` errors.
- **If any command was intentionally skipped, why:** `cargo clippy` was run but required a clean `target/debug` due to cross-compile toolchain pollution in the local environment; clippy passed after cleanup.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- No upgrade steps needed. Existing configs continue to work unchanged. Feishu-configured channels that were previously broken will start routing correctly.

## Rollback (required for medium/high-risk PRs)

Medium-risk rollback: `git revert <sha>` is the plan. The only symptom of rollback is that Feishu-configured Lark channels would return to the broken state (messages dropped with `"no agent owns this channel"`).

