### PR TITLE
fix(matrix): align marker path prompt with sender contract

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -884,8 +884,10 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
             "When responding on Matrix:\n\
              - Use Markdown formatting (bold, italic, code blocks)\n\
              - Be concise and direct\n\
-             - For media attachments use markers: [IMAGE:<absolute-path>], [DOCUMENT:<absolute-path>], [VIDEO:<absolute-path>], [AUDIO:<absolute-path>], or [VOICE:<absolute-path>]\n\
-             - Paths inside markers MUST be absolute (starting with /). Never use relative paths.\n\
+             - For media attachments use markers: [IMAGE:<path-or-url>], [DOCUMENT:<path-or-url>], [VIDEO:<path-or-url>], [AUDIO:<path-or-url>], or [VOICE:<path-or-url>]\n\
+             - Local marker paths may be workspace-relative or absolute, but they must resolve inside the configured workspace directory.\n\
+             - Copy paths from inbound messages or file tools exactly into markers. Do not add, remove, or rewrite path components.\n\
+             - Remote media is also accepted via http:// or https:// URLs in the same marker form.\n\
              - Keep normal text outside markers and never wrap markers in code fences.\n\
              - When you receive a [Voice message], the user spoke to you. Respond naturally as in conversation.\n\
              - Your text reply will automatically be converted to audio and sent back as a voice message.\n",
@@ -21270,6 +21272,36 @@ BTC is currently around $65,000 based on latest tool output."#
             "telegram media marker guidance should live in the system prompt"
         );
         assert!(!calls[0].iter().skip(1).any(|(role, _)| role == "system"));
+    }
+
+    #[test]
+    fn channel_delivery_instructions_for_matrix_match_marker_contract() {
+        let block = channel_delivery_instructions("matrix")
+            .expect("matrix channel must have a delivery-instructions block");
+        assert!(
+            block.contains("When responding on Matrix:"),
+            "matrix block must identify itself"
+        );
+        assert!(
+            block.contains("[IMAGE:<path-or-url>]"),
+            "matrix block must describe local path or URL marker syntax"
+        );
+        assert!(
+            block.contains("workspace-relative or absolute"),
+            "matrix block must match the validator's local path contract"
+        );
+        assert!(
+            block.contains("Copy paths from inbound messages or file tools exactly"),
+            "matrix block must prevent rewriting inbound or tool-returned paths"
+        );
+        assert!(
+            block.contains("http:// or https:// URLs"),
+            "matrix block must describe supported remote marker targets"
+        );
+        assert!(
+            !block.contains("Never use relative paths"),
+            "matrix block must not contradict the workspace-relative marker contract"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Updates the Matrix delivery instructions to match the sender contract: workspace-relative and absolute local paths are valid when they resolve inside the configured workspace.
  - Tells the model to preserve paths from inbound messages and file tools exactly instead of adding, removing, or rewriting path components.
  - Adds a focused regression test for the Matrix prompt contract.
  - The failure mode is a valid path such as `uploads/report.txt` being rewritten as `deliveries/uploads/report.txt` or `/uploads/report.txt`, which names a different or missing file.
- **Scope boundary:**
  - Does not change Matrix marker parsing, path validation, SSRF protections, upload behavior, or filesystem access rules.
  - Does not define a file-creation directory and does not enumerate deployment-specific workspace directories.
  - Does not change other channel delivery instructions or file-tool output formatting.
- **Blast radius:** Matrix channel system-prompt guidance and one unit test in `zeroclaw-channels`. Sender-side enforcement and other channels are unchanged.
- **Linked issue(s):** None.
- **Labels:** `bug`, `channel`, `channel:core`, `agent:prompt`, `rust`, `risk:medium`, `size:XS`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the focused unit test directly exercises the changed prompt contract, and the sender-side path behavior is unchanged.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh CI passed for head `c2c56a535`, including Format, Lint, Test, Security, platform checks, Benchmarks Compile, and the CI Required Gate. Local formatting, lint, focused, and full workspace tests were also completed before push.
- **Known CI coverage gap, if any:** No deterministic code-path gap. A live LLM may still ignore prompt guidance, but Matrix validation remains the enforcement boundary.
- **Commands run and tail output:**

```sh
$ cargo +1.96.1 fmt --all -- --check
# completed with no output
```

```sh
$ cargo +1.96.1 test -p zeroclaw-channels channel_delivery_instructions_for_matrix_match_marker_contract --lib -- --nocapture
running 1 test
test orchestrator::tests::channel_delivery_instructions_for_matrix_match_marker_contract ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1203 filtered out
```

```sh
$ cargo +1.96.1 clippy --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 43s
```

```sh
$ cargo +1.96.1 test
running 9 tests
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Doc-tests zeroclaw
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- **Beyond CI, what did you manually verify?**
  - Confirmed `matrix.rs::validate_marker_target` accepts workspace-relative paths and absolute paths inside the workspace while retaining the existing trust boundary.
  - Confirmed `file_write` echoes its path argument, so the model should preserve that path when emitting a Matrix marker.
  - Confirmed the follow-up changes only one prompt line and its matching assertion relative to the previous PR head.
- **If any command was intentionally skipped, why:** No required local command was skipped. A live Matrix/provider run was not used because this change does not alter sender behavior and model compliance would be nondeterministic.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`Yes`)
- If any `Yes`, describe the risk and mitigation: The Matrix system prompt now also names paths supplied by inbound messages. Those paths remain untrusted model context, and the existing Matrix validator still canonicalizes local targets, restricts them to the workspace, and enforces URL/SSRF policy before delivery.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A; no upgrade steps are required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert c2c56a535`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Matrix replies may again rewrite valid inbound or file-tool paths, causing existing workspace files not to upload as attachments.
