### PR TITLE
fix(runtime): gate agent stdout output on interactive flag (#8760)

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1832,7 +1832,9 @@ pub async fn run(
                 config.skills.install_suggestions.enabled,
             ) {
                 final_output = suggestion;
-                println!("{final_output}");
+                if interactive {
+                    println!("{final_output}");
+                }
                 observer.record_event(&ObserverEvent::TurnComplete);
                 return Ok(final_output);
             }
@@ -2132,7 +2134,9 @@ pub async fn run(
             // Emit the user-visible response before any background work so the
             // skill-review fork can never delay the user's answer.
             final_output = response;
-            println!("{final_output}");
+            if interactive {
+                println!("{final_output}");
+            }
             observer.record_event(&ObserverEvent::TurnComplete);
 
             // Background skill review fork — post-turn, opt-in


### PR DESCRIPTION
> **Maintainer's note** (Audacity88): I reshaped this PR body on behalf of wangmiao0668000666 so it matches the current high-risk PR template and does not overstate validation. The original author's commit `61bb4bc24b818e40a72c8c683306c5a2b80d1869` and description are preserved in the branch history; authorship of the code change remains with wangmiao0668000666.

## Summary

- **Base branch:** `master`
- **What changed and why:** `agent::loop_::run()` had two single-shot `println!("{final_output}")` sites reachable from daemon-owned runs because those callers pass `Some(message)`. This PR gates both sites on the existing `interactive` flag so daemon-owned runs continue returning, persisting, and broadcasting output through their normal surfaces without duplicating model text to daemon stdout.
- **Scope boundary:** Only the single-shot `Some(message)` path changes. The interactive REPL path (`message.is_none()`) keeps its prompts, streamed stdout, and CLI response rendering. `ObserverEvent::TurnComplete` remains recorded for all callers.
- **Blast radius:** `crates/zeroclaw-runtime/src/agent/loop_.rs` only. CLI interactive users should see no change. Daemon-owned runs stop printing final model output to daemon stdout.
- **Linked issue(s):** Fixes #8760
- **Labels:** `bug`, `agent`, `runtime`, `zerocode`, `risk:high`, `size:XS`

## Validation Evidence (required)

Author-reported local validation:

```text
cargo fmt --all -- --check
(no output - clean)

cargo clippy -p zeroclaw-runtime --lib -- -D warnings
(no warnings)
```

Live GitHub CI at head `61bb4bc24b818e40a72c8c683306c5a2b80d1869` is green, including `Test`, `Lint`, `Security`, and `CI Required Gate`.

- **Commands run and tail output:** See the author-reported command output above and live GitHub CI.
- **Beyond CI — what did you manually verify?** Maintainer source review checked the `run()` single-shot path, the interactive REPL branch, `spawn_subagent`, and cron agent call sites. The remaining stdout/streaming prints are in the `message.is_none()` interactive REPL branch; cron and `spawn_subagent` call `agent::run(...)` with `Some(message)` and `interactive = false`.
- **If any command was intentionally skipped, why:** No local maintainer Cargo validation was run in this review-only pass. This cleanup records the author-reported commands, live CI, and maintainer source review. No new dedicated stdout-capture regression test was added in this PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** This narrows where agent response text is printed.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- If any `Yes`, describe the risk and mitigation: Not applicable.

Positive privacy impact: daemon-owned agent output no longer duplicates final model text to daemon stdout when the caller is non-interactive.

## Compatibility (required)

- Backward compatible? **Yes.** CLI interactive output is preserved because `interactive = true` still prints.
- Config / env / CLI surface changed? **No.**
- If `No` or `Yes` to either: Not applicable.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <this-commit-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** If the fix regresses, daemon terminal output again shows duplicate final model text for `session/prompt`, cron agent jobs, or `spawn_subagent`; CLI interactive output should remain the comparison path.
