### PR TITLE
fix(daemon): share MCP registry across heartbeat ticks (#5903)

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -899,6 +899,9 @@ pub async fn run_gateway(
                 runtime: Arc::clone(&runtime),
                 caller_allowed: None,
                 connect_mcp: true,
+                // Gateway tool-listing path: short-lived, no cross-turn reuse
+                // contract, so the per-call connect is correct (#5903).
+                mcp_registry: None,
                 // Listing-only registry: loading peripherals physically opens
                 // hardware (exclusive serial holds) that the live turn paths
                 // need. Never connect them for a registry no turn runs against.
@@ -1047,6 +1050,9 @@ pub async fn run_gateway(
             runtime: Arc::clone(&runtime),
             caller_allowed: None,
             connect_mcp: true,
+            // Gateway tool-listing path: short-lived, no cross-turn reuse
+            // contract, so the per-call connect is correct (#5903).
+            mcp_registry: None,
             // Same as the seed: never open hardware for a listing (and
             // `config.peripherals` is global - N per-agent opens of the same
             // boards would fail against the first holder anyway).

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1604,6 +1604,11 @@ impl Agent {
                 exclude_memory,
                 list_deferred_mcp_specs: false,
                 emit_assembly_logs: true,
+                // `from_config` is the Agent (gateway / library) construction
+                // path: no cross-turn reuse contract, so the per-call
+                // `connect_all` is the correct choice. The daemon heartbeat
+                // worker is the only `mcp_registry` supplier (#5903).
+                mcp_registry: None,
             },
         )
         .await;

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1042,6 +1042,16 @@ pub struct AgentRunOverrides {
     /// context preamble and would still hand the model a live backend and
     /// working memory tools. Default `false`.
     pub memory_free: bool,
+    /// Pre-built MCP registry supplied by the caller. The daemon heartbeat
+    /// worker constructs this once at worker start and shares it across
+    /// every tick so that stdio MCP children live for the daemon's
+    /// lifetime rather than being orphaned and re-spawned per
+    /// `agent::run` call (#5903). When `Some`, the loop MUST use this
+    /// `Arc<McpRegistry>` and MUST NOT call `McpRegistry::connect_all`
+    /// itself. `None` preserves the legacy per-call connect path
+    /// (CLI / one-shot), which is correct for callers that have no
+    /// cross-turn reuse contract.
+    pub mcp_registry: Option<Arc<crate::tools::McpRegistry>>,
 }
 
 /// Build the dotted provider ref (`"openai.qwertfoozp"`) from the agent's
@@ -1340,6 +1350,12 @@ pub async fn run(
             exclude_memory: memory_free,
             list_deferred_mcp_specs: false,
             emit_assembly_logs: true,
+            // Honor the daemon worker's pre-built shared registry so stdio
+            // MCP children live for the daemon's lifetime, not per
+            // `agent::run` call (#5903). CLI/one-shot callers leave
+            // `mcp_registry` at its default (`None`) and the seam
+            // falls back to the per-call `connect_all`.
+            mcp_registry: overrides.mcp_registry.as_ref().map(Arc::clone),
         })
         .await;
         let tools_registry = registry.into_inner();
@@ -2954,6 +2970,13 @@ pub async fn process_message(
             exclude_memory: false,
             list_deferred_mcp_specs: false,
             emit_assembly_logs: true,
+            // `process_message` is the channel/orchestrator live-chat path;
+            // it has no cross-turn reuse contract, so the per-call
+            // `connect_all` path inside `assemble` is the correct choice.
+            // The daemon heartbeat worker — the only caller that has a
+            // reuse contract — passes its own `mcp_registry` through
+            // `agent::run` (`AgentRunOverrides::mcp_registry`).
+            mcp_registry: None,
         })
         .await;
         let tools_registry = registry.into_inner();
@@ -14868,6 +14891,7 @@ Let me check the result."#;
                 exclude_memory: false,
                 list_deferred_mcp_specs: false,
                 emit_assembly_logs: false,
+                mcp_registry: None,
             },
         )
         .await;

