### PR TITLE
fix(sop): notify approval routes after durable checkpoint parking

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -786,6 +786,12 @@ impl SopEngine {
                     // by that transition and must NOT be released out from under it.
                     if !holds_exec_claim(status) {
                         self.release_claim_on_park(&run_id);
+                        // The initial park deliberately withheld its route notice while
+                        // the snapshot was not durable. This successful retry is the
+                        // single point that makes the parked gate recoverable, so emit
+                        // the deferred request now. Removing the pending marker first
+                        // prevents later maintenance ticks from sending it again.
+                        self.notify_park_request(&run_id);
                     }
                 }
                 ActivePersistOutcome::CapacityFull | ActivePersistOutcome::Failed => {}
@@ -3748,7 +3754,11 @@ impl SopEngine {
                 // the run waits at the checkpoint - but only AFTER the parked
                 // snapshot is durably persisted (else keep the claim).
                 match self.persist_parked_snapshot_then_release_claim(run_id) {
-                    ParkPersistOutcome::Released => {}
+                    // A policy-gated checkpoint is the same durable approval boundary
+                    // as `WaitingApproval`: send its configured request notice only
+                    // after the parked snapshot is recoverable. If this write failed,
+                    // the maintenance retry owns the eventual single notification.
+                    ParkPersistOutcome::Released => self.notify_park_request(run_id),
                     ParkPersistOutcome::CapacityFull => {
                         let reason = self.pending_pool_capacity_raced_reason(sop);
                         Self::log_pending_capacity_full(run_id, &reason);
@@ -10562,6 +10572,121 @@ mod tests {
         let run = engine.get_run(&run_id).unwrap();
         assert_eq!(run.status, SopRunStatus::PausedCheckpoint);
         assert!(run.waiting_since.is_some());
+    }
+
+    #[test]
+    fn durable_policied_checkpoint_delivers_exactly_one_request_notice() {
+        use zeroclaw_config::schema::ApprovalPolicyConfig;
+
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let adapter = std::sync::Arc::new(RecordingRouteAdapter {
+            calls: calls.clone(),
+        });
+        let mut config = SopConfig::default();
+        config.approval.policies.insert(
+            "prod".to_string(),
+            ApprovalPolicyConfig {
+                required_group: None,
+                quorum: 0,
+                request_route: Some("discord.ops:checkpoint".to_string()),
+                escalation_route: None,
+            },
+        );
+        let mut sop = deterministic_sop("det-routed-checkpoint");
+        sop.steps[1].policy = Some("prod".to_string());
+        let mut engine = engine_with_config_sops(config, vec![sop]).with_approval_broker(
+            std::sync::Arc::new(crate::sop::approval::ApprovalBroker::with_route(adapter)),
+        );
+
+        let first = engine
+            .start_run("det-routed-checkpoint", manual_event())
+            .unwrap();
+        let run_id = extract_run_id(&first).to_string();
+        assert!(calls.lock().unwrap().is_empty());
+
+        let action = engine
+            .advance_deterministic_step(&run_id, serde_json::json!("step-one"), None)
+            .unwrap();
+        assert!(matches!(action, SopRunAction::CheckpointWait { .. }));
+
+        let recorded = calls.lock().unwrap().clone();
+        assert_eq!(recorded.len(), 1, "the durable checkpoint sends once");
+        assert_eq!(
+            recorded[0],
+            (
+                crate::sop::approval::ApprovalNoticeKind::Request,
+                "discord.ops:checkpoint".to_string(),
+                run_id,
+                "det-routed-checkpoint".to_string(),
+                2,
+            )
+        );
+    }
+
+    #[test]
+    fn policied_checkpoint_retry_delivers_once_after_persist_succeeds() {
+        use zeroclaw_config::schema::ApprovalPolicyConfig;
+
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let adapter = std::sync::Arc::new(RecordingRouteAdapter {
+            calls: calls.clone(),
+        });
+        let store = std::sync::Arc::new(FailingAppendStore {
+            inner: InMemoryRunStore::new(),
+            fail: std::sync::atomic::AtomicBool::new(false),
+            fail_save: std::sync::atomic::AtomicBool::new(false),
+            fail_finish: std::sync::atomic::AtomicBool::new(false),
+        });
+        let mut config = SopConfig::default();
+        config.approval.policies.insert(
+            "prod".to_string(),
+            ApprovalPolicyConfig {
+                required_group: None,
+                quorum: 0,
+                request_route: Some("discord.ops:checkpoint".to_string()),
+                escalation_route: None,
+            },
+        );
+        let mut sop = deterministic_sop("det-routed-checkpoint-retry");
+        sop.steps[1].policy = Some("prod".to_string());
+        let mut engine = engine_with_config_sops(config, vec![sop])
+            .with_store(store.clone())
+            .with_approval_broker(std::sync::Arc::new(
+                crate::sop::approval::ApprovalBroker::with_route(adapter),
+            ));
+
+        let first = engine
+            .start_run("det-routed-checkpoint-retry", manual_event())
+            .unwrap();
+        let run_id = extract_run_id(&first).to_string();
+        store
+            .fail_save
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let action = engine
+            .advance_deterministic_step(&run_id, serde_json::json!("step-one"), None)
+            .unwrap();
+        assert!(matches!(action, SopRunAction::Pending { .. }));
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "an undurable checkpoint must not send"
+        );
+        assert!(engine.is_park_persist_pending(&run_id));
+
+        store
+            .fail_save
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        engine.run_maintenance_tick();
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "the successful retry sends exactly once"
+        );
+        engine.run_maintenance_tick();
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "later maintenance ticks must not resend"
+        );
     }
 
     #[test]

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -197,10 +197,15 @@ Both routes are `channel:recipient`: `channel` is a configured channel's map key
 (`<channel>.<alias>`, or bare `<channel>` for a singleton) and `recipient` is that
 channel's addressee (a Discord channel id, a chat id, ...). Delivery is best-effort
 and never blocks or clears the gate - the approval itself still comes back through
