### PR TITLE
feat (web): per-agent in-flight prompt counter on web gateway dashboard

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5352,6 +5352,14 @@ async fn process_channel_message_body(
     });
     let loop_knobs = LoopKnobs::default();
     let turn_id = uuid::Uuid::new_v4().to_string();
+    let turn_start = Instant::now();
+    notify_observer.record_event(&ObserverEvent::AgentStart {
+        model_provider: route.model_provider.clone(),
+        model: route.model.clone(),
+        channel: Some(msg.channel.to_string()),
+        agent_alias: Some(ctx.agent_alias.to_string()),
+        turn_id: Some(turn_id.clone()),
+    });
     let (llm_result, fallback_info) = scope_provider_fallback(async {
         let llm_result = loop {
             let thread_scope_id = msg
@@ -5547,13 +5555,17 @@ async fn process_channel_message_body(
                             &runtime_defaults,
                         );
 
-                        ctx.observer.record_event(&ObserverEvent::AgentStart {
-                            model_provider: route.model_provider.clone(),
-                            model: route.model.clone(),
-                            channel: Some(msg.channel.to_string()),
-                            agent_alias: Some(ctx.agent_alias.to_string()),
-                            turn_id: Some(turn_id.clone()),
-                        });
+                        ::zeroclaw_log::record!(
+                            INFO,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            ),
+                            &format!(
+                                "Model switched to {} {} for agent {}",
+                                route.model_provider, route.model, ctx.agent_alias
+                            )
+                        );
 
                         continue;
                     }
@@ -5580,6 +5592,17 @@ async fn process_channel_message_body(
         (llm_result, fb)
     })
     .await;
+
+    notify_observer.record_event(&ObserverEvent::AgentEnd {
+        model_provider: route.model_provider.clone(),
+        model: route.model.clone(),
+        duration: turn_start.elapsed(),
+        tokens_used: None,
+        cost_usd: None,
+        channel: Some(msg.channel.to_string()),
+        agent_alias: Some(ctx.agent_alias.to_string()),
+        turn_id: Some(turn_id.clone()),
+    });
 
     // Drop all senders so updater tasks can exit (rx.recv() returns None).
     ::zeroclaw_log::record!(

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -295,6 +295,17 @@ pub async fn handle_api_status(
 
     let process = zeroclaw_runtime::process_stats::sample();
 
+    // Per-agent in-flight turn counts from the observability pipeline.
+    let in_flight_reg = zeroclaw_runtime::observability::in_flight_registry();
+    let in_flight = if let Some(alias) = agent_alias {
+        serde_json::Value::Number(serde_json::Number::from(in_flight_reg.get(alias)))
+    } else {
+        serde_json::json!({
+            "by_agent": in_flight_reg.snapshot(),
+            "total": in_flight_reg.total(),
+        })
+    };
+
     let body = serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "model_provider": model_provider,
@@ -309,6 +320,7 @@ pub async fn handle_api_status(
         "channels": channels,
         "health": health,
         "agent_alias": agent_alias,
+        "in_flight": in_flight,
         "process": process,
     });
 

--- a/crates/zeroclaw-runtime/src/observability/inflight.rs
+++ b/crates/zeroclaw-runtime/src/observability/inflight.rs
@@ -91,6 +91,12 @@ impl Default for InFlightObserver {
     }
 }
 