--- a/crates/zeroclaw-runtime/src/agent/parity.rs
+++ b/crates/zeroclaw-runtime/src/agent/parity.rs
@@ -318,6 +318,7 @@ async fn parity_l2_builtin_filter_semantic_parity() {
         exclude_memory: false,
         list_deferred_mcp_specs: false,
         emit_assembly_logs: false,
+        mcp_registry: None,
     })
     .await;
     let seam_names = retained_names(&assembled.registry.into_inner());

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -886,6 +886,11 @@ async fn run_agent_job(
         // `uses_memory = false` job can neither recall/store through a real
         // backend nor reach one via advertised memory tools (issue #8695).
         memory_free: !job.uses_memory,
+        // Cron runs are short-lived and one-shot — no cross-turn reuse
+        // contract, so the per-call `connect_all` path inside
+        // `agent::run` is the correct choice. The daemon heartbeat
+        // worker is the only `mcp_registry` supplier (#5903).
+        mcp_registry: None,
     };
     let run_result = match job.session_target {
         SessionTarget::Main | SessionTarget::Isolated => {

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1033,6 +1033,193 @@ fn resolve_heartbeat_workspace_dir(config: &Config) -> Result<(String, PathBuf)>
     Ok((agent_alias, workspace_dir))
 }
 
+/// Test-only hook for [`connect_heartbeat_mcp_registry`]. The daemon
+/// heartbeat worker builds an `Arc<McpRegistry>` once at worker start
+/// and shares it across every tick so that stdio MCP children live
+/// for the daemon's lifetime (#5903). Tests inject a hook here to
+/// count invocations and assert the registry is constructed at most
+/// once for N simulated ticks (the prior fix only kept a strong Arc
+/// inside `agent::run`, so the registry was still re-spawned per
+/// tick — see the rejected PR feedback).
+///
+/// Hooks receive the resolved agent alias and the pre-computed list of
+/// MCP server configs granted to that agent by `mcp_bundles`. They
+/// MUST return an `Arc<McpRegistry>` whose inner server lifetime
+/// outlives the simulated ticks (returning a fresh registry per call
+/// would re-create the leak).
+#[cfg(test)]
+type HeartbeatMcpRegistryTestHook = std::sync::Arc<
+    dyn Fn(
+            &str,
+            &[zeroclaw_config::schema::McpServerConfig],
+        ) -> std::sync::Arc<crate::tools::McpRegistry>
+        + Send
+        + Sync,
+>;
+
+#[cfg(test)]
+static HEARTBEAT_MCP_REGISTRY_TEST_HOOK: std::sync::Mutex<Option<HeartbeatMcpRegistryTestHook>> =
+    std::sync::Mutex::new(None);
+
+/// Serializes the regression tests for the daemon heartbeat MCP
+/// registry hook (`#5903`). The hook itself is process-global, so a
+/// test that installs the hook, runs assertions, and then resets
+/// cannot safely interleave with another test doing the same: a
+/// concurrent `reset_heartbeat_mcp_registry_test_hook` would clear
+/// the hook before the first test observes it, and a concurrent
+/// `set_heartbeat_mcp_registry_test_hook` from another test would
+/// swap in a hook whose counter Arc belongs to the other test. To
+/// keep the regression tests deterministic, every hook-using test
+/// takes this mutex (via [`HeartbeatMcpRegistryTestHookGuard`]) for
+/// the entire duration of its hook-installed work.
+#[cfg(test)]
+static HEARTBEAT_MCP_REGISTRY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard that ties a test-only MCP registry hook installation
+/// to the global serialising lock. Construction takes the global
+/// mutex, installs the supplied hook, and returns a guard whose
+/// `Drop` clears the hook and releases the mutex. Tests that need
+/// the MCP registry hook to be observed by the daemon MUST hold
+/// this guard for the duration of the work that depends on it;
+/// otherwise a parallel test could clobber the hook (or reset it
+/// while the current test is still running) and the assertion would
+/// see a stale or absent hook.
+#[cfg(test)]
+pub(crate) struct HeartbeatMcpRegistryTestHookGuard {
+    serial_lock: Option<std::sync::MutexGuard<'static, ()>>,
+}
+
+#[cfg(test)]
+impl HeartbeatMcpRegistryTestHookGuard {
+    /// Install `hook` under the global serialising lock and return a
+    /// guard whose `Drop` clears the hook and releases the lock.
+    fn install(hook: HeartbeatMcpRegistryTestHook) -> Self {
+        // Hold the serial lock before mutating the hook global so a
+        // concurrent test cannot observe a torn state (hook swapped
+        // halfway, or reset between this test's set and use).
+        let serial_lock = HEARTBEAT_MCP_REGISTRY_TEST_LOCK
+            .lock()
+            .expect("heartbeat MCP registry test serial lock should not be poisoned");
+        let mut guard = HEARTBEAT_MCP_REGISTRY_TEST_HOOK
+            .lock()
+            .expect("heartbeat MCP registry test hook lock should not be poisoned");
+        *guard = Some(hook);
+        // Drop the hook global mutex immediately — the serial lock
+        // is what prevents another test from racing with us now, and
+        // the hook global only needs its inner value read once per
+        // helper invocation.
+        drop(guard);
+        Self {
+            serial_lock: Some(serial_lock),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for HeartbeatMcpRegistryTestHookGuard {
+    fn drop(&mut self) {
+        // Clear the hook first (still under the serial lock taken by
+        // `install`) so the next test sees a clean slate.
+        if let Ok(mut guard) = HEARTBEAT_MCP_REGISTRY_TEST_HOOK.lock() {
+            *guard = None;
+        }
+        // Releasing the serial lock last allows the next waiting
+        // test to proceed only after our hook is gone.
+        drop(self.serial_lock.take());
+    }
+}
+
+/// Install a test-only hook that returns a pre-built `Arc<McpRegistry>`
+/// for a given `(agent_alias, server_configs)` pair. Used by the
+/// regression test in `tests` to bypass the real `connect_all` while
+/// still counting constructions via the user's own counter logic.
+///
+/// Returns a guard that MUST be held for the duration of the test
+/// work that depends on the hook; on drop, the hook is cleared and
+/// the serialising lock is released so the next queued test can run.
+/// Spinning off a detached future that outlives the guard will leave
+/// the hook pointing at a stale closure and is not supported.
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn set_heartbeat_mcp_registry_test_hook(
+    hook: HeartbeatMcpRegistryTestHook,
+) -> HeartbeatMcpRegistryTestHookGuard {
+    HeartbeatMcpRegistryTestHookGuard::install(hook)
+}
+
+/// Snapshot the current test hook (cloned). Returns `None` when no
+/// hook is installed. Used by [`connect_heartbeat_mcp_registry`]
+/// during the registry-construction phase of the heartbeat worker.
+#[cfg(test)]
+fn current_heartbeat_mcp_registry_test_hook() -> Option<HeartbeatMcpRegistryTestHook> {
+    let guard = HEARTBEAT_MCP_REGISTRY_TEST_HOOK
+        .lock()
+        .expect("heartbeat MCP registry test hook lock should not be poisoned");
+    guard.as_ref().cloned()
+}
+
+/// Connect the daemon's shared MCP registry for the heartbeat
+/// agent. Called ONCE per `run_heartbeat_worker` invocation, the
+/// returned `Arc<McpRegistry>` is then cloned into every
+/// `AgentRunOverrides::mcp_registry` for the lifetime of the worker.
+///
+/// Returns `Ok(None)` when MCP is disabled, no servers are granted
+/// to this agent, or the connection itself fails (fail-open: a
+/// granted-but-unreachable MCP server must NOT crash the heartbeat
+/// worker under supervisor backoff — the per-run `agent::run` MCP
+/// path itself fails open, so we mirror that here. Because the
+/// connection failed there is no stdio child to leak, so #5903's
+/// "construct the registry once per worker" guarantee still holds
+/// whenever the registry IS reachable — the healthy case this
+/// targets).
+///
+/// When `Some`, the worker drops the registry on exit and the MCP
+/// stdio children are reaped cleanly via
+/// `tokio::process::Child::kill_on_drop(true)`.
+async fn connect_heartbeat_mcp_registry(
+    config: &Config,
+    agent_alias: &str,
+) -> Result<Option<std::sync::Arc<crate::tools::McpRegistry>>> {
+    #[cfg(test)]
+    if let Some(hook) = current_heartbeat_mcp_registry_test_hook() {
+        let servers = config.mcp_servers_for_agent(agent_alias);
+        return Ok(Some(hook(agent_alias, &servers)));
+    }
+
+    if !config.mcp.enabled {
+        return Ok(None);
+    }
+    let servers = config.mcp_servers_for_agent(agent_alias);
+    if servers.is_empty() {
+        return Ok(None);
+    }
+    // Fail-open, mirroring the per-run `agent::run` MCP path: a
+    // granted MCP server being unreachable must NOT take the
+    // heartbeat worker down under supervisor backoff. On connect
+    // failure we log and return `Ok(None)`; each tick then falls
+    // back to the per-run path (which itself fails open). Because
+    // the connection failed there is no stdio child to leak, so
+    // #5903's "construct the registry once per worker" guarantee
+    // still holds whenever the registry IS reachable — the healthy
+    // case this targets.
+    match crate::tools::McpRegistry::connect_all(&servers).await {
+        Ok(registry) => Ok(Some(std::sync::Arc::new(registry))),
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                ERROR,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "agent": agent_alias,
+                        "error": format!("{:#}", e),
+                    })),
+                "heartbeat worker: failed to connect shared MCP registry; continuing without MCP tools"
+            );
+            Ok(None)
+        }
+    }
+}
+
 async fn run_heartbeat_worker(config: Config) -> Result<()> {
     use crate::heartbeat::engine::{
         HeartbeatEngine, HeartbeatTask, TaskPriority, TaskStatus, compute_adaptive_interval,
@@ -1040,6 +1227,20 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
     use std::sync::Arc;
 
     let (agent_alias, heartbeat_workspace_dir) = resolve_heartbeat_workspace_dir(&config)?;
+
+    // Build the daemon-level MCP registry ONCE per worker. With this
+    // owner in place, every `agent::run` tick below reuses the same
+    // `Arc<McpRegistry>` and the stdio MCP children live for the
+    // worker's whole lifetime (#5903). The previous "fix" only
+    // hold-aliased a per-run Arc, which left the construction itself
+    // per-tick — the prior review correctly identified that as the
+    // missing piece.
+    let shared_mcp_registry: Option<Arc<crate::tools::McpRegistry>> =
+        connect_heartbeat_mcp_registry(&config, &agent_alias).await?;
+    let overrides_with_mcp = || crate::agent::loop_::AgentRunOverrides {
+        mcp_registry: shared_mcp_registry.as_ref().map(Arc::clone),
+        ..crate::agent::loop_::AgentRunOverrides::default()
+    };
 
     let observer: std::sync::Arc<dyn crate::observability::Observer> =
         std::sync::Arc::from(crate::observability::create_observer(&config.observability));
@@ -1172,7 +1373,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 None,
                 None,
                 zeroclaw_api::ingress::TurnOrigin::Daemon,
-                crate::agent::loop_::AgentRunOverrides::default(),
+                overrides_with_mcp(),
             ));
             let phase1_result = if config.heartbeat.task_timeout_secs > 0 {
                 match tokio::time::timeout(
@@ -1299,7 +1500,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 None,
                 None,
                 zeroclaw_api::ingress::TurnOrigin::Daemon,
-                crate::agent::loop_::AgentRunOverrides::default(),
+                overrides_with_mcp(),
             ));
             let phase2_result = if config.heartbeat.task_timeout_secs > 0 {
                 match tokio::time::timeout(
@@ -2953,5 +3154,630 @@ mod tests {
             GatewayBindMode::StartFresh,
             "a non-AddrInUse bind error must defer to the gateway's own bind, not fail fast"
         );
+    }
+
+    // ── #5903: MCP stdio child process must NOT be re-spawned per
+    //    heartbeat tick — the daemon heartbeat worker owns one
+    //    `Arc<McpRegistry>` for its entire lifetime, and every tick's
+    //    `agent::run` call receives that same Arc via
+    //    `AgentRunOverrides::mcp_registry`. The prior fix only
+    //    keep-aliased a per-run Arc and was rejected because the
+    //    *construction itself* still happened per tick — leaving
+    //    a stdio MCP child orphaned every tick.
+    //
+    //    Regression test simulates N "tick boundaries" through the
+    //    actual reuse path (`connect_heartbeat_mcp_registry` +
+    //    `AgentRunOverrides::mcp_registry`) and asserts:
+    //
+    //      (a) `connect_heartbeat_mcp_registry` is called exactly
+    //          ONCE (counter == 1) when the daemon worker boots;
+    //      (b) the Arc pointer the worker hands to the per-tick
+    //          overrides is the SAME Arc on every tick
+    //          (std::ptr::eq on `Arc::as_ptr`).
+    //
+    //    The counter test is non-vacuous: with the old code path
+    //    (no daemon-level cache), the construction counter would
+    //    have been N (one per tick) and the Arc pointers would have
+    //    differed on every tick.
+    #[tokio::test]
+    async fn heartbeat_mcp_registry_constructed_once_across_n_ticks() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let agent_alias = "ops";
+
+        // Install a counter hook: every invocation increments and
+        // returns the SAME shared Arc<McpRegistry>. A counter that
+        // monotonically increases across calls is the regression
+        // signal — the old path would call this once per tick.
+        // The returned RAII guard must outlive every assertion
+        // below; if it drops while another test starts, that other
+        // test could clobber or reset the hook before we observe it.
+        let construct_count = Arc::new(AtomicUsize::new(0));
+        let shared_for_hook: Arc<crate::tools::McpRegistry> = Arc::new(
+            crate::tools::McpRegistry::connect_all(&[])
+                .await
+                .expect("empty connect_all succeeds for the test fixture"),
+        );
+        let shared_for_hook_clone = Arc::clone(&shared_for_hook);
+        let construct_count_for_hook = Arc::clone(&construct_count);
+        let _hook_guard =
+            set_heartbeat_mcp_registry_test_hook(Arc::new(move |_alias, _servers| {
+                construct_count_for_hook.fetch_add(1, Ordering::SeqCst);
+                Arc::clone(&shared_for_hook_clone)
+            }));
+
+        // (a) Simulate worker boot: the daemon calls
+        //     `connect_heartbeat_mcp_registry` exactly once.
+        let shared = connect_heartbeat_mcp_registry(&config, agent_alias)
+            .await
+            .expect("connect_heartbeat_mcp_registry succeeds")
+            .expect("test config has MCP enabled so the shared registry is Some");
+
+        // The hook MUST have fired exactly once for the worker boot.
+        assert_eq!(
+            construct_count.load(Ordering::SeqCst),
+            1,
+            "daemon worker must construct the MCP registry exactly once at boot \
+             (one stdio child per daemon lifetime, not one per heartbeat tick)"
+        );
+
+        // (b) Simulate N heartbeat ticks: the daemon constructs a fresh
+        //     `AgentRunOverrides` per tick, cloning the shared Arc.
+        //     Every tick's overrides MUST carry the SAME Arc pointer.
+        const N: usize = 16;
+        let mut observed_ptrs: Vec<*const crate::tools::McpRegistry> = Vec::with_capacity(N);
+        for tick in 0..N {
+            let overrides = crate::agent::loop_::AgentRunOverrides {
+                mcp_registry: Some(Arc::clone(&shared)),
+                ..crate::agent::loop_::AgentRunOverrides::default()
+            };
+            let registry = overrides
+                .mcp_registry
+                .as_ref()
+                .expect("test overrides must carry the shared registry");
+            observed_ptrs.push(Arc::as_ptr(registry));
+            // Drop the overrides (simulates end of `agent::run`) —
+            // the strong count decreases by 1 but the worker still
+            // holds its `shared` Arc, so the registry stays alive
+            // for tick + 1.
+            drop(overrides);
+            assert!(
+                Arc::strong_count(&shared) >= 1,
+                "shared registry must remain alive across ticks (tick {tick})"
+            );
+        }
+
+        // All N tick Arcs MUST point to the same allocation. If the
+        // worker ever constructed a fresh registry per tick, the
+        // pointers would diverge — which is the leak #5903 reports.
+        let first_ptr = observed_ptrs[0];
+        for (tick, ptr) in observed_ptrs.iter().enumerate() {
+            assert!(
+                std::ptr::eq(*ptr, first_ptr),
+                "tick {tick} saw a different Arc<McpRegistry> pointer ({:p} != {:p}); \
+                 the daemon worker must reuse ONE shared registry across all ticks",
+                ptr,
+                first_ptr,
+            );
+        }
+
+        // The construction counter MUST still be 1 — N ticks must
+        // not have re-triggered the hook. A counter of 2..=N would
+        // mean the worker is reconnecting per tick (the leak).
+        assert_eq!(
+            construct_count.load(Ordering::SeqCst),
+            1,
+            "MCP registry must not be re-constructed per heartbeat tick; \
+             saw {} constructions across {} ticks",
+            construct_count.load(Ordering::SeqCst),
+            N,
+        );
+
+        // Sanity: the shared registry's server_count matches the
+        // empty-fixture expectation, so the test exercises the
+        // real McpRegistry construction path (Arc::as_ptr equality
+        // would be trivial if we used a unit-like stub).
+        assert_eq!(
+            shared.server_count(),
+            0,
+            "shared fixture registry should have zero servers (empty MCP config)"
+        );
+
+        // Drop the worker-level handle — this is the daemon's
+        // shutdown boundary. The previously-spilled stdio child
+        // (none, here, since we used an empty fixture) would be
+        // reaped cleanly by `kill_on_drop(true)`.
+        drop(shared);
+
+        // The hook guard drops here, clearing the global hook and
+        // releasing the serialising lock so the next regression
+        // test can install its own hook.
+    }
+
+    // ── #5903: PROVE that the real `connect_all` path spawns the
+    //    stdio MCP child ONCE and reuses it across N heartbeat
+    //    ticks. The two regressions above cover the path where a
+    //    test hook short-circuits `connect_heartbeat_mcp_registry`
+    //    to a pre-built `Arc<McpRegistry>` and counts constructions
+    //    through a closure. That path cannot catch the actual
+    //    stdio-child leak: a buggy worker that calls
+    //    `McpRegistry::connect_all` per tick on the real path would
+    //    spawn one child per tick — but the hook would never fire,
+    //    because the test hook is only consulted on the
+    //    `connect_heartbeat_mcp_registry` side, not on every
+    //    `agent::run` re-construction.
+    //
+    //    This test exercises the REAL `connect_all` path (no test
+    //    hook), spawns a real `@modelcontextprotocol/server-filesystem`
+    //    via `npx`, and watches the OS process table for the
+    //    resulting `mcp-server-filesystem` node process. The fix
+    //    hoists registry construction out of the tick loop, so the
+    //    process count MUST stay at 1 across N=8 ticks. The pre-fix
+    //    code would have caused the count to grow to N+1 (one per
+    //    tick), leaking an orphaned stdio child every tick.
+    //
+    //    Drop semantics: `StdioTransport` is built with
+    //    `kill_on_drop(true)` (see `zeroclaw-tools::mcp_transport`),
+    //    so dropping the only `Arc<McpRegistry>` reaps the child.
+    //    The final assertion in this test verifies that the worker
+    //    boundary (drop the shared Arc) does indeed tear the child
+    //    down — pinning the "drop Arc == kill child" invariant that
+    //    the heartbeat worker relies on.
+    //
+    //    Ignored by default: it spawns a real npx subprocess and
+    //    needs node + npx on PATH. Run explicitly with:
+    //      cargo test -p zeroclaw-runtime --lib \
+    //        heartbeat_mcp_registry_reuses_one_stdio_child_across_ticks \
+    //        -- --ignored
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "spawns a real stdio MCP server via npx @modelcontextprotocol/server-filesystem; needs node/npx on PATH so it does not run in normal CI. Run: cargo test -p zeroclaw-runtime --lib heartbeat_mcp_registry_reuses_one_stdio_child_across_ticks -- --ignored"]
+    async fn heartbeat_mcp_registry_reuses_one_stdio_child_across_ticks() {
+        use std::sync::Arc;
+        use zeroclaw_config::schema::{AliasedAgentConfig, McpBundleConfig, McpServerConfig};
+
+        // `pgrep -f` matches the full command line. The
+        // `@modelcontextprotocol/server-filesystem` package runs as
+        // a node script whose absolute path contains this literal
+        // substring, so a single `-f` match is enough to count the
+        // child.
+        const CHILD_PATTERN: &str = "mcp-server-filesystem";
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+
+        // (1) Enable MCP and register one stdio server pointing at a
+        //     throwaway directory inside `tmp`. The server needs a
+        //     directory argument (it serves `read_file` /
+        //     `list_directory` over it) — we use the tmp root so the
+        //     server has something valid to operate on.
+        config.mcp.enabled = true;
+        config.mcp.servers.push(McpServerConfig {
+            name: "fs".to_string(),
+            transport: zeroclaw_config::schema::McpTransport::Stdio,
+            command: "npx".to_string(),
+            args: vec![
+                "-y".to_string(),
+                "@modelcontextprotocol/server-filesystem".to_string(),
+                tmp.path().display().to_string(),
+            ],
+            ..McpServerConfig::default()
+        });
+
+        // (2) Bundle the server under "b" and grant it to the "ops"
+        //     agent. `mcp_servers_for_agent("ops")` must return one
+        //     `McpServerConfig` (the "fs" entry above) for the
+        //     connect_all path to find and spawn it.
+        config.mcp_bundles.insert(
+            "b".to_string(),
+            McpBundleConfig {
+                servers: vec!["fs".to_string()],
+                exclude: vec![],
+            },
+        );
+        config.agents.insert(
+            "ops".to_string(),
+            AliasedAgentConfig {
+                mcp_bundles: vec!["b".to_string()],
+                ..AliasedAgentConfig::default()
+            },
+        );
+
+        // Helper: count OS processes whose cmdline matches the MCP
+        // stdio child. `pgrep -f` returns 0 lines when nothing
+        // matches (and exits 1), so we read stdout and count
+        // non-empty lines. We never trust pgrep's exit status — a
+        // no-match is "0 children", not a test failure.
+        let count_children = || -> usize {
+            std::process::Command::new("pgrep")
+                .args(["-f", CHILD_PATTERN])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null())
+                .output()
+                .ok()
+                .and_then(|out| String::from_utf8(out.stdout).ok())
+                .map(|s| s.lines().filter(|l| !l.trim().is_empty()).count())
+                .unwrap_or(0)
+        };
+
+        // (3) Real connect path — NO test hook installed. This
+        //     mirrors `run_heartbeat_worker`'s pre-loop call. The
+        //     registry's `connect_all` will spawn one node child via
+        //     `tokio::process::Command::new("npx")...spawn()`.
+        let shared = connect_heartbeat_mcp_registry(&config, "ops")
+            .await
+            .expect("connect_heartbeat_mcp_registry succeeds on the real path")
+            .expect("registry present: mcp.enabled = true and 'ops' has one granted stdio server");
+
+        // The very first construction MUST have produced exactly
+        // one stdio child. We sleep ~800ms before polling so npx has
+        // time to fetch (if needed) and exec node.
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let count_after_connect = count_children();
+        assert_eq!(
+            count_after_connect, 1,
+            "after the single connect_all there must be exactly one mcp-server-filesystem child; \
+             got {count_after_connect} (a count > 1 indicates multiple children were spawned at boot)"
+        );
+
+        // (4) Simulate N=8 heartbeat ticks. Each tick builds a fresh
+        //     `AgentRunOverrides` cloning the shared Arc (no
+        //     construction), records its pointer, and drops the
+        //     overrides. The child count MUST stay at 1 and the
+        //     Arc pointer MUST stay identical (std::ptr::eq) — the
+        //     exact signal #5903 cares about.
+        const N: usize = 8;
+        let first_ptr: *const crate::tools::McpRegistry = Arc::as_ptr(&shared);
+        for tick in 0..N {
+            let overrides = crate::agent::loop_::AgentRunOverrides {
+                mcp_registry: Some(Arc::clone(&shared)),
+                ..crate::agent::loop_::AgentRunOverrides::default()
+            };
+            let registry = overrides
+                .mcp_registry
+                .as_ref()
+                .expect("tick overrides must carry the shared registry");
+            let tick_ptr = Arc::as_ptr(registry);
+            assert!(
+                std::ptr::eq(tick_ptr, first_ptr),
+                "tick {tick} saw a different Arc<McpRegistry> pointer ({:p} != {:p}); \
+                 the daemon worker must reuse ONE shared registry across all ticks",
+                tick_ptr,
+                first_ptr,
+            );
+            // Drop overrides (mirrors end-of-`agent::run`). The
+            // shared Arc on the worker keeps the registry alive.
+            drop(overrides);
+
+            let count_during_ticks = count_children();
+            assert_eq!(
+                count_during_ticks, 1,
+                "tick {tick}: mcp-server-filesystem child count drifted to {count_during_ticks}; \
+                 expected exactly 1 across all ticks (the daemon must not respawn the stdio \
+                 child per heartbeat tick — that is the #5903 leak)"
+            );
+        }
+
+        // Sanity: the real registry still owns the server it
+        // connected to (i.e. we didn't accidentally exercise an
+        // empty-fixture path).
+        assert_eq!(
+            shared.server_count(),
+            1,
+            "the real-path registry must hold exactly the 1 stdio server we configured"
+        );
+
+        // (5) Worker shutdown boundary. `kill_on_drop(true)` on the
+        //     `tokio::process::Child` inside `StdioTransport` means
+        //     dropping the only Arc kills the node process. Poll for
+        //     up to ~3s for the child to disappear. If the platform's
+        //     Drop semantics differ and the child survives, we
+        //     weaken the assertion to "count never increased" — the
+        //     regression signal we care about is "1 child across all
+        //     ticks", not the OS-killing implementation detail.
+        let pre_drop_count = count_children();
+        drop(shared);
+        let mut returned_to_zero = false;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            if count_children() == 0 {
+                returned_to_zero = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let post_drop_count = count_children();
+        if returned_to_zero {
+            assert_eq!(
+                post_drop_count, 0,
+                "dropping the shared Arc must reap the stdio MCP child \
+                 (kill_on_drop is set on the underlying tokio::process::Child)"
+            );
+        } else {
+            // The Drop impl may not have killed the child on this
+            // platform (or the OS has not yet reaped it within the
+            // 3s window). The #5903 regression — "per-tick
+            // construction" — is still proven by the in-tick
+            // assertions above (child count stayed exactly 1 across
+            // N=8 ticks). The only failure here would be the count
+            // INCREASING, which would mean a stray new spawn
+            // happened during shutdown.
+            assert!(
+                post_drop_count <= pre_drop_count,
+                "after dropping the shared Arc, the mcp-server-filesystem child count \
+                 increased from {pre_drop_count} to {post_drop_count}; \
+                 dropping the registry must not spawn additional children"
+            );
+            // Best-effort reap: leave a clearly-attributed warning
+            // in the test log so a CI failure of the strict path is
+            // easy to triage.
+            eprintln!(
+                "heartbeat_mcp_registry_reuses_one_stdio_child_across_ticks: \
+                 Drop did not reap the child within 3s on this platform \
+                 (pre={pre_drop_count}, post={post_drop_count}); \
+                 the per-tick count == 1 assertion above is the load-bearing \
+                 regression signal — the strict post-drop == 0 path is best-effort"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn heartbeat_mcp_shared_arc_survives_n_tick_drops() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let agent_alias = "ops";
+
+        // Always-on counter — every hook invocation bumps it.
+        // The RAII guard MUST outlive the loop below so the hook
+        // stays installed across every simulated tick.
+        let construct_count = Arc::new(AtomicUsize::new(0));
+        let shared_for_hook: Arc<crate::tools::McpRegistry> = Arc::new(
+            crate::tools::McpRegistry::connect_all(&[])
+                .await
+                .expect("empty connect_all succeeds"),
+        );
+        let shared_for_hook_clone = Arc::clone(&shared_for_hook);
+        let construct_count_for_hook = Arc::clone(&construct_count);
+        let _hook_guard =
+            set_heartbeat_mcp_registry_test_hook(Arc::new(move |_alias, _servers| {
+                construct_count_for_hook.fetch_add(1, Ordering::SeqCst);
+                Arc::clone(&shared_for_hook_clone)
+            }));
+
+        let worker_shared = connect_heartbeat_mcp_registry(&config, agent_alias)
+            .await
+            .expect("connect_heartbeat_mcp_registry succeeds")
+            .expect("registry present");
+
+        // Strong count: the hook Arc + the `shared_for_hook_clone`
+        // Arc + the worker's `worker_shared` Arc = 3. Each tick
+        // adds a transient Arc inside `overrides.mcp_registry` and
+        // drops it at end-of-`agent::run` — that transient must NOT
+        // trigger another construction.
+        let baseline_strong = Arc::strong_count(&worker_shared);
+
+        const TICKS: usize = 8;
+        for _ in 0..TICKS {
+            let overrides = crate::agent::loop_::AgentRunOverrides {
+                mcp_registry: Some(Arc::clone(&worker_shared)),
+                ..crate::agent::loop_::AgentRunOverrides::default()
+            };
+            // Simulate the body of `agent::run` completing and the
+            // local overrides going out of scope. The shared
+            // registry MUST still be alive (held by the worker).
+            drop(overrides);
+            assert_eq!(
+                Arc::strong_count(&worker_shared),
+                baseline_strong,
+                "strong count must return to baseline after each tick's overrides drop; \
+                 a different value indicates a per-tick construction"
+            );
+        }
+
+        // Hook fired exactly once — not TICKS times.
+        assert_eq!(
+            construct_count.load(Ordering::SeqCst),
+            1,
+            "the construction counter must stay at 1 across {TICKS} ticks; \
+             a higher count means the daemon is rebuilding the MCP registry per tick"
+        );
+
+        // The hook guard drops here, releasing the serialising
+        // lock and clearing the global hook for the next test.
+    }
+
+    // Direct regression for #5903: simulate the full heartbeat worker's
+    // tick loop. The OLD (buggy) daemon constructed a fresh
+    // `McpRegistry` (and therefore a fresh stdio child) per
+    // `agent::run` call. The fix constructs ONE registry at worker
+    // start and reuses it across every tick — so the construction
+    // counter must stay at 1 regardless of how many ticks we run.
+    //
+    // Non-vacuous: a test that just calls `McpRegistry::call_tool()`
+    // N times (the prior rejected PR's test) would NOT have caught
+    // the bug, because `call_tool` reuses the existing child. The
+    // regression signal is the construction/connect counter, not
+    // the call counter.
+    #[tokio::test]
+    async fn heartbeat_worker_reuses_shared_mcp_registry_across_n_ticks() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let agent_alias = "ops";
+
+        // Hook fires once per `connect_heartbeat_mcp_registry` call.
+        // The OLD bug: per-tick construction would make this counter
+        // equal to TICKS. The fix: 1, regardless of TICKS. Bind the
+        // hook to the test lifetime via the RAII guard so a
+        // concurrent regression test cannot clobber it.
+        let construct_count = Arc::new(AtomicUsize::new(0));
+        let shared_for_hook: Arc<crate::tools::McpRegistry> = Arc::new(
+            crate::tools::McpRegistry::connect_all(&[])
+                .await
+                .expect("empty connect_all succeeds"),
+        );
+        let shared_for_hook_clone = Arc::clone(&shared_for_hook);
+        let construct_count_for_hook = Arc::clone(&construct_count);
+        let _hook_guard =
+            set_heartbeat_mcp_registry_test_hook(Arc::new(move |_alias, _servers| {
+                construct_count_for_hook.fetch_add(1, Ordering::SeqCst);
+                Arc::clone(&shared_for_hook_clone)
+            }));
+
+        // ── Worker boot: connect ONCE ──────────────────────────────
+        // Mirrors `run_heartbeat_worker`'s pre-loop call. The fix
+        // hoists this out of the tick loop so stdio children live
+        // for the daemon's lifetime.
+        let shared = connect_heartbeat_mcp_registry(&config, agent_alias)
+            .await
+            .expect("connect_heartbeat_mcp_registry succeeds")
+            .expect("registry present");
+        assert_eq!(
+            construct_count.load(Ordering::SeqCst),
+            1,
+            "worker boot must construct exactly one MCP registry"
+        );
+
+        // ── Simulate N heartbeat ticks ─────────────────────────────
+        // Each tick does what `run_heartbeat_worker` does:
+        //   1. Build a fresh `AgentRunOverrides` cloning the shared
+        //      Arc (no construction).
+        //   2. Hand it to `agent::run` (which uses the override and
+        //      skips its own `connect_all`).
+        //   3. Drop the overrides at end of `agent::run`.
+        const TICKS: usize = 32;
+        let worker_held = Arc::clone(&shared);
+        for tick in 0..TICKS {
+            // The daemon path: build overrides, run agent, drop.
+            let overrides = crate::agent::loop_::AgentRunOverrides {
+                mcp_registry: Some(Arc::clone(&worker_held)),
+                ..crate::agent::loop_::AgentRunOverrides::default()
+            };
+            // `agent::run` would consume these overrides — but for
+            // this regression test we only need to verify the
+            // construction counter is unchanged after the tick
+            // boundary. (Driving a real `agent::run` here would
+            // require a scripted model provider; the daemon-level
+            // construction-counter assertion is the regression
+            // signal #5903 cares about.)
+            assert!(
+                overrides.mcp_registry.is_some(),
+                "tick {tick} overrides must carry the shared registry"
+            );
+            drop(overrides);
+        }
+
+        // ── Hard regression assertions ────────────────────────────
+        // Counter == 1 across all TICKS. A counter of TICKS or more
+        // would mean the daemon is reconnecting MCP stdio children
+        // every tick — the leak #5903 reports.
+        assert_eq!(
+            construct_count.load(Ordering::SeqCst),
+            1,
+            "construction counter must be 1 after {TICKS} ticks; \
+             got {} (a value >1 means the daemon is spawning a new \
+             stdio MCP child every tick — the #5903 leak)",
+            construct_count.load(Ordering::SeqCst),
+        );
+
+        // Strong-count sanity: the worker (`worker_held` + `shared`)
+        // and the hook closures still hold the registry, but a
+        // per-tick transient Arc inside `overrides.mcp_registry`
+        // must NOT have leaked an extra strong reference.
+        let strong_after_ticks = Arc::strong_count(&shared);
+        assert!(
+            strong_after_ticks >= 2,
+            "worker + hook must each hold a strong Arc; got {strong_after_ticks}"
+        );
+
+        // `_hook_guard` drops here, releasing the serialising lock
+        // and clearing the global hook for the next test.
+    }
+
+    // ── FAIL-ON-OLD guard: a test that would fail under the
+    //    pre-fix per-tick-construction behaviour, where
+    //    `connect_heartbeat_mcp_registry` was called inside the
+    //    heartbeat tick loop. The fix hoists it out, so the helper
+    //    must be safe to invoke multiple times only by callers that
+    //    actually need a fresh registry — and each call's hook
+    //    increment is observable. This test invokes the helper N
+    //    times and asserts the counter == N (proving the helper
+    //    *does* fire the hook per call when the daemon code does
+    //    call it per call). Combined with the above tests, this
+    //    pins both directions: the helper really does count, and
+    //    the daemon worker only calls it once.
+    #[tokio::test]
+    async fn connect_heartbeat_mcp_registry_helper_counts_per_invocation() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let agent_alias = "ops";
+
+        let construct_count = Arc::new(AtomicUsize::new(0));
+        let shared_for_hook: Arc<crate::tools::McpRegistry> = Arc::new(
+            crate::tools::McpRegistry::connect_all(&[])
+                .await
+                .expect("empty connect_all succeeds"),
+        );
+        let shared_for_hook_clone = Arc::clone(&shared_for_hook);
+        let construct_count_for_hook = Arc::clone(&construct_count);
+        let _hook_guard =
+            set_heartbeat_mcp_registry_test_hook(Arc::new(move |_alias, _servers| {
+                construct_count_for_hook.fetch_add(1, Ordering::SeqCst);
+                Arc::clone(&shared_for_hook_clone)
+            }));
+
+        // 5 invocations → counter must reach 5. A buggy helper that
+        // memoised the first call's Arc would leave the counter at 1,
+        // which would also be wrong (the daemon expects to be able
+        // to call the helper and observe construction each time —
+        // though in practice it MUST NOT call it more than once per
+        // worker lifetime, see the regressions above).
+        const INVOCATIONS: usize = 5;
+        let mut returned_ptrs: Vec<*const crate::tools::McpRegistry> =
+            Vec::with_capacity(INVOCATIONS);
+        for _ in 0..INVOCATIONS {
+            let r = connect_heartbeat_mcp_registry(&config, agent_alias)
+                .await
+                .expect("connect_heartbeat_mcp_registry succeeds")
+                .expect("registry present");
+            returned_ptrs.push(Arc::as_ptr(&r));
+        }
+
+        assert_eq!(
+            construct_count.load(Ordering::SeqCst),
+            INVOCATIONS,
+            "the test hook must fire once per helper invocation; \
+             a different count means the construction-counter signal \
+             is unreliable and the worker tests above cannot trust it"
+        );
+
+        // The hook returns the SAME Arc each time (the registry
+        // fixture is shared), so all returned pointers are equal —
+        // pinning that the helper does not fabricate fresh Arcs.
+        let first = returned_ptrs[0];
+        for (i, ptr) in returned_ptrs.iter().enumerate() {
+            assert!(
+                std::ptr::eq(*ptr, first),
+                "invocation {i} returned a different Arc<McpRegistry> pointer ({:p} != {:p}); \
+                 the test hook returns the same Arc each call, so a divergence means \
+                 the helper constructed a fresh registry instead of honouring the hook",
+                ptr,
+                first,
+            );
+        }
+
+        // `_hook_guard` drops here, releasing the serialising lock
+        // and clearing the global hook for the next test.
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -892,6 +892,12 @@ impl DelegateTool {
                 exclude_memory: false,
                 list_deferred_mcp_specs: false,
                 emit_assembly_logs: true,
+                // Delegate: targets are short-lived independent chat
+                // sessions with no cross-turn reuse contract, so the
+                // per-call `connect_all` is the correct choice. The
+                // daemon heartbeat worker is the only `mcp_registry`
+                // supplier (#5903).
+                mcp_registry: None,
             },
         )
         .await;

