### PR TITLE
fix(providers): route pricing catalog through dispatch

### DIFF
--- a/crates/zeroclaw-providers/src/pricing.rs
+++ b/crates/zeroclaw-providers/src/pricing.rs
@@ -23,6 +23,7 @@
 //! what onboarding and the web rates editor display. Merging at snapshot
 //! assembly scopes live prices to cost tracking only.
 
+use crate::dispatch::ProviderDispatch;
 use crate::traits::{ModelInfo, ModelPricing};
 use futures_util::future::join_all;
 use parking_lot::RwLock;
@@ -525,11 +526,14 @@ async fn refresh_once(groups: &[GatewayGroup], total_aliases_per_family: &HashMa
     // gateway; first-fill latency is bounded by the slowest gateway, not the
     // sum of all of them) ──
     let mut any_ok = false;
-    let catalogs = join_all(
-        groups
-            .iter()
-            .map(|group| group.handle.list_models_with_pricing()),
-    )
+    let catalogs = join_all(groups.iter().map(|group| {
+        let handle = Arc::clone(&group.handle);
+        async move {
+            ProviderDispatch::new(handle)
+                .list_models_with_pricing()
+                .await
+        }
+    }))
     .await;
     let mut gateway_results: Vec<(&[WantedModel], HashMap<String, ModelRates>)> =
         Vec::with_capacity(groups.len());


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Routed the live pricing refresher's gateway catalog call through `ProviderDispatch`.
  - Keeps `list_models_with_pricing()` calls on the same attribution path enforced by the rust quality gate.
  - Preserves the existing `GatewayGroup` handle as the single source of truth; no config, schema, or runtime state is added.
- **Scope boundary:** This PR does not change pricing merge behavior, gateway grouping, model route selection, or cost lookup.
- **Blast radius:** Limited to provider attribution around live pricing catalog refresh calls.
- **Linked issue(s):** Related to the provider dispatch gate failure on `crates/zeroclaw-providers/src/pricing.rs`.
- **Labels:** `bug`, `provider`, `risk:low`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
cargo fmt --all -- --check
# clean

./scripts/ci/rust_quality_gate.sh
#     Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 37s
# ==> rust quality: provider dispatch gate clean

cargo clippy --all-targets -- -D warnings
#     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.88s

RUST_TEST_THREADS=1 cargo test --quiet
# test result: ok. 200 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
# test result: ok. 158 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
# test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
# TEST_STATUS=0
```

- **Beyond CI -- what did you manually verify?** Confirmed the existing `GatewayGroup.handle` remains the only provider handle source and the direct `list_models_with_pricing()` gate violation is gone.
- **If any command was intentionally skipped, why:** No required validation was skipped. Tests were serialized with `RUST_TEST_THREADS=1` because the orchestrator test group has shown order-sensitive failures under the default parallel runner.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need upgrade steps; this only routes an existing provider call through the dispatch wrapper.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert d4e0d3eb7f3ef731c86e7ae2171d0aa52f2f7070`

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
