### PR TITLE
ci(actions): narrow benchmark compile experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,7 @@ jobs:
           set +e
           cargo_log="${RUNNER_TEMP}/cargo-bench.log"
           SECONDS=0
-          cargo bench --no-run --locked 2>&1 | tee "$cargo_log"
+          cargo bench --bench agent_benchmarks --no-run --locked 2>&1 | tee "$cargo_log"
           cargo_status=${PIPESTATUS[0]}
           duration_seconds=$SECONDS
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,7 @@ jobs:
           set +e
           cargo_log="${RUNNER_TEMP}/cargo-bench.log"
           SECONDS=0
-          cargo bench --bench agent_benchmarks --no-run --locked 2>&1 | tee "$cargo_log"
+          cargo bench --bench agent_benchmarks --no-run --locked --no-default-features --features agent-runtime 2>&1 | tee "$cargo_log"
           cargo_status=${PIPESTATUS[0]}
           duration_seconds=$SECONDS
           set -e


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Narrows the `Benchmarks Compile` cargo command from full default-feature benchmark compilation to the explicit `agent_benchmarks` target under the lean `agent-runtime` feature graph.
  - Keeps the existing benchmark diagnostics, Rust cache behavior, timeout, runner, and required job wiring unchanged.
  - Creates a sharper GitHub Actions measurement slice for #7108 after target-only narrowing improved the benchmark job but left it as the Quality Gate tail.
- **Scope boundary:**
  - Does not remove `Benchmarks Compile` from required CI.
  - Does not change cache keys, runner class, branch protection, workflow triggers, benchmark source code, or benchmark profile settings.
  - Does not move the full default-feature benchmark compile to `master` or scheduled validation.
- **Blast radius:** High-risk workflow surface: pull request, push, and merge-group Quality Gate runs use this benchmark compile command. The intended behavioral change is limited to compiling the existing benchmark target with `agent-runtime` instead of the root crate's full default feature set.
- **Linked issue(s):** Related #7108.
- **Labels:** `ci`, `type:ci`, `risk:high`, `size:XS`

## Validation Evidence (required)

- **Commands run and tail output:**

```bash
cargo metadata --no-deps --format-version 1 --no-default-features --features agent-runtime
# exited 0

ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'
# ci.yml parsed

actionlint .github/workflows/ci.yml
# exited 0

git diff --check
# exited 0

./scripts/check-pr-title.sh 'ci(actions): narrow benchmark compile experiment'
# exited 0
```

- **Beyond CI - what did you manually verify?** Verified the diff is a single command change inside the existing `Benchmarks Compile` step, and that the cache/timing diagnostic summary remains intact. I also checked `benches/agent_benchmarks.rs` against the root feature graph: the benchmark imports the agent/runtime, memory, provider, and tool surfaces covered by `agent-runtime`; it does not directly need default channel bundles, gateway, ACP bridge, schema export, or Prometheus.
- **If any command was intentionally skipped, why:** I did not run a local `cargo bench` timing comparison because the value of this slice is the GitHub Actions runner/cache measurement. GitHub Actions passed on head `fbeac5e68f`: `Benchmarks Compile` completed in 6m42s job time, with the benchmark compile step and cargo run at 6m18s. The log showed an exact Rust cache full match, `RUST_CACHE_HIT: true`, 0 downloaded crate lines after cargo started, 14 local workspace crates compiled, and one emitted benchmark executable. For comparison, the prior target-only revision passed at 8m2s job time / 7m37s cargo time while still compiling 16 local workspace crates; the #8777 baseline was 9m42s job time / 9m09s cargo time.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No user upgrade steps.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR to restore the previous `cargo bench --no-run --locked` behavior in `.github/workflows/ci.yml`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `Benchmarks Compile` fails on GitHub Actions, the timing summary no longer reports expected benchmark diagnostics, or maintainers decide the narrowed feature graph no longer preserves the required benchmark compile signal.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A.
- Scope materially carried forward: N/A.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded contributor work is carried forward.