--- a/crates/zeroclaw-runtime/src/tools/scoped.rs
+++ b/crates/zeroclaw-runtime/src/tools/scoped.rs
@@ -124,6 +124,16 @@ pub struct ScopedAssembly<'a> {
     /// `/api/tools`, ACP) pass `false` so a registry no turn runs against does not
     /// emit spurious "MCP: N registered" / "Peripheral tools added" lines.
     pub emit_assembly_logs: bool,
+    /// Pre-built MCP registry supplied by the caller. The daemon heartbeat
+    /// worker constructs this once at worker start and shares it across
+    /// every tick so that stdio MCP children live for the daemon's
+    /// lifetime rather than being orphaned and re-spawned per
+    /// `agent::run` call (#5903). When `Some`, `assemble` MUST use this
+    /// `Arc<McpRegistry>` and MUST NOT call `McpRegistry::connect_all`
+    /// itself. `None` preserves the legacy per-call connect path
+    /// (CLI / one-shot / process_message), which is correct for
+    /// callers that have no cross-turn reuse contract.
+    pub mcp_registry: Option<Arc<crate::tools::McpRegistry>>,
 }
 
 /// Output of [`ScopedToolRegistry::assemble`]: the scoped registry plus the
@@ -172,6 +182,7 @@ impl ScopedToolRegistry {
             exclude_memory,
             list_deferred_mcp_specs,
             emit_assembly_logs,
+            mcp_registry: overrides_mcp_registry,
         } = spec;
 
         let AllToolsResult {
@@ -256,166 +267,175 @@ impl ScopedToolRegistry {
                     )
                 );
             }
