### PR TITLE
feat(zerocode): auto-resume most recent Code session on pane entry (#8653)

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -283,6 +283,15 @@ impl Chat {
         }
 
         if agents.len() == 1 {
+            // ACP pane (Code tab): try to auto-resume the most recent Code
+            // session instead of starting a blank one. The daemon-side session
+            // list is already sorted by last_activity DESC, so the first entry
+            // is the most recent. No sessions → fresh start (no-op).
+            if self.pane_kind == PaneKind::Acp && self.resume_session_id.is_none() {
+                if let Ok(list) = self.rpc.acp_session_list().await {
+                    self.resume_session_id = list.sessions.into_iter().next().map(|s| s.session_id);
+                }
+            }
             self.pick_or_start_session(&agents[0]).await;
             return Ok(());
         }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** When the user opens the ZeroCode Code (ACP) pane, it currently starts from a blank/new-session state. If the user has an existing Code session, they must manually open the session picker and select it. This PR auto-resumes the most recent Code session when entering the pane, so the user continues where they left off.
- **Scope boundary:** Only affects the ACP (Code) pane, not the Chat pane. Only triggers when no explicit `resume_session_id` is already set (e.g. from a reconnect). Only fires in the single-agent path (most common case); multi-agent users still see the agent picker first.
- **Blast radius:** `apps/zerocode/src/chat.rs` only — the `init()` method adds a single ACP session list check before auto-starting a session. No daemon-side changes.
- **Linked issue(s):** Fixes #8653

## Changes

- `apps/zerocode/src/chat.rs:285-296` — in the single-agent `init()` path, when the pane kind is ACP and no resume session ID is carried, fetch the ACP session list (already sorted by `last_activity DESC` on the daemon side) and set the most recent session ID as the resume target before calling `pick_or_start_session`.

## Tests

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy -p zerocode --lib -- -D warnings
(no warnings)

$ cargo test -p zerocode --lib
test result: ok. 153 passed; 0 failed
```

## Risk

Low. Falls back to a fresh session when no ACP sessions exist or the RPC call fails (no-op via `if let Ok`). Single-agent path only; multi-agent picker is unchanged. The resumed session could theoretically be for a different agent than the single configured one, but the session picker is one keypress away.