### PR TITLE
docs(sop): add condition syntax examples

### DIFF
--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -15,6 +15,45 @@ Each SOP must have `SOP.toml`. `SOP.md` is optional, but runs with no parsed ste
 
 ## 2. `SOP.toml`
 
+`SOP.toml` holds SOP metadata and trigger definitions. A minimal manual SOP
+looks like this:
+
+```toml
+[sop]
+name = "daily-digest"
+description = "Collect recent alerts and write a short digest."
+version = "1.0.0"
+
+[[triggers]]
+type = "manual"
+```
+
+The `mqtt`, `amqp`, `filesystem`, `peripheral`, and `channel` trigger types
+accept `condition`. Conditions are filters: the trigger must match its
+source-specific field first, then the condition must hold against the event
+payload before a run starts.
+
+```toml
+[sop]
+name = "high-temperature-alert"
+description = "Handle elevated sensor readings."
+
+[[triggers]]
+type = "mqtt"
+topic = "facility/+/temperature"
+condition = "$.value > 85"
+
+[[triggers]]
+type = "amqp"
+routing_key = "facility.*.temperature"
+condition = "$.status == \"critical\""
+
+[[triggers]]
+type = "channel"
+topic = "git.main:pull_request.opened"
+condition = "$.repo == \"example/project\""
+```
+
 ## 3. `SOP.md` Step Format
 
 Steps are parsed from the `## Steps` section.
@@ -43,9 +82,44 @@ Parser behavior:
 - `- input:` and `- output:` attach JSON Schema-like step boundary contracts.
 - `- next:` and `- depends_on:` route non-linear runs. Ineligible routed steps
   are marked `skipped` and leave the run `pending` instead of dispatching.
+- `- when:` guards routing after a completed step using the same comparison
+  syntax as trigger conditions, evaluated against accumulated step outputs.
 - `- on_failure:` accepts `fail`, `retry:<count>`, or `goto:<step>` and is
   enforced for reported step failures and output schema failures.
 - `- mode:` overrides the SOP execution mode for that step.
+
+Example conditional route:
+
+```md
+## Steps
+
+1. **Inspect payload** - Classify the incoming event.
+   - tools: memory_recall
+   - output: {"type":"object","properties":{"severity":{"type":"string"},"notify":{"type":"boolean"}}}
+   - when: $.steps.1.notify == "true"
+   - next: 2
+
+2. **Notify** - Send the alert summary.
+   - tools: pushover
+   - depends_on: 1
+```
+
+When step 1 completes with output such as `{"severity":"critical","notify":true}`,
+run data is exposed to `when` as:
+
+```json
+{
+  "steps": {
+    "1": {
+      "severity": "critical",
+      "notify": true
+    }
+  }
+}
+```
+
+The example then routes to step 2. If the `when` guard is false, the
+run completes after step 1 instead of taking the explicit `next:` route.
 
 ### Step Contract Enforcement
 
@@ -94,11 +168,54 @@ For the live-versus-unwired status of each source and the transport details, see
 
 ## 5. Condition Syntax
 
-`condition` is evaluated fail-closed (invalid condition/payload => no match).
+`condition` and step-level `when` use the same comparison syntax. Both are
+evaluated fail-closed: an invalid expression, missing payload, invalid JSON for
+a JSON-path expression, missing path, or incomparable values produce no match.
 
 - JSON path comparisons: `$.value > 85`, `$.status == "critical"`
+- Nested JSON paths and array indexes: `$.data.sensor.value >= 85`,
+  `$.readings.1 == 20`
 - Direct numeric comparisons: `> 0` (useful for simple payloads)
 - Operators: `>=`, `<=`, `!=`, `>`, `<`, `==`
+
+For boolean values, compare against quoted `"true"` or `"false"`.
+
+JSON-path comparisons require a JSON payload. For example, this trigger:
+
+```toml
+[[triggers]]
+type = "mqtt"
+topic = "facility/+/temperature"
+condition = "$.data.sensor.value >= 85"
+```
+
+matches a payload like:
+
+```json
+{
+  "data": {
+    "sensor": {
+      "value": 87.3
+    }
+  }
+}
+```
+
+A direct numeric comparison is for scalar payloads, such as peripheral signals:
+
+```toml
+[[triggers]]
+type = "peripheral"
+board = "board-01"
+signal = "pin_3"
+condition = "> 0"
+```
+
+That condition matches payload `1` and does not match payload `0` or
+non-numeric text.
+
+Conditions are single comparisons. Boolean combinators such as `and`, `or`,
+`&&`, and `||` are not part of the supported syntax.
 
 ## 6. Validation
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added focused `SOP.toml` examples for manual, MQTT, AMQP, channel, and peripheral trigger conditions.
  - Documented how step-level `when` guards evaluate against accumulated step outputs.
  - Expanded condition syntax notes for nested JSON paths, array indexes, direct numeric comparisons, booleans, and unsupported boolean combinators.
- **Scope boundary:** This PR changes documentation only. It does not change SOP parsing, routing, trigger evaluation, or runtime behavior.
- **Blast radius:** SOP documentation readers get more complete examples; no code or generated artifacts are changed.
- **Linked issue(s):** Related #8587.
- **Labels:** `docs`, `risk:low`, `size:S`, `type:docs`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
BASE_SHA=upstream/master DOCS_FILES='docs/book/src/sop/syntax.md' scripts/ci/docs_quality_gate.sh
# No prose em-dashes in changed docs files.
# markdownlint 0 errors

BASE_SHA=upstream/master DOCS_FILES='docs/book/src/sop/syntax.md' scripts/ci/docs_links_gate.sh
# Collected 0 added link(s) from 1 docs file(s).
# No added links detected in changed docs lines.

cargo fmt --all -- --check
# clean

git diff --check
# clean
```

- **Beyond CI -- what did you manually verify?** Cross-checked the documented `condition` and `when` examples against the SOP condition evaluator, routing code, and run-data payload shape.
- **If any command was intentionally skipped, why:** Full workspace tests were not run because this is a docs-only change covered by the docs quality and link gates.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need upgrade steps; this is documentation-only.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert a2933722bc1c9c4d00ec90c713b201c40914a623`

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
