### PR TITLE
feat(sop): add an approval broker with group membership and quorum over the gate chokepoint

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -21777,9 +21777,9 @@ pub enum ApprovalTimeoutAction {
 pub struct SopApprovalConfig {
     /// Named approver groups: `group name -> members`. A member is matched against
     /// the transport-derived (channel-authenticated) `ApprovalPrincipal` identity.
-    /// A member may be source-qualified (`<source>:<identity>`, e.g. `http:alice`,
+    /// A member may be source-qualified (`<source>:<identity>`, e.g. `http:ZeroClawOperator`,
     /// `ws:<subject>`, `agent:<alias>`) to grant rights on one transport only, or a
-    /// bare identity (`alice`) to grant from any source. A future auth system adds a
+    /// bare identity (`ZeroClawOperator`) to grant from any source. A future auth system adds a
     /// second resolver alongside this one; it does not replace channel identities.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     #[nested]

--- a/crates/zeroclaw-gateway/src/api_sop.rs
+++ b/crates/zeroclaw-gateway/src/api_sop.rs
@@ -249,6 +249,10 @@ fn broker_outcome_response(outcome: &BrokerOutcome) -> (StatusCode, String) {
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("policy_missing ('{name}')"),
         ),
+        BrokerOutcome::PolicyUnavailable { reason } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("policy_unavailable ({reason})"),
+        ),
     }
 }
 

--- a/crates/zeroclaw-gateway/src/api_sop_author.rs
+++ b/crates/zeroclaw-gateway/src/api_sop_author.rs
@@ -418,7 +418,10 @@ pub async fn handle_sop_decide(
         };
         let status = guard.get_run(&run_id).map(|r| r.status);
         match status {
-            Some(zeroclaw_runtime::sop::types::SopRunStatus::WaitingApproval) => {
+            Some(
+                zeroclaw_runtime::sop::types::SopRunStatus::WaitingApproval
+                | zeroclaw_runtime::sop::types::SopRunStatus::PausedCheckpoint,
+            ) => {
                 use zeroclaw_runtime::sop::approval::{BrokerOutcome, ResolveOutcome};
                 // Route through the broker (membership + quorum), not `resolve_gate`
                 // directly, otherwise this authoring surface would
@@ -456,10 +459,8 @@ pub async fn handle_sop_decide(
                         return (
                             StatusCode::SERVICE_UNAVAILABLE,
                             Json(serde_json::json!({
-                                "error": format!(
-                                    "Run {run_id} is approved but execution slots are full; \
-                                     it stays waiting and resumes when a slot frees. Retry shortly."
-                                )
+                                "outcome": "deferred_at_capacity",
+                                "run_id": run_id,
                             })),
                         )
                             .into_response();
@@ -480,6 +481,16 @@ pub async fn handle_sop_decide(
                             StatusCode::INTERNAL_SERVER_ERROR,
                             Json(serde_json::json!({
                                 "error": format!("approval policy '{name}' is not configured (gate left waiting)")
+                            })),
+                        )
+                            .into_response();
+                    }
+                    Ok(BrokerOutcome::PolicyUnavailable { reason }) => {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(serde_json::json!({
+                                "error": "policy_unavailable",
+                                "reason": reason,
                             })),
                         )
                             .into_response();
@@ -505,23 +516,17 @@ pub async fn handle_sop_decide(
                     }
                 }
             }
-            _ => match guard.decide_checkpoint(&run_id, decision) {
-                Ok(action) => {
-                    resumed_action = Some(action);
-                }
-                Err(e) => {
-                    // A checkpoint resume refused at capacity is transient backpressure, not a
-                    // bad request: return 503 to match the approval resume path's
-                    // `DeferredAtCapacity`. A genuine error stays 400.
-                    let status = if zeroclaw_runtime::sop::err_is_resume_at_capacity(&e) {
-                        StatusCode::SERVICE_UNAVAILABLE
-                    } else {
-                        StatusCode::BAD_REQUEST
-                    };
-                    return (status, Json(serde_json::json!({ "error": e.to_string() })))
-                        .into_response();
-                }
-            },
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!(
+                            "Run {run_id} is not waiting for approval or paused at a checkpoint"
+                        )
+                    })),
+                )
+                    .into_response();
+            }
         }
     }
 

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -1055,4 +1055,9 @@ cli-doctor-ctxwin-write-failed = {$provider_ref}: failed to write context_window
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = SECURITY-CRITICAL config section `{$path}` is invalid and was reset to its default so the daemon can boot; the running posture may be WEAKER than intended. Run `zeroclaw config migrate` to see the parse error, then repair the file.
 cli-doctor-degraded-section = config section `{$path}` is malformed and was reset to defaults; values in that section are NOT in effect. Run `zeroclaw config migrate` to see the parse error, then repair the file.
-
+sop-approval-deferred-at-capacity = Approval could not resume run {$run_id}: execution slots are full. The gate remains waiting; retry after a slot frees.
+sop-approval-policy-unavailable = Approval failed because the parked SOP step is unavailable: {$reason}. The run remains waiting.
+sop-rpc-decision-invalid-state = Run {$run_id} cannot be resolved in its current state.
+sop-rpc-decision-unauthorized = The RPC principal is not authorized to resolve this SOP step.
+sop-rpc-policy-missing = SOP approval policy '{$name}' is not configured.
+sop-rpc-policy-unavailable = The parked SOP policy is unavailable: {$reason}.

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -933,3 +933,9 @@ cli-doctor-ctxwin-write-failed = {$provider_ref}: error al escribir context_wind
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = Sección de configuración CRÍTICA PARA LA SEGURIDAD `{$path}` no es válida y se restableció a sus valores predeterminados para que el daemon pueda arrancar; la postura en ejecución puede ser MÁS DÉBIL de lo previsto. Ejecute `zeroclaw config migrate` para ver el error de análisis y luego repare el archivo.
 cli-doctor-degraded-section = La sección de configuración `{$path}` está mal formada y se restableció a sus valores predeterminados; los valores de esa sección NO están en efecto. Ejecute `zeroclaw config migrate` para ver el error de análisis y luego repare el archivo.
+sop-approval-deferred-at-capacity = No se pudo reanudar la ejecución {$run_id}: los cupos de ejecución están llenos. La aprobación sigue en espera; inténtalo de nuevo cuando se libere un cupo.
+sop-approval-policy-unavailable = La aprobación falló porque el paso de SOP en espera no está disponible: {$reason}. La ejecución sigue en espera.
+sop-rpc-decision-invalid-state = La ejecución {$run_id} no se puede resolver en su estado actual.
+sop-rpc-decision-unauthorized = La identidad RPC no está autorizada para resolver este paso de SOP.
+sop-rpc-policy-missing = La política de aprobación de SOP '{$name}' no está configurada.
+sop-rpc-policy-unavailable = La política del SOP en espera no está disponible: {$reason}.

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -936,3 +936,9 @@ cli-doctor-ctxwin-write-failed = {$provider_ref}: échec de l'écriture de conte
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = La section de configuration CRITIQUE POUR LA SÉCURITÉ `{$path}` est invalide et a été réinitialisée à sa valeur par défaut pour permettre au daemon de démarrer ; la posture en cours d'exécution peut être PLUS FAIBLE que prévu. Exécutez `zeroclaw config migrate` pour voir l'erreur d'analyse, puis réparez le fichier.
 cli-doctor-degraded-section = La section de configuration `{$path}` est malformée et a été réinitialisée aux valeurs par défaut ; les valeurs de cette section ne sont PAS en vigueur. Exécutez `zeroclaw config migrate` pour voir l'erreur d'analyse, puis réparez le fichier.
+sop-approval-deferred-at-capacity = Impossible de reprendre l’exécution {$run_id} : tous les créneaux d’exécution sont occupés. L’approbation reste en attente ; réessayez lorsqu’un créneau se libère.
+sop-approval-policy-unavailable = L’approbation a échoué car l’étape SOP en attente est indisponible : {$reason}. L’exécution reste en attente.
+sop-rpc-decision-invalid-state = L’exécution {$run_id} ne peut pas être résolue dans son état actuel.
+sop-rpc-decision-unauthorized = L’identité RPC n’est pas autorisée à résoudre cette étape SOP.
+sop-rpc-policy-missing = La politique d’approbation SOP « {$name} » n’est pas configurée.
+sop-rpc-policy-unavailable = La politique du SOP en attente est indisponible : {$reason}.

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -933,3 +933,9 @@ cli-doctor-ctxwin-write-failed = {$provider_ref}: context_window の書き込み
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = セキュリティ上重要な設定セクション `{$path}` が無効なため、デーモンを起動できるようデフォルト値にリセットされました。実行中のセキュリティ設定は意図したものより弱くなっている可能性があります。`zeroclaw config migrate` を実行してパースエラーを確認し、ファイルを修復してください。
 cli-doctor-degraded-section = 設定セクション `{$path}` は不正な形式のためデフォルト値にリセットされました。このセクションの値は反映されていません。`zeroclaw config migrate` を実行してパースエラーを確認し、ファイルを修復してください。
+sop-approval-deferred-at-capacity = 実行スロットが満杯のため、実行 {$run_id} を再開できませんでした。承認は待機状態のままです。スロットが空いてから再試行してください。
+sop-approval-policy-unavailable = 待機中の SOP ステップを利用できないため、承認に失敗しました: {$reason}。実行は待機状態のままです。
+sop-rpc-decision-invalid-state = 実行 {$run_id} は現在の状態では解決できません。
+sop-rpc-decision-unauthorized = RPC プリンシパルには、この SOP ステップを解決する権限がありません。
+sop-rpc-policy-missing = SOP 承認ポリシー '{$name}' が構成されていません。
+sop-rpc-policy-unavailable = 待機中の SOP ポリシーを利用できません: {$reason}。

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -932,3 +932,9 @@ cli-doctor-ctxwin-write-failed = {$provider_ref}: 写入 context_window 失败: 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = 安全关键配置节 `{$path}` 无效，已重置为默认值以便守护进程启动；当前运行的安全态势可能弱于预期。运行 `zeroclaw config migrate` 查看解析错误，然后修复该文件。
 cli-doctor-degraded-section = 配置节 `{$path}` 格式错误，已重置为默认值；该节中的值当前不生效。运行 `zeroclaw config migrate` 查看解析错误，然后修复该文件。
