### PR TITLE
fix(providers): remove unconditional strip_think_tags from compatible provider (#8615)

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1139,30 +1139,6 @@ struct Choice {
     message: ResponseMessage,
 }
 
-/// Remove `<think>...</think>` blocks from model output.
-/// Some reasoning models (e.g. MiniMax) embed their chain-of-thought inline
-/// in the `content` field rather than a separate `reasoning_content` field.
-/// The resulting `<think>` tags must be stripped before returning to the user.
-fn strip_think_tags(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut rest = s;
-    loop {
-        if let Some(start) = rest.find("<think>") {
-            result.push_str(&rest[..start]);
-            if let Some(end) = rest[start..].find("</think>") {
-                rest = &rest[start + end + "</think>".len()..];
-            } else {
-                // Unclosed tag: drop the rest to avoid leaking partial reasoning.
-                break;
-            }
-        } else {
-            result.push_str(rest);
-            break;
-        }
-    }
-    result.trim().to_string()
-}
-
 /// OpenAI Chat Completions may return assistant `message.content` as a string,
 /// null, or an array of typed parts. Normalize it before storing the internal
 /// response shape so compatible gateways that preserve typed parts still work,
@@ -1247,16 +1223,13 @@ impl ResponseMessage {
     fn effective_content(&self) -> String {
         self.content
             .as_ref()
-            .map(|c| strip_think_tags(c))
+            .cloned()
             .filter(|c| !c.is_empty())
             .unwrap_or_default()
     }
 
     fn effective_content_optional(&self) -> Option<String> {
-        self.content
-            .as_ref()
-            .map(|c| strip_think_tags(c))
-            .filter(|c| !c.is_empty())
+        self.content.as_ref().cloned().filter(|c| !c.is_empty())
     }
 }
 
@@ -5072,9 +5045,16 @@ mod tests {
     }
 
     #[test]
-    fn strip_think_tags_drops_unclosed_block_suffix() {
-        let input = "visible<think>hidden";
-        assert_eq!(strip_think_tags(input), "visible");
+    fn effective_content_preserves_literal_think_tags() {
+        // The compatible provider must not strip literal <thinking> tags
+        // from model output. See #8615.
+        let json = r#"{"choices":[{"message":{"content":"Here is the HTML: <thinking>internal note</thinking>"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(
+            msg.effective_content(),
+            "Here is the HTML: <thinking>internal note</thinking>"
+        );
     }
 
     #[test]
@@ -5851,17 +5831,34 @@ mod tests {
     }
 
     #[test]
-    fn strip_think_tags_removes_multiple_blocks_with_surrounding_text() {
-        let input = "Answer A <think>hidden 1</think> and B <think>hidden 2</think> done";
-        let output = strip_think_tags(input);
-        assert_eq!(output, "Answer A  and B  done");
+    fn effective_content_preserves_unclosed_think_tag() {
+        // An unclosed <thinking> must NOT discard the rest of the response.
+        // See #8615.
+        let json = r#"{"choices":[{"message":{"content":"Visible <thinking>hidden tail"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(msg.effective_content(), "Visible <thinking>hidden tail");
     }
 
     #[test]
-    fn strip_think_tags_drops_tail_for_unclosed_block() {
-        let input = "Visible<think>hidden tail";
-        let output = strip_think_tags(input);
-        assert_eq!(output, "Visible");
+    fn effective_content_preserves_multiple_think_blocks() {
+        // Multiple <thinking> blocks in content must survive intact.
+        let json = r#"{"choices":[{"message":{"content":"Answer A <thinking>hidden 1</thinking> and B <thinking>hidden 2</thinking> done"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(
+            msg.effective_content(),
+            "Answer A <thinking>hidden 1</thinking> and B <thinking>hidden 2</thinking> done"
+        );
+    }
+    #[test]
+    fn effective_content_preserves_think_tags_with_reasoning_content() {
+        // When both content and reasoning_content are present, the
+        // content with literal <thinking> tags is preserved.
+        let json = r#"{"choices":[{"message":{"content":"Visible <thinking>hidden tail"}}]}"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let msg = &resp.choices[0].message;
+        assert_eq!(msg.effective_content(), "Visible <thinking>hidden tail");
     }
 
     // ----------------------------------------------------------
@@ -5912,14 +5909,16 @@ mod tests {
 
     #[test]
     fn reasoning_content_preserved_when_content_only_think_tags() {
-        // When content only has <think> tags (stripped to empty),
-        // effective_content returns "" — reasoning_content is preserved
-        // separately, not leaked into the response text.
-        let json = r#"{"choices":[{"message":{"content":"<think>secret</think>","reasoning_content":"Thinking text"}}]}"#;
+        // The compatible provider no longer strips <thinking> tags from
+        // content (see #8615), so literal <thinking> blocks are preserved
+        // in effective_content. reasoning_content is still preserved
+        // separately and not leaked into the response text.
+        let json = r#"{"choices":[{"message":{"content":"<thinking>secret</thinking>","reasoning_content":"Thinking text"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
-        assert_eq!(msg.effective_content(), "");
-        assert_eq!(msg.effective_content_optional(), None);
+        assert!(msg.effective_content().contains("secret"));
+        assert!(msg.effective_content().contains("thinking"));
+        assert!(msg.effective_content_optional().is_some());
         assert_eq!(msg.reasoning_content.as_deref(), Some("Thinking text"));
     }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -5854,8 +5854,9 @@ mod tests {
     fn effective_content_preserves_unclosed_think_tag() {
         // An unclosed literal `<think>` tag must NOT discard the rest of the
         // response. The old `strip_think_tags()` helper saw no closing
-        // ` closing ` and dropped the trailing tail ("Visible  think"
-        // → "Visible"). The new path returns the input unchanged.
+        // `</think>` and dropped the trailing tail, collapsing
+        // "Visible <think>hidden tail" to "Visible". The new path returns
+        // the input unchanged.
         let json = r#"{"choices":[{"message":{"content":"Visible <think>hidden tail"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
@@ -5866,8 +5867,10 @@ mod tests {
     fn effective_content_preserves_multiple_think_blocks() {
         // Multiple literal `<think>` blocks in `content` survive the removal
         // intact. The old `strip_think_tags()` helper would have collapsed
-        // the visible text to "Answer A  and B  done", losing the
-        // inter-block separators and the tag delimiters themselves.
+        // the visible text to "Answer A  and B  done" — the double spaces
+        // mark where `<think>hidden 1</think>` and `<think>hidden 2</think>`
+        // used to be — losing the inter-block separators and the tag
+        // delimiters themselves.
         let json = r#"{"choices":[{"message":{"content":"Answer A <think>hidden 1</think> and B <think>hidden 2</think> done"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -5854,7 +5854,7 @@ mod tests {
     fn effective_content_preserves_unclosed_think_tag() {
         // An unclosed literal `<think>` tag must NOT discard the rest of the
         // response. The old `strip_think_tags()` helper saw no closing
-        // closing `</think>` and dropped the trailing tail ("Visible <think>"
+        // ` closing ` and dropped the trailing tail ("Visible  think"
         // → "Visible"). The new path returns the input unchanged.
         let json = r#"{"choices":[{"message":{"content":"Visible <think>hidden tail"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1220,6 +1220,22 @@ impl From<RawResponseMessage> for ResponseMessage {
 }
 
 impl ResponseMessage {
+    /// Extract text content from the `content` field only. Does NOT fall
+    /// back to `reasoning_content` — thinking/reasoning models (GLM-5.1,
+    /// DeepSeek, Qwen) return their thinking in `reasoning_content` which
+    /// must not leak into the user-visible response text. The
+    /// `reasoning_content` is preserved separately in
+    /// `ChatResponse.reasoning_content` for history round-tripping.
+    ///
+    /// Returns the `content` field as-is. Previously this stripped
+    /// `<think>...</think>` blocks that some reasoning models (e.g. MiniMax)
+    /// embedded inline in `content` instead of using a separate field, but
+    /// that unconditional rewrite silently mangled responses whose `content`
+    /// legitimately contained literal `<think>...</think>` markup (HTML, code
+    /// samples, quoted discussion of the tag itself, and unclosed tails).
+    /// Removed in #8615 — model providers that need inline think-block
+    /// filtering should do it downstream of this response shape, with full
+    /// visibility into the model's actual output.
     fn effective_content(&self) -> String {
         self.content
             .as_ref()
@@ -5046,14 +5062,18 @@ mod tests {
 
     #[test]
     fn effective_content_preserves_literal_think_tags() {
-        // The compatible provider must not strip literal <thinking> tags
-        // from model output. See #8615.
-        let json = r#"{"choices":[{"message":{"content":"Here is the HTML: <thinking>internal note</thinking>"}}]}"#;
+        // #8615 — the deleted `strip_think_tags()` helper searched for the
+        // exact substring `<think>` / `</think>` and stripped those blocks
+        // unconditionally. This regression pins that literal `<think>` tags
+        // now round-trip byte-for-byte, including legitimate uses where the
+        // model legitimately discusses the tag (HTML sample, code quoting,
+        // meta-discussion).
+        let json = r#"{"choices":[{"message":{"content":"Here is the HTML: <think>internal note</think>"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
         assert_eq!(
             msg.effective_content(),
-            "Here is the HTML: <thinking>internal note</thinking>"
+            "Here is the HTML: <think>internal note</think>"
         );
     }
 
@@ -5832,33 +5852,48 @@ mod tests {
 
     #[test]
     fn effective_content_preserves_unclosed_think_tag() {
-        // An unclosed <thinking> must NOT discard the rest of the response.
-        // See #8615.
-        let json = r#"{"choices":[{"message":{"content":"Visible <thinking>hidden tail"}}]}"#;
+        // #8615 — an unclosed literal `<think>` tag must NOT discard the
+        // rest of the response. The old `strip_think_tags()` helper saw no
+        // closing `</think>` and dropped the trailing tail ("Visible <think>"
+        // → "Visible"). The new path returns the input unchanged.
+        let json = r#"{"choices":[{"message":{"content":"Visible <think>hidden tail"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
-        assert_eq!(msg.effective_content(), "Visible <thinking>hidden tail");
+        assert_eq!(msg.effective_content(), "Visible <think>hidden tail");
     }
 
     #[test]
     fn effective_content_preserves_multiple_think_blocks() {
-        // Multiple <thinking> blocks in content must survive intact.
-        let json = r#"{"choices":[{"message":{"content":"Answer A <thinking>hidden 1</thinking> and B <thinking>hidden 2</thinking> done"}}]}"#;
+        // #8615 — multiple literal `<think>` blocks in `content` survive
+        // intact. The old `strip_think_tags()` helper would have collapsed
+        // the visible text to "Answer A  and B  done", losing the
+        // inter-block separators and the tag delimiters themselves.
+        let json = r#"{"choices":[{"message":{"content":"Answer A <think>hidden 1</think> and B <think>hidden 2</think> done"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
         assert_eq!(
             msg.effective_content(),
-            "Answer A <thinking>hidden 1</thinking> and B <thinking>hidden 2</thinking> done"
+            "Answer A <think>hidden 1</think> and B <think>hidden 2</think> done"
         );
     }
     #[test]
     fn effective_content_preserves_think_tags_with_reasoning_content() {
-        // When both content and reasoning_content are present, the
-        // content with literal <thinking> tags is preserved.
-        let json = r#"{"choices":[{"message":{"content":"Visible <thinking>hidden tail"}}]}"#;
+        // #8615 — when both `content` and `reasoning_content` are present,
+        // the literal `<think>` blocks in `content` survive intact while
+        // `reasoning_content` is preserved separately and is NOT leaked
+        // into the response text.
+        let json = r#"{"choices":[{"message":{"content":"Visible <think>hidden tail</think>","reasoning_content":"reasoning separately"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
-        assert_eq!(msg.effective_content(), "Visible <thinking>hidden tail");
+        assert_eq!(
+            msg.effective_content(),
+            "Visible <think>hidden tail</think>"
+        );
+        assert!(!msg.effective_content().contains("reasoning separately"));
+        assert_eq!(
+            msg.reasoning_content.as_deref(),
+            Some("reasoning separately")
+        );
     }
 
     // ----------------------------------------------------------
@@ -5909,15 +5944,20 @@ mod tests {
 
     #[test]
     fn reasoning_content_preserved_when_content_only_think_tags() {
-        // The compatible provider no longer strips <thinking> tags from
-        // content (see #8615), so literal <thinking> blocks are preserved
-        // in effective_content. reasoning_content is still preserved
-        // separately and not leaked into the response text.
-        let json = r#"{"choices":[{"message":{"content":"<thinking>secret</thinking>","reasoning_content":"Thinking text"}}]}"#;
+        // #8615 — the compatible provider no longer strips literal
+        // `<think>...</think>` blocks from `content`. Previously the
+        // `<think>secret</think>`-only content was collapsed to the empty
+        // string by `strip_think_tags()`, and `effective_content()` returned
+        // `""` so the visible-text field was effectively replaced by the
+        // model's chain-of-thought marker. Now the literal `<think>` tags
+        // round-trip into `effective_content()` byte-for-byte, and
+        // `reasoning_content` is still preserved separately and not leaked
+        // into the response text.
+        let json = r#"{"choices":[{"message":{"content":"<think>secret</think>","reasoning_content":"Thinking text"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         let msg = &resp.choices[0].message;
         assert!(msg.effective_content().contains("secret"));
-        assert!(msg.effective_content().contains("thinking"));
+        assert!(msg.effective_content().contains("<think>"));
         assert!(msg.effective_content_optional().is_some());
         assert_eq!(msg.reasoning_content.as_deref(), Some("Thinking text"));
     }

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1233,9 +1233,9 @@ impl ResponseMessage {
     /// that unconditional rewrite silently mangled responses whose `content`
     /// legitimately contained literal `<think>...</think>` markup (HTML, code
     /// samples, quoted discussion of the tag itself, and unclosed tails).
-    /// Removed in #8615 — model providers that need inline think-block
-    /// filtering should do it downstream of this response shape, with full
-    /// visibility into the model's actual output.
+    /// Model providers that need inline think-block filtering should do it
+    /// downstream of this response shape, with full visibility into the
+    /// model's actual output.
     fn effective_content(&self) -> String {
         self.content
             .as_ref()
@@ -5062,8 +5062,8 @@ mod tests {
 
     #[test]
     fn effective_content_preserves_literal_think_tags() {
-        // #8615 — the deleted `strip_think_tags()` helper searched for the
-        // exact substring `<think>` / `</think>` and stripped those blocks
+        // The deleted `strip_think_tags()` helper searched for the exact
+        // substring `<think>` / `</think>` and stripped those blocks
         // unconditionally. This regression pins that literal `<think>` tags
         // now round-trip byte-for-byte, including legitimate uses where the
         // model legitimately discusses the tag (HTML sample, code quoting,
@@ -5852,8 +5852,8 @@ mod tests {
 
     #[test]
     fn effective_content_preserves_unclosed_think_tag() {
-        // #8615 — an unclosed literal `<think>` tag must NOT discard the
-        // rest of the response. The old `strip_think_tags()` helper saw no
+        // An unclosed literal `<think>` tag must NOT discard the rest of the
+        // response. The old `strip_think_tags()` helper saw no closing
         // closing `</think>` and dropped the trailing tail ("Visible <think>"
         // → "Visible"). The new path returns the input unchanged.
         let json = r#"{"choices":[{"message":{"content":"Visible <think>hidden tail"}}]}"#;
@@ -5864,7 +5864,7 @@ mod tests {
 
     #[test]
     fn effective_content_preserves_multiple_think_blocks() {
-        // #8615 — multiple literal `<think>` blocks in `content` survive
+        // Multiple literal `<think>` blocks in `content` survive the removal
         // intact. The old `strip_think_tags()` helper would have collapsed
         // the visible text to "Answer A  and B  done", losing the
         // inter-block separators and the tag delimiters themselves.
@@ -5878,7 +5878,7 @@ mod tests {
     }
     #[test]
     fn effective_content_preserves_think_tags_with_reasoning_content() {
-        // #8615 — when both `content` and `reasoning_content` are present,
+        // When both `content` and `reasoning_content` are present,
         // the literal `<think>` blocks in `content` survive intact while
         // `reasoning_content` is preserved separately and is NOT leaked
         // into the response text.
@@ -5944,7 +5944,7 @@ mod tests {
 
     #[test]
     fn reasoning_content_preserved_when_content_only_think_tags() {
-        // #8615 — the compatible provider no longer strips literal
+        // The compatible provider no longer strips literal
         // `<think>...</think>` blocks from `content`. Previously the
         // `<think>secret</think>`-only content was collapsed to the empty
         // string by `strip_think_tags()`, and `effective_content()` returned
@@ -5958,7 +5958,10 @@ mod tests {
         let msg = &resp.choices[0].message;
         assert!(msg.effective_content().contains("secret"));
         assert!(msg.effective_content().contains("<think>"));
-        assert!(msg.effective_content_optional().is_some());
+        assert_eq!(
+            msg.effective_content_optional().as_deref(),
+            Some("<think>secret</think>"),
+        );
         assert_eq!(msg.reasoning_content.as_deref(), Some("Thinking text"));
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** #8615 reports that on OpenAI-compatible upstreams (notably MiniMax), some reasoning models embed their chain-of-thought inline in `content` using exact `<think>` / `</think>` tags instead of a separate `reasoning_content` field. The compatible provider used to strip those blocks unconditionally via `ResponseMessage::effective_content()` / `effective_content_optional()` (helper `strip_think_tags` in `crates/zeroclaw-providers/src/compatible.rs`). That unconditional rewrite silently mangled any response whose `content` legitimately contained literal `<think>` markup — HTML samples that show the tag, code that quotes it, models that discuss the tag in their reasoning preamble, and unclosed `<think>` tails that previously collapsed to `"Visible"` instead of `"Visible <think>"`. This PR removes the helper and lets `effective_content()` / `effective_content_optional()` return `content` as-is. Model providers that still want inline think-block filtering should do it downstream of this response shape, where they have full visibility into what the model actually emitted.
- **Scope boundary:** Only the two `ResponseMessage` accessors and the deleted `strip_think_tags()` helper in `compatible.rs`. The reasoning-model fallback path (`reasoning_content` preserved as a separate field) is unchanged. The inbound parse paths that translate upstream responses into `ProviderChatResponse` are unchanged in shape; only the post-parse accessors are simplified. Provider selection, default routing, and fallback behavior are explicitly out of scope.
- **Blast radius:** One file (`crates/zeroclaw-providers/src/compatible.rs`), one deleted private helper, two simplified accessors, and regression coverage that pins the contract. The provider-construction code path is unchanged. Downstream display filtering (`zeroclaw-channels` `strip_think_tags_inline`) is unchanged. One content-capture surface is affected and declared below under Security & Privacy Impact (OTel GenAI export now records the raw `<think>` content under the `full` policy).
- **Linked issue(s):** Fixes #8615.

## Changes

- `crates/zeroclaw-providers/src/compatible.rs` — deleted `fn strip_think_tags(s: &str) -> String` (the helper that searched for `rest.find("<think>")` and `rest[start..].find("</think>")`). `ResponseMessage::effective_content` and `ResponseMessage::effective_content_optional` now clone `self.content` directly. The doc comment on `effective_content()` was updated to drop the "Strips `<think>...</think>` blocks" wording and explain why the rewrite was removed.
- Downstream filtering is unchanged: `crates/zeroclaw-channels` still runs `strip_think_tags_inline()` before user-facing display, and `ollama.rs` keeps its own think-field handling (a separate wire contract). This PR only removes the unconditional rewrite at the compatible-provider response accessor.
- Regression tests rewritten to use the exact `<think>` / `</think>` tag shape from #8615:
  - `effective_content_preserves_literal_think_tags` — `content = "Here is the HTML: <think>internal note</think>"` round-trips byte-for-byte.
  - `effective_content_preserves_unclosed_think_tag` — `content = "Visible <think>hidden tail"` round-trips byte-for-byte (previously dropped to `"Visible"`).
  - `effective_content_preserves_multiple_think_blocks` — multi-block content round-trips with the inter-block separators preserved.
  - `effective_content_preserves_think_tags_with_reasoning_content` — fixture now supplies both `content` (with `<think>` tags) and `reasoning_content`, and asserts both are preserved while `reasoning_content` is not leaked into the response text.
  - `reasoning_content_preserved_when_content_only_think_tags` — content-only-`<think>` blocks now round-trip into `effective_content()` byte-for-byte; the `<think>` substring is asserted present; `reasoning_content` is still preserved separately.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes` — the fixture regressions below reproduce the old-vs-new behavior without provider credentials; run them against the branch and against `master` to see the delta.
- **Interface(s) exercised:** `surface cli` / `surface tui` via any compatible-provider conversation (the `provider` response shape is the changed surface).
- **Setup / preconditions:** None.
- **Steps to run:**
  ```bash
  cargo test --locked -p zeroclaw-providers --lib -- \
      "effective_content_preserves" \
      "reasoning_content_preserved_when_content_only_think_tags"
  ```
- **Expected on this branch (after):** `effective_content()` / `effective_content_optional()` return `content` exactly as received; literal `<think>` blocks, unclosed tails, and multi-block content all round-trip byte-for-byte.
- **Prior behavior on `master` (before):** any compatible-provider response whose `content` contained a literal `<think>` block (or an HTML sample showing the tag) returned the stripped form.

### How I tested

- **CI checks relied on and why they cover this change:** `Test` runs the `zeroclaw-providers` suite (the compatible accessor regressions are the changed surface); `Lint` runs clippy `-D warnings`; `Format` runs `cargo fmt --check`.
- **Known CI coverage gap, if any:** No live HTTP repro against MiniMax or any specific reasoning model — the regression suite pins the boundary contracts; live repro is gated by upstream-config outside this diff.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(clean)

$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
(clean)

$ cargo test --locked -p zeroclaw-providers --lib
test result: ok. 1182 passed; 0 failed
```

- **Beyond CI, what did you manually verify?** Reproduced locally with the four rewritten fixtures: literal `<think>`, unclosed `<think>`, multi-block, and content+reasoning_content combined. All four round-trip byte-for-byte. Verified by reading the OTel capture boundary that `capture_llm_messages` receives the raw `text_or_empty()` (see Security & Privacy Impact).
- **If any command was intentionally skipped, why:** `cargo fmt --all` (write mode) — only `--check` was needed and CI runs it; `cargo build --release` — CI handles release builds.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **`No`**
- New external network calls? **`No`**
- Secrets / tokens / credentials handling changed? **`No`**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **`No`** — fixtures use synthetic HTML/code snippets.
- Prompt injection or untrusted model-visible text introduced/changed? **`Yes`** — the change deliberately stops rewriting literal `<think>` markup in model `content`; downstream consumers that relied on the old implicit stripping now receive raw content and must filter at their own presentation/capture boundary. This is the intended design per #8615 triage.
- If any `Yes`, describe the risk and mitigation: one content-capture surface is affected: `crates/zeroclaw-runtime/src/agent/turn/parse_response.rs` passes `resp.text_or_empty()` to `capture_llm_messages` (line 151) before line 175 applies the shared `strip_think_tags` display filter. `capture_llm_messages` scrubs credentials and image data but does not strip think tags, so under `otel_genai_content = "full"` the OTel `gen_ai.output.messages` now records literal `<think>...</think>` from compatible-provider responses. This is a consequence of the raw-content contract, not a new telemetry surface. Operators who must keep reasoning tags out of telemetry should use the `off` GenAI content policy or apply an explicit capture-boundary filter. The `redacted` policy only bounds the field length — at `crates/zeroclaw-runtime/src/observability/otel.rs:1115-1122` it applies `truncate_field` and does not remove `<think>` markers, so a response beginning with a think block can still export part of it up to the limit. The `message_attrs` redacted policy likewise only truncates `snap.output_text`; the `full` policy preserves it by design.

## Compatibility (required)

- Backward compatible? **`No`** — the two `ResponseMessage` accessors now return `content` as-is instead of silently stripping literal `<think>` blocks. `strip_think_tags` was private (`fn` not `pub fn`) and the public `ProviderChatResponse` / `NativeChatResponse` shapes are unchanged, so this is source-compatible; callers that depended on the old stripping behavior receive raw content and must filter downstream if they need to.
- Config / env / CLI surface changed? **`No`**
- Rust/MSRV/toolchain floor changed? **`No`** — no new dependencies or language features.
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users:
  1. Any consumer that calls `ResponseMessage::effective_content()` / `effective_content_optional()` and expects `<think>` blocks stripped must add its own filtering (e.g. `zeroclaw-channels` already does via `strip_think_tags_inline`).
  2. OTel operators on `otel_genai_content = "full"` should review the tradeoff above; the `redacted` policy bounds length but does not exclude `<think>` markers, so use `off` or an explicit capture-boundary filter if reasoning tags must not be exported.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** after this PR lands, `git revert <squash-merge-commit>` on `master` reverts the entire fix. While the branch is unsquashed, revert the current commits in reverse order.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Reverting restores the pre-fix behavior: literal `<think>` blocks, unclosed tails, HTML samples, and code snippets containing the tag are silently dropped/collapsed in `effective_content()` output; `<think>`-tagged reasoning also disappears from OTel `gen_ai.output.messages` under the `full` policy (the old stripping applied at the accessor).

## Real behavior proof

- **Behavior addressed:** any OpenAI-compatible response whose `content` legitimately contained `<think>` markup was silently rewritten to drop the tag and the content between the markers. Unclosed `<think>` tails were dropped to the prefix only. HTML samples and code blocks showing the tag itself were corrupted.
- **Real environment tested:** Linux x86_64, Rust stable per `rust-toolchain.toml`, `zeroclaw-providers` crate only. Local test reproduction matches the four pinned fixtures.
- **Exact steps run after this patch:**
  - `cargo fmt --all -- --check` — clean
  - `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` — clean
  - `cargo test --locked -p zeroclaw-providers --lib` — 1182 / 1182 passed
- **Evidence after fix:** `effective_content_preserves_literal_think_tags` confirms literal `<think>` tags survive round-trip; `effective_content_preserves_unclosed_think_tag` confirms unclosed tails are preserved; `effective_content_preserves_multiple_think_blocks` confirms multi-block content is not collapsed; `effective_content_preserves_think_tags_with_reasoning_content` confirms `reasoning_content` stays separate; `reasoning_content_preserved_when_content_only_think_tags` confirms content-only-`<think>` payloads now pass through.
- **Observed result after fix:** `effective_content()` and `effective_content_optional()` return `content` exactly as received from the upstream. The only path that produces a rewritten string is downstream consumers that explicitly opt in to think-block filtering.
- **What was not tested:** Live HTTP against MiniMax or any other specific reasoning model — the regression suite only pins the boundary contracts. Live repro is gated by upstream-config that lives outside this diff.

**2026-08-05 re-review (ZeroClaw-Bot on head `f692bfff5`):** verdict COMMENT, blocking=0 — three warnings and one suggestion, all addressed in this body:

- **`How you can test` declaration (RESOLVED):** reviewer testing is now declared `Yes` with the A/B fixture steps, and the interface field uses the `surface cli` / `surface tui` vocabulary instead of `tool`.
- **OTel redaction mitigation overstated (RESOLVED):** the body no longer claims the `redacted` GenAI policy excludes `<think>` markers — it only bounds the field length (`otel.rs:1115-1122` truncates without tag removal). The guidance now points to `off` or an explicit capture-boundary filter when exclusion is required.
- **Validation evidence refresh (RESOLVED):** the test counts now reflect the current head (`cargo test --locked -p zeroclaw-providers --lib` = 1182 passed).
- **Rebase snapshot date (suggestion, RESOLVED):** corrected to 2026-08-05, matching the head's metadata.

## Risk & label snapshot

- **Live labels on this PR:** `bug`, `provider`, `provider:compatible`, `principal contributor`, `priority:p2`, `risk:medium`, `size:S`.
- **Rebase (2026-08-05):** Rebased onto current `master` (`c7f4435b9`). Branch is now 0 behind / 5 ahead. Since the prior snapshot (`53cba1ddd`), `fe805ec9f` (#9699) also changed `crates/zeroclaw-providers/src/compatible.rs`; the rebase replays cleanly with no conflicts, and the effective diff still contains only the one intended file.
