### PR TITLE
test(api): cover escaped schema refs in properties

### DIFF
--- a/crates/zeroclaw-api/src/schema.rs
+++ b/crates/zeroclaw-api/src/schema.rs
@@ -729,6 +729,27 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_ref_decodes_json_pointer_escapes() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "slash": { "$ref": "#/$defs/Foo~1Bar" },
+                "tilde": { "$ref": "#/$defs/Tilde~0Name" }
+            },
+            "$defs": {
+                "Foo/Bar": { "type": "string" },
+                "Tilde~Name": { "type": "integer" }
+            }
+        });
+
+        let cleaned = SchemaCleanr::clean_for_anthropic(schema);
+
+        assert_eq!(cleaned["properties"]["slash"]["type"], "string");
+        assert_eq!(cleaned["properties"]["tilde"]["type"], "integer");
+        assert!(cleaned.get("$defs").is_none());
+    }
+
+    #[test]
     fn test_flatten_literal_union() {
         let schema = json!({
             "anyOf": [


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a schema cleaner regression test for escaped local `$ref` names inside object properties.
  - Covers both JSON Pointer escape forms used in definition names: `~1` for `/` and `~0` for `~`.
  - Keeps the existing cleaner behavior unchanged; this is coverage for nested property resolution.
- **Scope boundary:** Test-only change. Does not change schema cleaning behavior, provider strategy rules, or public API.
- **Blast radius:** `zeroclaw-api` unit tests only.
- **Linked issue(s):** None.
- **Labels:** (maintainers: `type:test`, `risk:low`, `size:XS`; no path label currently applied)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-api --all-targets -- -D warnings
cargo test -p zeroclaw-api test_resolve_ref_decodes_json_pointer_escapes
cargo test -p zeroclaw-api
```

- **Commands run and tail output:**

  `cargo fmt --all -- --check` - exit 0 (no output)

  `cargo clippy -p zeroclaw-api --all-targets -- -D warnings`:
  ```text
  Checking zeroclaw-api v0.8.2 (.../crates/zeroclaw-api)
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.34s
  ```

  `cargo test -p zeroclaw-api test_resolve_ref_decodes_json_pointer_escapes`:
  ```text
  running 1 test
  test schema::tests::test_resolve_ref_decodes_json_pointer_escapes ... ok

  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 115 filtered out; finished in 0.00s
  ```

  `cargo test -p zeroclaw-api`:
  ```text
  test result: ok. 116 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

  Doc-tests zeroclaw_api
  test result: ok. 1 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
  ```

- **Beyond CI — what did you manually verify?** Confirmed the new test exercises nested property `$ref` resolution after JSON Pointer escape decoding.
- **If any command was intentionally skipped, why:** Full workspace checks skipped; this is a test-only change isolated to `zeroclaw-api`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: None.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` removes the added regression test.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A