+sop-approval-deferred-at-capacity = 执行槽位已满，无法恢复运行 {$run_id}。审批仍处于等待状态；请在槽位释放后重试。
+sop-approval-policy-unavailable = 无法使用暂停的 SOP 步骤，审批失败：{$reason}。运行仍处于等待状态。
+sop-rpc-decision-invalid-state = 运行 {$run_id} 无法在当前状态下完成决策。
+sop-rpc-decision-unauthorized = RPC 主体无权对该 SOP 步骤作出决策。
+sop-rpc-policy-missing = 未配置 SOP 审批策略“{$name}”。
+sop-rpc-policy-unavailable = 暂停的 SOP 策略不可用：{$reason}。

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -4131,13 +4131,72 @@ impl RpcDispatcher {
         );
         let _guard = span.enter();
 
+        let mut resumed_action = None;
         {
             let mut guard = engine
                 .lock()
                 .map_err(|_| rpc_err(INTERNAL_ERROR, "SOP engine lock poisoned"))?;
-            guard
-                .decide_checkpoint(&req.run_id, decision)
-                .map_err(|e| rpc_err(INVALID_PARAMS, e.to_string()))?;
+            use crate::sop::approval::{BrokerOutcome, ResolveOutcome};
+            let principal = crate::sop::approval::ApprovalPrincipal::cli(self.tui_id.clone());
+            match guard
+                .resolve_via_broker(&req.run_id, decision, principal)
+                .map_err(|e| rpc_err(INTERNAL_ERROR, e.to_string()))?
+            {
+                BrokerOutcome::Resolved(ResolveOutcome::Resumed(action)) => {
+                    resumed_action = Some(*action);
+                }
+                BrokerOutcome::Resolved(
+                    ResolveOutcome::Denied | ResolveOutcome::AlreadyResolved,
+                )
+                | BrokerOutcome::PendingQuorum { .. } => {}
+                BrokerOutcome::Resolved(
+                    ResolveOutcome::NotWaiting | ResolveOutcome::DeferredAtCapacity,
+                )
+                | BrokerOutcome::NotWaiting => {
+                    return Err(rpc_err(
+                        INVALID_PARAMS,
+                        crate::i18n::get_required_cli_string_with_args(
+                            "sop-rpc-decision-invalid-state",
+                            &[("run_id", req.run_id.as_str())],
+                        ),
+                    ));
+                }
+                BrokerOutcome::Resolved(ResolveOutcome::RejectedSelfApproval)
+                | BrokerOutcome::NotAuthorized { .. } => {
+                    return Err(rpc_err(
+                        AUTH_REQUIRED,
+                        crate::i18n::get_required_cli_string("sop-rpc-decision-unauthorized"),
+                    ));
+                }
+                BrokerOutcome::PolicyMissing { name } => {
+                    return Err(rpc_err(
+                        INTERNAL_ERROR,
+                        crate::i18n::get_required_cli_string_with_args(
+                            "sop-rpc-policy-missing",
+                            &[("name", name.as_str())],
+                        ),
+                    ));
+                }
+                BrokerOutcome::PolicyUnavailable { reason } => {
+                    return Err(rpc_err(
+                        INTERNAL_ERROR,
+                        crate::i18n::get_required_cli_string_with_args(
+                            "sop-rpc-policy-unavailable",
+                            &[("reason", reason.as_str())],
+                        ),
+                    ));
+                }
+            }
+        }
+
+        if let Some(action) = resumed_action {
+            let config = self.ctx.config.read().clone();
+            crate::sop::spawn_headless_run_driver(
+                config,
+                Arc::clone(&engine),
+                self.ctx.sop_audit.clone(),
+                action,
+            );
         }
 
         let overlay = crate::sop::run_overlay_for(&sop, &engine, &req.run_id).map_err(|e| {
@@ -5406,6 +5465,158 @@ mod tests {
             .handle_sops_runs(&serde_json::json!({ "sop": "some-sop" }))
             .expect_err("missing engine must error");
         assert_eq!(err.code, INTERNAL_ERROR);
+    }
+
+    fn make_checkpoint_rpc_dispatcher(
+        quorum: u32,
+        members: &[&str],
+        tui_id: &str,
+    ) -> (
+        RpcDispatcher,
+        Arc<std::sync::Mutex<crate::sop::SopEngine>>,
+        String,
+        tempfile::TempDir,
+    ) {
+        use crate::sop::types::{
+            Sop, SopAdmissionPolicy, SopEvent, SopExecutionMode, SopPriority, SopRunAction,
+            SopStep, SopStepKind, SopTrigger, SopTriggerSource,
+        };
+        use std::collections::HashMap;
+        use zeroclaw_config::schema::{
+            ApprovalGroupConfig, ApprovalPolicyConfig, Config, SopApprovalConfig,
+        };
+        use zeroclaw_infra::session_queue::SessionActorQueue;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let sops_dir = temp.path().join("sops");
+        let sop = Sop {
+            name: "rpc-checkpoint".into(),
+            description: "checkpoint RPC authorization test".into(),
+            version: "1.0.0".into(),
+            priority: SopPriority::Normal,
+            execution_mode: SopExecutionMode::Deterministic,
+            triggers: vec![SopTrigger::Manual],
+            steps: vec![
+                SopStep {
+                    number: 1,
+                    title: "authorize".into(),
+                    kind: SopStepKind::Checkpoint,
+                    policy: Some("prod".into()),
+                    ..SopStep::default()
+                },
+                SopStep {
+                    number: 2,
+                    title: "continue".into(),
+                    kind: SopStepKind::Execute,
+                    ..SopStep::default()
+                },
+            ],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+            admission_policy: SopAdmissionPolicy::Parallel,
+            max_pending_approvals: 0,
+            agent: None,
+        };
+        crate::sop::save_sop(&sops_dir, &sop).unwrap();
+
+        let mut groups = HashMap::new();
+        groups.insert(
+            "release".to_string(),
+            ApprovalGroupConfig {
+                members: members.iter().map(|member| (*member).to_string()).collect(),
+            },
+        );
+        let mut policies = HashMap::new();
+        policies.insert(
+            "prod".to_string(),
+            ApprovalPolicyConfig {
+                required_group: Some("release".into()),
+                quorum,
+                request_route: None,
+                escalation_route: None,
+            },
+        );
+        let mut config = Config::default();
+        config.sop.sops_dir = Some(sops_dir.to_string_lossy().into_owned());
+        config.sop.approval = SopApprovalConfig { groups, policies };
+
+        let mut engine = crate::sop::SopEngine::new(config.sop.clone())
+            .with_approval_broker(Arc::new(crate::sop::approval::ApprovalBroker::disabled()));
+        engine.set_sops_for_test(vec![sop]);
+        let action = engine
+            .start_run(
+                "rpc-checkpoint",
+                SopEvent {
+                    source: SopTriggerSource::Manual,
+                    topic: None,
+                    payload: None,
+                    timestamp: crate::sop::engine::now_iso8601(),
+                },
+            )
+            .unwrap();
+        let run_id = match action {
+            SopRunAction::CheckpointWait { run_id, .. } => run_id,
+            other => panic!("expected checkpoint wait, got {other:?}"),
+        };
+        let engine = Arc::new(std::sync::Mutex::new(engine));
+        let sessions = Arc::new(crate::rpc::session::SessionStore::new(
+            16,
+            Arc::new(SessionActorQueue::new(4, 10, 60)),
+        ));
+        let ctx = RpcContext::minimal_with_sop_engine(config, sessions, Arc::clone(&engine));
+        let (tx, _rx) = tokio::sync::mpsc::channel(64);
+        let mut dispatcher = RpcDispatcher::new(ctx, tx, "local:test".into());
+        dispatcher.set_tui_id_for_test(Some(tui_id.to_string()));
+        (dispatcher, engine, run_id, temp)
+    }
+
+    #[tokio::test]
+    async fn sops_decide_rpc_enforces_checkpoint_membership_and_quorum() {
+        use crate::sop::types::SopRunStatus;
+
+        let (unauthorized, engine, run_id, _temp) =
+            make_checkpoint_rpc_dispatcher(1, &["cli:ZeroClawOperator"], "ZeroClawAgent");
+        let error = unauthorized
+            .handle_sops_decide(&json!({
+                "name": "rpc-checkpoint",
+                "run_id": run_id.clone(),
+                "decision": "approve",
+            }))
+            .await
+            .expect_err("unauthorized RPC principal must be rejected");
+        assert_eq!(error.code, AUTH_REQUIRED);
+        assert_eq!(
+            engine
+                .lock()
+                .unwrap()
+                .get_run(&run_id)
+                .map(|run| run.status),
+            Some(SopRunStatus::PausedCheckpoint)
+        );
+
+        let (pending, engine, run_id, _temp) = make_checkpoint_rpc_dispatcher(
+            2,
+            &["cli:ZeroClawOperator", "cli:ZeroClawMaintainer"],
+            "ZeroClawOperator",
+        );
+        pending
+            .handle_sops_decide(&json!({
+                "name": "rpc-checkpoint",
+                "run_id": run_id.clone(),
+                "decision": "approve",
+            }))
+            .await
+            .expect("an authorized first vote returns the still-parked overlay");
+        assert_eq!(
+            engine
+                .lock()
+                .unwrap()
+                .get_run(&run_id)
+                .map(|run| run.status),
+            Some(SopRunStatus::PausedCheckpoint)
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/sop/approval/broker.rs
+++ b/crates/zeroclaw-runtime/src/sop/approval/broker.rs
@@ -101,6 +101,9 @@ pub enum BrokerOutcome {
     /// than treated as an unpoliced (quorum-1, no-membership) gate, so a typo can
     /// never downgrade a policied step to open approval.
     PolicyMissing { name: String },
+    /// The parked run's live SOP or current step could not be resolved. Fail
+    /// closed rather than interpreting unavailable state as intentionally unpoliced.
+    PolicyUnavailable { reason: String },
     /// The run is not a waiting gate (unknown / already-resolved / not applicable).
     NotWaiting,
 }
@@ -120,6 +123,9 @@ impl BrokerOutcome {
             BrokerOutcome::PolicyMissing { name } => {
                 format!("policy_missing ('{name}')")
             }
+            BrokerOutcome::PolicyUnavailable { reason } => {
+                format!("policy_unavailable ({reason})")
+            }
         }
     }
 }
@@ -138,6 +144,9 @@ enum StepPolicy {
     /// The step names a policy ABSENT from config: fail closed, never treat as
     /// unpoliced.
     MissingNamed(String),
+    /// The live run/SOP/step cannot be resolved. This is not equivalent to an
+    /// authored step with no policy and must fail closed.
+    Unavailable(String),
 }
 
 /// Authorization + quorum layer over `resolve_gate`. Holds NO copy of the approval
@@ -242,8 +251,10 @@ impl ApprovalBroker {
     /// from the engine's live config. Three-state so a NAMED-but-absent policy is
     /// distinguished from no policy at all - the caller fails closed on the former.
     fn step_policy(&self, engine: &SopEngine, run_id: &str) -> StepPolicy {
-        let Some(name) = engine.current_step_policy_name(run_id) else {
-            return StepPolicy::Unpoliced;
+        let name = match engine.current_step_policy_lookup(run_id) {
+            Ok(Some(name)) => name,
+            Ok(None) => return StepPolicy::Unpoliced,
+            Err(e) => return StepPolicy::Unavailable(e.to_string()),
         };
         match engine.approval_config().policies.get(&name) {
             Some(p) => StepPolicy::Named {
@@ -252,6 +263,68 @@ impl ApprovalBroker {
             },
             None => StepPolicy::MissingNamed(name),
         }
+    }
+
+    /// Authorize a deterministic checkpoint through the same live policy,
+    /// membership, approval-mode, and quorum rules as a waiting approval gate.
+    /// `None` means the checkpoint owner may apply the decision; `Some` leaves
+    /// the checkpoint parked with the returned broker outcome.
+    pub(crate) fn authorize_checkpoint(
+        &self,
+        engine: &mut SopEngine,
+        run_id: &str,
+        step: u32,
+        decision: &ApprovalDecision,
+        principal: &ApprovalPrincipal,
+    ) -> anyhow::Result<Option<BrokerOutcome>> {
+        let policy = match self.step_policy(engine, run_id) {
+            StepPolicy::Unavailable(reason) => {
+                return Ok(Some(BrokerOutcome::PolicyUnavailable { reason }));
+            }
+            StepPolicy::MissingNamed(name) => {
+                return Ok(Some(BrokerOutcome::PolicyMissing { name }));
+            }
+            StepPolicy::Unpoliced => return Ok(None),
+            StepPolicy::Named { name, config } => (name, config),
+        };
+
+        if let Some(group) = policy.1.required_group.as_deref().filter(|g| !g.is_empty())
+            && !self
+                .resolver
+                .is_member(engine.approval_config(), principal, group)
+        {
+            return Ok(Some(BrokerOutcome::NotAuthorized {
+                required_group: group.to_string(),
+            }));
+        }
+
+        if super::resolve::is_rejected_by_approval_mode(engine.config().approval_mode, principal) {
+            return Ok(Some(BrokerOutcome::Resolved(
+                ResolveOutcome::RejectedSelfApproval,
+            )));
+        }
+
+        if matches!(decision, ApprovalDecision::Deny { .. }) {
+            return Ok(None);
+        }
+        let need = policy.1.quorum.max(1) as usize;
+        if need <= 1 {
+            return Ok(None);
+        }
+        if engine.is_park_persist_pending(run_id) {
+            anyhow::bail!(
+                "cannot record checkpoint approval vote for run {run_id}: its parked snapshot is not yet durably persisted (retrying)"
+            );
+        }
+        engine.record_gate_vote(run_id, step, &policy.0, principal)?;
+        let have = self.count_qualified_voters(
+            engine,
+            run_id,
+            step,
+            &policy.0,
+            policy.1.required_group.as_deref().filter(|g| !g.is_empty()),
+        )?;
+        Ok((have < need).then_some(BrokerOutcome::PendingQuorum { have, need }))
     }
 
     /// Resolve a gate through the broker: enforce membership + quorum, then call the
@@ -276,6 +349,9 @@ impl ApprovalBroker {
         // waiting rather than falling through to an unpoliced (quorum-1) resolution.
         let policy: Option<(String, ApprovalPolicyConfig)> = match self.step_policy(engine, run_id)
         {
+            StepPolicy::Unavailable(reason) => {
+                return Ok(BrokerOutcome::PolicyUnavailable { reason });
+            }
             StepPolicy::MissingNamed(name) => return Ok(BrokerOutcome::PolicyMissing { name }),
             StepPolicy::Unpoliced => None,
             StepPolicy::Named { name, config } => Some((name, config)),
@@ -490,6 +566,39 @@ mod tests {
         }
     }
 
+    fn checkpoint_policy_sop(policy: &str) -> Sop {
+        Sop {
+            name: "checkpointed".into(),
+            description: "t".into(),
+            version: "1.0.0".into(),
+            priority: SopPriority::Normal,
+            execution_mode: SopExecutionMode::Deterministic,
+            triggers: vec![SopTrigger::Manual],
+            steps: vec![
+                SopStep {
+                    number: 1,
+                    title: "checkpoint".into(),
+                    kind: SopStepKind::Checkpoint,
+                    policy: Some(policy.into()),
+                    ..SopStep::default()
+                },
+                SopStep {
+                    number: 2,
+                    title: "go".into(),
+                    kind: SopStepKind::Execute,
+                    ..SopStep::default()
+                },
+            ],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+            admission_policy: SopAdmissionPolicy::Parallel,
+            max_pending_approvals: 0,
+            agent: None,
+        }
+    }
+
     /// approval config: group `release` with the given members, policy `prod`
     /// requiring that group and the given quorum.
     fn approval_cfg(members: &[&str], quorum: u32) -> SopApprovalConfig {
@@ -537,14 +646,126 @@ mod tests {
         (e, id)
     }
 
+    fn checkpoint_engine_with_broker(cfg: SopApprovalConfig) -> (SopEngine, String) {
+        let broker = Arc::new(ApprovalBroker::disabled());
+        let sop_config = SopConfig {
+            approval: cfg,
+            ..SopConfig::default()
+        };
+        let mut engine = SopEngine::new(sop_config).with_approval_broker(broker);
+        engine.set_sops_for_test(vec![checkpoint_policy_sop("prod")]);
+        let action = engine.start_run("checkpointed", manual()).unwrap();
+        let run_id = match action {
+            SopRunAction::CheckpointWait { run_id, .. } => run_id,
+            other => panic!("expected CheckpointWait, got {other:?}"),
+        };
+        (engine, run_id)
+    }
+
+    #[test]
+    fn checkpoint_non_member_is_not_authorized_and_stays_paused() {
+        let (mut engine, run_id) =
+            checkpoint_engine_with_broker(approval_cfg(&["ZeroClawOperator"], 1));
+        let outcome = engine
+            .resolve_via_broker(
+                &run_id,
+                ApprovalDecision::Approve,
+                ApprovalPrincipal::cli(Some("ZeroClawAgent".into())),
+            )
+            .unwrap();
+        assert!(matches!(outcome, BrokerOutcome::NotAuthorized { .. }));
+        assert_eq!(
+            engine.get_run(&run_id).map(|run| run.status),
+            Some(SopRunStatus::PausedCheckpoint)
+        );
+        assert!(
+            engine
+                .run_events(&run_id)
+                .unwrap()
+                .iter()
+                .all(|event| event.kind != "gate_resolved")
+        );
+    }
+
+    #[test]
+    fn checkpoint_quorum_waits_for_distinct_members_and_audits_resolver() {
+        let (mut engine, run_id) = checkpoint_engine_with_broker(approval_cfg(
+            &["ZeroClawOperator", "ZeroClawMaintainer"],
+            2,
+        ));
+        let first = engine
+            .resolve_via_broker(
+                &run_id,
+                ApprovalDecision::Approve,
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
+            )
+            .unwrap();
+        assert!(matches!(
+            first,
+            BrokerOutcome::PendingQuorum { have: 1, need: 2 }
+        ));
+        assert_eq!(
+            engine.get_run(&run_id).map(|run| run.status),
+            Some(SopRunStatus::PausedCheckpoint)
+        );
+
+        let second = engine
+            .resolve_via_broker(
+                &run_id,
+                ApprovalDecision::Approve,
+                ApprovalPrincipal::cli(Some("ZeroClawMaintainer".into())),
+            )
+            .unwrap();
+        assert!(matches!(
+            second,
+            BrokerOutcome::Resolved(ResolveOutcome::Resumed(_))
+        ));
+        let resolved = engine
+            .run_events(&run_id)
+            .unwrap()
+            .into_iter()
+            .find(|event| event.kind == "gate_resolved")
+            .expect("checkpoint decision audit");
+        assert_eq!(resolved.actor.as_deref(), Some("ZeroClawMaintainer"));
+        assert_eq!(resolved.payload["decision"], "approve");
+    }
+
+    #[test]
+    fn checkpoint_authorized_deny_audits_actor_and_decision() {
+        let (mut engine, run_id) =
+            checkpoint_engine_with_broker(approval_cfg(&["ZeroClawOperator"], 1));
+        let outcome = engine
+            .resolve_via_broker(
+                &run_id,
+                ApprovalDecision::Deny {
+                    reason: Some("release blocked".into()),
+                },
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
+            )
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            BrokerOutcome::Resolved(ResolveOutcome::Resumed(_))
+        ));
+        let resolved = engine
+            .run_events(&run_id)
+            .unwrap()
+            .into_iter()
+            .find(|event| event.kind == "gate_resolved")
+            .expect("checkpoint decision audit");
+        assert_eq!(resolved.actor.as_deref(), Some("ZeroClawOperator"));
+        assert_eq!(resolved.payload["decision"], "deny");
+        assert_eq!(resolved.reason.as_deref(), Some("release blocked"));
+    }
+
     #[test]
     fn non_member_is_not_authorized_and_gate_stays_open() {
-        let (mut e, id) = engine_with_broker(approval_cfg(&["alice"], 1));
+        let (mut e, id) = engine_with_broker(approval_cfg(&["ZeroClawOperator"], 1));
         let out = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("mallory".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawAgent".into())),
             )
             .unwrap();
         assert!(matches!(out, BrokerOutcome::NotAuthorized { .. }));
@@ -555,13 +776,43 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_live_step_fails_closed_for_approve_and_deny() {
+        for decision in [
+            ApprovalDecision::Approve,
+            ApprovalDecision::Deny { reason: None },
+        ] {
+            let (mut engine, run_id) = engine_with_broker(approval_cfg(&["ZeroClawOperator"], 1));
+            engine.set_sops_for_test(Vec::new());
+            let outcome = engine
+                .resolve_via_broker(
+                    &run_id,
+                    decision,
+                    ApprovalPrincipal::cli(Some("ZeroClawAgent".into())),
+                )
+                .unwrap();
+            assert!(matches!(outcome, BrokerOutcome::PolicyUnavailable { .. }));
+            assert_eq!(
+                engine.get_run(&run_id).map(|run| run.status),
+                Some(SopRunStatus::WaitingApproval)
+            );
+            assert!(
+                engine
+                    .run_events(&run_id)
+                    .unwrap()
+                    .iter()
+                    .all(|event| event.kind != "gate_resolved")
+            );
+        }
+    }
+
+    #[test]
     fn member_single_quorum_resolves() {
-        let (mut e, id) = engine_with_broker(approval_cfg(&["alice"], 1));
+        let (mut e, id) = engine_with_broker(approval_cfg(&["ZeroClawOperator"], 1));
         let out = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(matches!(
@@ -572,13 +823,14 @@ mod tests {
 
     #[test]
     fn quorum_of_two_needs_two_distinct_approvers() {
-        let (mut e, id) = engine_with_broker(approval_cfg(&["alice", "bob"], 2));
+        let (mut e, id) =
+            engine_with_broker(approval_cfg(&["ZeroClawOperator", "ZeroClawMaintainer"], 2));
         // First authorized approval: recorded, still pending.
         let first = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(
@@ -590,7 +842,7 @@ mod tests {
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(matches!(
@@ -602,7 +854,7 @@ mod tests {
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("bob".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawMaintainer".into())),
             )
             .unwrap();
         assert!(matches!(
@@ -622,13 +874,13 @@ mod tests {
         groups.insert(
             "g_old".to_string(),
             ApprovalGroupConfig {
-                members: vec!["alice".into()],
+                members: vec!["ZeroClawOperator".into()],
             },
         );
         groups.insert(
             "g_new".to_string(),
             ApprovalGroupConfig {
-                members: vec!["bob".into()],
+                members: vec!["ZeroClawMaintainer".into()],
             },
         );
         let mut policies = HashMap::new();
@@ -650,12 +902,12 @@ mod tests {
         );
         let (mut e, id) = engine_with_broker_step("old", SopApprovalConfig { groups, policies });
 
-        // alice (a g_old member) votes under `old`: recorded, quorum not yet met.
+        // ZeroClawOperator (a g_old member) votes under `old`: recorded, quorum not yet met.
         let first = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(matches!(
@@ -666,12 +918,12 @@ mod tests {
         // A SOP reload re-points the parked step at policy `new` (group g_new).
         e.set_sops_for_test(vec![policy_sop("new")]);
 
-        // bob (a g_new member) votes under `new`. alice's stale `old` vote must NOT count.
+        // ZeroClawMaintainer (a g_new member) votes under `new`. ZeroClawOperator's stale `old` vote must NOT count.
         let second = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("bob".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawMaintainer".into())),
             )
             .unwrap();
         assert!(
@@ -682,17 +934,18 @@ mod tests {
 
     #[test]
     fn revoked_member_vote_does_not_count_after_config_reload() {
-        // Membership revocation: alice votes under `prod`
-        // (group `release`), then a live config reload revokes alice from `release` while
+        // Membership revocation: ZeroClawOperator votes under `prod`
+        // (group `release`), then a live config reload revokes ZeroClawOperator from `release` while
         // the gate is parked. Her earlier vote is REVALIDATED against the live group at
         // count time, so it stops counting - the one remaining member cannot alone clear
         // a quorum of two.
-        let (mut e, id) = engine_with_broker(approval_cfg(&["alice", "bob"], 2));
+        let (mut e, id) =
+            engine_with_broker(approval_cfg(&["ZeroClawOperator", "ZeroClawMaintainer"], 2));
         let first = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(matches!(
@@ -700,16 +953,16 @@ mod tests {
             BrokerOutcome::PendingQuorum { have: 1, need: 2 }
         ));
 
-        // Live config reload revokes alice from the release group (bob remains).
-        e.set_approval_config_for_test(approval_cfg(&["bob"], 2));
+        // Live config reload revokes ZeroClawOperator from the release group (ZeroClawMaintainer remains).
+        e.set_approval_config_for_test(approval_cfg(&["ZeroClawMaintainer"], 2));
 
-        // bob votes. alice's earlier vote is revalidated against the CURRENT group and
+        // ZeroClawMaintainer votes. ZeroClawOperator's earlier vote is revalidated against the CURRENT group and
         // dropped (she is no longer a member), so quorum is still not met.
         let second = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("bob".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawMaintainer".into())),
             )
             .unwrap();
         assert!(
@@ -723,24 +976,34 @@ mod tests {
     /// persisted (mirrors `crate::sop::engine::tests::FailingSaveStore`).
     struct FailingSaveStore {
         inner: crate::sop::store::InMemoryRunStore,
+        fail_save: std::sync::atomic::AtomicBool,
+        fail_atomic: std::sync::atomic::AtomicBool,
     }
     impl crate::sop::store::SopRunStore for FailingSaveStore {
         fn save_run(
             &self,
-            _r: &crate::sop::store::PersistedRun,
+            r: &crate::sop::store::PersistedRun,
         ) -> Result<(), crate::sop::store::StoreError> {
-            Err(crate::sop::store::StoreError::Backend(
-                "injected save_run failure".into(),
-            ))
+            if self.fail_save.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(crate::sop::store::StoreError::Backend(
+                    "injected save_run failure".into(),
+                ));
+            }
+            self.inner.save_run(r)
         }
         fn save_run_with_event(
             &self,
-            _r: &crate::sop::store::PersistedRun,
-            _e: &crate::sop::store::SopEventRecord,
+            r: &crate::sop::store::PersistedRun,
+            e: &crate::sop::store::SopEventRecord,
         ) -> Result<u64, crate::sop::store::StoreError> {
-            Err(crate::sop::store::StoreError::Backend(
-                "injected save_run failure".into(),
-            ))
+            if self.fail_save.load(std::sync::atomic::Ordering::SeqCst)
+                || self.fail_atomic.load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(crate::sop::store::StoreError::Backend(
+                    "injected atomic save failure".into(),
+                ));
+            }
+            self.inner.save_run_with_event(r, e)
         }
         fn finish_run(
             &self,
@@ -755,6 +1018,11 @@ mod tests {
             t: &crate::sop::store::PersistedRun,
             e: &crate::sop::store::SopEventRecord,
         ) -> Result<u64, crate::sop::store::StoreError> {
+            if self.fail_atomic.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(crate::sop::store::StoreError::Backend(
+                    "injected atomic finish failure".into(),
+                ));
+            }
             self.inner.finish_run_with_event(id, t, e)
         }
         fn load_active_runs(
@@ -861,6 +1129,90 @@ mod tests {
         fn backend(&self) -> &'static str {
             "failing-save-test"
         }
+    }
+
+    fn checkpoint_engine_with_atomic_failure_store() -> (SopEngine, String, Arc<FailingSaveStore>) {
+        let store = Arc::new(FailingSaveStore {
+            inner: crate::sop::store::InMemoryRunStore::new(),
+            fail_save: std::sync::atomic::AtomicBool::new(false),
+            fail_atomic: std::sync::atomic::AtomicBool::new(false),
+        });
+        let config = SopConfig {
+            approval: approval_cfg(&["ZeroClawOperator"], 1),
+            ..SopConfig::default()
+        };
+        let mut engine = SopEngine::new(config)
+            .with_store(store.clone())
+            .with_approval_broker(Arc::new(ApprovalBroker::disabled()));
+        engine.set_sops_for_test(vec![checkpoint_policy_sop("prod")]);
+        let action = engine.start_run("checkpointed", manual()).unwrap();
+        let run_id = match action {
+            SopRunAction::CheckpointWait { run_id, .. } => run_id,
+            other => panic!("expected CheckpointWait, got {other:?}"),
+        };
+        (engine, run_id, store)
+    }
+
+    #[test]
+    fn checkpoint_approve_atomic_failure_keeps_state_parked_without_audit() {
+        let (mut engine, run_id, store) = checkpoint_engine_with_atomic_failure_store();
+        store
+            .fail_atomic
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let err = engine
+            .resolve_via_broker(
+                &run_id,
+                ApprovalDecision::Approve,
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
+            )
+            .expect_err("combined state/audit failure must reject checkpoint approval");
+        assert!(err.to_string().contains("atomic save failure"));
+        assert_eq!(
+            engine.get_run(&run_id).map(|run| run.status),
+            Some(SopRunStatus::PausedCheckpoint)
+        );
+        assert_eq!(
+            store.load_run(&run_id).unwrap().unwrap().run.status,
+            SopRunStatus::PausedCheckpoint
+        );
+        assert!(
+            store
+                .list_events(&run_id)
+                .unwrap()
+                .iter()
+                .all(|event| event.kind != "gate_resolved")
+        );
+    }
+
+    #[test]
+    fn checkpoint_deny_atomic_failure_keeps_state_parked_without_audit() {
+        let (mut engine, run_id, store) = checkpoint_engine_with_atomic_failure_store();
+        store
+            .fail_atomic
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let err = engine
+            .resolve_via_broker(
+                &run_id,
+                ApprovalDecision::Deny { reason: None },
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
+            )
+            .expect_err("combined state/audit failure must reject checkpoint denial");
+        assert!(err.to_string().contains("atomic finish failure"));
+        assert_eq!(
+            engine.get_run(&run_id).map(|run| run.status),
+            Some(SopRunStatus::PausedCheckpoint)
+        );
+        assert_eq!(
+            store.load_run(&run_id).unwrap().unwrap().run.status,
+            SopRunStatus::PausedCheckpoint
+        );
+        assert!(
+            store
+                .list_events(&run_id)
+                .unwrap()
+                .iter()
+                .all(|event| event.kind != "gate_resolved")
+        );
     }
 
     /// Delegates to an in-memory store but fails every `list_events`, to prove a
@@ -1019,7 +1371,7 @@ mod tests {
         });
         let broker = Arc::new(ApprovalBroker::disabled());
         let sop_config = SopConfig {
-            approval: approval_cfg(&["alice", "bob"], 2),
+            approval: approval_cfg(&["ZeroClawOperator", "ZeroClawMaintainer"], 2),
             ..SopConfig::default()
         };
         let mut e = SopEngine::new(sop_config)
@@ -1035,7 +1387,7 @@ mod tests {
         let res = e.resolve_via_broker(
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         );
         assert!(
             res.is_err(),
@@ -1055,10 +1407,12 @@ mod tests {
         // pending-persist state holds.
         let store = std::sync::Arc::new(FailingSaveStore {
             inner: crate::sop::store::InMemoryRunStore::new(),
+            fail_save: std::sync::atomic::AtomicBool::new(true),
+            fail_atomic: std::sync::atomic::AtomicBool::new(false),
         });
         let broker = Arc::new(ApprovalBroker::disabled());
         let sop_config = SopConfig {
-            approval: approval_cfg(&["alice", "bob"], 2),
+            approval: approval_cfg(&["ZeroClawOperator", "ZeroClawMaintainer"], 2),
             ..SopConfig::default()
         };
         let mut e = SopEngine::new(sop_config)
@@ -1083,7 +1437,7 @@ mod tests {
         let res = e.resolve_via_broker(
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         );
         assert!(
             res.is_err(),
@@ -1118,7 +1472,7 @@ mod tests {
         // "bot" is a bare (any-source) group member, so membership passes; the mode
         // check must be what blocks this, not group authorization.
         let sop_config = SopConfig {
-            approval: approval_cfg(&["bot", "alice"], 2),
+            approval: approval_cfg(&["bot", "ZeroClawOperator"], 2),
             approval_mode: zeroclaw_config::schema::ApprovalMode::OutOfBandRequired,
             ..SopConfig::default()
         };
@@ -1159,7 +1513,7 @@ mod tests {
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Approve,
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(
@@ -1312,12 +1666,13 @@ mod tests {
 
     #[test]
     fn member_deny_cancels_without_quorum() {
-        let (mut e, id) = engine_with_broker(approval_cfg(&["alice", "bob"], 2));
+        let (mut e, id) =
+            engine_with_broker(approval_cfg(&["ZeroClawOperator", "ZeroClawMaintainer"], 2));
         let out = e
             .resolve_via_broker(
                 &id,
                 ApprovalDecision::Deny { reason: None },
-                ApprovalPrincipal::cli(Some("alice".into())),
+                ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         assert!(matches!(

--- a/crates/zeroclaw-runtime/src/sop/approval/identity.rs
+++ b/crates/zeroclaw-runtime/src/sop/approval/identity.rs
@@ -102,53 +102,59 @@ mod tests {
 
     #[test]
     fn bare_member_matches_any_source() {
-        let cfg = cfg_with(&[("release", &["alice"])]);
+        let cfg = cfg_with(&[("release", &["ZeroClawOperator"])]);
         let r = LocalConfigApprovalIdentityResolver;
         assert!(r.is_member(
             &cfg,
-            &ApprovalPrincipal::cli(Some("alice".into())),
+            &ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             "release"
         ));
         assert!(r.is_member(
             &cfg,
-            &ApprovalPrincipal::http(Some("alice".into())),
+            &ApprovalPrincipal::http(Some("ZeroClawOperator".into())),
             "release"
         ));
     }
 
     #[test]
     fn source_qualified_member_scopes_to_one_transport() {
-        // `http:alice` grants to the HTTP alice but NOT the CLI alice - so a channel
+        // `http:ZeroClawOperator` grants to the HTTP ZeroClawOperator but NOT the CLI ZeroClawOperator - so a channel
         // identity does not collide with a same-named identity on another source.
-        let cfg = cfg_with(&[("release", &["http:alice"])]);
+        let cfg = cfg_with(&[("release", &["http:ZeroClawOperator"])]);
         let r = LocalConfigApprovalIdentityResolver;
         assert!(r.is_member(
             &cfg,
-            &ApprovalPrincipal::http(Some("alice".into())),
+            &ApprovalPrincipal::http(Some("ZeroClawOperator".into())),
             "release"
         ));
         assert!(!r.is_member(
             &cfg,
-            &ApprovalPrincipal::cli(Some("alice".into())),
+            &ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             "release"
         ));
     }
 
     #[test]
     fn resolves_multiple_groups() {
-        let cfg = cfg_with(&[("release", &["alice"]), ("sre", &["alice"])]);
+        let cfg = cfg_with(&[
+            ("release", &["ZeroClawOperator"]),
+            ("sre", &["ZeroClawOperator"]),
+        ]);
         let r = LocalConfigApprovalIdentityResolver;
-        let mut groups = r.groups_for(&cfg, &ApprovalPrincipal::cli(Some("alice".into())));
+        let mut groups = r.groups_for(
+            &cfg,
+            &ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
+        );
         groups.sort();
         assert_eq!(groups, vec!["release".to_string(), "sre".to_string()]);
     }
 
     #[test]
     fn unknown_or_identityless_principal_has_no_groups() {
-        let cfg = cfg_with(&[("release", &["alice"])]);
+        let cfg = cfg_with(&[("release", &["ZeroClawOperator"])]);
         let r = LocalConfigApprovalIdentityResolver;
         assert!(
-            r.groups_for(&cfg, &ApprovalPrincipal::cli(Some("mallory".into())))
+            r.groups_for(&cfg, &ApprovalPrincipal::cli(Some("ZeroClawAgent".into())))
                 .is_empty()
         );
         assert!(r.groups_for(&cfg, &ApprovalPrincipal::system()).is_empty());

--- a/crates/zeroclaw-runtime/src/sop/approval/ledger.rs
+++ b/crates/zeroclaw-runtime/src/sop/approval/ledger.rs
@@ -90,12 +90,12 @@ mod tests {
             step: 2,
             kind: GateEventKind::Resolved,
             decision: Some(ApprovalDecision::Approve),
-            principal: ApprovalPrincipal::cli(Some("alice".into())),
+            principal: ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
             ts: "2026-01-01T00:00:00Z".into(),
         };
         let rec = entry.into_event_record();
         assert_eq!(rec.kind, "gate_resolved");
-        assert_eq!(rec.actor.as_deref(), Some("alice"));
+        assert_eq!(rec.actor.as_deref(), Some("ZeroClawOperator"));
         assert_eq!(rec.payload["source"], "cli");
         assert_eq!(rec.payload["decision"], "approve");
         assert_eq!(rec.payload["step"], 2);

--- a/crates/zeroclaw-runtime/src/sop/approval/resolve.rs
+++ b/crates/zeroclaw-runtime/src/sop/approval/resolve.rs
@@ -360,7 +360,7 @@ mod tests {
             &mut e,
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         )
         .unwrap();
         assert!(out.is_resumed(), "first approve resumes");
@@ -437,7 +437,7 @@ mod tests {
             &mut e,
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         )
         .unwrap();
         let events = e.run_events(&id).unwrap();
@@ -445,7 +445,7 @@ mod tests {
             .iter()
             .find(|ev| ev.kind == "gate_resolved")
             .expect("a gate_resolved ledger row");
-        assert_eq!(resolved.actor.as_deref(), Some("alice"));
+        assert_eq!(resolved.actor.as_deref(), Some("ZeroClawOperator"));
         assert_eq!(resolved.payload["source"], "cli");
     }
 
@@ -472,7 +472,7 @@ mod tests {
             &mut e,
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         )
         .unwrap();
         assert_eq!(
@@ -529,7 +529,7 @@ mod tests {
             &mut e,
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         );
         assert!(
             res.is_err(),
@@ -565,7 +565,7 @@ mod tests {
             &mut e,
             &id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         );
         assert!(
             res.is_err(),

--- a/crates/zeroclaw-runtime/src/sop/approval/timeout.rs
+++ b/crates/zeroclaw-runtime/src/sop/approval/timeout.rs
@@ -110,6 +110,13 @@ fn deliver_escalation_route(engine: &SopEngine, run_id: &str) {
     };
     let broker = engine.approval_broker();
     if let Some(route) = broker.escalation_route(engine.approval_config(), &policy_name) {
+        let span = ::zeroclaw_log::info_span!(
+            target: "zeroclaw_log_internal_scope",
+            "zeroclaw_scope",
+            session_key = %run_id,
+            sop_name = %sop_name,
+        );
+        let _guard = span.enter();
         broker.deliver_escalation(&route, run_id, &sop_name, step);
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -316,7 +316,8 @@ impl SopEngine {
         Arc::clone(&self.approval_broker)
     }
 
-    /// Resolve a gate THROUGH the broker (membership + quorum), then the chokepoint.
+    /// Resolve a gate or deterministic checkpoint THROUGH the broker (membership +
+    /// quorum), then its single transition owner.
     /// This is the entry point out-of-band surfaces (gateway / CLI / tools) should
     /// call so a `[sop.approval]` policy is enforced; with no policy it is exactly
     /// `resolve_gate`. The broker is cloned out first so it does not borrow `self`
@@ -328,6 +329,19 @@ impl SopEngine {
         principal: super::approval::ApprovalPrincipal,
     ) -> Result<super::approval::BrokerOutcome> {
         let broker = Arc::clone(&self.approval_broker);
+        if let Some(step) = self.active_runs.get(run_id).and_then(|run| {
+            (run.status == SopRunStatus::PausedCheckpoint).then_some(run.current_step)
+        }) {
+            if let Some(outcome) =
+                broker.authorize_checkpoint(self, run_id, step, &decision, &principal)?
+            {
+                return Ok(outcome);
+            }
+            let action = self.decide_checkpoint_with_principal(run_id, decision, principal)?;
+            return Ok(super::approval::BrokerOutcome::Resolved(
+                super::approval::ResolveOutcome::Resumed(Box::new(action)),
+            ));
+        }
         broker.resolve(self, run_id, decision, principal)
     }
     /// Reconstruct in-flight runs from the store at startup (durable backends).
@@ -2675,6 +2689,216 @@ impl SopEngine {
         }
     }
 
+    /// Apply a broker-authorized checkpoint decision and persist the resulting run
+    /// state together with the approver audit row. The run store is the durable
+    /// source of truth for both surfaces, so a failed combined write leaves the
+    /// checkpoint parked with no false resolution event.
+    fn decide_checkpoint_with_principal(
+        &mut self,
+        run_id: &str,
+        decision: super::approval::ApprovalDecision,
+        principal: super::approval::ApprovalPrincipal,
+    ) -> Result<SopRunAction> {
+        let prior_run = self
+            .active_runs
+            .get(run_id)
+            .cloned()
+            .ok_or_else(|| anyhow::Error::msg(format!("Active run not found: {run_id}")))?;
+        if prior_run.status != SopRunStatus::PausedCheckpoint {
+            bail!(
+                "Run {run_id} is not paused at a checkpoint (status: {})",
+                prior_run.status
+            );
+        }
+        if self.is_park_persist_pending(run_id) {
+            bail!(
+                "Run {run_id} cannot resolve: its parked checkpoint snapshot is not yet durably persisted (retrying)"
+            );
+        }
+
+        let (_, sop) = self.resolve_active_run_sop(run_id)?;
+        let current_step = self.resolve_sop_step(&sop, prior_run.current_step)?;
+        let piped = prior_run
+            .step_results
+            .last()
+            .map(step_result_value)
+            .unwrap_or(serde_json::Value::Null);
+        let (status, recorded_output, routed_output, started_at, completed_at) = match &decision {
+            super::approval::ApprovalDecision::Approve => (
+                SopStepStatus::Completed,
+                piped.to_string(),
+                piped,
+                prior_run.started_at.clone(),
+                Some(now_iso8601()),
+            ),
+            super::approval::ApprovalDecision::Deny { reason } => {
+                if let super::step_contract::StepFailure::Goto { step } = &current_step.on_failure {
+                    self.resolve_sop_step(&sop, *step)?;
+                }
+                let detail = reason
+                    .clone()
+                    .unwrap_or_else(|| "checkpoint denied by operator".to_string());
+                let now = now_iso8601();
+                (
+                    SopStepStatus::Failed,
+                    detail.clone(),
+                    serde_json::Value::String(detail),
+                    now.clone(),
+                    Some(now),
+                )
+            }
+        };
+
+        let retries_consumed = prior_run
+            .step_results
+            .iter()
+            .filter(|result| {
+                result.step_number == current_step.number && result.status == SopStepStatus::Failed
+            })
+            .count()
+            .try_into()
+            .unwrap_or(u32::MAX);
+        let denial_terminates = matches!(decision, super::approval::ApprovalDecision::Deny { .. })
+            && matches!(
+                route::failure::route_failure(
+                    &current_step.on_failure,
+                    retries_consumed,
+                    self.config.max_step_retries,
+                ),
+                NextStep::Fail(_)
+            );
+        if denial_terminates {
+            self.reacquire_claim_uncapped(run_id)?;
+            if let Err(e) = self
+                .store
+                .mark_claim_retained_after_terminal_rollback(run_id)
+            {
+                self.release_claim_on_park(run_id);
+                return Err(anyhow::Error::msg(format!(
+                    "failed to persist terminal-rollback claim marker for run {run_id}: {e}"
+                )));
+            }
+        } else {
+            self.reacquire_claim_on_resume(run_id)?;
+        }
+
+        if let Some(run) = self.active_runs.get_mut(run_id) {
+            run.status = SopRunStatus::Running;
+            run.waiting_since = None;
+            run.step_results.push(SopStepResult {
+                step_number: current_step.number,
+                status,
+                output: recorded_output,
+                started_at,
+                completed_at,
+                effective_agent: None,
+                tool_calls: Vec::new(),
+            });
+        }
+
+        let mut routed_status = status;
+        if status == SopStepStatus::Completed {
+            if let Err(reason) = self.validate_step_output(&current_step, &routed_output) {
+                routed_status = SopStepStatus::Failed;
+                let full_reason = format!(
+                    "Step {} output schema validation failed: {reason}",
+                    current_step.number
+                );
+                if let Some(recorded) = self
+                    .active_runs
+                    .get_mut(run_id)
+                    .and_then(|run| run.step_results.last_mut())
+                {
+                    recorded.status = SopStepStatus::Failed;
+                    recorded.output = full_reason;
+                }
+            } else if let Some(run) = self.active_runs.get_mut(run_id) {
+                run.llm_calls_saved += 1;
+            }
+        }
+
+        let route = match self.route_decision_after_recorded_step(
+            run_id,
+            &sop,
+            &current_step,
+            routed_status,
+        ) {
+            Ok(route) => route,
+            Err(e) => {
+                self.active_runs.insert(run_id.to_string(), prior_run);
+                if !denial_terminates {
+                    self.release_claim_on_park(run_id);
+                }
+                return Err(e);
+            }
+        };
+        let event = super::approval::GateLedgerEntry {
+            run_id: run_id.to_string(),
+            step: current_step.number,
+            kind: super::approval::GateEventKind::Resolved,
+            decision: Some(decision),
+            principal,
+            ts: now_iso8601(),
+        }
+        .into_event_record();
+
+        match route {
+            NextStep::Complete => {
+                let saved = self
+                    .active_runs
+                    .get(run_id)
+                    .map(|run| run.llm_calls_saved)
+                    .unwrap_or(0);
+                match self.finish_run_with_gate_event(run_id, SopRunStatus::Completed, None, &event)
+                {
+                    Ok(action) => {
+                        self.deterministic_savings.total_llm_calls_saved += saved;
+                        self.deterministic_savings.total_runs += 1;
+                        Ok(action)
+                    }
+                    Err(e) => {
+                        self.active_runs.insert(run_id.to_string(), prior_run);
+                        if !denial_terminates {
+                            self.release_claim_on_park(run_id);
+                        }
+                        Err(e)
+                    }
+                }
+            }
+            NextStep::Fail(reason) => match self.finish_run_with_gate_event(
+                run_id,
+                SopRunStatus::Failed,
+                Some(reason),
+                &event,
+            ) {
+                Ok(action) => Ok(action),
+                Err(e) => {
+                    self.active_runs.insert(run_id.to_string(), prior_run);
+                    if !denial_terminates {
+                        self.release_claim_on_park(run_id);
+                    }
+                    Err(e)
+                }
+            },
+            next => {
+                if let Err(e) = self.persist_active_with_gate_event(run_id, &event) {
+                    self.active_runs.insert(run_id.to_string(), prior_run);
+                    self.release_claim_on_park(run_id);
+                    return Err(e);
+                }
+                self.apply_route_decision(
+                    run_id,
+                    &sop,
+                    current_step.number,
+                    next,
+                    true,
+                    Some(retry_input_value(&prior_run, current_step.number)),
+                    Some(routed_output),
+                )
+            }
+        }
+    }
+
     /// Failure path for a denied checkpoint: record the checkpoint step `Failed`
     /// and route through its `on_failure` policy via the shared deterministic
     /// record-and-route chokepoint. `Goto` reaches the authored failure step;
@@ -3944,29 +4168,47 @@ impl SopEngine {
         &self.config.approval
     }
 
-    /// The name of the approval policy that applies to the run's currently-waiting
-    /// step, if that step names one. Shared by the broker (membership/quorum) and
-    /// the approval query surfaces so the "which policy applies now" lookup lives in
-    /// exactly one place.
-    pub fn current_step_policy_name(&self, run_id: &str) -> Option<String> {
-        let run = self.get_run(run_id)?;
-        let sop = self.get_sop(&run.sop_name)?;
+    /// Fallible lookup for the approval policy that applies to the run's current
+    /// parked step. `Ok(None)` means the step is intentionally unpoliced; `Err`
+    /// means the live run/SOP/step state is unavailable and callers must fail
+    /// closed rather than treating it as unpoliced.
+    pub(crate) fn current_step_policy_lookup(&self, run_id: &str) -> Result<Option<String>> {
+        let run = self
+            .get_run(run_id)
+            .ok_or_else(|| anyhow::Error::msg(format!("Active run not found: {run_id}")))?;
+        let sop = self.get_sop(&run.sop_name).ok_or_else(|| {
+            anyhow::Error::msg(format!("SOP '{}' no longer loaded", run.sop_name))
+        })?;
         // Match the step by its `number`, NOT by vec position: routed / non-contiguous
         // step numbers mean position != number, and a positional lookup would read the
         // wrong step's policy (silently unpolicing a policied gate, or vice versa).
-        let name = sop
+        let step = sop
             .steps
             .iter()
-            .find(|s| s.number == run.current_step)?
-            .policy
-            .as_deref()?
-            .trim();
+            .find(|s| s.number == run.current_step)
+            .ok_or_else(|| {
+                anyhow::Error::msg(format!(
+                    "SOP '{}' no longer contains step {}",
+                    run.sop_name, run.current_step
+                ))
+            })?;
+        let Some(name) = step.policy.as_deref() else {
+            return Ok(None);
+        };
+        let name = name.trim();
         // An empty/whitespace name means "no policy", same as the Markdown parser's
         // `policy:` bullet (mod.rs). Without this, a TOML `policy = ""` step would
         // deserialize as `Some("")` and the broker would treat it as a NAMED-but-absent
         // policy (fail closed, gate stuck waiting forever) instead of unpoliced -
         // diverging from the equivalent Markdown SOP, which normalizes to `None`.
-        (!name.is_empty()).then(|| name.to_string())
+        Ok((!name.is_empty()).then(|| name.to_string()))
+    }
+
+    /// The name of the approval policy that applies to the run's current step, if
+    /// that step names one. Read surfaces collapse unavailable live state to
+    /// `None`; the broker uses the fallible lookup above to fail closed.
+    pub fn current_step_policy_name(&self, run_id: &str) -> Option<String> {
+        self.current_step_policy_lookup(run_id).ok().flatten()
     }
 
     /// Classify a run's approval gate for `resolve_gate` (idempotency + typed
@@ -6145,13 +6387,13 @@ mod tests {
         let store = std::sync::Arc::new(InMemoryRunStore::new());
         let engine = engine_with_sops(vec![]).with_store(store);
 
-        // Same subject "alice" over HTTP then WS: collapses to gateway:alice.
+        // Same subject "ZeroClawOperator" over HTTP then WS: collapses to gateway:ZeroClawOperator.
         engine
             .record_gate_vote(
                 "run-1",
                 1,
                 "p",
-                &ApprovalPrincipal::http(Some("alice".into())),
+                &ApprovalPrincipal::http(Some("ZeroClawOperator".into())),
             )
             .unwrap();
         engine
@@ -6159,7 +6401,7 @@ mod tests {
                 "run-1",
                 1,
                 "p",
-                &ApprovalPrincipal::ws("c".into(), Some("alice".into())),
+                &ApprovalPrincipal::ws("c".into(), Some("ZeroClawOperator".into())),
             )
             .unwrap();
         // A repeat over HTTP: still the same canonical voter.
@@ -6168,12 +6410,17 @@ mod tests {
                 "run-1",
                 1,
                 "p",
-                &ApprovalPrincipal::http(Some("alice".into())),
+                &ApprovalPrincipal::http(Some("ZeroClawOperator".into())),
             )
             .unwrap();
-        // A CLI actor is a genuinely distinct source (cli:bob).
+        // A CLI actor is a genuinely distinct source (cli:ZeroClawMaintainer).
         engine
-            .record_gate_vote("run-1", 1, "p", &ApprovalPrincipal::cli(Some("bob".into())))
+            .record_gate_vote(
+                "run-1",
+                1,
+                "p",
+                &ApprovalPrincipal::cli(Some("ZeroClawMaintainer".into())),
+            )
             .unwrap();
         // A vote on step 2 is a separate tally.
         engine
@@ -6199,7 +6446,7 @@ mod tests {
         assert_eq!(
             distinct(1),
             2,
-            "gateway:alice (http+ws collapsed) + cli:bob = 2 distinct step-1 voters"
+            "gateway:ZeroClawOperator (http+ws collapsed) + cli:ZeroClawMaintainer = 2 distinct step-1 voters"
         );
         assert_eq!(
             distinct(2),
@@ -6217,10 +6464,14 @@ mod tests {
         use crate::sop::approval::ApprovalPrincipal;
         let store = std::sync::Arc::new(InMemoryRunStore::new());
         let engine = engine_with_sops(vec![]).with_store(store);
-        let alice = ApprovalPrincipal::cli(Some("alice".into()));
+        let zero_claw_operator = ApprovalPrincipal::cli(Some("ZeroClawOperator".into()));
 
-        engine.record_gate_vote("run-1", 1, "prod", &alice).unwrap();
-        engine.record_gate_vote("run-1", 1, "prod", &alice).unwrap();
+        engine
+            .record_gate_vote("run-1", 1, "prod", &zero_claw_operator)
+            .unwrap();
+        engine
+            .record_gate_vote("run-1", 1, "prod", &zero_claw_operator)
+            .unwrap();
         assert_eq!(
             engine.gate_votes_for_step("run-1", 1).unwrap().len(),
             1,
@@ -6228,7 +6479,7 @@ mod tests {
         );
 
         engine
-            .record_gate_vote("run-1", 1, "prod2", &alice)
+            .record_gate_vote("run-1", 1, "prod2", &zero_claw_operator)
             .unwrap();
         assert_eq!(
             engine.gate_votes_for_step("run-1", 1).unwrap().len(),
@@ -9049,7 +9300,7 @@ mod tests {
         let res = engine.resolve_gate(
             &run_id,
             ApprovalDecision::Approve,
-            ApprovalPrincipal::cli(Some("alice".into())),
+            ApprovalPrincipal::cli(Some("ZeroClawOperator".into())),
         );
         assert!(
             res.is_err(),

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1194,12 +1194,16 @@ pub fn all_tools_with_runtime(
                 SopAdvanceTool::new(Arc::clone(sop_engine)).with_audit(Arc::clone(sop_audit)),
             ));
             tool_arcs.push(Arc::new(
-                SopApproveTool::new(Arc::clone(sop_engine)).with_audit(Arc::clone(sop_audit)),
+                SopApproveTool::new(Arc::clone(sop_engine))
+                    .with_agent_alias(agent_alias)
+                    .with_audit(Arc::clone(sop_audit)),
             ));
         } else {
             tool_arcs.push(Arc::new(SopExecuteTool::new(Arc::clone(sop_engine))));
             tool_arcs.push(Arc::new(SopAdvanceTool::new(Arc::clone(sop_engine))));
-            tool_arcs.push(Arc::new(SopApproveTool::new(Arc::clone(sop_engine))));
+            tool_arcs.push(Arc::new(
+                SopApproveTool::new(Arc::clone(sop_engine)).with_agent_alias(agent_alias),
+            ));
         }
         tool_arcs.push(Arc::new(
             SopStatusTool::new(Arc::clone(sop_engine))
@@ -1576,7 +1580,10 @@ pub fn all_tools_with_runtime(
 mod tests {
     use super::*;
     use tempfile::TempDir;
-    use zeroclaw_config::schema::{BrowserConfig, Config, MemoryConfig};
+    use zeroclaw_config::schema::{
+        ApprovalGroupConfig, ApprovalPolicyConfig, BrowserConfig, Config, MemoryConfig,
+        SopApprovalConfig,
+    };
 
     #[tokio::test]
     async fn mcp_capability_tools_respect_policy() {
@@ -1938,6 +1945,154 @@ mod tests {
         // copying state.
         assert!(Arc::strong_count(&shared_engine) >= 3);
         assert!(Arc::strong_count(&shared_audit) >= 3);
+    }
+
+    #[tokio::test]
+    async fn sop_approve_registry_binds_the_calling_agent_alias() {
+        use crate::sop::types::{
+            Sop, SopAdmissionPolicy, SopEvent, SopExecutionMode, SopPriority, SopRunAction,
+            SopRunStatus, SopStep, SopStepKind, SopTrigger, SopTriggerSource,
+        };
+
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+        let mut groups = HashMap::new();
+        groups.insert(
+            "release".to_string(),
+            ApprovalGroupConfig {
+                members: vec!["agent:ZeroClawOperator".to_string()],
+            },
+        );
+        let mut policies = HashMap::new();
+        policies.insert(
+            "prod".to_string(),
+            ApprovalPolicyConfig {
+                required_group: Some("release".to_string()),
+                quorum: 1,
+                request_route: None,
+                escalation_route: None,
+            },
+        );
+        let mut engine = SopEngine::new(zeroclaw_config::schema::SopConfig {
+            approval: SopApprovalConfig { groups, policies },
+            ..Default::default()
+        })
+        .with_approval_broker(Arc::new(crate::sop::approval::ApprovalBroker::disabled()));
+        engine.set_sops_for_test(vec![Sop {
+            name: "deploy".into(),
+            description: "test".into(),
+            version: "1.0.0".into(),
+            priority: SopPriority::Normal,
+            execution_mode: SopExecutionMode::Supervised,
+            triggers: vec![SopTrigger::Manual],
+            steps: vec![
+                SopStep {
+                    number: 1,
+                    title: "gate".into(),
+                    kind: SopStepKind::Execute,
+                    requires_confirmation: true,
+                    policy: Some("prod".into()),
+                    ..SopStep::default()
+                },
+                SopStep {
+                    number: 2,
+                    title: "execute".into(),
+                    kind: SopStepKind::Execute,
+                    ..SopStep::default()
+                },
+            ],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+            admission_policy: SopAdmissionPolicy::Parallel,
+            max_pending_approvals: 0,
+            agent: None,
+        }]);
+        let action = engine
+            .start_run(
+                "deploy",
+                SopEvent {
+                    source: SopTriggerSource::Manual,
+                    topic: None,
+                    payload: None,
+                    timestamp: crate::sop::engine::now_iso8601(),
+                },
+            )
+            .unwrap();
+        let run_id = match action {
+            SopRunAction::WaitApproval { run_id, .. } => run_id,
+            other => panic!("expected WaitApproval, got {other:?}"),
+        };
+        let shared_engine = Arc::new(Mutex::new(engine));
+        let cfg = test_config(&tmp);
+        let browser = BrowserConfig::default();
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let web = zeroclaw_config::schema::WebFetchConfig::default();
+        let risk = zeroclaw_config::schema::RiskProfileConfig::default();
+
+        let build = |agent_alias: &str, memory: Arc<dyn Memory>| {
+            all_tools_with_runtime(
+                Arc::new(Config::default()),
+                &security,
+                &risk,
+                agent_alias,
+                Arc::new(NativeRuntime::new()),
+                memory,
+                None,
+                None,
+                &browser,
+                &http,
+                &web,
+                tmp.path(),
+                &HashMap::new(),
+                None,
+                &cfg,
+                None,
+                false,
+                None,
+                Some(shared_engine.clone()),
+                None,
+                None,
+            )
+            .tools
+        };
+        let unauthorized_tools = build("ZeroClawAgent", mem.clone());
+        let authorized_tools = build("ZeroClawOperator", mem);
+
+        let unauthorized = unauthorized_tools
+            .iter()
+            .find(|tool| tool.name() == "sop_approve")
+            .expect("unauthorized registry has sop_approve");
+        let result = unauthorized
+            .execute(serde_json::json!({ "run_id": run_id.clone() }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert_eq!(
+            shared_engine
+                .lock()
+                .unwrap()
+                .get_run(&run_id)
+                .map(|run| run.status),
+            Some(SopRunStatus::WaitingApproval)
+        );
+
+        let authorized = authorized_tools
+            .iter()
+            .find(|tool| tool.name() == "sop_approve")
+            .expect("authorized registry has sop_approve");
+        let result = authorized
+            .execute(serde_json::json!({ "run_id": run_id }))
+            .await
+            .unwrap();
+        assert!(result.success, "authorized alias must resolve: {result:?}");
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/sop_approve.rs
+++ b/crates/zeroclaw-runtime/src/tools/sop_approve.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde_json::json;
 
 use crate::sop::approval::{ApprovalDecision, ApprovalPrincipal, BrokerOutcome, ResolveOutcome};
-use crate::sop::types::{SopRunAction, SopRunStatus};
+use crate::sop::types::SopRunAction;
 use crate::sop::{SopAuditLogger, SopEngine};
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult};
 
@@ -89,30 +89,11 @@ impl Tool for SopApproveTool {
             // `[sop.approval]` policy it is exactly `resolve_gate`, so behavior is
             // unchanged; with a policy the agent must be an authorized member and a
             // quorum must be met before the chokepoint clears the gate.
-            match engine.resolve_via_broker(
+            engine.resolve_via_broker(
                 run_id,
                 ApprovalDecision::Approve,
                 ApprovalPrincipal::agent(&self.agent_alias),
-            ) {
-                // A deterministic checkpoint is an in-band agent pause, not an
-                // out-of-band gate, so the broker reports NotWaiting; resume it
-                // through approve_step (the checkpoint owner).
-                Ok(BrokerOutcome::NotWaiting)
-                | Ok(BrokerOutcome::Resolved(ResolveOutcome::NotWaiting)) => {
-                    let is_checkpoint = matches!(
-                        engine.get_run(run_id).map(|r| r.status),
-                        Some(SopRunStatus::PausedCheckpoint)
-                    );
-                    if is_checkpoint {
-                        engine.approve_step(run_id).map(|action| {
-                            BrokerOutcome::Resolved(ResolveOutcome::Resumed(Box::new(action)))
-                        })
-                    } else {
-                        Ok(BrokerOutcome::NotWaiting)
-                    }
-                }
-                other => other,
-            }
+            )
         };
 
         match result {
@@ -198,6 +179,14 @@ impl Tool for SopApproveTool {
                 error: Some(format!(
                     "Approval failed: step names approval policy '{name}', which is not \
                      defined in [sop.approval].policies; the gate is left waiting."
+                )),
+            }),
+            Ok(BrokerOutcome::PolicyUnavailable { reason }) => Ok(ToolResult {
+                success: false,
+                output: ToolOutput::default(),
+                error: Some(crate::i18n::get_required_cli_string_with_args(
+                    "sop-approval-policy-unavailable",
+                    &[("reason", reason.as_str())],
                 )),
             }),
             Err(e) => Ok(ToolResult {

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -91,10 +91,17 @@ escalation_route = "oncall"
 `[sop.approval.groups.*]` members are approval identities, not account names.
 Members may be source-qualified (`http:<subject>`, `ws:<subject>`,
 `agent:<alias>`) to grant approval rights on one transport only, or bare
-(`alice`) to grant any source carrying that identity. HTTP and WebSocket
+(`ZeroClawOperator`) to grant any source carrying that identity. HTTP and WebSocket
 approval surfaces use the paired-token subject; the current CLI approval path
 (`zeroclaw sop approve`) is anonymous and cannot satisfy `cli:<user>`
 membership yet.
+
+The paired-token subject is the lowercase SHA-256 hex digest of the bearer
+token. After pairing, copy the digest from the canonical
+`gateway.paired_tokens` entry, or compute it from the bearer token without
+putting that secret in shell history. Rotating a paired token creates a new
+subject, so update every approval-group membership that references the old
+digest as part of the same rotation.
 
 ## 3. `SOP.md` Step Format
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`; this branch contains #8848 as an exact ancestor.
- **What changed and why:**
  - Add a broker-owned approval boundary over the existing SOP gate transition so named policies can require live group membership and a quorum of distinct approvers.
  - Keep live `[sop.approval]` config as the policy source of truth. Votes are durable, idempotent per canonical voter and policy, and revalidated against current membership before they count.
  - Bind the production agent tool to the calling agent alias, fail closed when the parked run's SOP or step cannot be resolved, and apply the same membership, approval-mode, and quorum rules to deterministic checkpoints.
  - Persist a checkpoint decision and its authorized actor through the same combined run/event store operation, so an audit write or state write cannot succeed alone.
  - Route HTTP, WebSocket, agent-tool, authoring `/decide`, and `sops.decide` RPC decisions through `resolve_via_broker`; the RPC principal comes from its connection-bound TUI identity, and unauthorized or incomplete-quorum decisions leave the run parked.
  - Re-establish run/SOP attribution around timeout-route delivery and document how paired-token approval subjects are derived and rotated.
- **Scope boundary:** This PR does not add an external identity provider or account directory, does not expose paired-token hashes through the device API, and does not add preflight rejection for missing groups or impossible quorums. Those configurations fail closed at decision time. The CLI/RPC identity is the authenticated TUI identity available at that boundary.
- **Blast radius:** SOP approval policy/config parsing, durable vote and decision audit records, checkpoint and waiting-gate resolution, gateway HTTP/WebSocket and authoring handlers, the agent tool registry, the TUI RPC decision surface, timeout-route logging attribution, locales, and SOP syntax documentation.
- **Linked issue(s):** Related #8288. Depends on #8848.
- **Labels:** `enhancement`, `docs`, `config`, `gateway`, `runtime`, `observability:log`, `tool:sop`, `risk:high`, `size:XL`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** Optional; the focused and required-CI evidence below covers the broker state machine.
- **Interface(s) exercised:** `cli`/RPC, `web` HTTP and WebSocket handlers, the agent `sop_approve` tool, and timeout-route delivery.
- **Setup / preconditions:** Configure two approval identities in `[sop.approval.groups.release]`, a named policy with `required_group = "release"` and `quorum = 2`, and a supervised or deterministic-checkpoint SOP step with `policy = "prod"`.
- **Steps to run:** Park a run at that step. Try an unauthorized identity, then one authorized identity, then a distinct second authorized identity. Repeat through `sops.decide` and a deterministic checkpoint. Finally inject a store failure during the checkpoint decision.
- **Expected on this branch (after):** The unauthorized attempt is rejected; the first valid vote returns pending quorum; the second distinct vote resolves the run; every resolving audit row names the authorized actor; and an injected combined-write failure leaves the run parked with no false `gate_resolved` row.
- **Prior behavior on `master` (before):** Broker decision surfaces could collapse agent identities, treat missing live policy state as unpoliced, bypass named checkpoint policy through RPC/direct checkpoint resolution, or persist a checkpoint decision without its authorized actor.

### How I tested

- **CI checks relied on and why they cover this change:** Required GitHub CI covers format, workspace lint, the full test suite, all-feature/no-default-feature builds, platforms, security, docs style, and the RPC boundary on the exact pushed head.
- **Known CI coverage gap, if any:** Required CI does not stand up a live paired HTTP/WebSocket gateway. Authenticated handler regressions exercise those boundaries, and the reviewer accepts that evidence for this slice.
- **Commands run and tail output:**

  ```text
  cargo fmt --all -- --check                                                   clean
  cargo test -p zeroclaw-runtime sop::approval::broker::tests --lib            22 passed; 0 failed
  cargo test -p zeroclaw-runtime sops_decide_rpc_enforces_checkpoint_membership_and_quorum --lib
                                                                                1 passed; 0 failed
  cargo test -p zeroclaw-runtime sop_approve_registry_binds_the_calling_agent_alias --lib
                                                                                1 passed; 0 failed
  cargo test -p zeroclaw-runtime timeout_ --lib                                 16 passed; 0 failed
  ```

- **Beyond CI, what did you manually verify?** I traced each production decision surface to `resolve_via_broker`, verified #8848 is an exact ancestor, inspected the combined run/event persistence path, and confirmed the effective diff adds no personal-name fixtures or review-history comments.
- **If any command was intentionally skipped, why:** I did not run a live paired HTTP/WebSocket smoke. Local docs-gate execution could not locate `markdownlint-cli2`; the exact-head required Docs Style job is the authoritative result.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` - configured group membership and quorum now authorize who may resolve named SOP gates and checkpoints; no new file-system scope is added.
- New external network calls? `Yes` - configured approval request and escalation routes can use the existing channel delivery adapters; delivery is best-effort and cannot clear the gate.
- Secrets / tokens / credentials handling changed? `Yes` - authenticated HTTP/WebSocket bearer tokens are represented by their lowercase SHA-256 digest for membership and audit identity. Plaintext tokens are not added to votes or decision events, and rotation creates a new subject that must be reflected in group membership.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `Yes` - production audit rows may contain an operator-configured agent alias, TUI identity, or paired-token digest as the decision actor. Fixtures and docs use neutral ZeroClaw role identities; audit data remains in the operator-owned SOP store.
- Prompt injection or untrusted model-visible text introduced/changed? `No`.
- If any `Yes`, describe the risk and mitigation: policy decisions fail closed, transport identities are derived server-side after authentication, durable actor records contain no plaintext bearer token, and group/policy config remains the live source of truth rather than a stale runtime copy.

## Compatibility (required)

- Backward compatible? `Yes` - steps without a named approval policy retain the historical single-approver behavior. Named policies and checkpoints now enforce the policy operators configured.
- Config / env / CLI surface changed? `Yes` - optional `[sop.approval.groups.*]`, `[sop.approval.policies.*]`, step `policy`, and broker outcome/error surfaces are added or enforced.
- Rust/MSRV/toolchain floor changed? `No` - the branch uses the repository's pinned Rust `1.96.1` toolchain.
- If backward compatibility is `No` or either surface/floor question is `Yes`: existing unpoliced SOPs require no change. Operators enabling a named policy must configure satisfiable group membership, update paired-token subjects after rotation, and expect incomplete quorum to leave the run parked.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR after #8848. That removes broker-specific membership/quorum enforcement and restores the prior single-approver decision routing.
- **Feature flags or config toggles:** Remove the step's `policy` reference (or the corresponding approval config) only as an intentional policy rollback; a missing named policy fails closed rather than silently disabling authorization.
- **Observable failure symptoms:** approvals return `not_authorized`, `pending_quorum`, `policy_missing`, or `policy_unavailable`; named checkpoints remain parked; audit/store failures report an error with no `gate_resolved` row; timeout-route delivery failures are logged inside the run/SOP attribution scope.
