### PR TITLE
fix(ci): stop passing rustdoc default theme globally

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,9 +4,6 @@ fluent = "run --release -p xtask --bin fluent --"
 web = "run --release -p xtask --bin web --"
 generate = "run --release -p xtask --bin generate --"
 
-[build]
-rustdocflags = ["--default-theme=ayu"]
-
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "link-arg=-static"]
 

--- a/crates/zeroclaw-providers/src/pricing.rs
+++ b/crates/zeroclaw-providers/src/pricing.rs
@@ -23,6 +23,7 @@
 //! what onboarding and the web rates editor display. Merging at snapshot
 //! assembly scopes live prices to cost tracking only.
 
+use crate::dispatch::ProviderDispatch;
 use crate::traits::{ModelInfo, ModelPricing};
 use futures_util::future::join_all;
 use parking_lot::RwLock;
@@ -525,11 +526,14 @@ async fn refresh_once(groups: &[GatewayGroup], total_aliases_per_family: &HashMa
     // gateway; first-fill latency is bounded by the slowest gateway, not the
     // sum of all of them) ──
     let mut any_ok = false;
-    let catalogs = join_all(
-        groups
-            .iter()
-            .map(|group| group.handle.list_models_with_pricing()),
-    )
+    let catalogs = join_all(groups.iter().map(|group| {
+        let handle = Arc::clone(&group.handle);
+        async move {
+            ProviderDispatch::new(handle)
+                .list_models_with_pricing()
+                .await
+        }
+    }))
     .await;
     let mut gateway_results: Vec<(&[WantedModel], HashMap<String, ModelRates>)> =
         Vec::with_capacity(groups.len());


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Removed the workspace-level `rustdocflags = ["--default-theme=ayu"]` from `.cargo/config.toml`.
  - Rust 1.96 now passes its own rustdoc theme flag during doctests, so the global workspace flag causes duplicate `--default-theme` arguments.
  - This keeps doctests using rustdoc defaults while leaving the mdBook theme configuration untouched.
- **Scope boundary:** This PR does not change documentation content, mdBook theme settings, or runtime behavior.
- **Blast radius:** Local cargo/rustdoc invocations from this repository no longer inherit the ayu rustdoc default theme. Build and runtime code paths are unaffected.
- **Linked issue(s):** Fixes #8847. Depends on #8885.
- **Labels:** Requested: `bug`, `ci`, `risk:low`, `size:XS`. Current `provider` label is from the stack base and should disappear after #8885 lands/rebase.

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
cargo fmt --all -- --check
# clean

cargo test --doc
#    Finished `test` profile [unoptimized + debuginfo] target(s) in ...
#  Doc-tests zeroclaw
# running 0 tests
# test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

git diff --check
# clean
```

- **Beyond CI -- what did you manually verify?** Verified on Rust 1.96.1 that doctest execution no longer fails from duplicated rustdoc theme flags.
- **If any command was intentionally skipped, why:** Full workspace checks were not run for this XS CI-config change; `cargo test --doc` covers the reported failure mode directly.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need upgrade steps; this only removes a repository-local cargo rustdoc default.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert 0872c740b1a76d248baa85b570f4d30e062ec5a5`

## Supersede Attribution (required only when `Supersedes #` is used)

N/A