### PR TITLE
test(log): flush async writes in emit() so reinit_* tests see them

### DIFF
--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -1022,6 +1022,13 @@ mod tests {
         let mut ev = LogEvent::new(Severity::Info, "test", EventCategory::Agent);
         ev.message = Some(msg.to_string());
         record_event(ev);
+        // #8439 moved the JSONL fsync off the async hot path, so `record_event`
+        // returns before the line is on disk. Tests that assert on the log file
+        // immediately after emitting must flush first (the explicit idiom used
+        // throughout this module); folding it into `emit` keeps every
+        // emit-then-read test correct — notably the `reinit_*` tests, which
+        // read the file right after emitting.
+        flush_for_test().unwrap();
     }
 
     fn set_mtime(path: &Path, when: SystemTime) {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `master` CI is currently red on two `zeroclaw-log` tests — `writer::tests::reinit_applies_changed_rotation_policy` and `reinit_can_disable_persistence_without_restart` — both failing deterministically (in isolation *and* under nextest) with `assert_eq!(left: 0, right: 1)` at the first file-content assertion.
  - Root cause: #8439 moved the JSONL fsync **off the async hot path**, so `record_event` now returns before the line is on disk. Every writer test that asserts on the log file already calls `flush_for_test()` after emitting — but the shared `emit()` test helper does not, and these two `reinit_*` tests read the file immediately after `emit()`, so they saw 0 events.
  - Fix: fold `flush_for_test()` into the `emit()` helper, so emit-then-read tests are correct by construction (and the trap can't recur for future tests). One-line behavioral change, tests-only.
- **Scope boundary:** Test-support only (`emit()` helper in `#[cfg(test)]`). No production code, no writer/runtime behavior, no public API change.
- **Blast radius:** `crates/zeroclaw-log` test module. `flush_for_test()` is a no-op when no writer is installed and short-circuits on a dead worker, so folding it into `emit()` is safe for every existing caller.
- **Linked issue(s):** Fixes the `zeroclaw-log` reinit-test failures on master (regression surfaced by #8439's async-fsync change).
- **Labels:** `observability:log`, `risk:low`, `size:XS`, `type:test`

## Validation Evidence (required)

Local validation (ULTRA arm64, rustc 1.96.1 — the repo MSRV):

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-log --all-targets -- -D warnings
cargo test -p zeroclaw-log
```

- **Commands run and tail output:**
  ```
  fmt --all -- --check                  → clean
  clippy -p zeroclaw-log -D warnings    → Finished (0 warnings)
  cargo test -p zeroclaw-log            → test result: ok. 81 passed; 0 failed
       writer::tests::reinit_applies_changed_rotation_policy ... ok
       writer::tests::reinit_can_disable_persistence_without_restart ... ok
  ```
  Before the change the same suite was `79 passed; 2 failed`.
- **Beyond CI — what did you manually verify?** Reproduced both failures on clean `master` (`left: 0, right: 1`) running each test **alone in its own process** (nextest-equivalent isolation) — confirming it was the missing flush, not cross-test global-`WRITER` contamination. Confirmed the full suite is green after the change (parallel and single-test).
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: None — test-support change only.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` (restores the two failing tests). Test-only, no state or migration.
