### PR TITLE
fix(log): shut down previous writer worker on re-init

### DIFF
--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -66,6 +66,12 @@ const SYNC_INTERVAL: Duration = Duration::from_secs(1);
 /// honoured even when no events are flowing.
 const IDLE_TICK: Duration = Duration::from_millis(50);
 
+/// Upper bound on how long re-init waits for a previous worker thread to
+/// observe channel disconnect and exit. Sized well above `IDLE_TICK` so a
+/// healthy worker always exits before the deadline; a stuck worker is
+/// logged and abandoned rather than blocking config reload forever.
+const SHUTDOWN_WAIT: Duration = Duration::from_millis(500);
+
 /// A unit of work sent from the async runtime to the disk-persistence
 /// worker. The `Value` payload is unavoidable because we serialize once
 /// on the producer side to keep the queue small.
@@ -122,6 +128,11 @@ fn current_state() -> Option<Arc<WriterState>> {
 /// When enabled, runs a streaming in-place migration of any schema-1 rows
 /// in the existing file before resuming appends, then spawns the disk
 /// worker thread.
+///
+/// Re-init replaces any previously installed writer: the prior worker is
+/// shut down (its channel closed and its exit observed) before the new
+/// policy is installed, so a config reload cannot leave two workers
+/// racing on the same path or leak threads across reloads.
 pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
     let policy = ResolvedPolicy::from_config(config, workspace_dir);
 
@@ -137,6 +148,11 @@ pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
         );
     }
 
+    // Tear down any previous writer before installing the new one. Taking
+    // the slot first stops new producers from cloning the old Arc; dropping
+    // the Arc drops its SyncSender and disconnects the old worker.
+    shutdown_current_writer();
+
     let (tx, rx) = sync_channel::<WriterJob>(QUEUE_CAPACITY);
     let worker_dead: WorkerDead = Arc::new(AtomicBool::new(false));
 
@@ -147,6 +163,11 @@ pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
             worker_dead: Arc::clone(&worker_dead),
         });
         spawn_worker(rx, worker_state);
+    } else {
+        // No worker will ever run for a disabled policy; mark dead so
+        // flush_for_test / re-init waiters do not spin on a false flag.
+        worker_dead.store(true, Ordering::Release);
+        drop(rx);
     }
 
     let state = Arc::new(WriterState {
@@ -156,6 +177,34 @@ pub fn init_from_config(config: &LogConfig, workspace_dir: &Path) {
         worker_dead,
     });
     *slot().write() = Some(state);
+}
+
+/// Remove the currently installed writer (if any) and wait for its worker
+/// thread to exit. Best-effort: if another thread still holds an
+/// `Arc<WriterState>` clone the channel stays open until that clone drops,
+/// and we only wait up to [`SHUTDOWN_WAIT`] before proceeding.
+fn shutdown_current_writer() {
+    let previous = slot().write().take();
+    let Some(prev) = previous else {
+        return;
+    };
+    let dead = Arc::clone(&prev.worker_dead);
+    // Dropping `prev` drops the last slot-owned SyncSender. Any in-flight
+    // `record_event` that already cloned the Arc may keep the channel open
+    // briefly; the wait below covers the common case.
+    drop(prev);
+
+    let start = Instant::now();
+    while !dead.load(Ordering::Acquire) && start.elapsed() < SHUTDOWN_WAIT {
+        thread::sleep(Duration::from_millis(1));
+    }
+    if !dead.load(Ordering::Acquire) {
+        tracing::warn!(
+            target: "zeroclaw_log",
+            "log: previous writer worker did not exit within {:?}; continuing with re-init",
+            SHUTDOWN_WAIT
+        );
+    }
 }
 
 /// Spawn the disk-persistence worker thread. The worker owns the active
