### PR TITLE
feat(memory): gated rerank stage in engine memory-context injection

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5403,9 +5403,14 @@ async fn process_channel_message_body(
                     query: msg.content.clone(),
                     sessions: memory_sessions.clone(),
                     suppress: false,
+                    // The relevance floor stays the context's resolved copy;
+                    // the rerank stage settings thread from the live config.
                     cfg: zeroclaw_runtime::agent::memory_inject::MemoryInjectConfig {
                         min_relevance_score: ctx.min_relevance_score,
-                        ..Default::default()
+                        ..zeroclaw_runtime::agent::memory_inject::MemoryInjectConfig::from_memory_config(
+                            &ctx.prompt_config.memory,
+                            zeroclaw_runtime::agent::memory_inject::DEFAULT_RECALL_LIMIT,
+                        )
                     },
                 }),
                 ingress: zeroclaw_api::ingress::IngressContext::channel(),

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10484,12 +10484,31 @@ pub struct MemoryConfig {
     /// call today, so those names have no effect (kept for forward compat).
     #[serde(default = "default_retrieval_stages")]
     pub retrieval_stages: Vec<String>,
-    /// Enable LLM reranking when candidate count exceeds threshold.
+    /// Candidate pool multiplier over the final recall limit before blend/rerank trimming.
+    /// Values must be in 1..=20; runtime also enforces a bounded candidate pool.
+    #[serde(default = "default_candidate_multiplier")]
+    pub candidate_multiplier: usize,
+    /// Enable the recall rerank stage: blend retrieval score with importance
+    /// and recency, collapse near-duplicate entries, then trim back to the
+    /// recall limit. The advanced strategy below runs when the candidate
+    /// count reaches `rerank_threshold`.
     #[serde(default)]
     pub rerank_enabled: bool,
-    /// Minimum candidate count to trigger reranking.
+    /// Minimum candidate count to trigger the advanced rerank strategy.
     #[serde(default = "default_rerank_threshold")]
     pub rerank_threshold: usize,
+    /// Advanced rerank strategy. Valid: "none", "mmr".
+    #[serde(default = "default_rerank_strategy")]
+    pub rerank_strategy: String,
+    /// MMR relevance-vs-diversity weight, where 1.0 means relevance-only.
+    #[serde(default = "default_mmr_lambda")]
+    pub mmr_lambda: f64,
+    /// Importance weight used by the recall blend.
+    #[serde(default = "default_importance_weight")]
+    pub importance_weight: f64,
+    /// Recency weight used by the recall blend.
+    #[serde(default = "default_recency_weight")]
+    pub recency_weight: f64,
     /// Reserved (0.0-1.0): the FTS score above which recall would skip the
     /// vector stage. Inert until the backend exposes distinct FTS and vector
     /// operations; recall is a single hybrid call today, so this has no effect.
@@ -10652,8 +10671,49 @@ fn default_retrieval_stages() -> Vec<String> {
 fn default_rerank_threshold() -> usize {
     5
 }
+
+/// Largest allowed multiplier for the bounded query-time rerank candidate pool.
+pub const MAX_MEMORY_RERANK_CANDIDATE_MULTIPLIER: usize = 20;
+
+fn default_candidate_multiplier() -> usize {
+    4
+}
+fn default_rerank_strategy() -> String {
+    "none".into()
+}
+fn default_mmr_lambda() -> f64 {
+    0.7
+}
+fn default_importance_weight() -> f64 {
+    0.2
+}
+fn default_recency_weight() -> f64 {
+    0.1
+}
 fn default_fts_early_return_score() -> f64 {
     0.85
+}
+
+fn validate_memory_rerank_config(memory: &MemoryConfig) -> Result<()> {
+    if !(1..=MAX_MEMORY_RERANK_CANDIDATE_MULTIPLIER).contains(&memory.candidate_multiplier) {
+        anyhow::bail!(
+            "memory.candidate_multiplier must be in 1..={MAX_MEMORY_RERANK_CANDIDATE_MULTIPLIER} (got {})",
+            memory.candidate_multiplier
+        );
+    }
+
+    for (path, value) in [
+        ("memory.min_relevance_score", memory.min_relevance_score),
+        ("memory.mmr_lambda", memory.mmr_lambda),
+        ("memory.importance_weight", memory.importance_weight),
+        ("memory.recency_weight", memory.recency_weight),
+    ] {
+        if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+            anyhow::bail!("{path} must be a finite number in 0.0..=1.0 (got {value})");
+        }
+    }
+
+    Ok(())
 }
 fn default_namespace() -> String {
     "default".into()
@@ -10850,8 +10910,13 @@ impl Default for MemoryConfig {
             snapshot_on_hygiene: false,
             auto_hydrate: true,
             retrieval_stages: default_retrieval_stages(),
+            candidate_multiplier: default_candidate_multiplier(),
             rerank_enabled: false,
             rerank_threshold: default_rerank_threshold(),
+            rerank_strategy: default_rerank_strategy(),
+            mmr_lambda: default_mmr_lambda(),
+            importance_weight: default_importance_weight(),
+            recency_weight: default_recency_weight(),
             fts_early_return_score: default_fts_early_return_score(),
             default_namespace: default_namespace(),
             conflict_threshold: default_conflict_threshold(),
@@ -18898,6 +18963,8 @@ impl Config {
     /// Called after TOML deserialization and env-override application to catch
     /// obviously invalid values early instead of failing at arbitrary runtime points.
     pub fn validate(&self) -> Result<()> {
+        validate_memory_rerank_config(&self.memory)?;
+
         // Tunnel — OpenVPN
         if self.tunnel.tunnel_provider.trim() == "openvpn" {
             let openvpn = self.tunnel.openvpn.as_ref().ok_or_else(|| {
@@ -22002,6 +22069,74 @@ max_height = 8
         .expect("legacy filter_builtins key must not break deserialization");
         assert!(matches!(group.mode, super::ToolFilterGroupMode::Always));
         assert_eq!(group.tools, vec!["filesystem__*".to_string()]);
+    }
+
+    #[::core::prelude::v1::test]
+    fn memory_config_rerank_stage_defaults() {
+        // An empty [memory] block resolves the rerank-stage keys to their
+        // inert defaults (stage off, "none" strategy).
+        let cfg: super::MemoryConfig = serde_json::from_str("{}").unwrap();
+        assert!(!cfg.rerank_enabled);
+        assert_eq!(cfg.candidate_multiplier, 4);
+        assert_eq!(cfg.rerank_threshold, 5);
+        assert_eq!(cfg.rerank_strategy, "none");
+        assert!((cfg.mmr_lambda - 0.7).abs() < f64::EPSILON);
+        assert!((cfg.importance_weight - 0.2).abs() < f64::EPSILON);
+        assert!((cfg.recency_weight - 0.1).abs() < f64::EPSILON);
+
+        // The Default impl agrees with the serde defaults.
+        let def = super::MemoryConfig::default();
+        assert_eq!(def.candidate_multiplier, cfg.candidate_multiplier);
+        assert_eq!(def.rerank_strategy, cfg.rerank_strategy);
+        assert!((def.mmr_lambda - cfg.mmr_lambda).abs() < f64::EPSILON);
+        assert!((def.importance_weight - cfg.importance_weight).abs() < f64::EPSILON);
+        assert!((def.recency_weight - cfg.recency_weight).abs() < f64::EPSILON);
+    }
+
+    #[::core::prelude::v1::test]
+    fn config_validate_rejects_invalid_memory_rerank_values() {
+        // A NaN in any of the blend/floor floats must be rejected outright: it
+        // survives `clamp` and would silently drop valid memories downstream.
+        let reject_nan = |field: &str| {
+            let mut config = super::Config::default();
+            match field {
+                "memory.min_relevance_score" => config.memory.min_relevance_score = f64::NAN,
+                "memory.mmr_lambda" => config.memory.mmr_lambda = f64::NAN,
+                "memory.importance_weight" => config.memory.importance_weight = f64::NAN,
+                "memory.recency_weight" => config.memory.recency_weight = f64::NAN,
+                other => panic!("unhandled field {other}"),
+            }
+            let err = config
+                .validate()
+                .expect_err("non-finite value must fail validation");
+            assert!(
+                err.to_string().contains(field),
+                "expected {field}, got {err}"
+            );
+        };
+        reject_nan("memory.min_relevance_score");
+        reject_nan("memory.mmr_lambda");
+        reject_nan("memory.importance_weight");
+        reject_nan("memory.recency_weight");
+
+        for multiplier in [0, super::MAX_MEMORY_RERANK_CANDIDATE_MULTIPLIER + 1] {
+            let mut config = super::Config::default();
+            config.memory.candidate_multiplier = multiplier;
+            let err = config
+                .validate()
+                .expect_err("out-of-range multiplier must fail validation");
+            assert!(
+                err.to_string().contains("memory.candidate_multiplier"),
+                "unexpected error: {err}"
+            );
+        }
+
+        let mut config = super::Config::default();
+        config.memory.mmr_lambda = 1.1;
+        let err = config
+            .validate()
+            .expect_err("out-of-range MMR lambda must fail validation");
+        assert!(err.to_string().contains("memory.mmr_lambda"));
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -34,6 +34,7 @@ pub mod policy_gate;
 pub mod postgres;
 pub mod qdrant;
 pub mod redact;
+pub mod rerank;
 pub mod response_cache;
 pub mod retrieval;
 pub mod scanned;
@@ -62,6 +63,7 @@ pub use policy::PolicyEnforcer;
 #[allow(unused_imports)]
 pub use postgres::PostgresMemory;
 pub use qdrant::QdrantMemory;
+pub use rerank::{RerankConfig, RerankStrategy};
 pub use response_cache::ResponseCache;
 #[allow(unused_imports)]
 pub use retrieval::{RetrievalConfig, RetrievalPipeline};

--- a/crates/zeroclaw-memory/src/rerank.rs
+++ b/crates/zeroclaw-memory/src/rerank.rs
@@ -18,7 +18,7 @@ pub const MAX_CANDIDATE_POOL: usize = 1024;
 
 #[must_use]
 pub fn bounded_final_limit(final_limit: usize) -> usize {
-    final_limit.min(MAX_CANDIDATE_POOL).max(1)
+    final_limit.clamp(1, MAX_CANDIDATE_POOL)
 }
 
 #[must_use]

--- a/crates/zeroclaw-memory/src/rerank.rs
+++ b/crates/zeroclaw-memory/src/rerank.rs
@@ -14,7 +14,20 @@ const DEFAULT_RECENCY_WEIGHT: f64 = 0.1;
 /// returns. Bounds the O(n^2) duplicate-collapse and MMR scans against a
 /// mis-sized config or a backend that ignores the requested recall limit
 /// (for example a no-embedding fallback that returns its whole list).
-const MAX_CANDIDATE_POOL: usize = 1024;
+pub const MAX_CANDIDATE_POOL: usize = 1024;
+
+#[must_use]
+pub fn bounded_final_limit(final_limit: usize) -> usize {
+    final_limit.min(MAX_CANDIDATE_POOL).max(1)
+}
+
+#[must_use]
+pub fn bounded_pool_cap(final_limit: usize, candidate_pool_cap: usize) -> usize {
+    candidate_pool_cap
+        .min(MAX_CANDIDATE_POOL)
+        .max(bounded_final_limit(final_limit))
+        .max(1)
+}
 
 /// Advanced rerank strategy.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -69,11 +82,8 @@ pub fn run(
     // limit and returns its whole list, never scan more than the configured
     // cap, itself held under an absolute ceiling. Applied to the raw pool in
     // backend order so a scoreless time-only recall keeps its newest-first head.
-    let pool_cap = config
-        .candidate_pool_cap
-        .min(MAX_CANDIDATE_POOL)
-        .max(config.final_limit)
-        .max(1);
+    let final_limit = bounded_final_limit(config.final_limit);
+    let pool_cap = bounded_pool_cap(config.final_limit, config.candidate_pool_cap);
     if pool.len() > pool_cap {
         pool.truncate(pool_cap);
     }
@@ -113,7 +123,7 @@ pub fn run(
     // media markers, orphan tool-result blocks) before the final trim so the
     // over-fetched candidates below the cutoff can fill the freed slots.
     candidates.retain(|entry| is_eligible(entry));
-    candidates.truncate(config.final_limit);
+    candidates.truncate(final_limit);
     candidates
 }
 

--- a/crates/zeroclaw-memory/src/rerank.rs
+++ b/crates/zeroclaw-memory/src/rerank.rs
@@ -68,11 +68,11 @@ impl RerankConfig {
     }
 }
 
-/// Run blend, duplicate collapse, optional advanced rerank, threshold, and
-/// trim. `is_eligible` is the caller's render-eligibility predicate; it is
-/// applied after ranking but before the final trim so ineligible rows do not
-/// consume final-selection slots while the over-fetched pool still does the
-/// ranking work.
+/// Run blend, eligibility filtering, duplicate collapse, optional advanced
+/// rerank, threshold, and trim. `is_eligible` is the caller's render-eligibility
+/// predicate; it is applied before duplicate collapse so an ineligible row
+/// cannot shadow an eligible fact with the same content, and before the final
+/// trim so it cannot consume a selection slot.
 pub fn run(
     mut pool: Vec<MemoryEntry>,
     config: &RerankConfig,
@@ -104,6 +104,10 @@ pub fn run(
         ));
     }
 
+    // Apply the renderer's scope and hygiene boundary before duplicate
+    // collapse. Otherwise a higher-scoring Conversation/autosave row can
+    // discard an eligible fact with the same content, then be removed itself.
+    pool.retain(|entry| is_eligible(entry));
     let mut candidates = collapse_exact_and_near_duplicates(pool, DEFAULT_NEAR_DUPLICATE_THRESHOLD);
     sort_by_score(&mut candidates);
 
@@ -119,10 +123,6 @@ pub fn run(
             .score
             .is_none_or(|score| score >= config.min_relevance_score)
     });
-    // Drop render-ineligible entries (Conversation, autosave/history keys,
-    // media markers, orphan tool-result blocks) before the final trim so the
-    // over-fetched candidates below the cutoff can fill the freed slots.
-    candidates.retain(|entry| is_eligible(entry));
     candidates.truncate(final_limit);
     candidates
 }
@@ -529,6 +529,30 @@ mod tests {
         assert_eq!(results.len(), 2, "eligible candidate fills the freed slot");
         assert_eq!(results[0].key, "keep_a");
         assert_eq!(results[1].key, "keep_b");
+    }
+
+    /// An ineligible row with duplicate content must not shadow an eligible
+    /// fact during collapse and then disappear at the render boundary.
+    #[test]
+    fn ineligible_duplicate_cannot_collapse_eligible_fact() {
+        let mut cfg = config(RerankStrategy::None);
+        cfg.final_limit = 1;
+        let results = run(
+            vec![
+                entry(
+                    "skip_autosave",
+                    "the release train leaves Friday",
+                    0.99,
+                    0.0,
+                ),
+                entry("curated_fact", "the release train leaves Friday", 0.8, 0.0),
+            ],
+            &cfg,
+            |entry| entry.key != "skip_autosave",
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "curated_fact");
     }
 
     /// Diversity-only endpoint: every candidate ties on the first MMR pass, so

--- a/crates/zeroclaw-memory/src/rerank.rs
+++ b/crates/zeroclaw-memory/src/rerank.rs
@@ -1,0 +1,565 @@
+//! Query-time rerank machinery for recalled memory candidates.
+
+use crate::importance::weighted_final_score;
+use crate::traits::{MemoryCategory, MemoryEntry};
+use chrono::{DateTime, Utc};
+use std::collections::HashSet;
+
+const DEFAULT_NEAR_DUPLICATE_THRESHOLD: f64 = 0.92;
+const DEFAULT_IMPORTANCE_WEIGHT: f64 = 0.2;
+const DEFAULT_RECENCY_WEIGHT: f64 = 0.1;
+
+/// Absolute ceiling on the query-time candidate pool, enforced in `run`
+/// regardless of the configured multiplier or how many entries a backend
+/// returns. Bounds the O(n^2) duplicate-collapse and MMR scans against a
+/// mis-sized config or a backend that ignores the requested recall limit
+/// (for example a no-embedding fallback that returns its whole list).
+const MAX_CANDIDATE_POOL: usize = 1024;
+
+/// Advanced rerank strategy.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RerankStrategy {
+    None,
+    Mmr { lambda: f64 },
+}
+
+/// Rerank stage configuration, materialized from canonical memory config.
+/// `Copy` so the engine's injection config (which embeds one) stays `Copy`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RerankConfig {
+    pub strategy: RerankStrategy,
+    pub threshold: usize,
+    pub importance_weight: f64,
+    pub recency_weight: f64,
+    pub min_relevance_score: f64,
+    pub final_limit: usize,
+    /// Upper bound on the candidate pool the stage will scan, materialized
+    /// from the recall limit and the configured candidate multiplier. `run`
+    /// trims the incoming pool to this bound (held under `MAX_CANDIDATE_POOL`)
+    /// before any blend/dedup/MMR work, so an over-returning backend cannot
+    /// feed an unbounded list into the quadratic scans.
+    pub candidate_pool_cap: usize,
+}
+
+impl RerankConfig {
+    pub fn disabled(final_limit: usize, min_relevance_score: f64) -> Self {
+        Self {
+            strategy: RerankStrategy::None,
+            threshold: usize::MAX,
+            importance_weight: DEFAULT_IMPORTANCE_WEIGHT,
+            recency_weight: DEFAULT_RECENCY_WEIGHT,
+            min_relevance_score,
+            final_limit: final_limit.max(1),
+            candidate_pool_cap: final_limit.max(1),
+        }
+    }
+}
+
+/// Run blend, duplicate collapse, optional advanced rerank, threshold, and
+/// trim. `is_eligible` is the caller's render-eligibility predicate; it is
+/// applied after ranking but before the final trim so ineligible rows do not
+/// consume final-selection slots while the over-fetched pool still does the
+/// ranking work.
+pub fn run(
+    mut pool: Vec<MemoryEntry>,
+    config: &RerankConfig,
+    is_eligible: impl Fn(&MemoryEntry) -> bool,
+) -> Vec<MemoryEntry> {
+    // Caller-side pool bound: even if a backend ignores the requested recall
+    // limit and returns its whole list, never scan more than the configured
+    // cap, itself held under an absolute ceiling. Applied to the raw pool in
+    // backend order so a scoreless time-only recall keeps its newest-first head.
+    let pool_cap = config
+        .candidate_pool_cap
+        .min(MAX_CANDIDATE_POOL)
+        .max(config.final_limit)
+        .max(1);
+    if pool.len() > pool_cap {
+        pool.truncate(pool_cap);
+    }
+
+    for entry in &mut pool {
+        let Some(hybrid_score) = entry.score else {
+            continue;
+        };
+        let hybrid_score = hybrid_score.clamp(0.0, 1.0);
+        let importance = entry.importance.unwrap_or(0.0).clamp(0.0, 1.0);
+        let recency = recency_factor(entry).clamp(0.0, 1.0);
+        entry.score = Some(blended_score(
+            hybrid_score,
+            importance,
+            recency,
+            config.importance_weight,
+            config.recency_weight,
+        ));
+    }
+
+    let mut candidates = collapse_exact_and_near_duplicates(pool, DEFAULT_NEAR_DUPLICATE_THRESHOLD);
+    sort_by_score(&mut candidates);
+
+    if candidates.len() >= config.threshold {
+        candidates = match config.strategy {
+            RerankStrategy::None => candidates,
+            RerankStrategy::Mmr { lambda } => mmr_rerank(candidates, lambda),
+        };
+    }
+
+    candidates.retain(|entry| {
+        entry
+            .score
+            .is_none_or(|score| score >= config.min_relevance_score)
+    });
+    // Drop render-ineligible entries (Conversation, autosave/history keys,
+    // media markers, orphan tool-result blocks) before the final trim so the
+    // over-fetched candidates below the cutoff can fill the freed slots.
+    candidates.retain(|entry| is_eligible(entry));
+    candidates.truncate(config.final_limit);
+    candidates
+}
+
+/// Collapse exact and near-duplicate entries, preserving the highest score.
+pub fn collapse_exact_and_near_duplicates(
+    mut entries: Vec<MemoryEntry>,
+    near_duplicate_threshold: f64,
+) -> Vec<MemoryEntry> {
+    sort_by_score(&mut entries);
+    let mut kept: Vec<MemoryEntry> = Vec::new();
+    let mut exact_contents: HashSet<String> = HashSet::new();
+
+    'entry: for entry in entries {
+        let normalized = normalize_content(&entry.content);
+        if !exact_contents.insert(normalized.clone()) {
+            continue;
+        }
+        for kept_entry in &kept {
+            // Order-aware: token shingles keep directionally different facts
+            // ("Alice manages Bob" vs "Bob manages Alice") apart, which an
+            // unordered token-set overlap would score as identical.
+            if shingle_similarity(&normalized, &normalize_content(&kept_entry.content))
+                >= near_duplicate_threshold
+            {
+                continue 'entry;
+            }
+        }
+        kept.push(entry);
+    }
+
+    kept
+}
+
+fn blended_score(
+    hybrid_score: f64,
+    importance: f64,
+    recency: f64,
+    importance_weight: f64,
+    recency_weight: f64,
+) -> f64 {
+    if (importance_weight - DEFAULT_IMPORTANCE_WEIGHT).abs() < f64::EPSILON
+        && (recency_weight - DEFAULT_RECENCY_WEIGHT).abs() < f64::EPSILON
+    {
+        return weighted_final_score(hybrid_score, importance, recency).clamp(0.0, 1.0);
+    }
+
+    let importance_weight = importance_weight.clamp(0.0, 1.0);
+    let recency_weight = recency_weight.clamp(0.0, 1.0);
+    let retrieval_weight = (1.0 - importance_weight - recency_weight).max(0.0);
+    let total = retrieval_weight + importance_weight + recency_weight;
+    if total < f64::EPSILON {
+        return hybrid_score;
+    }
+
+    ((hybrid_score * retrieval_weight)
+        + (importance * importance_weight)
+        + (recency * recency_weight))
+        / total
+}
+
+fn recency_factor(entry: &MemoryEntry) -> f64 {
+    if entry.category == MemoryCategory::Core {
+        return 1.0;
+    }
+
+    let Ok(timestamp) = DateTime::parse_from_rfc3339(&entry.timestamp) else {
+        return 1.0;
+    };
+    let age_days = Utc::now()
+        .signed_duration_since(timestamp.with_timezone(&Utc))
+        .num_seconds()
+        .max(0) as f64
+        / 86_400.0;
+
+    (-age_days / crate::decay::DEFAULT_HALF_LIFE_DAYS * std::f64::consts::LN_2).exp()
+}
+
+fn mmr_rerank(mut candidates: Vec<MemoryEntry>, lambda: f64) -> Vec<MemoryEntry> {
+    if candidates.len() <= 1 {
+        return candidates;
+    }
+
+    let lambda = lambda.clamp(0.0, 1.0);
+    let mut selected: Vec<MemoryEntry> = Vec::with_capacity(candidates.len());
+
+    // Seed with the relevance leader (the pool arrives sorted by score, so the
+    // head is the most relevant candidate). Without this, a diversity-only
+    // endpoint (`lambda = 0`) has every candidate tie at redundancy 0 on the
+    // first pass, and `max_by` would return the last, least-relevant item.
+    selected.push(candidates.remove(0));
+
+    while !candidates.is_empty() {
+        let best_index = candidates
+            .iter()
+            .enumerate()
+            .map(|(index, candidate)| {
+                let relevance = candidate.score.unwrap_or(0.0);
+                let redundancy = selected
+                    .iter()
+                    .map(|selected| lexical_similarity(&candidate.content, &selected.content))
+                    .fold(0.0_f64, f64::max);
+                let mmr_score = lambda * relevance - (1.0 - lambda) * redundancy;
+                (index, mmr_score)
+            })
+            .max_by(|(_, left), (_, right)| {
+                left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(index, _)| index)
+            .unwrap_or(0);
+
+        selected.push(candidates.remove(best_index));
+    }
+
+    selected
+}
+
+fn sort_by_score(entries: &mut [MemoryEntry]) {
+    // Stable sort with no key tiebreak: entries that tie on score (notably a
+    // scoreless time-only recall, where every score is `None`) keep their
+    // incoming backend order instead of being reshuffled into lexicographic
+    // key order, so a newest-first recall is not silently reordered.
+    entries.sort_by(|left, right| {
+        right
+            .score
+            .unwrap_or(0.0)
+            .partial_cmp(&left.score.unwrap_or(0.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+}
+
+fn normalize_content(content: &str) -> String {
+    content
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn lexical_similarity(left: &str, right: &str) -> f64 {
+    let left_tokens: HashSet<&str> = left.split_whitespace().collect();
+    let right_tokens: HashSet<&str> = right.split_whitespace().collect();
+    if left_tokens.is_empty() || right_tokens.is_empty() {
+        return 0.0;
+    }
+    let intersection = left_tokens.intersection(&right_tokens).count() as f64;
+    let union = left_tokens.union(&right_tokens).count() as f64;
+    if union < f64::EPSILON {
+        0.0
+    } else {
+        intersection / union
+    }
+}
+
+/// Adjacent-token (bigram) shingles of `content`. Single-token content falls
+/// back to its unigram so short entries still compare.
+fn token_shingles(content: &str) -> HashSet<String> {
+    let tokens: Vec<&str> = content.split_whitespace().collect();
+    if tokens.len() < 2 {
+        return tokens.into_iter().map(str::to_string).collect();
+    }
+    tokens
+        .windows(2)
+        .map(|window| format!("{} {}", window[0], window[1]))
+        .collect()
+}
+
+/// Order-aware Jaccard similarity over token bigrams. Unlike the unordered
+/// token-set overlap, reversing the token order (a role-reversed fact) yields
+/// disjoint shingles and a similarity of 0, so the two facts are not collapsed.
+fn shingle_similarity(left: &str, right: &str) -> f64 {
+    let left_shingles = token_shingles(left);
+    let right_shingles = token_shingles(right);
+    if left_shingles.is_empty() || right_shingles.is_empty() {
+        return 0.0;
+    }
+    let intersection = left_shingles.intersection(&right_shingles).count() as f64;
+    let union = left_shingles.union(&right_shingles).count() as f64;
+    if union < f64::EPSILON {
+        0.0
+    } else {
+        intersection / union
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn entry(id: &str, content: &str, score: f64, importance: f64) -> MemoryEntry {
+        MemoryEntry {
+            id: id.into(),
+            key: id.into(),
+            content: content.into(),
+            category: MemoryCategory::Daily,
+            timestamp: Utc::now().to_rfc3339(),
+            session_id: None,
+            score: Some(score),
+            namespace: "default".into(),
+            importance: Some(importance),
+            superseded_by: None,
+            kind: None,
+            pinned: false,
+            tenant_id: None,
+            agent_alias: None,
+            agent_id: None,
+        }
+    }
+
+    fn config(strategy: RerankStrategy) -> RerankConfig {
+        RerankConfig {
+            strategy,
+            threshold: 1,
+            importance_weight: DEFAULT_IMPORTANCE_WEIGHT,
+            recency_weight: DEFAULT_RECENCY_WEIGHT,
+            min_relevance_score: 0.0,
+            final_limit: 10,
+            candidate_pool_cap: 64,
+        }
+    }
+
+    /// Keep-everything eligibility predicate for the ranking-only tests.
+    fn all_eligible(_entry: &MemoryEntry) -> bool {
+        true
+    }
+
+    #[test]
+    fn run_blends_and_sorts_with_weighted_final_score() {
+        let results = run(
+            vec![
+                entry("low", "lower", 0.7, 0.0),
+                entry("high", "higher", 0.6, 1.0),
+            ],
+            &config(RerankStrategy::None),
+            all_eligible,
+        );
+
+        assert_eq!(results[0].key, "high");
+        let expected = weighted_final_score(0.6, 1.0, 1.0);
+        assert!((results[0].score.unwrap() - expected).abs() < 0.001);
+    }
+
+    #[test]
+    fn threshold_applies_after_blend() {
+        let mut cfg = config(RerankStrategy::None);
+        cfg.min_relevance_score = 0.8;
+        let results = run(
+            vec![
+                entry("drop", "drop this", 0.2, 0.0),
+                entry("keep", "keep this", 0.9, 1.0),
+            ],
+            &cfg,
+            all_eligible,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "keep");
+    }
+
+    #[test]
+    fn exact_duplicate_content_collapses() {
+        let results = collapse_exact_and_near_duplicates(
+            vec![
+                entry("a", "same content", 0.9, 0.0),
+                entry("b", "same   content", 0.8, 0.0),
+            ],
+            DEFAULT_NEAR_DUPLICATE_THRESHOLD,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "a");
+    }
+
+    #[test]
+    fn near_duplicate_content_collapses() {
+        let results = collapse_exact_and_near_duplicates(
+            vec![
+                entry("a", "alpha beta gamma delta epsilon", 0.9, 0.0),
+                entry("b", "alpha beta gamma delta zeta", 0.8, 0.0),
+            ],
+            0.6,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "a");
+    }
+
+    #[test]
+    fn mmr_diversifies_after_highest_relevance_item() {
+        let mut cfg = config(RerankStrategy::Mmr { lambda: 0.5 });
+        cfg.final_limit = 3;
+        let results = run(
+            vec![
+                entry("a", "rust memory scoring pipeline", 1.0, 0.0),
+                entry("b", "rust memory scoring pipeline duplicate", 0.98, 0.0),
+                entry("c", "garden tomatoes irrigation calendar", 0.8, 0.0),
+            ],
+            &cfg,
+            all_eligible,
+        );
+
+        assert_eq!(results[0].key, "a");
+        assert_eq!(results[1].key, "c");
+    }
+
+    #[test]
+    fn old_entries_get_lower_recency_signal() {
+        let mut old = entry("old", "old", 1.0, 0.0);
+        old.timestamp = (Utc::now() - Duration::days(7)).to_rfc3339();
+        assert!(recency_factor(&old) < 0.6);
+    }
+
+    // -- review-requested regressions ------------------------------------
+
+    /// A backend that ignores the requested limit (over-returns) must not push
+    /// an unbounded pool into the quadratic scans: `run` trims the raw pool in
+    /// backend order to the cap before any ranking work. An entry beyond the
+    /// cap is dropped even though its score would otherwise win, proving the
+    /// bound bites ahead of the scans rather than only at the final trim.
+    #[test]
+    fn run_bounds_oversized_candidate_pool() {
+        let mut cfg = config(RerankStrategy::None);
+        cfg.final_limit = 3;
+        cfg.candidate_pool_cap = 3;
+        let mut pool = vec![
+            entry("in_a", "candidate a", 0.10, 0.0),
+            entry("in_b", "candidate b", 0.20, 0.0),
+            entry("in_c", "candidate c", 0.30, 0.0),
+            // Position 4 is beyond the cap; its high score never gets a vote.
+            entry("out_of_bound", "candidate d", 0.99, 0.0),
+        ];
+        for index in 0..40 {
+            pool.push(entry(&format!("filler{index:02}"), "filler", 0.05, 0.0));
+        }
+
+        let results = run(pool, &cfg, all_eligible);
+
+        assert_eq!(results.len(), 3, "output bounded by the pool cap");
+        assert!(
+            !results.iter().any(|entry| entry.key == "out_of_bound"),
+            "entry beyond the pool cap is truncated before ranking"
+        );
+    }
+
+    /// Role-reversed facts share every token but no ordered bigram, so the
+    /// near-duplicate pass must keep both instead of discarding one.
+    #[test]
+    fn role_reversed_facts_are_not_collapsed() {
+        let results = collapse_exact_and_near_duplicates(
+            vec![
+                entry("fwd", "alice manages bob", 0.9, 0.0),
+                entry("rev", "bob manages alice", 0.8, 0.0),
+            ],
+            DEFAULT_NEAR_DUPLICATE_THRESHOLD,
+        );
+
+        assert_eq!(results.len(), 2, "reversed relationship must survive");
+        assert!(results.iter().any(|entry| entry.key == "fwd"));
+        assert!(results.iter().any(|entry| entry.key == "rev"));
+    }
+
+    /// A scoreless time-only recall arrives newest-first; the stage must not
+    /// reorder it into lexicographic key order, which would discard the newest
+    /// entries at the final trim.
+    #[test]
+    fn scoreless_entries_preserve_backend_order() {
+        // Keys are reverse-sorted against backend (newest-first) order, so key
+        // ordering and backend ordering disagree.
+        let mut newest = entry("z_newest", "newest fact", 0.0, 0.0);
+        newest.score = None;
+        let mut middle = entry("m_middle", "middle fact", 0.0, 0.0);
+        middle.score = None;
+        let mut oldest = entry("a_oldest", "oldest fact", 0.0, 0.0);
+        oldest.score = None;
+
+        let mut cfg = config(RerankStrategy::None);
+        cfg.final_limit = 2;
+        let results = run(vec![newest, middle, oldest], &cfg, all_eligible);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].key, "z_newest", "newest stays first");
+        assert_eq!(results[1].key, "m_middle");
+    }
+
+    /// Ineligible rows are removed after ranking but before the final trim, so
+    /// eligible over-fetched candidates below the cutoff fill the freed slots.
+    #[test]
+    fn ineligible_entries_filtered_before_final_trim() {
+        let mut cfg = config(RerankStrategy::None);
+        cfg.final_limit = 2;
+        // "skip_top" outranks everything but is ineligible; without the
+        // pre-trim filter it would occupy a final slot and shrink the output.
+        let results = run(
+            vec![
+                entry("skip_top", "ineligible leader", 0.99, 0.0),
+                entry("keep_a", "first eligible", 0.9, 0.0),
+                entry("keep_b", "second eligible", 0.8, 0.0),
+            ],
+            &cfg,
+            |entry| entry.key != "skip_top",
+        );
+
+        assert_eq!(results.len(), 2, "eligible candidate fills the freed slot");
+        assert_eq!(results[0].key, "keep_a");
+        assert_eq!(results[1].key, "keep_b");
+    }
+
+    /// Diversity-only endpoint: every candidate ties on the first MMR pass, so
+    /// the seed must be the relevance leader, not an arbitrary tail item.
+    #[test]
+    fn mmr_lambda_zero_keeps_relevance_leader_first() {
+        let mut cfg = config(RerankStrategy::Mmr { lambda: 0.0 });
+        cfg.final_limit = 1;
+        cfg.threshold = 1;
+        let results = run(
+            vec![
+                entry("leader", "top relevance fact", 0.95, 0.0),
+                entry("mid", "middle relevance fact", 0.6, 0.0),
+                entry("tail", "low relevance fact", 0.2, 0.0),
+            ],
+            &cfg,
+            all_eligible,
+        );
+
+        assert_eq!(results[0].key, "leader");
+    }
+
+    /// Relevance-only endpoint: `lambda = 1` collapses MMR to pure relevance
+    /// order, leader first.
+    #[test]
+    fn mmr_lambda_one_is_pure_relevance() {
+        let mut cfg = config(RerankStrategy::Mmr { lambda: 1.0 });
+        cfg.final_limit = 3;
+        cfg.threshold = 1;
+        let results = run(
+            vec![
+                entry("mid", "middle relevance fact", 0.6, 0.0),
+                entry("leader", "top relevance fact", 0.95, 0.0),
+                entry("tail", "low relevance fact", 0.2, 0.0),
+            ],
+            &cfg,
+            all_eligible,
+        );
+
+        assert_eq!(results[0].key, "leader");
+        assert_eq!(results[1].key, "mid");
+        assert_eq!(results[2].key, "tail");
+    }
+}

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -839,11 +839,10 @@ impl AgentBuilder {
                 anyhow::Error::msg("tool_dispatcher is required")
             })?,
             memory_inject_cfg: self.memory_inject_cfg.unwrap_or_else(|| {
-                crate::agent::memory_inject::MemoryInjectConfig {
-                    min_relevance_score: zeroclaw_config::schema::MemoryConfig::default()
-                        .min_relevance_score,
-                    ..Default::default()
-                }
+                crate::agent::memory_inject::MemoryInjectConfig::from_memory_config(
+                    &zeroclaw_config::schema::MemoryConfig::default(),
+                    crate::agent::memory_inject::DEFAULT_RECALL_LIMIT,
+                )
             }),
             config,
             structured_history_cap_resolver: self.structured_history_cap_resolver,
@@ -1638,11 +1637,12 @@ impl Agent {
             .observer(observer)
             .response_cache(response_cache)
             .tool_dispatcher(tool_dispatcher)
-            .memory_inject_cfg(crate::agent::memory_inject::MemoryInjectConfig {
-                limit: config.effective_memory_recall_limit(agent_alias),
-                min_relevance_score: config.memory.min_relevance_score,
-                ..Default::default()
-            })
+            .memory_inject_cfg(
+                crate::agent::memory_inject::MemoryInjectConfig::from_memory_config(
+                    &config.memory,
+                    config.effective_memory_recall_limit(agent_alias),
+                ),
+            )
             .prompt_builder(SystemPromptBuilder::with_defaults())
             .config(
                 config

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1919,10 +1919,10 @@ pub async fn run(
                                     query: effective_msg.clone(),
                                     sessions: vec![memory_session_id.clone()],
                                     suppress: suppress_memory_inject,
-                                    cfg: crate::agent::memory_inject::MemoryInjectConfig {
-                                        min_relevance_score: config.memory.min_relevance_score,
-                                        ..Default::default()
-                                    },
+                                    cfg: crate::agent::memory_inject::MemoryInjectConfig::from_memory_config(
+                                        &config.memory,
+                                        crate::agent::memory_inject::DEFAULT_RECALL_LIMIT,
+                                    ),
                                 }),
                                 ingress: IngressContext::from_origin(origin),
                                 agent_alias: Some(agent_alias),
@@ -2468,10 +2468,10 @@ pub async fn run(
                                         query: effective_input.clone(),
                                         sessions: vec![memory_session_id.clone()],
                                         suppress: suppress_memory_inject,
-                                        cfg: crate::agent::memory_inject::MemoryInjectConfig {
-                                            min_relevance_score: config.memory.min_relevance_score,
-                                            ..Default::default()
-                                        },
+                                        cfg: crate::agent::memory_inject::MemoryInjectConfig::from_memory_config(
+                                            &config.memory,
+                                            crate::agent::memory_inject::DEFAULT_RECALL_LIMIT,
+                                        ),
                                     }),
                                     ingress: IngressContext::from_origin(origin),
                                     agent_alias: Some(agent_alias),
@@ -3287,10 +3287,10 @@ pub async fn process_message(
                         query: effective_message.clone(),
                         sessions: vec![session_id.map(str::to_string)],
                         suppress: false,
-                        cfg: crate::agent::memory_inject::MemoryInjectConfig {
-                            min_relevance_score: config.memory.min_relevance_score,
-                            ..Default::default()
-                        },
+                        cfg: crate::agent::memory_inject::MemoryInjectConfig::from_memory_config(
+                            &config.memory,
+                            crate::agent::memory_inject::DEFAULT_RECALL_LIMIT,
+                        ),
                     }),
                     Some(agent_alias),
                     Some(SopStepReassembly { config: &config }),

--- a/crates/zeroclaw-runtime/src/agent/memory_inject.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_inject.rs
@@ -97,6 +97,11 @@ impl MemoryInjectConfig {
         memory: &zeroclaw_config::schema::MemoryConfig,
         limit: usize,
     ) -> Self {
+        let limit = if memory.rerank_enabled {
+            rerank::bounded_final_limit(limit)
+        } else {
+            limit
+        };
         Self {
             limit,
             min_relevance_score: memory.min_relevance_score,
@@ -141,6 +146,7 @@ fn build_rerank_config(
     // bounded so a mis-sized config or an over-returning backend cannot feed an
     // unbounded pool into the rerank scans. `candidate_multiplier` is validated
     // to `1..=MAX_MEMORY_RERANK_CANDIDATE_MULTIPLIER` at config load.
+    let final_limit = rerank::bounded_final_limit(final_limit);
     let candidate_pool_cap = final_limit
         .max(1)
         .saturating_mul(memory.candidate_multiplier.max(1));
@@ -151,8 +157,8 @@ fn build_rerank_config(
         importance_weight: memory.importance_weight,
         recency_weight: memory.recency_weight,
         min_relevance_score: memory.min_relevance_score,
-        final_limit: final_limit.max(1),
-        candidate_pool_cap,
+        final_limit,
+        candidate_pool_cap: rerank::bounded_pool_cap(final_limit, candidate_pool_cap),
     }
 }
 
@@ -256,9 +262,12 @@ pub async fn render_memory_context(
     // Over-fetch a larger candidate pool only when reranking is enabled;
     // otherwise recall exactly `limit` so the default path is unchanged.
     let recall_limit = if cfg.rerank_enabled {
-        cfg.limit
+        let requested_pool = cfg
+            .limit
             .saturating_mul(cfg.candidate_multiplier)
             .max(cfg.limit)
+            .max(cfg.rerank.candidate_pool_cap);
+        rerank::bounded_pool_cap(cfg.limit.max(cfg.rerank.final_limit), requested_pool)
     } else {
         cfg.limit
     };
@@ -1282,6 +1291,70 @@ mod tests {
         };
         render_memory_context(&mem, &RecordingObserver::default(), "q", &[], &cfg, false).await;
         assert_eq!(mem.recorded_limits.lock().as_slice(), &[5]);
+    }
+
+    #[tokio::test]
+    async fn rerank_bounds_unlimited_recall_sentinel_before_backend_and_scan() {
+        let now = chrono::Utc::now();
+        let mut pool: Vec<MemoryEntry> = (0..rerank::MAX_CANDIDATE_POOL)
+            .map(|i| {
+                scored_entry(
+                    &format!("bounded_{i:04}"),
+                    &format!("unique bounded topic {i} marker_{i}"),
+                    MemoryCategory::Daily,
+                    Some(0.2 + (i as f64 / 10_000.0)),
+                    Some(0.0),
+                    now,
+                )
+            })
+            .collect();
+        pool.push(scored_entry(
+            "out_of_bound_winner",
+            "tail candidate should never enter rerank scans",
+            MemoryCategory::Core,
+            Some(1.0),
+            Some(1.0),
+            now,
+        ));
+
+        let mem = FixtureMemory::with(pool);
+        let mut memory = zeroclaw_config::schema::MemoryConfig {
+            rerank_enabled: true,
+            candidate_multiplier: 20,
+            min_relevance_score: 0.0,
+            ..Default::default()
+        };
+        memory.rerank_strategy = "none".into();
+        let cfg = MemoryInjectConfig::from_memory_config(&memory, usize::MAX);
+
+        assert_eq!(cfg.limit, rerank::MAX_CANDIDATE_POOL);
+        assert_eq!(cfg.rerank.final_limit, rerank::MAX_CANDIDATE_POOL);
+        assert_eq!(cfg.rerank.candidate_pool_cap, rerank::MAX_CANDIDATE_POOL);
+
+        let context = render_memory_context(
+            &mem,
+            &RecordingObserver::default(),
+            "query",
+            &[],
+            &cfg,
+            false,
+        )
+        .await;
+
+        assert_eq!(
+            mem.recorded_limits.lock().as_slice(),
+            &[rerank::MAX_CANDIDATE_POOL],
+            "unlimited profile sentinel must be capped before backend recall"
+        );
+        assert!(
+            !context.contains("out_of_bound_winner"),
+            "over-returned tail candidate must be truncated before rerank work"
+        );
+        assert_eq!(
+            context.matches("\n- ").count(),
+            DEFAULT_MAX_ENTRIES,
+            "renderer entry budget still applies after bounded rerank"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/memory_inject.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_inject.rs
@@ -1068,6 +1068,15 @@ mod tests {
         - stale: quarterly report workflow uses legacy tool\n\
         - alpha_dup: deploy target is prod-cluster-3 for staging\n\
         [/Memory context]\n\n";
+    // Conversation exclusion is an eligibility boundary, so it runs before
+    // duplicate collapse and MMR. Once the ineligible rows are removed, this
+    // fixture is below the advanced-strategy threshold and keeps blend order.
+    const GOLDEN_RERANK_NO_CONVERSATION: &str = "[Memory context]\n\
+        - alpha: deploy target is prod-cluster-3\n\
+        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - beta: team standup moved to 0930\n\
+        - stale: quarterly report workflow uses legacy tool\n\
+        [/Memory context]\n\n";
 
     #[tokio::test]
     async fn injection_goldens_across_origin_budget_and_flags() {
@@ -1171,7 +1180,7 @@ mod tests {
                 true,
                 false,
                 rerank_on,
-                GOLDEN_RERANK,
+                GOLDEN_RERANK_NO_CONVERSATION,
             ),
         ];
 
@@ -1525,5 +1534,82 @@ mod tests {
             "ineligible row dropped"
         );
         assert!(context.contains("- fact_e: epsilon elderberry"));
+    }
+
+    /// Composed score-domain regression: current SQLite recall owns BM25
+    /// calibration, while this module owns the blend and relevance floor.
+    /// Exercise the stock no-embedding backend through the real renderer so
+    /// those two layers cannot silently drift back onto incompatible scales.
+    #[tokio::test]
+    async fn noop_sqlite_bm25_recall_stays_ranked_through_rerank_injection() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let memory = zeroclaw_memory::SqliteMemory::new("rerank-bm25", tmp.path()).unwrap();
+        assert_eq!(
+            memory.embedder_dimensions(),
+            0,
+            "the regression must exercise the BM25-only recall path"
+        );
+
+        memory
+            .store(
+                "best_match",
+                "orbital vault orbital vault passphrase",
+                MemoryCategory::Core,
+                None,
+            )
+            .await
+            .unwrap();
+        memory
+            .store(
+                "supporting_match",
+                "orbital vault maintenance schedule",
+                MemoryCategory::Core,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let recalled = memory
+            .recall("orbital vault", 20, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(recalled.len(), 2);
+        assert!(
+            recalled.iter().all(|entry| {
+                entry
+                    .score
+                    .is_some_and(|score| (0.0..=1.0).contains(&score))
+            }),
+            "the recall boundary must normalize every BM25 score"
+        );
+        assert!(
+            recalled[0].score > recalled[1].score,
+            "term-frequency relevance must remain distinguishable"
+        );
+
+        let config = zeroclaw_config::schema::MemoryConfig {
+            rerank_enabled: true,
+            rerank_strategy: "none".into(),
+            min_relevance_score: 0.4,
+            ..Default::default()
+        };
+        let inject = MemoryInjectConfig::from_memory_config(&config, 5);
+        let context = render_memory_context(
+            &memory,
+            &RecordingObserver::default(),
+            "orbital vault",
+            &[],
+            &inject,
+            false,
+        )
+        .await;
+
+        let best = context
+            .find("- best_match: ")
+            .expect("the relevance leader survives the configured floor");
+        let supporting = context
+            .find("- supporting_match: ")
+            .expect("the weaker relevant entry survives the configured floor");
+        assert!(best < supporting, "BM25 relevance order survives blending");
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/memory_inject.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_inject.rs
@@ -1,5 +1,25 @@
 //! Unified memory-context injection: ONE policy and ONE renderer for the
 //! memory preamble, applied at the turn engine.
+//!
+//! Replaces the per-path inline renderers (the three `loop_` sites, the
+//! channel orchestrator's budgeted renderer, the agent-direct loader, and
+//! the cron/daemon pre-prompt blocks). The injection decision is keyed on
+//! [`TurnOrigin`] (who initiated the turn), resolved by
+//! [`resolve_inject_policy`]; the pipeline in [`render_memory_context`] is
+//! the uniform superset of the legacy renderers' behavior. Divergences from
+//! any individual legacy path are deliberate and documented on the PR that
+//! wires this module (uniform rigour: a per-path difference is an error
+//! unless documented).
+//!
+//! Pipeline: recall (per session, key-deduped) -> time decay OR the gated
+//! rerank stage (`rerank_enabled`: over-fetched candidate pool, then
+//! recency/importance blend + duplicate collapse + optional MMR + trim,
+//! replacing decay on that arm) -> relevance filter -> skip set (autosave
+//! keys/content, `*_history` keys, `[IMAGE:` markers, `<tool_result`
+//! blocks, optional Conversation-category exclusion) -> budget caps (entry
+//! count, per-entry chars, total chars) -> `[Memory context]` wrapper.
+//! Exactly one `MemoryRecall` observer event is emitted per render,
+//! covering all recalls.
 
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -8,6 +28,7 @@ use std::time::Instant;
 use zeroclaw_api::ingress::TurnOrigin;
 use zeroclaw_memory::{
     self, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN, Memory, MemoryCategory, MemoryEntry, decay,
+    rerank,
 };
 
 use super::loop_::make_query_summary;
@@ -41,6 +62,15 @@ pub struct MemoryInjectConfig {
     pub entry_max_chars: usize,
     /// Total character budget for the block.
     pub max_total_chars: usize,
+    /// Gate for the rerank stage. Off (the default) keeps the pipeline on
+    /// the time-decay arm, byte-identical to the pre-rerank renderer.
+    pub rerank_enabled: bool,
+    /// Candidate pool multiplier over `limit` when reranking: the stage
+    /// over-fetches so blend/dedup/MMR have a pool to trim back down.
+    pub candidate_multiplier: usize,
+    /// Rerank stage parameters (strategy, threshold, blend weights, floor,
+    /// final trim). Only consulted when `rerank_enabled` is set.
+    pub rerank: rerank::RerankConfig,
 }
 
 impl Default for MemoryInjectConfig {
@@ -51,7 +81,78 @@ impl Default for MemoryInjectConfig {
             max_entries: DEFAULT_MAX_ENTRIES,
             entry_max_chars: DEFAULT_ENTRY_MAX_CHARS,
             max_total_chars: DEFAULT_MAX_TOTAL_CHARS,
+            rerank_enabled: false,
+            candidate_multiplier: 1,
+            rerank: rerank::RerankConfig::disabled(DEFAULT_RECALL_LIMIT, 0.0),
         }
+    }
+}
+
+impl MemoryInjectConfig {
+    /// Build the injection config from the agent's resolved memory config
+    /// plus the effective recall limit. Threads the relevance floor and the
+    /// rerank stage settings; budgets stay at the renderer defaults.
+    #[must_use]
+    pub fn from_memory_config(
+        memory: &zeroclaw_config::schema::MemoryConfig,
+        limit: usize,
+    ) -> Self {
+        Self {
+            limit,
+            min_relevance_score: memory.min_relevance_score,
+            rerank_enabled: memory.rerank_enabled,
+            candidate_multiplier: memory.candidate_multiplier.max(1),
+            rerank: build_rerank_config(memory, limit),
+            ..Default::default()
+        }
+    }
+}
+
+/// Materialize the rerank stage config from the canonical memory config.
+/// An unknown `rerank_strategy` falls back to no advanced rerank (the blend,
+/// duplicate collapse, and trim still run) with a once-per-process warning.
+fn build_rerank_config(
+    memory: &zeroclaw_config::schema::MemoryConfig,
+    final_limit: usize,
+) -> rerank::RerankConfig {
+    let strategy = match memory.rerank_strategy.trim().to_ascii_lowercase().as_str() {
+        "mmr" => rerank::RerankStrategy::Mmr {
+            lambda: memory.mmr_lambda,
+        },
+        "none" | "" => rerank::RerankStrategy::None,
+        other => {
+            static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+            WARN_ONCE.call_once(|| {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "rerank_strategy": other,
+                        })),
+                    "unknown memory rerank_strategy; falling back to no advanced rerank"
+                );
+            });
+            rerank::RerankStrategy::None
+        }
+    };
+
+    // Cap the candidate pool at the requested over-fetch (limit * multiplier),
+    // bounded so a mis-sized config or an over-returning backend cannot feed an
+    // unbounded pool into the rerank scans. `candidate_multiplier` is validated
+    // to `1..=MAX_MEMORY_RERANK_CANDIDATE_MULTIPLIER` at config load.
+    let candidate_pool_cap = final_limit
+        .max(1)
+        .saturating_mul(memory.candidate_multiplier.max(1));
+
+    rerank::RerankConfig {
+        strategy,
+        threshold: memory.rerank_threshold,
+        importance_weight: memory.importance_weight,
+        recency_weight: memory.recency_weight,
+        min_relevance_score: memory.min_relevance_score,
+        final_limit: final_limit.max(1),
+        candidate_pool_cap,
     }
 }
 
@@ -152,6 +253,16 @@ pub async fn render_memory_context(
     let backend = mem.name().to_string();
     let query_summary = make_query_summary(user_msg);
 
+    // Over-fetch a larger candidate pool only when reranking is enabled;
+    // otherwise recall exactly `limit` so the default path is unchanged.
+    let recall_limit = if cfg.rerank_enabled {
+        cfg.limit
+            .saturating_mul(cfg.candidate_multiplier)
+            .max(cfg.limit)
+    } else {
+        cfg.limit
+    };
+
     let start = Instant::now();
     let mut entries: Vec<MemoryEntry> = Vec::new();
     let mut seen_keys: HashSet<String> = HashSet::new();
@@ -164,7 +275,7 @@ pub async fn render_memory_context(
     };
     for session_id in scopes {
         match mem
-            .recall(user_msg, cfg.limit, *session_id, None, None)
+            .recall(user_msg, recall_limit, *session_id, None, None)
             .await
         {
             Ok(recalled) => {
@@ -190,8 +301,24 @@ pub async fn render_memory_context(
         success: any_ok,
     });
 
-    // Older non-Core memories score lower; Core is evergreen.
-    decay::apply_time_decay(&mut entries, decay::DEFAULT_HALF_LIFE_DAYS);
+    if cfg.rerank_enabled {
+        // Relevance plane: blend (retrieval + importance + recency), collapse
+        // near-duplicates, optionally diversify via MMR, apply the floor, and
+        // trim back to the recall limit. The blend's recency factor subsumes
+        // time decay, so this arm replaces it; the budget loop below still
+        // caps the rendered block. The eligibility predicate mirrors the
+        // renderer's skip set so ineligible rows are dropped before the trim,
+        // not after, letting over-fetched candidates fill the freed slots.
+        entries = rerank::run(entries, &cfg.rerank, |entry| {
+            if exclude_conversation && matches!(entry.category, MemoryCategory::Conversation) {
+                return false;
+            }
+            !should_skip_entry(&entry.key, &entry.content)
+        });
+    } else {
+        // Older non-Core memories score lower; Core is evergreen.
+        decay::apply_time_decay(&mut entries, decay::DEFAULT_HALF_LIFE_DAYS);
+    }
 
     let mut context = String::new();
     let mut included = 0usize;
@@ -276,21 +403,28 @@ mod tests {
 
     /// Recall returns the fixture list for the requested session scope;
     /// `fail` simulates a backend error. `recalls` counts backend recalls
-    /// so decorator-composition tests can observe forwarding.
+    /// for decorator-composition tests, while requested limits are recorded
+    /// so rerank tests can assert the over-fetch gating.
     struct FixtureMemory {
         by_session: HashMap<Option<String>, Vec<MemoryEntry>>,
         fail: bool,
         recalls: std::sync::atomic::AtomicUsize,
+        recorded_limits: Mutex<Vec<usize>>,
     }
 
     impl FixtureMemory {
         fn with(entries: Vec<MemoryEntry>) -> Self {
             let mut by_session = HashMap::new();
             by_session.insert(None, entries);
+            Self::with_sessions(by_session)
+        }
+
+        fn with_sessions(by_session: HashMap<Option<String>, Vec<MemoryEntry>>) -> Self {
             Self {
                 by_session,
                 fail: false,
                 recalls: std::sync::atomic::AtomicUsize::new(0),
+                recorded_limits: Mutex::new(Vec::new()),
             }
         }
 
@@ -299,6 +433,7 @@ mod tests {
                 by_session: HashMap::new(),
                 fail: true,
                 recalls: std::sync::atomic::AtomicUsize::new(0),
+                recorded_limits: Mutex::new(Vec::new()),
             }
         }
     }
@@ -318,13 +453,14 @@ mod tests {
         async fn recall(
             &self,
             _query: &str,
-            _limit: usize,
+            limit: usize,
             session_id: Option<&str>,
             _since: Option<&str>,
             _until: Option<&str>,
         ) -> anyhow::Result<Vec<MemoryEntry>> {
             self.recalls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.recorded_limits.lock().push(limit);
             if self.fail {
                 anyhow::bail!("backend down");
             }
@@ -717,11 +853,7 @@ mod tests {
                 entry("only_sender", "s", MemoryCategory::Core, None),
             ],
         );
-        let mem = FixtureMemory {
-            by_session,
-            fail: false,
-            recalls: std::sync::atomic::AtomicUsize::new(0),
-        };
+        let mem = FixtureMemory::with_sessions(by_session);
         let observer = RecordingObserver::default();
 
         let context = render_memory_context(
@@ -794,5 +926,531 @@ mod tests {
             &[(1, true), (1, true)],
             "both renders emit a MemoryRecall event"
         );
+    }
+
+    // -- rerank stage + injection goldens --------------------------------
+
+    fn scored_entry(
+        key: &str,
+        content: &str,
+        category: MemoryCategory,
+        score: Option<f64>,
+        importance: Option<f64>,
+        timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> MemoryEntry {
+        MemoryEntry {
+            timestamp: timestamp.to_rfc3339(),
+            importance,
+            ..entry(key, content, category, score)
+        }
+    }
+
+    /// The golden fixture corpus: a near-duplicate pair (single-entry pools
+    /// cannot distinguish the rerank arm), a Conversation entry, a stale
+    /// scored entry old enough for time decay to drop it, and an autosave
+    /// key the skip set filters on every arm. Recall order is fixture order.
+    fn golden_corpus() -> Vec<MemoryEntry> {
+        let now = chrono::Utc::now();
+        vec![
+            scored_entry(
+                "alpha",
+                "deploy target is prod-cluster-3",
+                MemoryCategory::Core,
+                Some(0.9),
+                Some(0.8),
+                now,
+            ),
+            scored_entry(
+                "alpha_dup",
+                "deploy target is prod-cluster-3 for staging",
+                MemoryCategory::Core,
+                Some(0.85),
+                Some(0.1),
+                now,
+            ),
+            scored_entry(
+                "beta",
+                "team standup moved to 0930",
+                MemoryCategory::Daily,
+                Some(0.7),
+                Some(0.5),
+                now,
+            ),
+            scored_entry(
+                "chat",
+                "user said hello",
+                MemoryCategory::Conversation,
+                None,
+                None,
+                now,
+            ),
+            scored_entry(
+                "stale",
+                "quarterly report workflow uses legacy tool",
+                MemoryCategory::Daily,
+                Some(0.6),
+                Some(0.4),
+                now - chrono::Duration::days(60),
+            ),
+            scored_entry(
+                "user_msg_9",
+                "raw autosave user message",
+                MemoryCategory::Core,
+                Some(0.99),
+                None,
+                now,
+            ),
+        ]
+    }
+
+    /// Resolve the injection policy for `origin` and render against it,
+    /// mirroring the engine's policy-then-render wiring.
+    async fn render_for_origin(
+        origin: TurnOrigin,
+        has_session: bool,
+        suppress: bool,
+        mem: &FixtureMemory,
+        cfg: &MemoryInjectConfig,
+    ) -> String {
+        match resolve_inject_policy(origin, has_session, suppress) {
+            InjectPolicy::Skip => String::new(),
+            InjectPolicy::Inject {
+                exclude_conversation,
+            } => {
+                render_memory_context(
+                    mem,
+                    &RecordingObserver::default(),
+                    "query",
+                    &[],
+                    cfg,
+                    exclude_conversation,
+                )
+                .await
+            }
+        }
+    }
+
+    // Flags-off goldens: captured from the pre-rerank renderer's behavior on
+    // the corpus (decay drops `stale`, the skip set drops `user_msg_9`, the
+    // near-duplicate pair renders twice, recall order is preserved). Later
+    // pipeline stages re-prove against these.
+    const GOLDEN_FULL: &str = "[Memory context]\n\
+        - alpha: deploy target is prod-cluster-3\n\
+        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - beta: team standup moved to 0930\n\
+        - chat: user said hello\n\
+        [/Memory context]\n\n";
+    const GOLDEN_NO_CONVERSATION: &str = "[Memory context]\n\
+        - alpha: deploy target is prod-cluster-3\n\
+        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - beta: team standup moved to 0930\n\
+        [/Memory context]\n\n";
+    const GOLDEN_TIGHT_BUDGET: &str = "[Memory context]\n\
+        - alpha: deploy target is prod-cluster-3\n\
+        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        [/Memory context]\n\n";
+    // Rerank arm on the same corpus: the blend re-sorts, MMR demotes the
+    // near-duplicate to the tail, the trim drops the unscored Conversation
+    // entry, and `stale` survives (the blend's recency factor replaces the
+    // decay drop). Divergence from the flags-off goldens is the point.
+    const GOLDEN_RERANK: &str = "[Memory context]\n\
+        - alpha: deploy target is prod-cluster-3\n\
+        - beta: team standup moved to 0930\n\
+        - stale: quarterly report workflow uses legacy tool\n\
+        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        [/Memory context]\n\n";
+
+    #[tokio::test]
+    async fn injection_goldens_across_origin_budget_and_flags() {
+        let flags_off = MemoryInjectConfig::from_memory_config(
+            &zeroclaw_config::schema::MemoryConfig::default(),
+            DEFAULT_RECALL_LIMIT,
+        );
+        let rerank_on = MemoryInjectConfig::from_memory_config(
+            &zeroclaw_config::schema::MemoryConfig {
+                rerank_enabled: true,
+                rerank_strategy: "mmr".into(),
+                ..Default::default()
+            },
+            DEFAULT_RECALL_LIMIT,
+        );
+
+        let cases: Vec<(&str, TurnOrigin, bool, bool, MemoryInjectConfig, &str)> = vec![
+            (
+                "interactive_scoped",
+                TurnOrigin::Interactive,
+                true,
+                false,
+                flags_off,
+                GOLDEN_FULL,
+            ),
+            (
+                "channel_unscoped_excludes_conversation",
+                TurnOrigin::Channel,
+                false,
+                false,
+                flags_off,
+                GOLDEN_NO_CONVERSATION,
+            ),
+            (
+                "cron_excludes_conversation",
+                TurnOrigin::Cron,
+                true,
+                false,
+                flags_off,
+                GOLDEN_NO_CONVERSATION,
+            ),
+            (
+                "daemon_excludes_conversation",
+                TurnOrigin::Daemon,
+                false,
+                false,
+                flags_off,
+                GOLDEN_NO_CONVERSATION,
+            ),
+            (
+                "sub_turn_never_injects",
+                TurnOrigin::SubTurn,
+                true,
+                false,
+                flags_off,
+                "",
+            ),
+            // The cron `uses_memory = false` spawn-site opt-out arrives here
+            // as `suppress`, so the whole render is skipped.
+            (
+                "cron_uses_memory_false_suppresses",
+                TurnOrigin::Cron,
+                true,
+                true,
+                flags_off,
+                "",
+            ),
+            (
+                "tight_entry_budget",
+                TurnOrigin::Interactive,
+                true,
+                false,
+                MemoryInjectConfig {
+                    max_entries: 2,
+                    ..flags_off
+                },
+                GOLDEN_TIGHT_BUDGET,
+            ),
+            (
+                "tight_total_char_budget",
+                TurnOrigin::Interactive,
+                true,
+                false,
+                MemoryInjectConfig {
+                    max_total_chars: 100,
+                    ..flags_off
+                },
+                GOLDEN_TIGHT_BUDGET,
+            ),
+            (
+                "rerank_on_interactive",
+                TurnOrigin::Interactive,
+                true,
+                false,
+                rerank_on,
+                GOLDEN_RERANK,
+            ),
+            (
+                "rerank_on_cron",
+                TurnOrigin::Cron,
+                true,
+                false,
+                rerank_on,
+                GOLDEN_RERANK,
+            ),
+        ];
+
+        for (name, origin, has_session, suppress, cfg, want) in cases {
+            let mem = FixtureMemory::with(golden_corpus());
+            let got = render_for_origin(origin, has_session, suppress, &mem, &cfg).await;
+            assert_eq!(got, want, "golden mismatch for case {name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn rerank_on_mmr_drops_near_duplicate_and_reorders() {
+        let now = chrono::Utc::now();
+        let pool = vec![
+            scored_entry(
+                "a",
+                "rust memory scoring pipeline",
+                MemoryCategory::Daily,
+                Some(0.95),
+                None,
+                now,
+            ),
+            scored_entry(
+                "b",
+                "rust memory scoring pipeline latency",
+                MemoryCategory::Daily,
+                Some(0.93),
+                None,
+                now,
+            ),
+            scored_entry(
+                "c",
+                "garden tomatoes irrigation calendar",
+                MemoryCategory::Daily,
+                Some(0.75),
+                None,
+                now,
+            ),
+        ];
+
+        // Flags off: the near-duplicate pair renders untouched, recall order.
+        let mem = FixtureMemory::with(pool.clone());
+        let off = MemoryInjectConfig {
+            min_relevance_score: 0.4,
+            ..Default::default()
+        };
+        let context = render_memory_context(
+            &mem,
+            &RecordingObserver::default(),
+            "query",
+            &[],
+            &off,
+            false,
+        )
+        .await;
+        assert!(context.contains("- a: "));
+        assert!(context.contains("- b: "));
+        assert!(context.contains("- c: "));
+
+        // Rerank on with a 2-slot trim: MMR demotes the near-duplicate below
+        // the unrelated entry and the trim drops it.
+        let mem = FixtureMemory::with(pool);
+        let on = MemoryInjectConfig {
+            limit: 2,
+            min_relevance_score: 0.4,
+            rerank_enabled: true,
+            candidate_multiplier: 3,
+            rerank: rerank::RerankConfig {
+                strategy: rerank::RerankStrategy::Mmr { lambda: 0.5 },
+                threshold: 2,
+                importance_weight: 0.2,
+                recency_weight: 0.1,
+                min_relevance_score: 0.4,
+                final_limit: 2,
+                candidate_pool_cap: 6,
+            },
+            ..Default::default()
+        };
+        let context = render_memory_context(
+            &mem,
+            &RecordingObserver::default(),
+            "query",
+            &[],
+            &on,
+            false,
+        )
+        .await;
+        let a_pos = context.find("- a: ").expect("top entry renders");
+        let c_pos = context.find("- c: ").expect("diverse entry renders");
+        assert!(a_pos < c_pos, "relevance leader stays first");
+        assert!(
+            !context.contains("- b: "),
+            "near-duplicate must be demoted out of the trimmed set"
+        );
+    }
+
+    #[tokio::test]
+    async fn rerank_gates_candidate_over_fetch() {
+        // On: recall over-fetches limit * candidate_multiplier.
+        let mem = FixtureMemory::with(vec![]);
+        let cfg = MemoryInjectConfig {
+            limit: 5,
+            rerank_enabled: true,
+            candidate_multiplier: 4,
+            ..Default::default()
+        };
+        render_memory_context(&mem, &RecordingObserver::default(), "q", &[], &cfg, false).await;
+        assert_eq!(mem.recorded_limits.lock().as_slice(), &[20]);
+
+        // Off: the multiplier is inert; recall requests exactly `limit`.
+        let mem = FixtureMemory::with(vec![]);
+        let cfg = MemoryInjectConfig {
+            limit: 5,
+            rerank_enabled: false,
+            candidate_multiplier: 4,
+            ..Default::default()
+        };
+        render_memory_context(&mem, &RecordingObserver::default(), "q", &[], &cfg, false).await;
+        assert_eq!(mem.recorded_limits.lock().as_slice(), &[5]);
+    }
+
+    #[tokio::test]
+    async fn rerank_output_still_flows_through_budget_caps() {
+        let now = chrono::Utc::now();
+        let pool: Vec<MemoryEntry> = (0..6)
+            .map(|i| {
+                scored_entry(
+                    &format!("k{i}"),
+                    &format!("distinct topic number {i} zebra{i}"),
+                    MemoryCategory::Daily,
+                    Some(0.9 - i as f64 * 0.05),
+                    None,
+                    now,
+                )
+            })
+            .collect();
+        let mem = FixtureMemory::with(pool);
+        let cfg = MemoryInjectConfig {
+            limit: 6,
+            rerank_enabled: true,
+            candidate_multiplier: 2,
+            rerank: rerank::RerankConfig::disabled(6, 0.0),
+            ..Default::default()
+        };
+        let context = render_memory_context(
+            &mem,
+            &RecordingObserver::default(),
+            "query",
+            &[],
+            &cfg,
+            false,
+        )
+        .await;
+        // Rerank returned 6 candidates; the entry-count budget still caps
+        // the rendered block at the default 4.
+        assert_eq!(context.matches("\n- ").count(), DEFAULT_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn from_memory_config_threads_rerank_settings() {
+        let mut memory = zeroclaw_config::schema::MemoryConfig::default();
+        let cfg = MemoryInjectConfig::from_memory_config(&memory, 7);
+        assert_eq!(cfg.limit, 7);
+        assert!((cfg.min_relevance_score - memory.min_relevance_score).abs() < f64::EPSILON);
+        assert!(!cfg.rerank_enabled);
+        assert_eq!(cfg.candidate_multiplier, memory.candidate_multiplier);
+        assert_eq!(cfg.rerank.strategy, rerank::RerankStrategy::None);
+        assert_eq!(cfg.rerank.threshold, memory.rerank_threshold);
+        assert_eq!(cfg.rerank.final_limit, 7);
+
+        // Strategy parsing is case- and whitespace-tolerant.
+        memory.rerank_enabled = true;
+        memory.rerank_strategy = " MMR ".into();
+        memory.mmr_lambda = 0.6;
+        let cfg = MemoryInjectConfig::from_memory_config(&memory, 5);
+        assert!(cfg.rerank_enabled);
+        assert_eq!(
+            cfg.rerank.strategy,
+            rerank::RerankStrategy::Mmr { lambda: 0.6 }
+        );
+
+        // Unknown strategies fall back to no advanced rerank.
+        memory.rerank_strategy = "llm_judge".into();
+        let cfg = MemoryInjectConfig::from_memory_config(&memory, 5);
+        assert_eq!(cfg.rerank.strategy, rerank::RerankStrategy::None);
+
+        // A zero multiplier is clamped so over-fetch never zeroes recall.
+        memory.candidate_multiplier = 0;
+        let cfg = MemoryInjectConfig::from_memory_config(&memory, 5);
+        assert_eq!(cfg.candidate_multiplier, 1);
+    }
+
+    /// Regression: a high-scoring but render-ineligible entry must not consume
+    /// a final-selection slot. With a five-entry budget and five eligible facts
+    /// plus one ineligible top-scored row, the pre-trim eligibility filter lets
+    /// all five eligible facts render instead of only four.
+    #[tokio::test]
+    async fn rerank_eligibility_filter_frees_slots_for_valid_candidates() {
+        let now = chrono::Utc::now();
+        let pool = vec![
+            // Ineligible (`_history` key) yet outranks every fact.
+            scored_entry(
+                "channel_history",
+                "raw transcript blob",
+                MemoryCategory::Core,
+                Some(0.99),
+                Some(1.0),
+                now,
+            ),
+            scored_entry(
+                "fact_a",
+                "alpha apples",
+                MemoryCategory::Core,
+                Some(0.9),
+                Some(0.5),
+                now,
+            ),
+            scored_entry(
+                "fact_b",
+                "beta bananas",
+                MemoryCategory::Daily,
+                Some(0.8),
+                Some(0.5),
+                now,
+            ),
+            scored_entry(
+                "fact_c",
+                "gamma grapes",
+                MemoryCategory::Daily,
+                Some(0.7),
+                Some(0.5),
+                now,
+            ),
+            scored_entry(
+                "fact_d",
+                "delta dates",
+                MemoryCategory::Daily,
+                Some(0.6),
+                Some(0.5),
+                now,
+            ),
+            scored_entry(
+                "fact_e",
+                "epsilon elderberry",
+                MemoryCategory::Daily,
+                Some(0.5),
+                Some(0.5),
+                now,
+            ),
+        ];
+        let mem = FixtureMemory::with(pool);
+        let cfg = MemoryInjectConfig {
+            limit: 5,
+            min_relevance_score: 0.0,
+            max_entries: 5,
+            rerank_enabled: true,
+            candidate_multiplier: 2,
+            rerank: rerank::RerankConfig {
+                strategy: rerank::RerankStrategy::None,
+                threshold: usize::MAX,
+                importance_weight: 0.2,
+                recency_weight: 0.1,
+                min_relevance_score: 0.0,
+                final_limit: 5,
+                candidate_pool_cap: 10,
+            },
+            ..Default::default()
+        };
+
+        let context = render_memory_context(
+            &mem,
+            &RecordingObserver::default(),
+            "query",
+            &[],
+            &cfg,
+            false,
+        )
+        .await;
+
+        assert_eq!(
+            context.matches("\n- ").count(),
+            5,
+            "all five eligible facts fill the budget"
+        );
+        assert!(
+            !context.contains("channel_history"),
+            "ineligible row dropped"
+        );
+        assert!(context.contains("- fact_e: epsilon elderberry"));
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
@@ -14,22 +14,6 @@ impl DefaultMemoryStrategy {
         memory_config: zeroclaw_config::schema::MemoryConfig,
         workspace_dir: impl Into<std::path::PathBuf>,
     ) -> Self {
-        // rerank_enabled is declared on the config schema but the
-        // retrieval-pipeline rerank stage was never landed.
-        // Emit a one-time warning so operators who set these
-        // fields know they currently have no effect.
-        if memory_config.rerank_enabled {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({
-                        "rerank_enabled": true,
-                        "rerank_threshold": memory_config.rerank_threshold,
-                    })),
-                "memory.rerank_enabled is set but the rerank stage is not yet implemented; this setting currently has no effect"
-            );
-        }
         Self {
             memory,
             memory_config,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Makes the existing default-off `memory.rerank_enabled` setting real in the shared engine memory-context injection path. When enabled, recall over-fetches a bounded candidate pool, blends the recall score with importance and recency, removes exact/near duplicates, optionally applies MMR, filters render-ineligible rows, applies the relevance floor, and trims to the effective recall limit. The branch is refreshed over merged #8898 so both vector and stock BM25-only SQLite recall provide the calibrated `[0, 1]` score domain consumed by rerank.
- **What changed and why:** Adds validated additive rerank settings and one shared `MemoryInjectConfig::from_memory_config` materializer used by all production injection sites. Candidate work is bounded at configuration, backend-request, over-return, unlimited-profile, and final-selection boundaries.
- **What changed and why:** Preserves reviewed edge contracts: default-off output is golden-pinned, directionally reversed facts are not treated as duplicates, scoreless backend order is stable, MMR endpoints are deterministic, and renderer-ineligible rows are removed before duplicate collapse so they cannot shadow eligible curated facts.
- **Scope boundary:** This does not add an external/LLM reranker, change storage backends or memory authority, modify embedding generation, or alter the flags-off recall renderer.
- **Blast radius:** Opt-in memory-context ordering/content in runtime and channel turns; additive `[memory]` configuration; bounded extra recall work when reranking is enabled.
- **Linked issue(s):** Part of #8891. Related #8898, #6722, and #4245.
- **Labels:** `enhancement`, `agent`, `channel`, `config`, `memory`, `runtime`, `channel:core`, `risk:high`, `size:XL`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; deterministic unit and composed SQLite tests cover the ranking, scope, score-domain, and configuration boundaries without an external provider.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI is pending on the refreshed head. The Rust quality matrix covers formatting, lint, cross-target compilation, features, tests, and security checks for the changed crates.
- **Known CI coverage gap, if any:** No live quality tuning against an embedding provider; this PR establishes deterministic mechanics and safety bounds, while weight tuning remains follow-up work.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
passed

$ cargo test -p zeroclaw-memory --lib --quiet
test result: ok. 493 passed; 0 failed; 0 ignored

$ cargo test -p zeroclaw-config --lib --quiet
test result: ok. 1131 passed; 0 failed; 0 ignored

$ cargo test -p zeroclaw-runtime memory_inject --lib --quiet
test result: ok. 23 passed; 0 failed; 0 ignored

$ PATH=<rust-1.96.1-bin> CARGO_TARGET_DIR=<isolated-target> cargo clippy -p zeroclaw-memory -p zeroclaw-config -p zeroclaw-runtime -p zeroclaw-channels --lib -- -D warnings
Finished `dev` profile [unoptimized + debuginfo]

$ git diff origin/master...HEAD --check
passed
```

- **Beyond CI, what did you manually verify?** I rebased onto merged #8898 and added a composed stock `SqliteMemory`/`NoopEmbedding` regression that drives real BM25-only recall through `render_memory_context`: both normalized scores remain distinguishable, both relevant entries survive the configured `0.4` floor, and relevance order survives blending. I also added a regression proving an ineligible duplicate cannot collapse an eligible fact before being filtered.
- **If any command was intentionally skipped, why:** The local Rust 1.96.1 all-target clippy run reaches two unrelated current-`master` macOS test-only unused imports in `crates/zeroclaw-channels/src/login_probe.rs` and `login_relink.rs`; the changed-crate library clippy run passes, and fresh hosted CI is the authoritative all-target check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `Yes`
- If any `Yes`, describe the risk and mitigation: With reranking explicitly enabled, existing recalled memories can be selected and ordered differently in the provider-visible `[Memory context]`. The change does not widen the backend, agent, session, or category scope; recalled content still passes the existing memory scan, conversation exclusion, autosave/history/media/tool-result skip set, relevance floor, and prompt-size budgets before injection.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: The additive `[memory]` keys are serde-defaulted. No upgrade is required; the default `rerank_enabled = false` path remains byte-identical. Operators who previously set the warned no-op `rerank_enabled = true` will now receive the advertised reranking behavior and can set it to `false` to retain the old path.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Set `[memory] rerank_enabled = false` for immediate per-instance rollback, or revert this PR's commits.
- **Feature flags or config toggles:** `memory.rerank_enabled` gates the entire stage; `memory.rerank_strategy = "none"` disables only MMR while retaining blend/dedup/trim.
- **Observable failure symptoms:** Unexpected ordering or omission inside `[Memory context]`, the unknown-strategy warning, or recall latency growth when reranking is enabled. Disable `rerank_enabled` to restore the golden-pinned prior renderer.

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy the exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
