### PR TITLE
fix(infra): ignore non-file JSONL session entries

### DIFF
--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -115,7 +115,7 @@ impl SessionStore {
     /// Delete a session's JSONL file. Returns `true` if the file existed.
     pub fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
         let path = self.session_path(session_key);
-        if !path.exists() {
+        if !path.is_file() {
             return Ok(false);
         }
         std::fs::remove_file(&path)?;
@@ -139,6 +139,9 @@ impl SessionStore {
         entries
             .filter_map(|entry| {
                 let entry = entry.ok()?;
+                if !entry.file_type().ok()?.is_file() {
+                    return None;
+                }
                 let name = entry.file_name().into_string().ok()?;
                 name.strip_suffix(".jsonl").map(String::from)
             })
@@ -208,7 +211,7 @@ impl SessionBackend for SessionStore {
     /// the session is on disk (#7126). Checking file presence is the same
     /// O(1) `stat` that `delete_session` itself performs.
     fn session_exists(&self, session_key: &str) -> bool {
-        self.session_path(session_key).exists()
+        self.session_path(session_key).is_file()
     }
 }
 
@@ -310,6 +313,21 @@ mod tests {
         assert_eq!(sessions.len(), 2);
         assert!(sessions.contains(&"discord_bob".to_string()));
         assert!(sessions.contains(&"telegram_alice".to_string()));
+    }
+
+    #[test]
+    fn list_and_exists_ignore_non_file_jsonl_entries() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+
+        store.append("valid", &ChatMessage::user("hi")).unwrap();
+        std::fs::create_dir(store.session_path("phantom")).unwrap();
+
+        let sessions = store.list_sessions();
+        assert_eq!(sessions, vec!["valid".to_string()]);
+        assert!(store.session_exists("valid"));
+        assert!(!store.session_exists("phantom"));
+        assert!(!store.delete_session("phantom").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - JSONL session listing now ignores `.jsonl` directory entries and other non-files instead of treating them as persisted sessions.
  - `session_exists` and `delete_session` now use the same file-only definition of an on-disk JSONL session.
  - Adds a regression test that creates a `phantom.jsonl` directory next to a real session file.
- **Scope boundary:** Does not change JSONL serialization, key sanitization, SQLite session storage, or session metadata schema.
- **Blast radius:** JSONL `SessionStore` only; SQLite-backed session persistence is untouched.
- **Linked issue(s):** None.
- **Labels:** (maintainers: `type:bug`, `risk:low`, `size:XS`; no path label currently applied)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-infra --all-targets -- -D warnings
cargo test -p zeroclaw-infra list_and_exists_ignore_non_file_jsonl_entries
cargo test -p zeroclaw-infra
```

- **Commands run and tail output:**

  `cargo fmt --all -- --check` - exit 0 (no output)

  `cargo clippy -p zeroclaw-infra --all-targets -- -D warnings`:
  ```text
  Checking zeroclaw-infra v0.8.2 (.../crates/zeroclaw-infra)
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.77s
  ```

  `cargo test -p zeroclaw-infra list_and_exists_ignore_non_file_jsonl_entries`:
  ```text
  running 1 test
  test session_store::tests::list_and_exists_ignore_non_file_jsonl_entries ... ok

  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 106 filtered out; finished in 0.00s
  ```

  `cargo test -p zeroclaw-infra`:
  ```text
  test result: ok. 107 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.30s

  Running tests/proof_session_routing_columns.rs
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

  Doc-tests zeroclaw_infra
  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
  ```

- **Beyond CI — what did you manually verify?** The regression test verifies listing, existence checks, and delete semantics all reject a directory named like a session JSONL file.
- **If any command was intentionally skipped, why:** Full workspace checks skipped; change is isolated to `zeroclaw-infra` JSONL session store behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users: None. Existing valid `.jsonl` session files continue to load and list normally.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` restores the previous behavior where any `.jsonl` directory entry could be listed as a session.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A

