### PR TITLE
docs(pr-template): add human-run Testing section with A/B recipe

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Summary
 
 - **Base branch:** `master` (all contributions)
-- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
+- **What changed and why:** (2 to 5 bullets; the diff shows *what*, you explain *why*)
 - **Scope boundary:** (what this PR explicitly does NOT change)
 - **Blast radius:** (what other subsystems or consumers could be affected)
 - **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
@@ -11,11 +11,24 @@
   example `type:docs`, `risk:low`, `size:S`, `docs`. During label-spelling
   migration, copy the exact live label spelling from the GitHub UI.
 
-## Validation Evidence (required)
+## Testing (required)
 
-Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").
+### How you can test
 
-```bash
+Written for a human reviewer to run by hand, not for CI. Frame it A/B: the same steps should show the old behavior on `master` and the new behavior on this branch, so the reviewer can see the delta themselves.
+
+- **Reviewer testing requested?** (`Yes` / `N/A`; if `N/A`, one line why, e.g. docs-only, pure refactor)
+- **Interface(s) exercised:** Name the surface(s) this touches using the same vocabulary the attribution span records: `surface` (`web` / `tui` / `cli`) and `channel` for messaging surfaces. Match the live attribution values; do not invent interface names.
+- **Setup / preconditions:** (config, provider, channel, or state needed first)
+- **Steps to run:** (the exact click-through or command sequence)
+- **Expected on this branch (after):** (what the reviewer should observe if it works)
+- **Prior behavior on `master` (before):** (run the same steps unpatched; what breaks or is missing, so the fix is visible)
+
+### How I tested
+
+Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings, not "all passed").
+
+```sh
 cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 cargo test
@@ -24,12 +37,12 @@ cargo test
 Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.
 
 - **Commands run and tail output:**
-- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
+- **Beyond CI, what did you manually verify?** (functional scenarios, edge cases, and any security-relevant behavior; also what you did NOT verify)
 - **If any command was intentionally skipped, why:**
 
 ## Security & Privacy Impact (required)
 
-Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.
+Yes/No for each. Answer any `Yes` with a 1-2 sentence risk-and-mitigation note. Manual verification of these scenarios goes under `### How I tested`, not here.
 
 - New permissions, capabilities, or file system access scope? (`Yes/No`)
 - New external network calls? (`Yes/No`)


### PR DESCRIPTION
> This PR body is written against the **new** template it introduces (dogfood). The section names below (`## Testing`, `### How you can test`, `### How I tested`) will not match other in-flight PRs on master until this lands.

## Summary

- **Base branch:** `master`
- **What changed and why:** (2 to 5 bullets; the diff shows *what*, you explain *why*)
  - Add a required `## Testing` block directly below `## Summary`, splitting reviewer-facing (`### How you can test`) from author-facing (`### How I tested`) evidence. The old `## Validation Evidence` heading disappears; its contents move into `### How I tested`.
  - `### How you can test` is a human-run A/B recipe: reviewer runs the same steps on `master` and this branch to observe the delta by hand. Carries a `Yes / N/A` toggle with a one-line reason for docs-only or pure-refactor overrides.
  - Interface(s) exercised are named against the live attribution vocabulary (`surface` = `web` / `tui` / `cli`, plus `channel` for messaging surfaces) rather than a hardcoded interface list, so the template tracks the attribution registry instead of drifting from it.
  - `## Security & Privacy Impact` becomes a pure Yes/No risk grid; its verification prompt now points at `### How I tested` so manual verification lives in exactly one place.
  - Scrub the template of em-dashes and en-dashes so the file complies with AGENTS.md end to end.
- **Scope boundary:** Does not touch `docs/book/src/contributing/*` guides, labeler config, CI, or any other template. Single-file change.
- **Blast radius:** Every future PR on this repo. Contributors will see a different template starting from the merge; existing draft PRs authored against the old template will still render fine (extra `Validation Evidence` heading is not required to match).
- **Linked issue(s):** None.
- **Labels:** `type:docs`.

## Testing (required)

### How you can test

Written for a human reviewer to run by hand, not for CI. Frame it A/B: the same steps should show the old behavior on `master` and the new behavior on this branch, so the reviewer can see the delta themselves.

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `surface = web` (the GitHub PR compose page).
- **Setup / preconditions:** A GitHub account with access to `zeroclaw-labs/zeroclaw`. No local checkout required.
- **Steps to run:**
  1. Open a draft PR against `master` from any branch other than this one, or open the "New pull request" compose page.
  2. Observe the template prefilled in the PR body.
  3. On this PR (`docs/pr-template-testing-section`), open the "Files changed" tab and read `.github/pull_request_template.md` at HEAD.
- **Expected on this branch (after):** The template contains a `## Testing (required)` section immediately after `## Summary`, with `### How you can test` (A/B recipe, interface named against attribution vocabulary, Yes/N/A toggle) and `### How I tested` (cargo battery + manual-verify + skip rationale). `## Security & Privacy Impact` is a pure Yes/No grid and its intro points verification at `### How I tested`. No em-dashes or en-dashes anywhere.
- **Prior behavior on `master` (before):** Same compose page shows a `## Validation Evidence (required)` section instead of `## Testing`, with no `### How you can test` and no A/B recipe. Reviewer manual verification and security manual verification are not clearly separated.

### How I tested

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings, not "all passed").

```sh
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**
  - The cargo battery is not applicable: this PR changes only `.github/pull_request_template.md`, no Rust source or config schema.
  - `scripts/ci/docs_quality_gate.sh` is not applicable either: the gate scopes to `docs/book/src/*.md` and reports "No docs files detected; skipping docs quality gate." against `upstream/master` for this diff.
  - Manual checks I did run:
    - `grep -nE '^#{1,3} ' .github/pull_request_template.md` to confirm heading tree: `## Summary` -> `## Testing` -> `### How you can test` -> `### How I tested` -> the remaining top-level sections, all at `##`.
    - `grep -nE '\u2014|\u2013' .github/pull_request_template.md` returns no matches (em-dash and en-dash clean end to end).
- **Beyond CI, what did you manually verify?** Rendered the template mentally against a hypothetical multi-surface PR (web + cli) to confirm the interface prompt does not force authors to pick one bucket. Confirmed the `N/A` escape hatch handles docs-only and pure-refactor cases without demanding invented verification steps. Confirmed the Security section still asks its four Yes/No questions unchanged; only the intro was tightened to point verification at `### How I tested`.
- **If any command was intentionally skipped, why:** The full cargo battery and `docs_quality_gate.sh` are both skipped because neither surface applies to a single-file `.github/` change. Skipping is recorded here rather than silently omitted.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1-2 sentence risk-and-mitigation note. Manual verification of these scenarios goes under `### How I tested`, not here.

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None; the template is only used at PR compose time. In-flight PRs authored against the old template continue to render fine.

## Rollback (required for medium/high-risk PRs)

Low-risk PR. `git revert <sha>` is the plan.
