### PR TITLE
chore(ci): document local gate vs required-CI divergence (#8843)

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -87,6 +87,15 @@ case "$1" in
     ;;
 
   test)
+    # Local Docker test path uses the stable `cargo test` runner. Required
+    # CI uses `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`
+    # (see `.github/workflows/ci.yml`). Both select the same workspace
+    # package boundary, but they differ in runner, scheduling, isolation,
+    # and reporting behavior (nextest runs each test binary in its own
+    # process and emits per-binary JUnit reports; cargo test uses the test
+    # harness's default process model). Keep this delta explicit so a
+    # local-green run does not silently read as "matches CI exactly"
+    # (issue #8843).
     run_in_ci "cargo test --locked --workspace --exclude zeroclaw-desktop --verbose"
     ;;
 
@@ -133,6 +142,10 @@ case "$1" in
     ;;
 
   all)
+    # The `test` arm above and the `cargo test` invocation below both use
+    # `cargo test` (not `nextest`) — see the comment on the `test` case
+    # for why this differs from required CI (issue #8843). If you change
+    # the runner here, update that comment in lockstep.
     run_in_ci "./scripts/ci/rust_quality_gate.sh"
     run_in_ci "cargo test --locked --workspace --exclude zeroclaw-desktop --verbose"
     run_in_ci "bash tests/manual/test_dockerignore.sh"

--- a/scripts/ci/rust_quality_gate.sh
+++ b/scripts/ci/rust_quality_gate.sh
@@ -13,9 +13,18 @@ cargo fmt --all -- --check
 CLIPPY_WORKSPACE_ARGS=(--workspace --exclude zeroclaw-desktop --all-targets)
 
 if [ "$MODE" = "strict" ]; then
+    # Local `--strict` path: same lint set and feature surface as required
+    # CI (both compile with `--features ci-all`). Remaining deltas vs CI
+    # are runner, scheduling, and reporting only — see #8843 for the full
+    # divergence inventory.
     echo "==> rust quality: cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings"
     cargo clippy --locked "${CLIPPY_WORKSPACE_ARGS[@]}" --features ci-all -- -D warnings
 else
+    # Local `--correctness` path: deny `clippy::correctness` only on the
+    # default-feature surface. Intentionally lighter than both `--strict`
+    # and required CI, which compile the `ci-all` feature set. This path
+    # is meant for fast local feedback; full-surface validation happens
+    # via `--strict` or in CI. See #8843 for the full divergence inventory.
     echo "==> rust quality: cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets -- -D clippy::correctness"
     cargo clippy --locked "${CLIPPY_WORKSPACE_ARGS[@]}" -- -D clippy::correctness
 fi


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds in-source comments to `scripts/ci/rust_quality_gate.sh` and `dev/ci.sh` making the two remaining local-gate / required-CI deltas (non-strict clippy feature surface; local `cargo test` vs required-CI `nextest`) visible at the call site, so a local-green run does not silently read as "matches CI exactly". The `#8776` PR (parent fix for #8753) explicitly carved these out as a follow-up; this issue (#8843) is that follow-up.
- **Scope boundary:** No Rust source change, no GitHub Actions workflow change, no test definitions change, no workspace membership change, no Cargo feature change. Comments only. The proposed code change in the issue ("add `--features ci-all` to the non-strict clippy arm") is deliberately not applied - keeping the lighter local-correctness path as fast local feedback is the existing design intent, and making that intent visible (option 2 in the issue's proposed solution) preserves it.
- **Blast radius:** Documentation only in two repository-root shell scripts. No runtime, config, public API, or data model impact. Downstream forks that copy the local CI scripts verbatim pick up the comments unchanged.
- **Linked issue(s):** Fixes #8843

## Changes

- `scripts/ci/rust_quality_gate.sh`: comments above both the `--strict` and `--correctness` clippy arms explain the local-vs-required-CI feature surface delta and reference #8843.
- `dev/ci.sh`: comment above the `test` case explains the `cargo test` vs `nextest` runner delta; a short cross-reference comment above the `all` arm's `cargo test` invocation points back to it so the two are kept in lockstep.
- No regression test added: the diff is comment-only, and the original failure mode ("local gate silently drops packages / silently uses a different runner") was the workspace-boundary fix in #8776, not the divergence inventory itself. The comments are the regression net - a future change to either script that drops the local-vs-CI distinction becomes reviewable on its own.

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
(no output - clean)

$ cargo check -p zeroclaw-config
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 45s
(no errors)

$ bash -n dev/ci.sh && bash -n scripts/ci/rust_quality_gate.sh
(no output - both scripts parse)
```

The `cargo clippy` and `cargo test --locked` arms of the verification battery were not run because no Rust source was touched; the touched files are bash scripts in `scripts/ci/` and `dev/`. A bash syntax check (`bash -n`) is the local equivalent for shell-script edits and is clean. CI on the patched scripts is the authoritative regression check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the rollback plan.

## Risk

Low. Comments only, no executable change. The non-strict clippy path is unchanged in behavior; the local Docker test path is unchanged in behavior. The added comments do introduce a one-line maintenance obligation (keep the two `cargo test` references in `dev/ci.sh` in lockstep if the runner is ever switched), which is itself documented in the cross-reference comment.