-the normal approve/deny surfaces (`zeroclaw sop approve|deny`, the gateway
-approve/deny route, or the `sop_approve` agent tool). Routes fire only in the daemon
-(where channels are configured); leave them unset (or empty) to notify only the
-originating surface, which is the default.
+an authenticated approve/deny surface whose principal can satisfy the policy's
+group and quorum requirements. Routes fire only in the daemon (where channels are
+configured); leave them unset (or empty) to notify only the originating surface,
+which is the default.
+
+Route delivery has no durable retry queue. A daemon exit before the asynchronous
+send completes, or a channel send failure, can lose the notice without changing
+the parked gate. Operators can inspect pending runs with `zeroclaw sop pending`
+and contact an eligible approver through an authenticated approval surface.
 
 ### Step Contract Enforcement
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** The approval-route feature reached `master` through its lower stack, so this PR is restacked to the current base and now fixes the two remaining correctness gaps: a policy-gated deterministic checkpoint emits its request notice only after its parked snapshot is durable, and a failed park persist emits exactly once when the maintenance retry succeeds. The operator docs now state the authenticated group/quorum requirement and the best-effort delivery loss window.
- **Scope boundary:** This does not add a durable notification queue, change approval policy evaluation, or alter channel routing/configuration.
- **Blast radius:** SOP deterministic checkpoints with a configured approval `request_route`; the shared retry path for a parked snapshot whose first persistence attempt failed; SOP operator documentation.
- **Linked issue(s):** Related #8288
- **Labels:** `bug`, `docs`, `runtime`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; focused unit tests exercise both the immediate durable-persist path and the maintenance-retry path without requiring a live channel.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI is pending on the restacked head. `Docs Style` covers the changed Markdown lines; the Rust quality jobs cover formatting, lint, compilation, and tests across the repository targets.
- **Known CI coverage gap, if any:** No live outbound-channel smoke test; the route adapter already has focused unit coverage, and these new tests verify the engine invokes it at the durable checkpoint boundary.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
passed

$ cargo test -p zeroclaw-runtime --lib 'sop::' --quiet
running 485 tests
test result: ok. 485 passed; 0 failed; 0 ignored; 0 measured; 2818 filtered out

$ cargo test -p zeroclaw-runtime policied_checkpoint --lib
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 3301 filtered out

$ cargo test -p zeroclaw-runtime channel_route --lib
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 3293 filtered out

$ cargo clippy -p zeroclaw-runtime --lib --no-deps -- -D warnings
passed

$ scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** I verified that the immediate path sends only after `persist_parked_snapshot_then_release_claim` reports success, that the failure path withholds the notice, and that two maintenance ticks after recovery still produce only one notice. I did not send a notice through a live external channel.
- **If any command was intentionally skipped, why:** `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` reaches the workspace and currently stops on an unrelated pre-existing `clippy::question_mark` warning in `crates/zeroclaw-tool-call-parser/src/lib.rs:1632`; the scoped runtime-library clippy command passes. The local docs quality script could not find `npx`; running its pinned `markdownlint-cli2@0.20.0` directly reported only the pre-existing MD001 at `docs/book/src/sop/syntax.md:350`, outside this PR's changed lines. Fresh CI remains the authoritative full check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: A configured request route now receives the already-intended notice for policy-gated deterministic checkpoints. Delivery remains restricted to the operator-configured route, occurs only after the parked state is durable, and never clears or bypasses the authenticated approval gate.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 90fa81e2e`
- **Feature flags or config toggles:** Remove the policy's `request_route` to disable routed notices without reverting.
- **Observable failure symptoms:** Missing or duplicate approval-request notices for deterministic checkpoints; inspect pending gates with `zeroclaw sop pending` and route-delivery warnings in daemon logs.

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy the exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
