### PR TITLE
docs(contributing): document drift-surface comments

### DIFF
--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -41,6 +41,24 @@ The key checkpoints:
 - Inline unit tests: `#[cfg(test)] mod tests {}` at the bottom of the file or a sibling `tests.rs`
 - Don't commit secrets, personal data, or real-user identities: the [Privacy & PII discipline](./privacy.md) page is the merge gate
 
+### Comments and drift
+
+Comments should explain durable intent, invariants, hazards, or source ownership. Do not add comments that restate nearby control flow, duplicate schema or config field lists, mirror enum variants, or describe runtime behavior that the code and tests do not enforce. Those comments become drift surfaces: future contributors and tools may trust the prose after the source has changed.
+
+If a comment needs to mention behavior owned elsewhere, point to the owner instead of copying it. Prefer comments that say why a branch is safe, which contract owns a rule, or which source must change first.
+
+Prefer:
+
+- `The config schema owns accepted aliases; keep this resolver generic.`
+- `This panic is unreachable because the parser rejects empty tool names earlier.`
+
+Avoid:
+
+- `Supported variants are A, B, and C.`
+- `This flag always enables vector search.`
+
+If the statement can only stay true by manually editing the comment whenever code, config, WIT, schema, or tests change, make the source clearer or add a source pointer instead.
+
 ## Testing
 
 - Unit tests co-located with the code (`mod tests`)

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -14,6 +14,7 @@ Use [PR lanes](./pr-workflow.md#pr-lanes) for routing expectations; use this pla
 |---|---|---|
 | Intake fails in the first 5 minutes | Leave one actionable checklist comment, stop deep review | [Five-minute intake](#five-minute-intake) |
 | Risk is high or unclear | Treat as `risk:high` until proven otherwise | [Review depth matrix](#review-depth-matrix) |
+| Diff adds a parallel interpretive surface | Verify it is derived from, or explicitly points to, the canonical source | [Drift-surface review](#drift-surface-review) |
 | Automation output is wrong or noisy | Apply the override protocol | [Automation override](#automation-override) |
 | Need to hand off to another maintainer | Use the handoff template | [Handoff](#handoff) |
 
@@ -55,6 +56,33 @@ If any intake check fails, leave one actionable checklist comment and stop. Don'
 - Compatibility and migration impact is clear.
 - No personal or sensitive data leaked into diff artifacts; tests use neutral, project-scoped placeholders.
 - Naming and architecture boundaries follow project contracts (`AGENTS.md`, [Architecture overview](../architecture/overview.md#core-traits)).
+
+### Drift-surface review
+
+Treat new duplicate interpretive surfaces as review risk. A PR should not add
+comments, examples, generated snapshots, mapping tables, configuration mirrors,
+or parallel registries that restate behavior already owned by code, schemas,
+tests, WIT, config, or runtime dispatch unless the new surface is mechanically
+derived from that owner or clearly points back to it.
+
+Block or request changes when the new surface can drift and future readers,
+reviewers, or automation might treat it as more authoritative than the source.
+Common examples include comments that describe behavior not enforced by code,
+docs that duplicate an enum or schema list by hand, tests that snapshot an
+implementation detail rather than user-observable behavior, and registries that
+copy a key space already owned by another module.
+
+Prefer one of these resolutions:
+
+- Remove the duplicate surface and make the canonical owner easier to read.
+- Generate the secondary surface from the canonical owner.
+- Replace the restatement with a source pointer plus the reason that the
+  pointer belongs there.
+
+`why` comments are still welcome when they capture non-obvious invariants,
+hazards, or tradeoffs that the type system and tests cannot express. They
+should explain intent, not restate the nearby control flow or become a second
+contract.
 
 ### Deep-review checklist (high-risk only)
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added maintainer-review guidance for duplicate interpretive surfaces that can drift from canonical code, schema, test, config, WIT, or runtime owners.
  - Added a fast-path routing row so reviewers check this risk before deep review.
  - Added contributor-guide guidance that comments should preserve durable intent, invariants, hazards, or source ownership instead of duplicating mutable facts.
- **Scope boundary:** Docs-only contributor and maintainer guidance. This PR does not change review protocol commands, labels, CI, runtime behavior, schemas, or contributor PR requirements.
- **Blast radius:** Contributor and maintainer documentation only. Contributors get clearer guidance before writing drift-prone comments, and reviewers may cite the maintainer playbook when evaluating duplicated comments, docs, snapshots, mappings, or registries.
- **Linked issue(s):** None.
- **Labels:** `docs`, `type:docs`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` - this is a docs-only guidance change without a meaningful manual behavior path for reviewers to exercise.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on head `e16d0bf0f5d515a03ced2f057e959cb37e97f7e3`. `Docs Style` covers the changed Markdown lines, and `CI Required Gate` confirms the required jobs completed successfully on the current head.
- **Known CI coverage gap, if any:** None after the focused docs quality and added-link checks below.
- **Commands run and tail output:**

```bash
git diff --check
```

Passed with no output.

```bash
DOCS_FILES=$'docs/book/src/maintainers/reviewer-playbook.md\ndocs/book/src/contributing/how-to.md' scripts/ci/docs_quality_gate.sh
```

```text
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/maintainers/reviewer-playbook.md docs/book/src/contributing/how-to.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/maintainers/reviewer-playbook.md docs/book/src/contributing/how-to.md !target/** !docs/book/src/SUMMARY.md
Linting: 2 file(s)
Summary: 0 error(s)
```

```bash
DOCS_FILES=$'docs/book/src/maintainers/reviewer-playbook.md\ndocs/book/src/contributing/how-to.md' scripts/ci/docs_links_gate.sh
```

```text
Collected 0 added link(s) from 2 docs file(s).
No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** Read the surrounding reviewer playbook placement, the contributor-guide `Code style`, `Testing`, `Docs changes`, and `Pull requests` sections, FND-005 contribution-culture review guidance, and the root `AGENTS.md` single-source-of-truth rule so the new guidance fits the existing contribution contract.
- **If any command was intentionally skipped, why:** Rust fmt, Clippy, and tests were skipped because this is a docs-only guidance change with no Rust, config, workflow, or generated reference output changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the rollback plan.
