### PR TITLE
fix(memory): wrap SqliteMemory embedder in Arc + flush before assert in log reinit test

### DIFF
--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -856,6 +856,7 @@ mod tests {
         install_rotating(tmp.path(), 0, false, 0, 0);
 
         emit("before-reload");
+        flush_for_test().unwrap();
 
         let path = runtime_trace_path().unwrap();
         assert!(
@@ -866,6 +867,7 @@ mod tests {
 
         install_rotating(tmp.path(), 1, false, 1, 0);
         emit("after-reload");
+        flush_for_test().unwrap();
 
         let archives = list_archives(&path).unwrap();
         assert_eq!(
@@ -887,6 +889,7 @@ mod tests {
         install_writer(tmp.path(), 10);
 
         emit("persisted-before-disable");
+        flush_for_test().unwrap();
 
         let path = runtime_trace_path().unwrap();
         assert_eq!(count_lines(&path), 1);
@@ -898,6 +901,7 @@ mod tests {
         init_from_config(&cfg, tmp.path());
 
         emit("not-persisted-after-disable");
+        flush_for_test().unwrap();
 
         assert_eq!(
             count_lines(&path),

--- a/crates/zeroclaw-memory/src/sqlite.rs
+++ b/crates/zeroclaw-memory/src/sqlite.rs
@@ -51,7 +51,7 @@ pub struct SqliteMemory {
     // long-lived handle after a provider-profile change, without a daemon
     // restart (#8359). Reads snapshot the `Arc` and drop the guard before any
     // `.await`, so the lock is never held across async work.
-    embedder: RwLock<Arc<dyn EmbeddingProvider>>,
+    embedder: Arc<RwLock<Arc<dyn EmbeddingProvider>>>,
     vector_weight: f32,
     keyword_weight: f32,
     cache_max: usize,
@@ -98,7 +98,7 @@ impl SqliteMemory {
         Ok(Self {
             alias: alias.to_string(),
             conn: Arc::new(Mutex::new(conn)),
-            embedder: RwLock::new(Arc::new(super::embeddings::NoopEmbedding)),
+            embedder: Arc::new(RwLock::new(Arc::new(super::embeddings::NoopEmbedding))),
             vector_weight: 0.7,
             keyword_weight: 0.3,
             cache_max: 10_000,
@@ -155,7 +155,7 @@ impl SqliteMemory {
         Ok(Self {
             alias: alias.to_string(),
             conn: Arc::new(Mutex::new(conn)),
-            embedder: RwLock::new(embedder),
+            embedder: Arc::new(RwLock::new(embedder)),
             vector_weight,
             keyword_weight,
             cache_max,


### PR DESCRIPTION
### Context

During the stale-PR sweep this morning, #8623 (add embedding identity + auto-migrate) and #8359-era changes (hot-swap embedder without daemon restart) both landed on master. Additionally, #8439 (move JSONL fsync off the async hot path) landed. Each PR was green in isolation. The combined state has two problems:

**1. SqliteMemory does not compile:**

```
error[E0277]: the trait bound `RwLock<RawRwLock, Arc<dyn EmbeddingProvider>>: Clone` is not satisfied
  --> crates/zeroclaw-memory/src/sqlite.rs:54:5
   |
46 | #[derive(Clone)]
   |          -----
...
54 |     embedder: RwLock<Arc<dyn EmbeddingProvider>>,
```

`parking_lot::RwLock` is not `Clone`. #8623 added `#[derive(Clone)]`. #8359's hot-swap change had put `embedder` behind a bare `RwLock`. Neither CI run saw the other.

**2. `writer::tests::reinit_applies_changed_rotation_policy` races the async flush:**

```
thread 'writer::tests::reinit_applies_changed_rotation_policy' panicked at crates/zeroclaw-log/src/writer.rs:865:9:
assertion `left == right` failed
  left: 0
 right: 1
```

The test asserts `total_events(&path) == 1` immediately after `emit(\"before-reload\")`. Prior to #8439 the fsync was synchronous. #8439 moved it to a background worker, so the file has zero events by the time the assertion runs. Every other test that observes on-disk state after `emit()` already calls `flush_for_test()` for exactly this reason.

### Fix

**SqliteMemory:** wrap the `RwLock` in an `Arc`:

```rust
- embedder: RwLock<Arc<dyn EmbeddingProvider>>,
+ embedder: Arc<RwLock<Arc<dyn EmbeddingProvider>>>,
```

That makes the field `Clone`, keeps every `self.embedder.read()` / `.write()` call site identical via `Deref`, and matches what the type's doc comment already promised: \"all shared state is behind `Arc`\".

**Log reinit test:** add `flush_for_test().unwrap()` before each assertion, matching the pattern used by every other test in the same file.

### Validation

- `cargo check --workspace` passes clean
- `cargo test -p zeroclaw-log --lib writer::tests::reinit_applies_changed_rotation_policy` passes

### Risk

Low. The Arc wrap is a lock-sharing change that matches the field's stated intent. The test fix aligns one outlier test with the existing pattern used across the same file.