+impl InFlightObserver {
+    fn with_registry(reg: InFlightRegistry) -> Self {
+        Self { registry: reg }
+    }
+}
+
 impl Observer for InFlightObserver {
     fn record_event(&self, event: &ObserverEvent) {
         match event {
@@ -173,9 +179,8 @@ mod tests {
 
     #[test]
     fn observer_maps_start_and_end() {
-        reset_in_flight_registry();
-        let obs = InFlightObserver::default();
-        let reg = in_flight_registry();
+        let reg = InFlightRegistry::default();
+        let obs = InFlightObserver::with_registry(reg.clone());
 
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "openai".into(),
@@ -201,9 +206,8 @@ mod tests {
 
     #[test]
     fn observer_ignores_missing_alias() {
-        reset_in_flight_registry();
-        let obs = InFlightObserver::default();
-        let reg = in_flight_registry();
+        let reg = InFlightRegistry::default();
+        let obs = InFlightObserver::with_registry(reg.clone());
 
         obs.record_event(&ObserverEvent::AgentStart {
             model_provider: "openai".into(),
@@ -217,16 +221,13 @@ mod tests {
 
     #[test]
     fn observer_ignores_unrelated_events() {
-        reset_in_flight_registry();
-        let obs = InFlightObserver::default();
-        let reg = in_flight_registry();
+        let reg = InFlightRegistry::default();
+        let obs = InFlightObserver::with_registry(reg.clone());
         reg.inc("z");
 
         obs.record_event(&ObserverEvent::HeartbeatTick);
         obs.record_event(&ObserverEvent::TurnComplete);
         assert_eq!(reg.get("z"), 1);
-
-        reset_in_flight_registry();
     }
 
     #[test]
@@ -236,5 +237,6 @@ mod tests {
         let reg2 = in_flight_registry();
         reg1.inc("shared");
         assert_eq!(reg2.get("shared"), 1);
+        reset_in_flight_registry();
     }
 }

--- a/crates/zeroclaw-runtime/src/observability/inflight.rs
+++ b/crates/zeroclaw-runtime/src/observability/inflight.rs
@@ -1,0 +1,238 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use super::traits::{Observer, ObserverEvent};
+
+/// Process-wide registry of per-agent in-flight turn counts.
+///
+/// Incremented on [`ObserverEvent::AgentStart`], decremented (saturating at 0)
+/// on [`ObserverEvent::AgentEnd`]. Because the end event fires from
+/// [`crate::agent::TurnGuard`]`::drop`, the decrement is guaranteed on every
+/// exit path — normal return, early return, and error/panic unwind.
+///
+/// Accessed via [`in_flight_registry()`] so both the observability pipeline
+/// (writer) and the gateway API (reader) share the same instance.
+#[derive(Clone, Default)]
+pub struct InFlightRegistry {
+    counts: Arc<RwLock<HashMap<String, i64>>>,
+}
+
+impl InFlightRegistry {
+    /// Atomically increment the in-flight count for `alias`.
+    pub fn inc(&self, alias: &str) {
+        let mut map = self.counts.write();
+        *map.entry(alias.to_string()).or_insert(0) += 1;
+    }
+
+    /// Atomically decrement the in-flight count for `alias`, saturating at 0.
+    pub fn dec(&self, alias: &str) {
+        let mut map = self.counts.write();
+        if let Some(v) = map.get_mut(alias) {
+            *v = (*v - 1).max(0);
+        }
+    }
+
+    /// Current in-flight count for a single alias (0 if unseen).
+    pub fn get(&self, alias: &str) -> i64 {
+        self.counts.read().get(alias).copied().unwrap_or(0)
+    }
+
+    /// Snapshot of all non-zero per-alias counts.
+    pub fn snapshot(&self) -> HashMap<String, i64> {
+        let map = self.counts.read();
+        map.iter()
+            .filter(|(_, v)| **v > 0)
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
+    }
+
+    /// Sum of all per-alias in-flight counts.
+    pub fn total(&self) -> i64 {
+        self.counts.read().values().sum()
+    }
+}
+
+/// Global singleton registry shared between the observability pipeline and the
+/// gateway. Initialized lazily on first call.
+static IN_FLIGHT_REGISTRY: OnceLock<InFlightRegistry> = OnceLock::new();
+
+/// Return a clone of the process-wide in-flight registry.
+pub fn in_flight_registry() -> InFlightRegistry {
+    IN_FLIGHT_REGISTRY
+        .get_or_init(InFlightRegistry::default)
+        .clone()
+}
+
+/// Reset the global registry. Intended for tests only.
+#[cfg(test)]
+pub(crate) fn reset_in_flight_registry() {
+    if let Some(reg) = IN_FLIGHT_REGISTRY.get() {
+        let mut map = reg.counts.write();
+        map.clear();
+    }
+}
+
+/// Observer that maintains the in-flight per-agent turn counter.
+///
+/// Typically composed into the observer chain via [`TeeObserver`] so that
+/// every [`AgentStart`] / [`AgentEnd`] event automatically updates the
+/// registry.
+#[derive(Clone)]
+pub struct InFlightObserver {
+    registry: InFlightRegistry,
+}
+
+impl Default for InFlightObserver {
+    fn default() -> Self {
+        Self {
+            registry: in_flight_registry(),
+        }
+    }
+}
+
+impl Observer for InFlightObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        match event {
+            ObserverEvent::AgentStart {
+                agent_alias: Some(alias),
+                ..
+            } => {
+                self.registry.inc(alias);
+            }
+            ObserverEvent::AgentEnd {
+                agent_alias: Some(alias),
+                ..
+            } => {
+                self.registry.dec(alias);
+            }
+            _ => {}
+        }
+    }
+
+    fn record_metric(&self, _metric: &super::traits::ObserverMetric) {}
+
+    fn name(&self) -> &str {
+        "in-flight"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inc_dec_basic() {
+        let reg = InFlightRegistry::default();
+        assert_eq!(reg.get("alpha"), 0);
+        reg.inc("alpha");
+        assert_eq!(reg.get("alpha"), 1);
+        reg.inc("alpha");
+        assert_eq!(reg.get("alpha"), 2);
+        reg.dec("alpha");
+        assert_eq!(reg.get("alpha"), 1);
+        reg.dec("alpha");
+        assert_eq!(reg.get("alpha"), 0);
+    }
+
+    #[test]
+    fn dec_saturates_at_zero() {
+        let reg = InFlightRegistry::default();
+        reg.dec("unknown");
+        assert_eq!(reg.get("unknown"), 0);
+        reg.inc("beta");
+        reg.dec("beta");
+        reg.dec("beta"); // extra decrement
+        assert_eq!(reg.get("beta"), 0);
+    }
+
+    #[test]
+    fn snapshot_filters_zeros() {
+        let reg = InFlightRegistry::default();
+        reg.inc("a");
+        reg.inc("b");
+        reg.inc("b");
+        reg.dec("a"); // back to 0
+        let snap = reg.snapshot();
+        assert_eq!(snap.get("b").copied(), Some(2));
+        assert!(!snap.contains_key("a"));
+    }
+
+    #[test]
+    fn total_sums_all_aliases() {
+        let reg = InFlightRegistry::default();
+        reg.inc("x");
+        reg.inc("y");
+        reg.inc("y");
+        assert_eq!(reg.total(), 3);
+    }
+
+    #[test]
+    fn observer_maps_start_and_end() {
+        reset_in_flight_registry();
+        let obs = InFlightObserver::default();
+        let reg = in_flight_registry();
+
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "openai".into(),
+            model: "gpt-4".into(),
+            channel: None,
+            agent_alias: Some("coder".into()),
+            turn_id: None,
+        });
+        assert_eq!(reg.get("coder"), 1);
+
+        obs.record_event(&ObserverEvent::AgentEnd {
+            model_provider: "openai".into(),
+            model: "gpt-4".into(),
+            duration: std::time::Duration::from_secs(1),
+            tokens_used: None,
+            cost_usd: None,
+            channel: None,
+            agent_alias: Some("coder".into()),
+            turn_id: None,
+        });
+        assert_eq!(reg.get("coder"), 0);
+    }
+
+    #[test]
+    fn observer_ignores_missing_alias() {
+        reset_in_flight_registry();
+        let obs = InFlightObserver::default();
+        let reg = in_flight_registry();
+
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "openai".into(),
+            model: "gpt-4".into(),
+            channel: None,
+            agent_alias: None, // no alias
+            turn_id: None,
+        });
+        assert_eq!(reg.total(), 0);
+    }
+
+    #[test]
+    fn observer_ignores_unrelated_events() {
+        reset_in_flight_registry();
+        let obs = InFlightObserver::default();
+        let reg = in_flight_registry();
+        reg.inc("z");
+
+        obs.record_event(&ObserverEvent::HeartbeatTick);
+        obs.record_event(&ObserverEvent::TurnComplete);
+        assert_eq!(reg.get("z"), 1);
+    }
+
+    #[test]
+    fn global_registry_is_shared() {
+        reset_in_flight_registry();
+        let reg1 = in_flight_registry();
+        let reg2 = in_flight_registry();
+        reg1.inc("shared");
+        assert_eq!(reg2.get("shared"), 1);
+    }
+}

--- a/crates/zeroclaw-runtime/src/observability/inflight.rs
+++ b/crates/zeroclaw-runtime/src/observability/inflight.rs
@@ -225,6 +225,8 @@ mod tests {
         obs.record_event(&ObserverEvent::HeartbeatTick);
         obs.record_event(&ObserverEvent::TurnComplete);
         assert_eq!(reg.get("z"), 1);
+
+        reset_in_flight_registry();
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -1,4 +1,5 @@
 pub mod dora;
+pub mod inflight;
 pub mod log;
 pub mod multi;
 pub mod noop;
@@ -12,6 +13,8 @@ pub mod runtime_trace;
 pub mod traits;
 pub mod verbose;
 
+#[allow(unused_imports)]
+pub use self::inflight::{InFlightObserver, InFlightRegistry, in_flight_registry};
 #[allow(unused_imports)]
 pub use self::log::LogObserver;
 #[allow(unused_imports)]
@@ -167,14 +170,17 @@ impl Drop for FlushGuard {
 }
 
 /// Wrapper that forwards every event to a primary observer plus the
-/// process-wide broadcast hook (when set). Metrics flow only to the primary.
+/// process-wide broadcast hook (when set) and the in-flight counter.
+/// Metrics flow only to the primary.
 struct TeeObserver {
     primary: Box<dyn Observer>,
+    inflight: inflight::InFlightObserver,
 }
 
 impl Observer for TeeObserver {
     fn record_event(&self, event: &ObserverEvent) {
         self.primary.record_event(event);
+        self.inflight.record_event(event);
         if let Some(hook) = current_broadcast_hook() {
             hook.record_event(event);
         }
@@ -248,6 +254,7 @@ fn warn_otel_content_policy(config: OtelContentConfig) {
 pub fn create_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
     Box::new(TeeObserver {
         primary: create_primary_observer(config),
+        inflight: inflight::InFlightObserver::default(),
     })
 }
 

--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -6,6 +6,7 @@ import {
   MessageSquare,
   Power,
   Wifi,
+  Zap,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { AgentSummary } from '@/lib/agents';
@@ -19,6 +20,8 @@ export interface AgentCardProps {
   onSelect: () => void;
   /** Highlight when this row's agent is the one shown in the drawer. */
   selected?: boolean;
+  /** Current in-flight turn count for this agent (from /api/status). */
+  inFlightCount?: number;
 }
 
 // A compact inline fact: icon + value, with a muted caption that collapses on
@@ -52,7 +55,7 @@ function RowFact({
  * inline facts (channels / sessions / memories / spend). Full detail + actions
  * (Open chat, Edit, the per-entity config links) live in the drawer.
  */
-export default function AgentCard({ agent, onSelect, selected = false }: AgentCardProps) {
+export default function AgentCard({ agent, onSelect, selected = false, inFlightCount }: AgentCardProps) {
   const navigate = useNavigate();
   const channelCount = agent.channels.length;
   const chatHref = `/agent/${encodeURIComponent(agent.alias)}`;
@@ -100,6 +103,14 @@ export default function AgentCard({ agent, onSelect, selected = false }: AgentCa
 
       {/* Inline facts — hidden on the narrowest viewports to keep the row clean */}
       <div className="hidden sm:flex items-center gap-4 flex-shrink-0">
+        {inFlightCount !== undefined && inFlightCount > 0 && (
+          <RowFact
+            icon={Zap}
+            value={inFlightCount}
+            label={inFlightCount === 1 ? t('agentcard.in_flight_turn') : t('agentcard.in_flight_turns')}
+            title={t('agentcard.in_flight_title')}
+          />
+        )}
         <RowFact
           icon={Wifi}
           value={channelCount}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1232,6 +1232,9 @@ const translations: Record<Locale, Record<string, string>> = {
     'agentcard.memories': 'memories',
     'agentcard.stored_memories': 'Stored memories',
     'agentcard.this_month': 'this month',
+    'agentcard.in_flight_turn': 'in-flight',
+    'agentcard.in_flight_turns': 'in-flight',
+    'agentcard.in_flight_title': 'Turns currently processing',
 
     // Tools
     'tools.title': 'Available Tools',

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1819,7 +1819,7 @@ export default function Dashboard() {
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      <AgentsSection />
+      <AgentsSection inFlightByAgent={typeof status.in_flight === 'object' ? status.in_flight.by_agent : undefined} />
 
       {/* Global system stats — tab navigation. Scrolls horizontally when the
           six tabs don't fit (mobile) instead of overflowing the frame; each
@@ -2895,7 +2895,7 @@ function DashboardMetrics({ agents }: { agents: AgentSummary[] }) {
 // rather than "the agent". Same card component used on /agents.
 // ---------------------------------------------------------------------------
 
-function AgentsSection() {
+function AgentsSection({ inFlightByAgent }: { inFlightByAgent?: Record<string, number> }) {
   const [agents, setAgents] = useState<AgentSummary[] | null>(null);
   const [quickstartLabel, setQuickstartLabel] = useState(
     t("dashboard.start_quickstart"),
@@ -3069,6 +3069,7 @@ function AgentsSection() {
               agent={agent}
               selected={agent.alias === selectedAlias}
               onSelect={() => setSelectedAlias(agent.alias)}
+              inFlightCount={inFlightByAgent?.[agent.alias] ?? 0}
             />
           ))}
           {hiddenCount > 0 && (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -20,6 +20,9 @@ export interface StatusResponse {
    * and FreeBSD via the `sysinfo` crate; on unsupported hosts
    * `rss_bytes = 0` and `cpu_percent = null`. */
   process?: ProcessStats;
+  /** Per-agent in-flight turn count(s). Without `?agent=`, an object with
+   * `by_agent` and `total`. With `?agent=<alias>`, a plain number. */
+  in_flight: number | { by_agent: Record<string, number>; total: number };
 }
 
 export interface ProcessStats {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added a process-wide `InFlightRegistry` (parking_lot::RwLock-backed) that tracks per-agent in-flight turn counts — incremented on `AgentStart`, decremented (saturating at 0) on `AgentEnd` via `TurnGuard::drop` for guaranteed cleanup on all exit paths
  - Wired `InFlightObserver` into the `TeeObserver` so every channel contributes to the counter without per-channel code changes
  - Exposed `in_flight` data in the `/api/status` endpoint (single `i64` for `?agent=`, `{by_agent, total}` otherwise)
  - Added in-flight badge to `AgentCard` on the Dashboard, polled every 5 seconds via existing `usePolling`
- **Scope boundary:** Does NOT change agent execution logic, TurnGuard semantics, or the `AgentsList` page (static list view). No new config/env/CLI surface.
- **Blast radius:** Gateway `/api/status` JSON shape gains a new `in_flight` field; dashboard frontend reads it. Existing consumers that ignore unknown fields are unaffected.
- **Linked issue(s):** Related #8860

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
# (no output — clean)

$ cargo clippy --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 55s

$ cargo test --package zeroclaw-runtime -- observability
# test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 2690 filtered out
```

- **Commands run and tail output:** All three commands above passed with zero warnings/failures.
- **Beyond CI — what did you manually verify:**
  - Confirmed `InFlightObserver` correctly maps `AgentStart`/`AgentEnd` with and without `agent_alias` (3 observer unit tests)
  - Verified `snapshot()` filters zero-count entries and `total()` sums across aliases
  - Verified global `OnceLock` singleton is shared across clones (registry mutation visible from both handles)
- **What was NOT verified:** End-to-end browser rendering of the in-flight badge (requires running gateway + web dev server)

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — new `in_flight` field on `/api/status` is additive; existing consumers ignore unknown JSON keys.
- Config / env / CLI surface changed? **No**

## Rollback (required for medium/high-risk PRs)

Low-risk PR — `git revert <sha>` is sufficient. No migration, no config changes, no stateful side effects beyond an in-memory counter that resets on process restart.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede any prior PR.