@@ -856,6 +905,7 @@ mod tests {
         install_rotating(tmp.path(), 0, false, 0, 0);
 
         emit("before-reload");
+        flush_for_test().unwrap();
 
         let path = runtime_trace_path().unwrap();
         assert!(
@@ -866,6 +916,7 @@ mod tests {
 
         install_rotating(tmp.path(), 1, false, 1, 0);
         emit("after-reload");
+        flush_for_test().unwrap();
 
         let archives = list_archives(&path).unwrap();
         assert_eq!(
@@ -887,6 +938,7 @@ mod tests {
         install_writer(tmp.path(), 10);
 
         emit("persisted-before-disable");
+        flush_for_test().unwrap();
 
         let path = runtime_trace_path().unwrap();
         assert_eq!(count_lines(&path), 1);
@@ -898,11 +950,51 @@ mod tests {
         init_from_config(&cfg, tmp.path());
 
         emit("not-persisted-after-disable");
+        // Disabled policy has no worker; flush is a no-op. Prior writes were
+        // drained by the shutdown path inside init_from_config.
+        flush_for_test().unwrap();
 
         assert_eq!(
             count_lines(&path),
             1,
             "disabled persistence after re-init should stop appending without deleting existing logs"
+        );
+    }
+
+    #[test]
+    fn reinit_shuts_down_previous_worker_before_installing_new() {
+        let _guard = WRITER_TEST_LOCK.lock();
+        let tmp = tempfile::tempdir().unwrap();
+        install_writer(tmp.path(), 10);
+
+        let first = current_state().expect("writer installed");
+        let first_dead = Arc::clone(&first.worker_dead);
+        assert!(
+            !first_dead.load(Ordering::Acquire),
+            "fresh worker should be alive"
+        );
+        // Drop our Arc clone so shutdown can close the channel. Holding it
+        // would keep the SyncSender alive and prevent the worker from exiting.
+        drop(first);
+
+        // Re-init with a different policy must tear down the first worker
+        // (channel disconnect → worker_dead) before installing the second.
+        install_rotating(tmp.path(), 0, false, 0, 0);
+
+        assert!(
+            first_dead.load(Ordering::Acquire),
+            "previous worker must exit during re-init so it cannot race the new policy"
+        );
+        let second = current_state().expect("replacement writer installed");
+        assert!(
+            !second.worker_dead.load(Ordering::Acquire),
+            "replacement worker should be alive"
+        );
+        // The replacement must not share the previous worker_dead flag —
+        // that would mean the old Arc was reused rather than replaced.
+        assert!(
+            !Arc::ptr_eq(&first_dead, &second.worker_dead),
+            "re-init must install a fresh WriterState, not mutate the old one"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - After the async disk-writer worker (#8439), `init_from_config` overwrote the process-global `WRITER` slot without shutting down the previous worker thread. Config reloads and tests could leave a stale worker racing the new policy.
  - The reinit unit tests (`reinit_applies_changed_rotation_policy`, `reinit_can_disable_persistence_without_restart`) asserted on the log file immediately after `emit()` without `flush_for_test()`, so they failed under `--test-threads=1` with `left: 0, right: 1`.
  - Re-init now tears down the previous writer (drop sender → wait for `worker_dead`) before installing the new policy; disabled policies mark `worker_dead` immediately; reinit tests flush; added a regression test that the previous worker exits and is replaced.
- **Scope boundary:** Does not change the write path, rotation/retention policy, queue capacity, or fsync cadence. No public API surface change beyond re-init lifecycle behavior.
- **Blast radius:** `zeroclaw-log` writer re-init used by daemon config reload (`runtime_trace::init_from_config` / `main.rs` reload path) and any test that installs the global writer. Correctness improvement for hot-reload; no change for first-time init.
- **Linked issue(s):** Related to fallout from #8307 / #8437 / #8439 / #8816 (reinit tests + rotating persistence worker).
- **Labels:** (maintainers: `type:bug`, `risk:low`, `size:S`, path labels from labeler)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-log --all-targets -- -D warnings
cargo test -p zeroclaw-log --lib -- --test-threads=1
```

- **Commands run and tail output:**

  `cargo fmt --all -- --check` — exit 0 (no output)

  `cargo clippy -p zeroclaw-log --all-targets -- -D warnings`:
  ```
  Checking zeroclaw-log v0.8.2 (.../crates/zeroclaw-log)
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
  ```

  `cargo test -p zeroclaw-log --lib -- --test-threads=1`:
  ```
  test writer::tests::reinit_applies_changed_rotation_policy ... ok
  test writer::tests::reinit_can_disable_persistence_without_restart ... ok
  test writer::tests::reinit_shuts_down_previous_worker_before_installing_new ... ok
  ...
  test result: ok. 82 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
  ```

  Also re-ran with `--test-threads=4`: `82 passed`.

- **Beyond CI — what did you manually verify?**
  - Reproduced the original failure on `origin/master` for both reinit tests (`left: 0, right: 1`) before the fix.
  - Confirmed the new regression test fails if the previous `Arc` is held across re-init (channel stays open) and passes when the slot-owned sender is the last one dropped.
  - Did **not** run full workspace `cargo test` (scoped to `zeroclaw-log` where the bug lives).
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` / full-workspace clippy skipped for turnaround; change is isolated to `crates/zeroclaw-log/src/writer.rs`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: None. Re-init now waits briefly (≤500ms) for the previous worker to exit; healthy workers exit within one `IDLE_TICK` (50ms).

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` restores the previous re-init behavior (overwrite slot without shutdown) and the unflushed reinit tests.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A