### PR TITLE
feat(web-search): classify provider HTTP failures with precise search_status (#5316)

### DIFF
--- a/crates/zeroclaw-tools/src/web_search_provider_routing.rs
+++ b/crates/zeroclaw-tools/src/web_search_provider_routing.rs
@@ -8,6 +8,21 @@ pub enum WebSearchProviderRoute {
     Bocha,
 }
 
+/// Structured search status: distinguishes "provider failure" from "no results".
+///
+/// The first slice (issue #5316) only fills `Blocked` on the HTTP failure
+/// path; `Timeout`/`Empty`/`ParseError` are reserved for later slices. The
+/// enum is defined once with all variants so later tasks can use it without
+/// changing every match site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchStatus {
+    Ok,
+    Blocked,
+    Timeout,
+    Empty,
+    ParseError,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WebSearchProviderResolution {
     pub route: WebSearchProviderRoute,
@@ -180,5 +195,16 @@ mod tests {
         let r = resolve_web_search_provider("Tavily-Search");
         assert_eq!(r.route, WebSearchProviderRoute::Tavily);
         assert!(!r.used_fallback);
+    }
+
+    #[test]
+    fn search_status_variants_exist() {
+        // 首切片主要用 Blocked；其余变体为后续切片（Empty 检测、timeout 归类）预留，
+        // 但必须在首个 PR 就定义，避免后续改 enum 破坏 match。
+        let _ = SearchStatus::Ok;
+        let _ = SearchStatus::Blocked;
+        let _ = SearchStatus::Timeout;
+        let _ = SearchStatus::Empty;
+        let _ = SearchStatus::ParseError;
     }
 }

--- a/crates/zeroclaw-tools/src/web_search_provider_routing.rs
+++ b/crates/zeroclaw-tools/src/web_search_provider_routing.rs
@@ -8,11 +8,14 @@ pub enum WebSearchProviderRoute {
     Bocha,
 }
 
-/// Structured search status: distinguishes provider failure from a genuine empty result.
+/// Structured search status: distinguishes provider failure classes from a
+/// genuine empty result and from each other.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchStatus {
     Ok,
     Blocked,
+    Unavailable,
+    ClientError,
     Timeout,
     Empty,
     ParseError,
@@ -24,6 +27,8 @@ impl SearchStatus {
         match self {
             Self::Ok => "ok",
             Self::Blocked => "blocked",
+            Self::Unavailable => "unavailable",
+            Self::ClientError => "client_error",
             Self::Timeout => "timeout",
             Self::Empty => "empty",
             Self::ParseError => "parse_error",
@@ -211,6 +216,8 @@ mod tests {
         // strings — drifting one silently breaks agent routing heuristics.
         assert_eq!(SearchStatus::Ok.as_str(), "ok");
         assert_eq!(SearchStatus::Blocked.as_str(), "blocked");
+        assert_eq!(SearchStatus::Unavailable.as_str(), "unavailable");
+        assert_eq!(SearchStatus::ClientError.as_str(), "client_error");
         assert_eq!(SearchStatus::Timeout.as_str(), "timeout");
         assert_eq!(SearchStatus::Empty.as_str(), "empty");
         assert_eq!(SearchStatus::ParseError.as_str(), "parse_error");

--- a/crates/zeroclaw-tools/src/web_search_provider_routing.rs
+++ b/crates/zeroclaw-tools/src/web_search_provider_routing.rs
@@ -8,30 +8,25 @@ pub enum WebSearchProviderRoute {
     Bocha,
 }
 
-/// Structured search status: distinguishes provider failure classes from a
-/// genuine empty result and from each other.
+/// Provider HTTP-failure status surfaced to the agent via the error message's
+/// `search_status=` tag. Only the classes `classify_http_status` actually
+/// produces appear here — no speculative variants (wire-or-remove).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchStatus {
-    Ok,
     Blocked,
     Unavailable,
     ClientError,
-    Timeout,
-    Empty,
-    ParseError,
 }
 
 impl SearchStatus {
-    /// Stable lowercase wire string for log attrs and error-message tags.
+    /// Stable lowercase tag embedded in the agent-visible error message
+    /// (`search_status=<tag>`). This is an error-text tag, not a structured
+    /// wire or log-attr contract — the runtime forwards the error as opaque text.
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::Ok => "ok",
             Self::Blocked => "blocked",
             Self::Unavailable => "unavailable",
             Self::ClientError => "client_error",
-            Self::Timeout => "timeout",
-            Self::Empty => "empty",
-            Self::ParseError => "parse_error",
         }
     }
 }
@@ -211,15 +206,10 @@ mod tests {
     }
 
     #[test]
-    fn search_status_as_str_returns_stable_wire_strings() {
-        // Log attrs and error-message tags depend on these exact lowercase
-        // strings — drifting one silently breaks agent routing heuristics.
-        assert_eq!(SearchStatus::Ok.as_str(), "ok");
+    fn search_status_as_str_returns_stable_tags() {
+        // The agent-visible error tag depends on these exact lowercase strings.
         assert_eq!(SearchStatus::Blocked.as_str(), "blocked");
         assert_eq!(SearchStatus::Unavailable.as_str(), "unavailable");
         assert_eq!(SearchStatus::ClientError.as_str(), "client_error");
-        assert_eq!(SearchStatus::Timeout.as_str(), "timeout");
-        assert_eq!(SearchStatus::Empty.as_str(), "empty");
-        assert_eq!(SearchStatus::ParseError.as_str(), "parse_error");
     }
 }

--- a/crates/zeroclaw-tools/src/web_search_provider_routing.rs
+++ b/crates/zeroclaw-tools/src/web_search_provider_routing.rs
@@ -8,12 +8,7 @@ pub enum WebSearchProviderRoute {
     Bocha,
 }
 
-/// Structured search status: distinguishes "provider failure" from "no results".
-///
-/// The first slice (issue #5316) only fills `Blocked` on the HTTP failure
-/// path; `Timeout`/`Empty`/`ParseError` are reserved for later slices. The
-/// enum is defined once with all variants so later tasks can use it without
-/// changing every match site.
+/// Structured search status: distinguishes provider failure from a genuine empty result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchStatus {
     Ok,
@@ -21,6 +16,19 @@ pub enum SearchStatus {
     Timeout,
     Empty,
     ParseError,
+}
+
+impl SearchStatus {
+    /// Stable lowercase wire string for log attrs and error-message tags.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Blocked => "blocked",
+            Self::Timeout => "timeout",
+            Self::Empty => "empty",
+            Self::ParseError => "parse_error",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -198,14 +206,13 @@ mod tests {
     }
 
     #[test]
-    fn search_status_variants_exist() {
-        // First slice uses Blocked primarily; the remaining variants are reserved
-        // for later slices (Empty detection, timeout classification) but must be
-        // defined in the first PR so later enum changes don't break match sites.
-        let _ = SearchStatus::Ok;
-        let _ = SearchStatus::Blocked;
-        let _ = SearchStatus::Timeout;
-        let _ = SearchStatus::Empty;
-        let _ = SearchStatus::ParseError;
+    fn search_status_as_str_returns_stable_wire_strings() {
+        // Log attrs and error-message tags depend on these exact lowercase
+        // strings — drifting one silently breaks agent routing heuristics.
+        assert_eq!(SearchStatus::Ok.as_str(), "ok");
+        assert_eq!(SearchStatus::Blocked.as_str(), "blocked");
+        assert_eq!(SearchStatus::Timeout.as_str(), "timeout");
+        assert_eq!(SearchStatus::Empty.as_str(), "empty");
+        assert_eq!(SearchStatus::ParseError.as_str(), "parse_error");
     }
 }

--- a/crates/zeroclaw-tools/src/web_search_provider_routing.rs
+++ b/crates/zeroclaw-tools/src/web_search_provider_routing.rs
@@ -199,8 +199,9 @@ mod tests {
 
     #[test]
     fn search_status_variants_exist() {
-        // 首切片主要用 Blocked；其余变体为后续切片（Empty 检测、timeout 归类）预留，
-        // 但必须在首个 PR 就定义，避免后续改 enum 破坏 match。
+        // First slice uses Blocked primarily; the remaining variants are reserved
+        // for later slices (Empty detection, timeout classification) but must be
+        // defined in the first PR so later enum changes don't break match sites.
         let _ = SearchStatus::Ok;
         let _ = SearchStatus::Blocked;
         let _ = SearchStatus::Timeout;

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1020,15 +1020,23 @@ fn duckduckgo_block_message(
     }
 }
 
-/// Classify a non-2xx HTTP status into a structured search status. Called only
-/// on the failure path (`!status.is_success()`); 2xx never reaches here.
+/// Classify a non-2xx HTTP status into a search status. Called only on the
+/// failure path (`!status.is_success()`); 2xx never reaches here.
+///
+/// 403 maps to `ClientError`, not `Blocked`: an API provider's 403 means
+/// authenticated-but-not-permitted (per Brave/Tavily docs) or a disabled/quota
+/// key — not an automated-search block. DuckDuckGo's confirmed CAPTCHA 403 is
+/// intercepted earlier by `duckduckgo_block_message`, so a 403 reaching here is
+/// always an API-provider permission failure. 451 (legal block) is the one
+/// status that unambiguously means "blocked" across providers.
 fn classify_http_status(status: reqwest::StatusCode) -> SearchStatus {
     match status.as_u16() {
-        403 | 451 => SearchStatus::Blocked, // active block / legal block
-        402 | 404 | 410 | 429 => SearchStatus::Unavailable, // quota / not-found / rate-limit
+        451 => SearchStatus::Blocked,                             // legal block (unambiguous)
+        403 => SearchStatus::ClientError,                         // API provider 403 = permission (DDG 403 handled upstream)
+        408 | 402 | 404 | 410 | 429 => SearchStatus::Unavailable,  // transient / provider-side
         400 | 401 => SearchStatus::ClientError,
         500..=599 => SearchStatus::Unavailable,
-        _ => SearchStatus::ClientError, // other non-success → request-side
+        _ => SearchStatus::ClientError,                           // other 4xx → request-side
     }
 }
 
@@ -1044,15 +1052,9 @@ fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::E
     let search_status = classify_http_status(status);
     let hint = match search_status {
         SearchStatus::Blocked | SearchStatus::Unavailable => {
-            "Try a different provider (SearXNG, Brave, or Tavily)."
+            "Provider may be transiently unavailable or blocking the request; retry, or try a different provider (SearXNG, Brave, or Tavily)."
         }
-        SearchStatus::ClientError => "Check the query and API key for this provider.",
-        // classify_http_status only returns failure classes (Blocked / Unavailable /
-        // ClientError); the remaining variants are unreachable on this path.
-        SearchStatus::Ok
-        | SearchStatus::Timeout
-        | SearchStatus::Empty
-        | SearchStatus::ParseError => "Try a different provider.",
+        SearchStatus::ClientError => "Check the query, API key, quota, and permissions for this provider.",
     };
     anyhow::Error::msg(format!(
         "{provider} search failed (search_status={}, http={status}). {hint}",
@@ -1254,37 +1256,33 @@ mod tests {
     }
 
     #[test]
-    fn http_search_failure_classifies_forbidden_as_blocked_with_provider_hint() {
-        // 403 is the canonical signal of active provider blocking; 451 is the
-        // legal-block variant. Both must surface a precise `search_status=blocked`
-        // tag and direct the agent at a different provider.
-        for status in [
-            reqwest::StatusCode::FORBIDDEN,
+    fn http_search_failure_classifies_legal_block_as_blocked() {
+        // 451 (legal block) is the one status that unambiguously means "blocked"
+        // across providers. It must surface search_status=blocked and the
+        // "different provider" hint. (403 is covered by the client_error case —
+        // an API provider's 403 is a permission failure, not a block.)
+        let err = http_search_failure(
+            "brave",
             reqwest::StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
-        ] {
-            let err = http_search_failure("brave", status);
-            let msg = format!("{err}");
-            assert!(
-                msg.contains("search_status=blocked"),
-                "{status} must tag search_status=blocked, got: {msg}"
-            );
-            assert!(
-                msg.contains(&format!("http={}", status.as_u16())),
-                "message must include the HTTP status code, got: {msg}"
-            );
-            assert!(
-                msg.contains("different provider"),
-                "blocked status must suggest switching providers, got: {msg}"
-            );
-        }
+        );
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("search_status=blocked"),
+            "451 must tag search_status=blocked, got: {msg}"
+        );
+        assert!(msg.contains("http=451"));
+        assert!(
+            msg.contains("different provider"),
+            "blocked status must suggest switching providers, got: {msg}"
+        );
     }
 
     #[test]
     fn http_search_failure_classifies_provider_side_failures_as_unavailable() {
-        // 5xx outages, 429 rate limiting, 402 quota, and 404 endpoint problems
-        // are all provider-side in the sense that switching provider is the
-        // actionable remedy; each must tag `search_status=unavailable` and
-        // surface the "different provider" hint.
+        // 5xx outages, 429 rate limiting, 402 quota, 404/410 endpoint problems,
+        // and 408 timeout are all transient/provider-side in the sense that
+        // retrying or switching provider is the actionable remedy; each must tag
+        // `search_status=unavailable` and surface the "different provider" hint.
         for status in [
             reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             reqwest::StatusCode::BAD_GATEWAY,
@@ -1292,6 +1290,7 @@ mod tests {
             reqwest::StatusCode::PAYMENT_REQUIRED,
             reqwest::StatusCode::NOT_FOUND,
             reqwest::StatusCode::GONE,
+            reqwest::StatusCode::REQUEST_TIMEOUT,
         ] {
             let err = http_search_failure("searxng", status);
             let msg = format!("{err}");
@@ -1312,11 +1311,14 @@ mod tests {
 
     #[test]
     fn http_search_failure_classifies_client_errors_as_client_error() {
-        // 400/401 are request/credential problems; switching provider may
-        // NOT help, so the hint must direct at query/key, not "different provider".
+        // 400/401 are request/credential problems, and 403 is an API provider
+        // permission failure (DuckDuckGo's confirmed-block 403 is intercepted
+        // upstream by duckduckgo_block_message). Switching provider may NOT help,
+        // so the hint must direct at key/quota/permissions, not "different provider".
         for status in [
             reqwest::StatusCode::BAD_REQUEST,
             reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::FORBIDDEN,
         ] {
             let err = http_search_failure("tavily", status);
             let msg = format!("{err}");
@@ -1329,8 +1331,8 @@ mod tests {
                 "message must include the HTTP status code, got: {msg}"
             );
             assert!(
-                msg.contains("Check the query and API key"),
-                "client_error hint must direct at query/key, got: {msg}"
+                msg.contains("Check the query, API key, quota, and permissions"),
+                "client_error hint must direct at query/key/quota/permissions, got: {msg}"
             );
             assert!(
                 !msg.contains("different provider"),

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1049,7 +1049,9 @@ fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::E
         SearchStatus::ClientError => "Check the query and API key for this provider.",
         // classify_http_status only returns failure classes (Blocked / Unavailable /
         // ClientError); the remaining variants are unreachable on this path.
-        SearchStatus::Ok | SearchStatus::Timeout | SearchStatus::Empty
+        SearchStatus::Ok
+        | SearchStatus::Timeout
+        | SearchStatus::Empty
         | SearchStatus::ParseError => "Try a different provider.",
     };
     anyhow::Error::msg(format!(

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1291,6 +1291,7 @@ mod tests {
             reqwest::StatusCode::TOO_MANY_REQUESTS,
             reqwest::StatusCode::PAYMENT_REQUIRED,
             reqwest::StatusCode::NOT_FOUND,
+            reqwest::StatusCode::GONE,
         ] {
             let err = http_search_failure("searxng", status);
             let msg = format!("{err}");

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1,4 +1,6 @@
-use super::web_search_provider_routing::{WebSearchProviderRoute, resolve_web_search_provider};
+use super::web_search_provider_routing::{
+    SearchStatus, WebSearchProviderRoute, resolve_web_search_provider,
+};
 use async_trait::async_trait;
 use regex::Regex;
 use serde_json::json;
@@ -204,10 +206,10 @@ impl WebSearchTool {
                     .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                     .with_attrs(::serde_json::json!({
                         "search_provider": "duckduckgo",
-                        "search_status": "blocked",
+                        "search_status": SearchStatus::Blocked.as_str(),
                         "http_status": status.as_u16(),
                     })),
-                format!("web_search: DuckDuckGo request blocked (http {status})")
+                "web_search provider request blocked"
             );
             if let Some(message) = duckduckgo_block_message(status, final_url_is_block, false) {
                 anyhow::bail!(message);
@@ -1044,14 +1046,15 @@ fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::E
             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
             .with_attrs(::serde_json::json!({
                 "search_provider": provider,
-                "search_status": "blocked",
+                "search_status": SearchStatus::Blocked.as_str(),
                 "http_status": status.as_u16(),
             })),
-        format!("web_search: {provider} request blocked (http {status})")
+        "web_search provider request blocked"
     );
     anyhow::Error::msg(format!(
-        "{provider} search failed (search_status=blocked, http={status}). \
-         Try a different provider (SearXNG, Brave, or Tavily)."
+        "{provider} search failed (search_status={}, http={status}). \
+         Try a different provider (SearXNG, Brave, or Tavily).",
+        SearchStatus::Blocked.as_str()
     ))
 }
 

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1024,11 +1024,11 @@ fn duckduckgo_block_message(
 /// on the failure path (`!status.is_success()`); 2xx never reaches here.
 fn classify_http_status(status: reqwest::StatusCode) -> SearchStatus {
     match status.as_u16() {
-        403 => SearchStatus::Blocked,
-        429 => SearchStatus::Unavailable,
+        403 | 451 => SearchStatus::Blocked, // active block / legal block
+        402 | 429 => SearchStatus::Unavailable, // quota / rate-limit
         400 | 401 | 404 => SearchStatus::ClientError,
         500..=599 => SearchStatus::Unavailable,
-        _ => SearchStatus::ClientError, // other 4xx -> request-side problem
+        _ => SearchStatus::ClientError, // other non-success → request-side
     }
 }
 
@@ -1047,7 +1047,10 @@ fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::E
             "Try a different provider (SearXNG, Brave, or Tavily)."
         }
         SearchStatus::ClientError => "Check the query and API key for this provider.",
-        _ => "Try a different provider.",
+        // classify_http_status only returns failure classes (Blocked / Unavailable /
+        // ClientError); the remaining variants are unreachable on this path.
+        SearchStatus::Ok | SearchStatus::Timeout | SearchStatus::Empty
+        | SearchStatus::ParseError => "Try a different provider.",
     };
     anyhow::Error::msg(format!(
         "{provider} search failed (search_status={}, http={status}). {hint}",

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -416,7 +416,7 @@ impl WebSearchTool {
             .await?;
 
         if !response.status().is_success() {
-            anyhow::bail!("Tavily search failed with status: {}", response.status());
+            return Err(http_search_failure("tavily", response.status()));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -570,7 +570,7 @@ impl WebSearchTool {
             .await?;
 
         if !response.status().is_success() {
-            anyhow::bail!("Jina AI search failed with status: {}", response.status());
+            return Err(http_search_failure("jina", response.status()));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -724,7 +724,7 @@ impl WebSearchTool {
 
         let status = response.status();
         if !status.is_success() {
-            anyhow::bail!("Bocha AI search failed with status: {}", status);
+            return Err(http_search_failure("bocha", status));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -941,7 +941,7 @@ impl WebSearchTool {
             .await?;
 
         if !response.status().is_success() {
-            anyhow::bail!("SearXNG search failed with status: {}", response.status());
+            return Err(http_search_failure("searxng", response.status()));
         }
 
         let json: serde_json::Value = response.json().await?;

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1020,23 +1020,23 @@ fn duckduckgo_block_message(
     }
 }
 
-/// Classify a non-2xx HTTP status into a search status. Called only on the
-/// failure path (`!status.is_success()`); 2xx never reaches here.
+/// Classify a non-2xx HTTP status into a coarse search status for the agent-
+/// visible error tag. Called only on the failure path (`!status.is_success()`);
+/// 2xx never reaches here.
 ///
-/// 403 maps to `ClientError`, not `Blocked`: an API provider's 403 means
-/// authenticated-but-not-permitted (per Brave/Tavily docs) or a disabled/quota
-/// key — not an automated-search block. DuckDuckGo's confirmed CAPTCHA 403 is
-/// intercepted earlier by `duckduckgo_block_message`, so a 403 reaching here is
-/// always an API-provider permission failure. 451 (legal block) is the one
-/// status that unambiguously means "blocked" across providers.
+/// These classes are coarse heuristics, not verified provider contracts — a
+/// status code alone does not prove why a provider refused the request, and
+/// providers differ. 451 stays `Blocked` because RFC 9110 ties it to a
+/// legal-refusal reason; 5xx, 429, and 408 are `Unavailable` (provider-side or
+/// transient); other non-2xx statuses fall through to `ClientError` (request/
+/// credential side). DuckDuckGo's confirmed CAPTCHA block is intercepted
+/// upstream by `duckduckgo_block_message`, so this helper only sees non-block
+/// failures. The agent should treat the tag as a hint to verify, not a diagnosis.
 fn classify_http_status(status: reqwest::StatusCode) -> SearchStatus {
     match status.as_u16() {
-        451 => SearchStatus::Blocked,     // legal block (unambiguous)
-        403 => SearchStatus::ClientError, // API provider 403 = permission (DDG 403 handled upstream)
-        408 | 402 | 404 | 410 | 429 => SearchStatus::Unavailable, // transient / provider-side
-        400 | 401 => SearchStatus::ClientError,
-        500..=599 => SearchStatus::Unavailable,
-        _ => SearchStatus::ClientError, // other 4xx → request-side
+        451 => SearchStatus::Blocked, // legal block (RFC-tied refusal reason)
+        408 | 429 | 500..=599 => SearchStatus::Unavailable, // provider-side / transient
+        _ => SearchStatus::ClientError, // other non-success → request/credential side (coarse)
     }
 }
 
@@ -1055,7 +1055,7 @@ fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::E
             "Provider may be transiently unavailable or blocking the request; retry, or try a different provider (SearXNG, Brave, or Tavily)."
         }
         SearchStatus::ClientError => {
-            "Check the query, API key, quota, and permissions for this provider."
+            "The provider refused the request; verify the query, credentials, billing or quota, and provider configuration."
         }
     };
     anyhow::Error::msg(format!(
@@ -1259,10 +1259,10 @@ mod tests {
 
     #[test]
     fn http_search_failure_classifies_legal_block_as_blocked() {
-        // 451 (legal block) is the one status that unambiguously means "blocked"
-        // across providers. It must surface search_status=blocked and the
-        // "different provider" hint. (403 is covered by the client_error case —
-        // an API provider's 403 is a permission failure, not a block.)
+        // 451 (legal block) is the one status RFC 9110 ties to a refusal reason,
+        // so it is the one status classified as `Blocked`. It must surface
+        // search_status=blocked and the "different provider" hint. (403 and other
+        // 4xx fall through to client_error — see that case.)
         let err = http_search_failure("brave", reqwest::StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
         let msg = format!("{err}");
         assert!(
@@ -1278,17 +1278,14 @@ mod tests {
 
     #[test]
     fn http_search_failure_classifies_provider_side_failures_as_unavailable() {
-        // 5xx outages, 429 rate limiting, 402 quota, 404/410 endpoint problems,
-        // and 408 timeout are all transient/provider-side in the sense that
-        // retrying or switching provider is the actionable remedy; each must tag
-        // `search_status=unavailable` and surface the "different provider" hint.
+        // 5xx outages, 429 rate limiting, and 408 timeout are provider-side or
+        // transient — retrying or switching provider is the actionable remedy;
+        // each must tag `search_status=unavailable` and surface the "different
+        // provider" hint.
         for status in [
             reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             reqwest::StatusCode::BAD_GATEWAY,
             reqwest::StatusCode::TOO_MANY_REQUESTS,
-            reqwest::StatusCode::PAYMENT_REQUIRED,
-            reqwest::StatusCode::NOT_FOUND,
-            reqwest::StatusCode::GONE,
             reqwest::StatusCode::REQUEST_TIMEOUT,
         ] {
             let err = http_search_failure("searxng", status);
@@ -1310,14 +1307,18 @@ mod tests {
 
     #[test]
     fn http_search_failure_classifies_client_errors_as_client_error() {
-        // 400/401 are request/credential problems, and 403 is an API provider
-        // permission failure (DuckDuckGo's confirmed-block 403 is intercepted
-        // upstream by duckduckgo_block_message). Switching provider may NOT help,
-        // so the hint must direct at key/quota/permissions, not "different provider".
+        // 400/401/402/403/404/410 all fall through to client_error as a coarse
+        // request/credential-side bucket — a status code alone doesn't prove the
+        // cause, so the hint stays neutral and asks the agent to verify, not to
+        // switch provider. DuckDuckGo's confirmed-block 403 is intercepted
+        // upstream by duckduckgo_block_message.
         for status in [
             reqwest::StatusCode::BAD_REQUEST,
             reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::PAYMENT_REQUIRED,
             reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::NOT_FOUND,
+            reqwest::StatusCode::GONE,
         ] {
             let err = http_search_failure("tavily", status);
             let msg = format!("{err}");
@@ -1330,8 +1331,8 @@ mod tests {
                 "message must include the HTTP status code, got: {msg}"
             );
             assert!(
-                msg.contains("Check the query, API key, quota, and permissions"),
-                "client_error hint must direct at query/key/quota/permissions, got: {msg}"
+                msg.contains("provider refused the request"),
+                "client_error hint must stay neutral, got: {msg}"
             );
             assert!(
                 !msg.contains("different provider"),

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -203,7 +203,7 @@ impl WebSearchTool {
             if let Some(message) = duckduckgo_block_message(status, final_url_is_block, false) {
                 anyhow::bail!(message);
             }
-            anyhow::bail!("DuckDuckGo search failed with status: {}", status);
+            return Err(http_search_failure("duckduckgo", status));
         }
 
         let html = response.text().await?;
@@ -1025,8 +1025,8 @@ fn duckduckgo_block_message(
 fn classify_http_status(status: reqwest::StatusCode) -> SearchStatus {
     match status.as_u16() {
         403 | 451 => SearchStatus::Blocked, // active block / legal block
-        402 | 429 => SearchStatus::Unavailable, // quota / rate-limit
-        400 | 401 | 404 => SearchStatus::ClientError,
+        402 | 404 | 410 | 429 => SearchStatus::Unavailable, // quota / not-found / rate-limit
+        400 | 401 => SearchStatus::ClientError,
         500..=599 => SearchStatus::Unavailable,
         _ => SearchStatus::ClientError, // other non-success → request-side
     }
@@ -1255,66 +1255,67 @@ mod tests {
 
     #[test]
     fn http_search_failure_classifies_forbidden_as_blocked_with_provider_hint() {
-        // 403 is the canonical signal of active provider blocking.
-        let err = http_search_failure("brave", reqwest::StatusCode::FORBIDDEN);
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("search_status=blocked"),
-            "403 must tag search_status=blocked, got: {msg}"
-        );
-        assert!(
-            msg.contains("http=403"),
-            "message must include the HTTP status code, got: {msg}"
-        );
-        assert!(
-            msg.contains("different provider"),
-            "blocked status must suggest switching providers, got: {msg}"
-        );
+        // 403 is the canonical signal of active provider blocking; 451 is the
+        // legal-block variant. Both must surface a precise `search_status=blocked`
+        // tag and direct the agent at a different provider.
+        for status in [
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
+        ] {
+            let err = http_search_failure("brave", status);
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("search_status=blocked"),
+                "{status} must tag search_status=blocked, got: {msg}"
+            );
+            assert!(
+                msg.contains(&format!("http={}", status.as_u16())),
+                "message must include the HTTP status code, got: {msg}"
+            );
+            assert!(
+                msg.contains("different provider"),
+                "blocked status must suggest switching providers, got: {msg}"
+            );
+        }
     }
 
     #[test]
-    fn http_search_failure_classifies_server_error_as_unavailable() {
-        // 5xx is a provider-side outage; switching provider is the right suggestion.
-        let err = http_search_failure("searxng", reqwest::StatusCode::BAD_GATEWAY);
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("search_status=unavailable"),
-            "5xx must classify as unavailable, got: {msg}"
-        );
-        assert!(msg.contains("http=502"));
-        assert!(
-            msg.contains("different provider"),
-            "unavailable status must suggest switching providers, got: {msg}"
-        );
-
-        // 500 is also Unavailable.
-        let err500 = http_search_failure("searxng", reqwest::StatusCode::INTERNAL_SERVER_ERROR);
-        let msg500 = format!("{err500}");
-        assert!(msg500.contains("search_status=unavailable"));
-        assert!(msg500.contains("http=500"));
-    }
-
-    #[test]
-    fn http_search_failure_classifies_rate_limit_as_unavailable() {
-        // 429 is provider-side rate limiting; switching provider helps.
-        let err = http_search_failure("jina", reqwest::StatusCode::TOO_MANY_REQUESTS);
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("search_status=unavailable"),
-            "429 must classify as unavailable, got: {msg}"
-        );
-        assert!(msg.contains("http=429"));
-        assert!(msg.contains("different provider"));
+    fn http_search_failure_classifies_provider_side_failures_as_unavailable() {
+        // 5xx outages, 429 rate limiting, 402 quota, and 404 endpoint problems
+        // are all provider-side in the sense that switching provider is the
+        // actionable remedy; each must tag `search_status=unavailable` and
+        // surface the "different provider" hint.
+        for status in [
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            reqwest::StatusCode::BAD_GATEWAY,
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            reqwest::StatusCode::PAYMENT_REQUIRED,
+            reqwest::StatusCode::NOT_FOUND,
+        ] {
+            let err = http_search_failure("searxng", status);
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("search_status=unavailable"),
+                "{status} must classify as unavailable, got: {msg}"
+            );
+            assert!(
+                msg.contains(&format!("http={}", status.as_u16())),
+                "message must include the HTTP status code, got: {msg}"
+            );
+            assert!(
+                msg.contains("different provider"),
+                "unavailable status must suggest switching providers, got: {msg}"
+            );
+        }
     }
 
     #[test]
     fn http_search_failure_classifies_client_errors_as_client_error() {
-        // 400/401/404 are request/credential problems; switching provider may
+        // 400/401 are request/credential problems; switching provider may
         // NOT help, so the hint must direct at query/key, not "different provider".
         for status in [
             reqwest::StatusCode::BAD_REQUEST,
             reqwest::StatusCode::UNAUTHORIZED,
-            reqwest::StatusCode::NOT_FOUND,
         ] {
             let err = http_search_failure("tavily", status);
             let msg = format!("{err}");
@@ -1358,6 +1359,36 @@ mod tests {
 
         assert!(err.to_string().contains("DuckDuckGo blocked"));
         assert!(err.to_string().contains("SearXNG"));
+    }
+
+    #[tokio::test]
+    async fn test_duckduckgo_request_reports_non_block_failure_with_status_tag() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/html/"))
+            .and(query_param("q", "test"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
+        let err = tool
+            .search_duckduckgo_at(&format!("{}/html/", server.uri()), "test")
+            .await
+            .expect_err("500 should be reported as a non-block HTTP failure");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("search_status=unavailable"),
+            "non-block DDG failure must carry the search_status tag, got: {msg}"
+        );
+        assert!(
+            msg.contains("http=500"),
+            "non-block DDG failure must carry the HTTP status code, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -285,7 +285,7 @@ impl WebSearchTool {
             .await?;
 
         if !response.status().is_success() {
-            anyhow::bail!("Brave search failed with status: {}", response.status());
+            return Err(http_search_failure("brave", response.status()));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -1026,10 +1026,6 @@ fn duckduckgo_block_message(
 /// The runtime (`tool_execution.rs`) forwards the `Err` returned by `execute`
 /// to the agent as readable text, so placing actionable hints in the message
 /// makes them visible to the agent.
-//
-// Callers land in the follow-up provider-wiring tasks; allow dead code until
-// they are wired in.
-#[allow(dead_code)]
 fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::Error {
     ::zeroclaw_log::record!(
         WARN,

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -198,6 +198,17 @@ impl WebSearchTool {
             contains_ascii_case_insensitive(response.url().as_str(), "/wr.do?");
 
         if !status.is_success() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "search_provider": "duckduckgo",
+                        "search_status": "blocked",
+                        "http_status": status.as_u16(),
+                    })),
+                format!("web_search: DuckDuckGo request blocked (http {status})")
+            );
             if let Some(message) = duckduckgo_block_message(status, final_url_is_block, false) {
                 anyhow::bail!(message);
             }

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1031,12 +1031,12 @@ fn duckduckgo_block_message(
 /// status that unambiguously means "blocked" across providers.
 fn classify_http_status(status: reqwest::StatusCode) -> SearchStatus {
     match status.as_u16() {
-        451 => SearchStatus::Blocked,                             // legal block (unambiguous)
-        403 => SearchStatus::ClientError,                         // API provider 403 = permission (DDG 403 handled upstream)
-        408 | 402 | 404 | 410 | 429 => SearchStatus::Unavailable,  // transient / provider-side
+        451 => SearchStatus::Blocked,     // legal block (unambiguous)
+        403 => SearchStatus::ClientError, // API provider 403 = permission (DDG 403 handled upstream)
+        408 | 402 | 404 | 410 | 429 => SearchStatus::Unavailable, // transient / provider-side
         400 | 401 => SearchStatus::ClientError,
         500..=599 => SearchStatus::Unavailable,
-        _ => SearchStatus::ClientError,                           // other 4xx → request-side
+        _ => SearchStatus::ClientError, // other 4xx → request-side
     }
 }
 
@@ -1054,7 +1054,9 @@ fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::E
         SearchStatus::Blocked | SearchStatus::Unavailable => {
             "Provider may be transiently unavailable or blocking the request; retry, or try a different provider (SearXNG, Brave, or Tavily)."
         }
-        SearchStatus::ClientError => "Check the query, API key, quota, and permissions for this provider.",
+        SearchStatus::ClientError => {
+            "Check the query, API key, quota, and permissions for this provider."
+        }
     };
     anyhow::Error::msg(format!(
         "{provider} search failed (search_status={}, http={status}). {hint}",
@@ -1261,10 +1263,7 @@ mod tests {
         // across providers. It must surface search_status=blocked and the
         // "different provider" hint. (403 is covered by the client_error case —
         // an API provider's 403 is a permission failure, not a block.)
-        let err = http_search_failure(
-            "brave",
-            reqwest::StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
-        );
+        let err = http_search_failure("brave", reqwest::StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
         let msg = format!("{err}");
         assert!(
             msg.contains("search_status=blocked"),

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -200,17 +200,6 @@ impl WebSearchTool {
             contains_ascii_case_insensitive(response.url().as_str(), "/wr.do?");
 
         if !status.is_success() {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                    .with_attrs(::serde_json::json!({
-                        "search_provider": "duckduckgo",
-                        "search_status": SearchStatus::Blocked.as_str(),
-                        "http_status": status.as_u16(),
-                    })),
-                "web_search provider request blocked"
-            );
             if let Some(message) = duckduckgo_block_message(status, final_url_is_block, false) {
                 anyhow::bail!(message);
             }
@@ -1031,30 +1020,38 @@ fn duckduckgo_block_message(
     }
 }
 
-/// Build a provider HTTP-failure error tagged with `search_status=blocked` and
-/// emit a structured log record. Used when a provider returns a non-2xx status
-/// code — the status is already in hand, so we can classify it directly as
-/// `Blocked` without inferring from an `anyhow::Error`.
+/// Classify a non-2xx HTTP status into a structured search status. Called only
+/// on the failure path (`!status.is_success()`); 2xx never reaches here.
+fn classify_http_status(status: reqwest::StatusCode) -> SearchStatus {
+    match status.as_u16() {
+        403 => SearchStatus::Blocked,
+        429 => SearchStatus::Unavailable,
+        400 | 401 | 404 => SearchStatus::ClientError,
+        500..=599 => SearchStatus::Unavailable,
+        _ => SearchStatus::ClientError, // other 4xx -> request-side problem
+    }
+}
+
+/// Build a provider HTTP-failure error whose message carries a precise
+/// `search_status` tag (blocked / unavailable / client_error) and an actionable
+/// hint matching the class. The central tool executor owns the failure log
+/// record; this helper emits no log of its own.
 ///
 /// The runtime (`tool_execution.rs`) forwards the `Err` returned by `execute`
 /// to the agent as readable text, so placing actionable hints in the message
 /// makes them visible to the agent.
 fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::Error {
-    ::zeroclaw_log::record!(
-        WARN,
-        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-            .with_attrs(::serde_json::json!({
-                "search_provider": provider,
-                "search_status": SearchStatus::Blocked.as_str(),
-                "http_status": status.as_u16(),
-            })),
-        "web_search provider request blocked"
-    );
+    let search_status = classify_http_status(status);
+    let hint = match search_status {
+        SearchStatus::Blocked | SearchStatus::Unavailable => {
+            "Try a different provider (SearXNG, Brave, or Tavily)."
+        }
+        SearchStatus::ClientError => "Check the query and API key for this provider.",
+        _ => "Try a different provider.",
+    };
     anyhow::Error::msg(format!(
-        "{provider} search failed (search_status={}, http={status}). \
-         Try a different provider (SearXNG, Brave, or Tavily).",
-        SearchStatus::Blocked.as_str()
+        "{provider} search failed (search_status={}, http={status}). {hint}",
+        search_status.as_str()
     ))
 }
 
@@ -1252,31 +1249,87 @@ mod tests {
     }
 
     #[test]
-    fn http_search_failure_marks_status_blocked_and_lists_alternatives() {
-        // 403 is a typical signal of active provider blocking.
+    fn http_search_failure_classifies_forbidden_as_blocked_with_provider_hint() {
+        // 403 is the canonical signal of active provider blocking.
         let err = http_search_failure("brave", reqwest::StatusCode::FORBIDDEN);
         let msg = format!("{err}");
         assert!(
             msg.contains("search_status=blocked"),
-            "message must tag search_status=blocked for agent routing, got: {msg}"
+            "403 must tag search_status=blocked, got: {msg}"
         );
         assert!(
             msg.contains("http=403"),
             "message must include the HTTP status code, got: {msg}"
         );
         assert!(
-            msg.contains("SearXNG") && msg.contains("Tavily"),
-            "message must suggest alternative providers, got: {msg}"
+            msg.contains("different provider"),
+            "blocked status must suggest switching providers, got: {msg}"
         );
     }
 
     #[test]
-    fn http_search_failure_tags_server_errors_as_blocked() {
-        // 5xx is also classified as Blocked (provider unavailable; switching
-        // provider is the right suggestion).
+    fn http_search_failure_classifies_server_error_as_unavailable() {
+        // 5xx is a provider-side outage; switching provider is the right suggestion.
         let err = http_search_failure("searxng", reqwest::StatusCode::BAD_GATEWAY);
-        assert!(format!("{err}").contains("search_status=blocked"));
-        assert!(format!("{err}").contains("http=502"));
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("search_status=unavailable"),
+            "5xx must classify as unavailable, got: {msg}"
+        );
+        assert!(msg.contains("http=502"));
+        assert!(
+            msg.contains("different provider"),
+            "unavailable status must suggest switching providers, got: {msg}"
+        );
+
+        // 500 is also Unavailable.
+        let err500 = http_search_failure("searxng", reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+        let msg500 = format!("{err500}");
+        assert!(msg500.contains("search_status=unavailable"));
+        assert!(msg500.contains("http=500"));
+    }
+
+    #[test]
+    fn http_search_failure_classifies_rate_limit_as_unavailable() {
+        // 429 is provider-side rate limiting; switching provider helps.
+        let err = http_search_failure("jina", reqwest::StatusCode::TOO_MANY_REQUESTS);
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("search_status=unavailable"),
+            "429 must classify as unavailable, got: {msg}"
+        );
+        assert!(msg.contains("http=429"));
+        assert!(msg.contains("different provider"));
+    }
+
+    #[test]
+    fn http_search_failure_classifies_client_errors_as_client_error() {
+        // 400/401/404 are request/credential problems; switching provider may
+        // NOT help, so the hint must direct at query/key, not "different provider".
+        for status in [
+            reqwest::StatusCode::BAD_REQUEST,
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::NOT_FOUND,
+        ] {
+            let err = http_search_failure("tavily", status);
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("search_status=client_error"),
+                "{status} must classify as client_error, got: {msg}"
+            );
+            assert!(
+                msg.contains(&format!("http={}", status.as_u16())),
+                "message must include the HTTP status code, got: {msg}"
+            );
+            assert!(
+                msg.contains("Check the query and API key"),
+                "client_error hint must direct at query/key, got: {msg}"
+            );
+            assert!(
+                !msg.contains("different provider"),
+                "client_error must NOT suggest switching providers, got: {msg}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/web_search_tool.rs
+++ b/crates/zeroclaw-tools/src/web_search_tool.rs
@@ -1018,6 +1018,36 @@ fn duckduckgo_block_message(
     }
 }
 
+/// Build a provider HTTP-failure error tagged with `search_status=blocked` and
+/// emit a structured log record. Used when a provider returns a non-2xx status
+/// code — the status is already in hand, so we can classify it directly as
+/// `Blocked` without inferring from an `anyhow::Error`.
+///
+/// The runtime (`tool_execution.rs`) forwards the `Err` returned by `execute`
+/// to the agent as readable text, so placing actionable hints in the message
+/// makes them visible to the agent.
+//
+// Callers land in the follow-up provider-wiring tasks; allow dead code until
+// they are wired in.
+#[allow(dead_code)]
+fn http_search_failure(provider: &str, status: reqwest::StatusCode) -> anyhow::Error {
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+            .with_attrs(::serde_json::json!({
+                "search_provider": provider,
+                "search_status": "blocked",
+                "http_status": status.as_u16(),
+            })),
+        format!("web_search: {provider} request blocked (http {status})")
+    );
+    anyhow::Error::msg(format!(
+        "{provider} search failed (search_status=blocked, http={status}). \
+         Try a different provider (SearXNG, Brave, or Tavily)."
+    ))
+}
+
 fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
     haystack
         .as_bytes()
@@ -1209,6 +1239,34 @@ mod tests {
             r#"<form action="/WR.DO?u=https%3A%2F%2Fhtml.duckduckgo.com%2Fhtml%2F"></form>"#,
             "/wr.do?"
         ));
+    }
+
+    #[test]
+    fn http_search_failure_marks_status_blocked_and_lists_alternatives() {
+        // 403 is a typical signal of active provider blocking.
+        let err = http_search_failure("brave", reqwest::StatusCode::FORBIDDEN);
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("search_status=blocked"),
+            "message must tag search_status=blocked for agent routing, got: {msg}"
+        );
+        assert!(
+            msg.contains("http=403"),
+            "message must include the HTTP status code, got: {msg}"
+        );
+        assert!(
+            msg.contains("SearXNG") && msg.contains("Tavily"),
+            "message must suggest alternative providers, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn http_search_failure_tags_server_errors_as_blocked() {
+        // 5xx is also classified as Blocked (provider unavailable; switching
+        // provider is the right suggestion).
+        let err = http_search_failure("searxng", reqwest::StatusCode::BAD_GATEWAY);
+        assert!(format!("{err}").contains("search_status=blocked"));
+        assert!(format!("{err}").contains("http=502"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `SearchStatus` enum trimmed to the 3 classes `classify_http_status` produces — `Blocked` / `Unavailable` / `ClientError` (wire-or-remove). `as_str()` is an agent-visible error tag, not a structured wire contract.
  - `classify_http_status` mapping (**coarse heuristics, not verified provider contracts**): `451`→`Blocked` (RFC 9110 legal-refusal reason); `408`/`429`/`5xx`→`Unavailable` (provider-side or transient); all other non-2xx→`ClientError` (coarse catch-all, incl. 400/401/402/403/404/410).
  - `http_search_failure`'s match covers only the 3 produced variants; `ClientError` hint is neutral — "the provider refused the request; verify query/credentials/billing/quota/config" — no longer claiming 403 is a key/permission failure.
  - Why: #5316 — provider failure and "no results" were conflated. Status is now coarse-but-honest: the tag tells the agent which bucket to act on, without overclaiming a cause the status code alone can't prove.

- **Evidence discipline (per provider):** A status code alone doesn't prove why a provider refused.
  - **DuckDuckGo:** confirmed CAPTCHA block detected upstream by `duckduckgo_block_message` (#6582) — 403 never reaches `classify_http_status` on the DDG path.
  - **Jina:** docs document 403 as `Insufficient account balance` / `Resource limit exceeded` (client-actionable).
  - **Brave / Tavily / SearXNG / Bocha:** no reliable 403 contract found (Brave/Tavily confirmed by reviewer; SearXNG is a metasearch with no status-code docs; Bocha's error reference is behind login) — treated as **unverified**, not asserted.
  - **402:** RFC 9110 §15.5.3 reserves it **without defining semantics** — not asserted as billing or transient; falls into the coarse ClientError catch-all.
  - The `ClientError` hint lists aspects to verify rather than diagnosing a single cause, since the cause isn't provable from the status code for unverified providers.

- **Scope boundary:** HTTP-failure paths only. Transport/timeout (`send().await?`) and parse errors propagate raw. `Empty` detection, retry/backoff, lifting `SearchStatus` to `zeroclaw-api` deferred. No per-tool logging — central executor owns failure emission.
- **Blast radius:** `web_search_tool` consumers only.
- **Linked issue(s):** Related #5316 (slice 1). Baseline from #6582.

## Testing

### How you can test

A. **Legal block (451):** → `search_status=blocked` + switch hint — `http_search_failure_classifies_legal_block_as_blocked`
B. **Unavailable (5xx/429/408):** → `search_status=unavailable` + retry/switch hint — `http_search_failure_classifies_provider_side_failures_as_unavailable`
C. **ClientError (400/401/402/403/404/410):** → `search_status=client_error` + neutral "refused; verify ..." (NOT switch) — `http_search_failure_classifies_client_errors_as_client_error`
D. **#6582 regression:** DDG 403 block tests unchanged — `test_duckduckgo_block_detection test_duckduckgo_request_reports_forbidden_status`

### How I tested

- `cargo fmt --all -- --check` — clean (local rustfmt 1.9.0; CI is source of truth)
- `cargo clippy -p zeroclaw-tools --all-targets -- -D warnings` — clean
- `cargo test -p zeroclaw-tools --lib` — 1488 passed / 6 failed (pre-existing `stash_push_*` + `http_request::execute_sends_auth_secret`, unrelated).

## Security & Privacy Impact
- New permissions/capabilities/file-system access? **No**
- New external network calls? **No**
- Secrets/tokens/credentials handling changed? **No**
- PII/real identities in diff/tests/fixtures/docs? **No**

## Compatibility
- Backward compatible? **Yes**
- Error-message text: `"X search failed (search_status=<status>, http=<code>). <hint>"`. 403 now reports `client_error` (previously the inaccurate `blocked`).

## Rollback (high-risk path: `crates/zeroclaw-tools/src/**`)
- **Fast rollback:** `git revert <merge-sha>` — additive in error-message construction.
- **Observable failure symptoms if this regresses:**
  - web_search error without a `search_status=` tag (regression to pre-PR)
  - `search_status=blocked` for a non-DDG 403 (403 misclassification crept back)
  - duplicate tool-fail events (per-tool logging crept back — should NOT happen)
  - #6582 DDG block tests fail (DDG message drifted)