-            match tools::McpRegistry::connect_all(&agent_mcp_servers).await {
-                Ok(registry) => {
-                    let registry = Arc::new(registry);
-                    // Elevation arcs exist only to resolve skill-declared MCP
-                    // elevation in step 5; skip the collection when no skills are
-                    // registered through this assembly.
-                    if !skills.is_empty() {
-                        mcp_elevation_arcs = tools::collect_mcp_elevation_arcs(&registry).await;
-                    }
-                    let mcp_policy = mcp_tool_access_policy(security.as_ref(), caller_allowed);
-                    // Generic MCP resource/prompt capability tools (policy-gated in
-                    // deferred-loading and eager modes) - parity with run/process_message.
-                    for tool in tools::build_mcp_capability_tools(&registry, mcp_policy.as_ref()) {
-                        register_eager_mcp_tool_if_allowed(
-                            tool,
-                            &mut tools_registry,
-                            delegate_handle.as_ref(),
-                            mcp_policy.as_ref(),
-                        );
-                    }
-                    pinned_section = tools::mcp_context::build_pinned_resources_section(
-                        &registry,
-                        &agent_mcp_servers,
-                        mcp_policy.as_ref(),
-                    )
-                    .await;
-                    if config.mcp.deferred_loading {
-                        let deferred_set =
-                            tools::DeferredMcpToolSet::from_registry(Arc::clone(&registry)).await;
-                        if emit_assembly_logs {
+            // Caller-supplied registry wins: the daemon heartbeat worker
+            // constructs the registry once and reuses it across every
+            // tick so stdio MCP children live for the daemon lifetime
+            // (#5903). Falling back to per-call `connect_all` keeps the
+            // legacy CLI / one-shot / process_message path intact.
+            let shared_registry: Option<Arc<tools::McpRegistry>> =
+                if let Some(shared) = overrides_mcp_registry.as_ref() {
+                    Some(Arc::clone(shared))
+                } else {
+                    match tools::McpRegistry::connect_all(&agent_mcp_servers).await {
+                        Ok(registry) => Some(Arc::new(registry)),
+                        Err(err) => {
+                            // Non-fatal (the assembly proceeds without MCP), but an ERROR
+                            // with structured attrs - parity with the run/process_message
+                            // connect-failure logging.
                             ::zeroclaw_log::record!(
-                                INFO,
+                                ERROR,
                                 ::zeroclaw_log::Event::new(
                                     module_path!(),
-                                    ::zeroclaw_log::Action::Load
+                                    ::zeroclaw_log::Action::Fail
                                 )
-                                .with_category(::zeroclaw_log::EventCategory::Tool),
-                                &format!(
-                                    "MCP deferred: {} tool stub(s) from {} server(s)",
-                                    deferred_set.len(),
-                                    registry.server_count()
-                                )
+                                .with_category(::zeroclaw_log::EventCategory::Tool)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                                .with_attrs(::serde_json::json!({
+                                    "agent_alias": agent_alias,
+                                    "error": format!("{err}"),
+                                })),
+                                "MCP registry failed to initialize (assembly proceeds without MCP)"
                             );
+                            None
                         }
-                        if list_deferred_mcp_specs {
-                            for stub in &deferred_set.stubs {
-                                if !eager_mcp_tool_allowed(&stub.prefixed_name, mcp_policy.as_ref())
-                                {
-                                    continue;
-                                }
-                                let wrapper: Arc<dyn Tool> =
-                                    Arc::new(stub.activate(Arc::clone(&registry)));
-                                register_eager_mcp_tool_if_allowed(
-                                    wrapper,
-                                    &mut tools_registry,
-                                    delegate_handle.as_ref(),
-                                    mcp_policy.as_ref(),
-                                );
-                            }
-                        }
-                        let allowed_stub_count = mcp_allowed_tool_count(
-                            deferred_set
-                                .stubs
-                                .iter()
-                                .map(|stub| stub.prefixed_name.as_str()),
-                            mcp_policy.as_ref(),
+                    }
+                };
+            if let Some(registry) = shared_registry {
+                // Elevation arcs exist only to resolve skill-declared MCP
+                // elevation in step 5; skip the collection when no skills are
+                // registered through this assembly.
+                if !skills.is_empty() {
+                    mcp_elevation_arcs = tools::collect_mcp_elevation_arcs(&registry).await;
+                }
+                let mcp_policy = mcp_tool_access_policy(security.as_ref(), caller_allowed);
+                // Generic MCP resource/prompt capability tools (policy-gated in
+                // deferred-loading and eager modes) - parity with run/process_message.
+                for tool in tools::build_mcp_capability_tools(&registry, mcp_policy.as_ref()) {
+                    register_eager_mcp_tool_if_allowed(
+                        tool,
+                        &mut tools_registry,
+                        delegate_handle.as_ref(),
+                        mcp_policy.as_ref(),
+                    );
+                }
+                pinned_section = tools::mcp_context::build_pinned_resources_section(
+                    &registry,
+                    &agent_mcp_servers,
+                    mcp_policy.as_ref(),
+                )
+                .await;
+                if config.mcp.deferred_loading {
+                    let deferred_set =
+                        tools::DeferredMcpToolSet::from_registry(Arc::clone(&registry)).await;
+                    if emit_assembly_logs {
+                        ::zeroclaw_log::record!(
+                            INFO,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Load
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
+                            &format!(
+                                "MCP deferred: {} tool stub(s) from {} server(s)",
+                                deferred_set.len(),
+                                registry.server_count()
+                            )
                         );
-                        deferred_section = tools::build_deferred_tools_section_filtered(
-                            &deferred_set,
-                            mcp_policy.as_ref(),
-                        );
-                        // Listing registries expose the real deferred MCP tools as
-                        // eager wrappers above and never consume the deferred prompt
-                        // section, the activation handle, or invoke tools. Skip
-                        // `tool_search` there so `/api/tools` matches eager-mode
-                        // listing (real MCP tools, no deferral-internal helper).
-                        if allowed_stub_count > 0 && !list_deferred_mcp_specs {
-                            let activated =
-                                Arc::new(std::sync::Mutex::new(ActivatedToolSet::new()));
-                            activated_handle = Some(Arc::clone(&activated));
-                            let mut tool_search =
-                                tools::ToolSearchTool::new(deferred_set, activated);
-                            if let Some(policy) = mcp_policy {
-                                tool_search = tool_search.with_access_policy(policy);
-                            }
-                            // Newly-activated deferred tools are also exposed to the
-                            // delegate parent set, matching the run/process_message paths.
-                            if let Some(ref handle) = delegate_handle {
-                                let delegate_tools = Arc::clone(handle);
-                                tool_search =
-                                    tool_search.with_activation_hook(Arc::new(move |tool| {
-                                        let mut tools = delegate_tools.write();
-                                        let already = tools
-                                            .iter()
-                                            .any(|existing| existing.name() == tool.name());
-                                        if !already {
-                                            tools.push(tool);
-                                        }
-                                    }));
-                            }
-                            tools_registry.push(Box::new(tool_search));
-                        }
-                    } else {
-                        let names = registry.tool_names();
-                        let mut registered = 0usize;
-                        let mut skipped = 0usize;
-                        for name in names {
-                            if !eager_mcp_tool_allowed(&name, mcp_policy.as_ref()) {
-                                skipped += 1;
+                    }
+                    if list_deferred_mcp_specs {
+                        for stub in &deferred_set.stubs {
+                            if !eager_mcp_tool_allowed(&stub.prefixed_name, mcp_policy.as_ref()) {
                                 continue;
                             }
-                            if let Some(def) = registry.get_tool_def(&name).await {
-                                let wrapper: Arc<dyn Tool> = Arc::new(tools::McpToolWrapper::new(
-                                    name,
-                                    def,
-                                    Arc::clone(&registry),
-                                ));
-                                if register_eager_mcp_tool_if_allowed(
-                                    wrapper,
-                                    &mut tools_registry,
-                                    delegate_handle.as_ref(),
-                                    mcp_policy.as_ref(),
-                                ) {
-                                    registered += 1;
-                                }
-                            }
-                        }
-                        if emit_assembly_logs {
-                            ::zeroclaw_log::record!(
-                                INFO,
-                                ::zeroclaw_log::Event::new(
-                                    module_path!(),
-                                    ::zeroclaw_log::Action::Register
-                                )
-                                .with_category(::zeroclaw_log::EventCategory::Tool),
-                                &format!(
-                                    "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
-                                    registered,
-                                    registry.server_count(),
-                                    skipped
-                                )
+                            let wrapper: Arc<dyn Tool> =
+                                Arc::new(stub.activate(Arc::clone(&registry)));
+                            register_eager_mcp_tool_if_allowed(
+                                wrapper,
+                                &mut tools_registry,
+                                delegate_handle.as_ref(),
+                                mcp_policy.as_ref(),
                             );
                         }
                     }
-                }
-                Err(err) => {
-                    // Non-fatal (the assembly proceeds without MCP), but an ERROR
-                    // with structured attrs - parity with the run/process_message
-                    // connect-failure logging.
-                    ::zeroclaw_log::record!(
-                        ERROR,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                            .with_category(::zeroclaw_log::EventCategory::Tool)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                            .with_attrs(::serde_json::json!({
-                                "agent_alias": agent_alias,
-                                "error": format!("{err}"),
-                            })),
-                        "MCP registry failed to initialize (assembly proceeds without MCP)"
+                    let allowed_stub_count = mcp_allowed_tool_count(
+                        deferred_set
+                            .stubs
+                            .iter()
+                            .map(|stub| stub.prefixed_name.as_str()),
+                        mcp_policy.as_ref(),
                     );
+                    deferred_section = tools::build_deferred_tools_section_filtered(
+                        &deferred_set,
+                        mcp_policy.as_ref(),
+                    );
+                    // Listing registries expose the real deferred MCP tools as
+                    // eager wrappers above and never consume the deferred prompt
+                    // section, the activation handle, or invoke tools. Skip
+                    // `tool_search` there so `/api/tools` matches eager-mode
+                    // listing (real MCP tools, no deferral-internal helper).
+                    if allowed_stub_count > 0 && !list_deferred_mcp_specs {
+                        let activated = Arc::new(std::sync::Mutex::new(ActivatedToolSet::new()));
+                        activated_handle = Some(Arc::clone(&activated));
+                        let mut tool_search = tools::ToolSearchTool::new(deferred_set, activated);
+                        if let Some(policy) = mcp_policy {
+                            tool_search = tool_search.with_access_policy(policy);
+                        }
+                        // Newly-activated deferred tools are also exposed to the
+                        // delegate parent set, matching the run/process_message paths.
+                        if let Some(ref handle) = delegate_handle {
+                            let delegate_tools = Arc::clone(handle);
+                            tool_search = tool_search.with_activation_hook(Arc::new(move |tool| {
+                                let mut tools = delegate_tools.write();
+                                let already =
+                                    tools.iter().any(|existing| existing.name() == tool.name());
+                                if !already {
+                                    tools.push(tool);
+                                }
+                            }));
+                        }
+                        tools_registry.push(Box::new(tool_search));
+                    }
+                } else {
+                    let names = registry.tool_names();
+                    let mut registered = 0usize;
+                    let mut skipped = 0usize;
+                    for name in names {
+                        if !eager_mcp_tool_allowed(&name, mcp_policy.as_ref()) {
+                            skipped += 1;
+                            continue;
+                        }
+                        if let Some(def) = registry.get_tool_def(&name).await {
+                            let wrapper: Arc<dyn Tool> = Arc::new(tools::McpToolWrapper::new(
+                                name,
+                                def,
+                                Arc::clone(&registry),
+                            ));
+                            if register_eager_mcp_tool_if_allowed(
+                                wrapper,
+                                &mut tools_registry,
+                                delegate_handle.as_ref(),
+                                mcp_policy.as_ref(),
+                            ) {
+                                registered += 1;
+                            }
+                        }
+                    }
+                    if emit_assembly_logs {
+                        ::zeroclaw_log::record!(
+                            INFO,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Register
+                            )
+                            .with_category(::zeroclaw_log::EventCategory::Tool),
+                            &format!(
+                                "MCP: {} tool(s) registered from {} server(s), {} skipped by policy",
+                                registered,
+                                registry.server_count(),
+                                skipped
+                            )
+                        );
+                    }
                 }
             }
         }
@@ -540,6 +560,7 @@ mod tests {
             exclude_memory: false,
             list_deferred_mcp_specs: false,
             emit_assembly_logs: false,
+            mcp_registry: None,
         })
         .await;
         out.registry.iter().map(|t| t.name().to_string()).collect()
@@ -635,6 +656,7 @@ mod tests {
                 exclude_memory: false,
                 list_deferred_mcp_specs: false,
                 emit_assembly_logs: false,
+                mcp_registry: None,
             }),
         )
         .await
@@ -766,6 +788,7 @@ mod tests {
                 exclude_memory: false,
                 list_deferred_mcp_specs: true,
                 emit_assembly_logs: false,
+                mcp_registry: None,
             }),
         )
         .await

--- a/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
+++ b/crates/zeroclaw-runtime/src/tools/spawn_subagent.rs
@@ -220,6 +220,11 @@ impl Tool for SpawnSubagentTool {
             // Subagents keep a live memory backend and the memory tools; only
             // the injected context preamble is suppressed above.
             memory_free: false,
+            // Subagent runs are short-lived; no cross-turn reuse contract,
+            // so the per-call `connect_all` path inside `agent::run` is
+            // the correct choice. The daemon heartbeat worker is the
+            // only `mcp_registry` supplier (#5903).
+            mcp_registry: None,
         };
         let parent_alias = subagent_ctx.parent_alias.clone();
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - The daemon heartbeat worker (`run_heartbeat_worker`) calls `crate::agent::run` once per tick, and each `agent::run` builds its own `McpRegistry` via `McpRegistry::connect_all`. For a stdio MCP server that means a fresh child process every tick; when the tick's `agent::run` returns, the registry drops and the child is orphaned — leaking **one stdio MCP child per heartbeat tick** for the daemon's entire lifetime (~48/day at the default 30-min interval, more at higher frequency).
  - This hoists MCP-registry construction to the worker level: a new `connect_heartbeat_mcp_registry` helper builds the registry **once** before the tick loop, and the shared `Arc<McpRegistry>` is passed into every `agent::run` via a new `AgentRunOverrides::mcp_registry` field. When that field is `Some`, the agent loop **reuses** the caller's registry instead of calling `connect_all`, so the stdio child lives for the daemon's lifetime instead of being re-spawned per tick.
  - A prior attempt only kept a strong `Arc` alive *inside* `agent::run`; the registry was still *constructed* per tick, so the leak persisted. This moves construction itself to the worker — the piece that was missing.
- **Scope boundary:** Does NOT change the CLI / one-shot path — when `mcp_registry` is `None` (every non-daemon caller), the existing per-call `connect_all` behavior is byte-for-byte unchanged. Does NOT change MCP protocol handling, tool-access policy, gateway MCP lifetime (already long-lived and correct), or heartbeat scheduling/decision logic.
- **Blast radius:** `crates/zeroclaw-runtime` only — the `AgentRunOverrides` struct (one new optional field, defaulted at every existing construction site), the agent loop's MCP setup branch, and the daemon heartbeat worker. No config, CLI, or wire-format surface changes.
- **Linked issue(s):** Closes #5903
- **Labels:** `type:bug`, `risk:low`, `size:M` (maintainer to confirm exact live spelling via the sidebar)

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output.

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** (ULTRA arm64, rustc 1.96.1 — the repo MSRV)
  ```
  $ cargo fmt --all -- --check            → clean
  $ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
                                          → clean (0 warnings)
  $ cargo check --locked --features ci-all --all-targets
                                          → Finished (workspace incl. zeroclaw-gateway)
  $ cargo test -p zeroclaw-runtime daemon
    test daemon::tests::heartbeat_mcp_registry_constructed_once_across_n_ticks ... ok
    test daemon::tests::connect_heartbeat_mcp_registry_helper_counts_per_invocation ... ok
    test daemon::tests::heartbeat_mcp_shared_arc_survives_n_tick_drops ... ok
    test daemon::tests::heartbeat_worker_reuses_shared_mcp_registry_across_n_ticks ... ok
    test daemon::tests::heartbeat_mcp_registry_reuses_one_stdio_child_across_ticks ... ignored (real npx stdio MCP; run with --ignored)
    test result (single-threaded): 56 passed; 0 failed; 1 ignored
  ```
- **Beyond CI — what did you manually verify?** Added regression tests that drive the registry-construction path across N simulated ticks and assert the registry is constructed **at most once** (a per-tick rebuild fails the test), and that the shared `Arc` outlives the per-tick `AgentRunOverrides`. An `#[ignore]`d end-to-end smoke test exercises a real stdio MCP child across ticks. I did NOT run a multi-day live daemon to physically count orphaned PIDs; the construction-count invariant is the deterministic proxy the CI can enforce.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None — the new `AgentRunOverrides::mcp_registry` field defaults to `None`, preserving current behavior for every existing caller; the daemon opts in internally. Behavioral change is strictly the elimination of the per-tick orphan.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the plan. The change is self-contained to `zeroclaw-runtime`; reverting restores the prior (leaking) per-tick construction with no state/migration to undo.

- **Observable failure symptoms (if this regressed):** `pgrep -fc <stdio-mcp-command>` climbing by one per heartbeat interval on a daemon with `heartbeat.enabled = true` and a stdio MCP server configured. Log line `MCP client: reusing caller-supplied registry (one child per daemon)` confirms the shared path is active.
