### PR TITLE
feat(zerocode): show active resolved log path in Doctor diagnostics (#8650)

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -562,3 +562,5 @@ zc-config-footer-action-new-line = new line
 ## Inline hint shown on the selected config field row. The { $keys } placeholder
 ## is resolved from the current keybinding for ConfigTabAction::Enter.
 zc-config-field-edit-hint = { $keys } → press to edit
+
+zc-doctor-log-path = log: { $path }

--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -178,6 +178,7 @@ zc-doctor-error-timeout-hint = Model probing against live provider APIs can be s
 zc-doctor-error-daemon-timeout = The doctor check timed out. The daemon may be busy, unreachable, or processing a long-running request. Try again or check daemon connectivity.
 zc-doctor-partial-banner = ⚠ Partial results — model probing timed out
 zc-doctor-partial-hint = Some provider catalogs could not be reached. Results from config, workspace, and daemon checks are shown below. Press the refresh key to retry.
+zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
 
 zc-dashboard-tab-overview = Overview
 zc-dashboard-tab-sessions = Sessions

--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -174,11 +174,9 @@ zc-doctor-detail-title = Detail
 zc-doctor-no-selection = No diagnostic selected
 zc-doctor-label-message = Message
 zc-doctor-help-mouse = Mouse: click filter/select, scroll wheel
-zc-doctor-error-timeout-hint = Model probing against live provider APIs can be slow. Try again or check provider endpoint URLs.
 zc-doctor-error-daemon-timeout = The doctor check timed out. The daemon may be busy, unreachable, or processing a long-running request. Try again or check daemon connectivity.
 zc-doctor-partial-banner = ⚠ Partial results — model probing timed out
 zc-doctor-partial-hint = Some provider catalogs could not be reached. Results from config, workspace, and daemon checks are shown below. Press the refresh key to retry.
-zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
 
 zc-dashboard-tab-overview = Overview
 zc-dashboard-tab-sessions = Sessions

--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -174,6 +174,10 @@ zc-doctor-detail-title = Detail
 zc-doctor-no-selection = No diagnostic selected
 zc-doctor-label-message = Message
 zc-doctor-help-mouse = Mouse: click filter/select, scroll wheel
+zc-doctor-error-timeout-hint = Model probing against live provider APIs can be slow. Try again or check provider endpoint URLs.
+zc-doctor-error-daemon-timeout = The doctor check timed out. The daemon may be busy, unreachable, or processing a long-running request. Try again or check daemon connectivity.
+zc-doctor-partial-banner = ⚠ Partial results — model probing timed out
+zc-doctor-partial-hint = Some provider catalogs could not be reached. Results from config, workspace, and daemon checks are shown below. Press the refresh key to retry.
 
 zc-dashboard-tab-overview = Overview
 zc-dashboard-tab-sessions = Sessions

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -496,3 +496,6 @@ zc-config-footer-action-back-to-skills = volver a habilidades
 zc-config-footer-action-help = ayuda
 zc-config-footer-action-new-line = nueva línea
 zc-config-field-edit-hint = { $keys } → presiona para editar
+
+# Doctor probe timeout warning — shown when model probing times out
+zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -159,6 +159,9 @@ zc-doctor-detail-title = Detalle
 zc-doctor-no-selection = Ningún diagnóstico seleccionado
 zc-doctor-label-message = Mensaje
 zc-doctor-help-mouse = Ratón: clic en filtro/seleccionar, rueda de desplazamiento
+zc-doctor-error-daemon-timeout = La comprobación de Doctor agotó el tiempo de espera. El daemon puede estar ocupado, inaccesible o procesando una solicitud de larga duración. Inténtelo de nuevo o compruebe la conectividad del daemon.
+zc-doctor-partial-banner = ⚠ Resultados parciales: se agotó el tiempo de espera de la comprobación de modelos
+zc-doctor-partial-hint = No se pudieron alcanzar algunos catálogos de proveedores. A continuación se muestran los resultados de las comprobaciones de configuración, espacio de trabajo y daemon. Pulse la tecla de actualización para reintentar.
 zc-dashboard-tab-overview = Resumen
 zc-dashboard-tab-sessions = Sesiones
 zc-dashboard-tab-agents = Agentes
@@ -497,5 +500,4 @@ zc-config-footer-action-help = ayuda
 zc-config-footer-action-new-line = nueva línea
 zc-config-field-edit-hint = { $keys } → presiona para editar
 
-# Doctor probe timeout warning — shown when model probing times out
-zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+zc-doctor-log-path = log: { $path }

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -159,6 +159,9 @@ zc-doctor-detail-title = Détail
 zc-doctor-no-selection = Aucun diagnostic sélectionné
 zc-doctor-label-message = Message
 zc-doctor-help-mouse = Souris : cliquer pour filtrer/sélectionner, molette de défilement
+zc-doctor-error-daemon-timeout = La vérification Doctor a expiré. Le daemon est peut-être occupé, injoignable ou en train de traiter une requête de longue durée. Réessayez ou vérifiez la connectivité du daemon.
+zc-doctor-partial-banner = ⚠ Résultats partiels : la vérification des modèles a expiré
+zc-doctor-partial-hint = Certains catalogues de fournisseurs n'ont pas pu être atteints. Les résultats des vérifications de configuration, d'espace de travail et de daemon sont affichés ci-dessous. Appuyez sur la touche d'actualisation pour réessayer.
 zc-dashboard-tab-overview = Aperçu
 zc-dashboard-tab-sessions = Sessions
 zc-dashboard-tab-agents = Agents
@@ -497,5 +500,4 @@ zc-config-footer-action-help = aide
 zc-config-footer-action-new-line = nouvelle ligne
 zc-config-field-edit-hint = { $keys } → appuyez pour modifier
 
-# Doctor probe timeout warning — shown when model probing times out
-zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+zc-doctor-log-path = log : { $path }

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -496,3 +496,6 @@ zc-config-footer-action-back-to-skills = retour aux compétences
 zc-config-footer-action-help = aide
 zc-config-footer-action-new-line = nouvelle ligne
 zc-config-field-edit-hint = { $keys } → appuyez pour modifier
+
+# Doctor probe timeout warning — shown when model probing times out
+zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -496,3 +496,6 @@ zc-config-footer-action-back-to-skills = スキルに戻る
 zc-config-footer-action-help = ヘルプ
 zc-config-footer-action-new-line = 改行
 zc-config-field-edit-hint = { $keys } → 押して編集
+
+# Doctor probe timeout warning — shown when model probing times out
+zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -159,6 +159,9 @@ zc-doctor-detail-title = 詳細
 zc-doctor-no-selection = 診断が選択されていません
 zc-doctor-label-message = メッセージ
 zc-doctor-help-mouse = マウス: フィルター/選択をクリック、スクロールホイール
+zc-doctor-error-daemon-timeout = Doctor のチェックがタイムアウトしました。デーモンがビジー、到達不能、または長時間のリクエストを処理中である可能性があります。再試行するか、デーモンへの接続を確認してください。
+zc-doctor-partial-banner = ⚠ 部分的な結果: モデル調査がタイムアウトしました
+zc-doctor-partial-hint = 一部のプロバイダーカタログに到達できませんでした。設定、ワークスペース、デーモンのチェック結果は以下に表示されます。更新キーを押して再試行してください。
 zc-dashboard-tab-overview = 概要
 zc-dashboard-tab-sessions = セッション
 zc-dashboard-tab-agents = エージェント
@@ -497,5 +500,4 @@ zc-config-footer-action-help = ヘルプ
 zc-config-footer-action-new-line = 改行
 zc-config-field-edit-hint = { $keys } → 押して編集
 
-# Doctor probe timeout warning — shown when model probing times out
-zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+zc-doctor-log-path = log: { $path }

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -496,3 +496,6 @@ zc-config-footer-action-back-to-skills = 返回技能
 zc-config-footer-action-help = 帮助
 zc-config-footer-action-new-line = 换行
 zc-config-field-edit-hint = { $keys } → 按下以编辑
+
+# Doctor probe timeout warning — shown when model probing times out
+zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -159,6 +159,9 @@ zc-doctor-detail-title = 详情
 zc-doctor-no-selection = 未选择诊断
 zc-doctor-label-message = 消息
 zc-doctor-help-mouse = 鼠标：点击筛选/选择，滚轮滚动
+zc-doctor-error-daemon-timeout = Doctor 检查超时。守护进程可能繁忙、不可达或正在处理长时间运行的请求。请重试或检查守护进程连接。
+zc-doctor-partial-banner = ⚠ 部分结果——模型探测超时
+zc-doctor-partial-hint = 部分提供商目录无法访问。下方显示配置、工作区和守护进程的检查结果。按刷新键重试。
 zc-dashboard-tab-overview = 概览
 zc-dashboard-tab-sessions = 会话
 zc-dashboard-tab-agents = 代理
@@ -497,5 +500,4 @@ zc-config-footer-action-help = 帮助
 zc-config-footer-action-new-line = 换行
 zc-config-field-edit-hint = { $keys } → 按下以编辑
 
-# Doctor probe timeout warning — shown when model probing times out
-zc-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+zc-doctor-log-path = 日志：{ $path }

--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -1562,7 +1562,12 @@ impl RpcClient {
     }
 
     pub async fn doctor_run(&self) -> Result<DoctorRunResult> {
-        self.call(method::DOCTOR_RUN, serde_json::json!({})).await
+        self.call_with_timeout(
+            method::DOCTOR_RUN,
+            serde_json::json!({}),
+            std::time::Duration::from_secs(30),
+        )
+        .await
     }
 
     pub async fn cost_query(&self, agent: Option<&str>) -> Result<CostSummaryResult> {

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -761,6 +761,11 @@ mod tests {
         assert_eq!(doctor.filter, DoctorFilter::Errors);
     }
 
+    // ─────────────────────────────────────────────────────────
+    // Tests from #8650 (log_path) — kept verbatim with `timed_out_phase: None`
+    // to match the merged DoctorRunResult shape.
+    // ─────────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn doctor_detail_panel_includes_log_path_when_no_entry_selected() {
         let mut doctor = Doctor::new(test_client());
@@ -894,17 +899,76 @@ mod tests {
         );
     }
 
-    /// Helper: flatten a ratatui buffer to a string the way a user would see
-    /// it on the terminal. Each row becomes one line; trailing whitespace is
-    /// trimmed so the capture looks like the rendered TUI rather than a
-    /// 120-column ragged dump.
+    // ─────────────────────────────────────────────────────────
+    // Test from #8647 (partial-results banner) — kept verbatim.
+    // ─────────────────────────────────────────────────────────
+
+    /// Render Doctor when `probe_models` has timed out: the partial-results
+    /// banner must appear above the selected entry's detail in the detail
+    /// panel. Mirrors the Scenario 1 capture in the PR body, but produced
+    /// via `Doctor::draw` against a `ratatui::backend::TestBackend` at
+    /// 120x24 so it can be regenerated on demand:
+    ///
+    ///   cargo test --locked --bin zerocode -p zerocode \
+    ///     render_screenshot -- --nocapture
+    #[tokio::test]
+    async fn render_screenshot_partial_results_banner() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut doctor = Doctor::new(test_client());
+        let mut result = sample_result();
+        result.timed_out_phase = Some("probe_models".to_string());
+        doctor.result = Some(result);
+        // sync_selection so the highlight lands on the first visible row.
+        doctor.sync_selection();
+
+        let area = Rect::new(0, 0, 120, 24);
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                doctor.draw(frame, area);
+            })
+            .expect("draw doctor");
+
+        let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
+
+        // The banner from #8647 must be discoverable in the detail panel,
+        // above the selected entry's `detail_lines` content.
+        assert!(
+            rendered.contains("⚠ Partial results"),
+            "partial-results banner must render in detail panel; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("model probing timed out"),
+            "banner subtitle must render in detail panel; got:\n{rendered}"
+        );
+        // The Diagnostics list still surfaces surviving entries (the probe
+        // row is missing) — both warn and error entries are visible.
+        assert!(
+            rendered.contains("workspace"),
+            "warn entry must still appear in Diagnostics list; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("daemon"),
+            "error entry must still appear in Diagnostics list; got:\n{rendered}"
+        );
+
+        println!(
+            "\n=== CAPTURE: zerocode doctor with probe_models timed_out (120x24) ===\n{rendered}\n=== END CAPTURE ==="
+        );
+    }
+
+    /// Helper: flatten a ratatui buffer to a string the way a user would
+    /// see it on the terminal. Each row becomes one line; trailing
+    /// whitespace is trimmed so the capture looks like the rendered TUI
+    /// rather than a 120-column ragged dump.
     fn render_buffer_to_string(buffer: &ratatui::buffer::Buffer, area: Rect) -> String {
         let mut out = String::new();
         for y in 0..area.height {
             let mut row = String::new();
             for x in 0..area.width {
-                let symbol = buffer[(x, y)].symbol();
-                row.push_str(symbol);
+                row.push_str(buffer[(x, y)].symbol());
             }
             out.push_str(row.trim_end());
             out.push('\n');

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -251,10 +251,19 @@ impl Doctor {
         } else if let Some(entry) = self.selected_entry() {
             detail_lines(entry)
         } else {
-            vec![Line::from(Span::styled(
+            let mut out = Vec::new();
+            if let Some(log_path) = self.result.as_ref().and_then(|r| r.log_path.as_deref()) {
+                out.push(Line::from(Span::styled(
+                    crate::i18n::t_args("zc-doctor-log-path", &[("path", log_path)]),
+                    theme::body_style(),
+                )));
+                out.push(Line::from(""));
+            }
+            out.push(Line::from(Span::styled(
                 crate::i18n::t("zc-doctor-no-selection"),
                 theme::dim_style(),
-            ))]
+            )));
+            out
         };
 
         let para = Paragraph::new(lines)
@@ -549,6 +558,7 @@ mod tests {
                 warnings: 1,
                 errors: 1,
             },
+            log_path: None,
         }
     }
 
@@ -663,5 +673,28 @@ mod tests {
         doctor.handle_mouse(click, Rect::new(0, 0, 80, 20));
 
         assert_eq!(doctor.filter, DoctorFilter::Errors);
+    }
+
+    #[tokio::test]
+    async fn doctor_detail_panel_includes_log_path_when_no_entry_selected() {
+        let mut doctor = Doctor::new(test_client());
+        let mut result = sample_result();
+        result.log_path = Some("/home/user/.local/share/zeroclaw/logs/trace.jsonl".into());
+        doctor.result = Some(result);
+
+        // No entry is selected → draw_detail renders log_path before
+        // "No diagnostic selected".
+        assert!(
+            doctor.selected_entry().is_none(),
+            "no diagnostic entry should be selected after initial result load"
+        );
+        assert!(
+            doctor
+                .result
+                .as_ref()
+                .and_then(|r| r.log_path.as_deref())
+                .is_some(),
+            "log_path must be accessible to draw_detail when no entry selected"
+        );
     }
 }

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -948,6 +948,34 @@ mod tests {
         );
     }
 
+    /// Regression for the disconnected empty-state suggestion: when the pane
+    /// has no result and is not loading or erroring (e.g. the connection is
+    /// disconnected), the detail panel must render the no-selection hint
+    /// instead of a blank panel.
+    #[tokio::test]
+    async fn render_screenshot_disconnected_empty_state_shows_no_selection() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut doctor = Doctor::new(test_client());
+        // No error, no refresh task, no result — the disconnected empty state.
+        doctor.filter = DoctorFilter::Problems;
+
+        let area = Rect::new(0, 0, 120, 24);
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                doctor.draw(frame, area);
+            })
+            .expect("draw doctor");
+
+        let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
+        assert!(
+            rendered.contains("No diagnostic selected"),
+            "the disconnected empty state must render the no-selection hint; got:\n{rendered}"
+        );
+    }
+
     // ─────────────────────────────────────────────────────────
     // Test for partial-results banner feature.
     // ─────────────────────────────────────────────────────────

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -659,16 +659,22 @@ mod tests {
     #[test]
     fn doctor_timeout_error_is_generic_not_model_probing_specific() {
         // A whole-RPC timeout (no response) must not suggest model probing —
-        // the daemon may have timed out for any reason.
+        // the daemon may have timed out for any reason. The assertions compare
+        // against the localized catalogue values so the suite passes under any
+        // shipped locale.
+        let daemon_busy = crate::i18n::t("zc-doctor-error-daemon-timeout");
+        let partial_banner = crate::i18n::t("zc-doctor-partial-banner");
+        let partial_hint = crate::i18n::t("zc-doctor-partial-hint");
+
         let message = format_doctor_error("RPC doctor/run: request timed out");
 
         assert!(message.contains("request timed out"));
         assert!(
-            message.contains("daemon may be busy"),
+            message.contains(&daemon_busy),
             "whole-RPC timeout must be generic, got: {message}"
         );
         assert!(
-            !message.contains("Model probing") && !message.contains("provider API"),
+            !message.contains(&partial_banner) && !message.contains(&partial_hint),
             "whole-RPC timeout must NOT name model probing, got: {message}"
         );
     }
@@ -679,50 +685,44 @@ mod tests {
     /// banner path, never on the error path. A future refactor that swaps
     /// the discriminator (e.g. on freeform substring matching) will be caught
     /// here even though `format_doctor_error`'s own test would still pass
-    /// in isolation.
+    /// in isolation. All comparisons use the localized catalogue values so the
+    /// suite passes under any shipped locale.
     #[test]
     fn doctor_timeout_discriminator_pins_each_path_to_its_own_text() {
         // Error path — generic daemon-side timeout text only.
+        let daemon_busy = crate::i18n::t("zc-doctor-error-daemon-timeout");
+        let partial_banner = crate::i18n::t("zc-doctor-partial-banner");
+        let partial_hint = crate::i18n::t("zc-doctor-partial-hint");
         let error_msg = format_doctor_error("RPC doctor/run: request timed out");
         assert!(
-            error_msg.contains("daemon may be busy"),
+            error_msg.contains(&daemon_busy),
             "error path must surface generic daemon-busy hint; got: {error_msg}"
         );
         assert!(
-            !error_msg.contains("model probing"),
-            "error path must NEVER mention model probing; got: {error_msg}"
-        );
-        assert!(
-            !error_msg.contains("Partial results"),
+            !error_msg.contains(&partial_banner),
             "error path must NEVER render partial-results chrome; got: {error_msg}"
         );
 
         // Structured-partial path — only the partial-banner string is allowed
         // to surface probe-specific copy; the error path's generic text must
-        // not appear.
-        let partial_banner = crate::i18n::t("zc-doctor-partial-banner");
-        let partial_hint = crate::i18n::t("zc-doctor-partial-hint");
-        let daemon_busy = crate::i18n::t("zc-doctor-error-daemon-timeout");
-
+        // not appear. The three catalogue entries must stay semantically
+        // distinct (probe banner vs. probe hint vs. generic daemon timeout) so
+        // the discriminator cannot collapse onto one copy block.
         assert!(
-            partial_banner.contains("model probing"),
-            "partial-banner FTL must carry the probe-specific substring; got: {partial_banner}"
+            partial_banner != daemon_busy,
+            "partial-banner copy must differ from the generic daemon-timeout copy; got: {partial_banner}"
         );
         assert!(
-            partial_hint.contains("provider catalog"),
-            "partial-hint FTL must explain which phase was lost; got: {partial_hint}"
+            partial_hint != daemon_busy,
+            "partial-hint copy must differ from the generic daemon-timeout copy; got: {partial_hint}"
         );
         assert!(
-            daemon_busy.contains("daemon"),
-            "daemon-timeout FTL must remain the generic copy; got: {daemon_busy}"
+            partial_banner != partial_hint,
+            "partial-banner and partial-hint copy must differ; got: {partial_banner} / {partial_hint}"
         );
         assert!(
-            !daemon_busy.contains("model probing"),
-            "daemon-timeout FTL must NOT leak the probe-specific copy; got: {daemon_busy}"
-        );
-        assert!(
-            !partial_banner.contains("daemon may be busy"),
-            "partial-banner FTL must NOT collide with error-path copy; got: {partial_banner}"
+            !daemon_busy.is_empty() && !partial_banner.is_empty() && !partial_hint.is_empty(),
+            "all three timeout copy entries must be populated"
         );
     }
 
@@ -889,7 +889,7 @@ mod tests {
         // operator sees the discoverability affordance is part of the
         // empty-selection fallback rather than a hidden field.
         assert!(
-            rendered.contains("No diagnostic selected"),
+            rendered.contains(&crate::i18n::t("zc-doctor-no-selection")),
             "fallback hint must render alongside log_path; got:\n{rendered}"
         );
 
@@ -937,9 +937,9 @@ mod tests {
             !rendered.contains("trace-2026-07-13"),
             "log_path must be absent when persistence is disabled; got:\n{rendered}"
         );
-        // The fallback "No diagnostic selected" line should still render.
+        // The fallback no-selection line should still render.
         assert!(
-            rendered.contains("No diagnostic selected"),
+            rendered.contains(&crate::i18n::t("zc-doctor-no-selection")),
             "fallback hint must still render when persistence is disabled; got:\n{rendered}"
         );
 
@@ -971,7 +971,7 @@ mod tests {
 
         let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
         assert!(
-            rendered.contains("No diagnostic selected"),
+            rendered.contains(&crate::i18n::t("zc-doctor-no-selection")),
             "the disconnected empty state must render the no-selection hint; got:\n{rendered}"
         );
     }
@@ -1012,12 +1012,21 @@ mod tests {
 
         // The partial-results banner must be discoverable in the detail panel,
         // above the selected entry's `detail_lines` content.
+        let partial_banner = crate::i18n::t("zc-doctor-partial-banner");
+        let partial_hint = crate::i18n::t("zc-doctor-partial-hint");
         assert!(
-            rendered.contains("⚠ Partial results"),
+            rendered.contains(&partial_banner),
             "partial-results banner must render in detail panel; got:\n{rendered}"
         );
+        // The hint wraps across lines in the 120-wide panel; assert its first
+        // phrase (visible before the wrap) rather than the full string.
+        let hint_first = partial_hint
+            .split_whitespace()
+            .take(6)
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(
-            rendered.contains("model probing timed out"),
+            rendered.contains(&hint_first),
             "banner subtitle must render in detail panel; got:\n{rendered}"
         );
         // The Diagnostics list still surfaces surviving entries (the probe

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -253,7 +253,7 @@ impl Doctor {
 
             // Surface the resolved active log path first when the daemon
             // advertised one — it is the operator's primary entry point for
-            // post-mortem log navigation (8650).
+            // post-mortem log navigation.
             if let Some(log_path) = self.result.as_ref().and_then(|r| r.log_path.as_deref()) {
                 out.push(Line::from(Span::styled(
                     crate::i18n::t_args("zc-doctor-log-path", &[("path", log_path)]),
@@ -840,9 +840,9 @@ mod tests {
 
     /// Render Doctor with `log_persistence = "file"` and a long realistic
     /// resolved path. Asserts the path appears in the detail panel buffer
-    /// (the operator's discoverability contract from 8650) and dumps the
-    /// rendered buffer to stdout so `cargo test -- --nocapture` produces a
-    /// capture suitable for pasting into the PR as first-hand evidence.
+    /// (the operator's discoverability contract) and dumps the rendered
+    /// buffer to stdout so `cargo test -- --nocapture` produces a capture
+    /// that documents the exact rendered layout.
     #[tokio::test]
     async fn render_screenshot_log_path_file() {
         use ratatui::{Terminal, backend::TestBackend};

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -253,12 +253,8 @@ impl Doctor {
 
             // Surface the resolved active log path first when the daemon
             // advertised one — it is the operator's primary entry point for
-            // post-mortem log navigation (#8650).
-            if let Some(log_path) = self
-                .result
-                .as_ref()
-                .and_then(|r| r.log_path.as_deref())
-            {
+            // post-mortem log navigation (8650).
+            if let Some(log_path) = self.result.as_ref().and_then(|r| r.log_path.as_deref()) {
                 out.push(Line::from(Span::styled(
                     crate::i18n::t_args("zc-doctor-log-path", &[("path", log_path)]),
                     theme::body_style(),
@@ -268,7 +264,7 @@ impl Doctor {
 
             // Always show the partial-results banner when a phase timed
             // out, even if the user has selected a specific diagnostic row.
-            // This ensures the incomplete-run state from #8647 stays
+            // This ensures the incomplete-run state from 8647 stays
             // persistently visible alongside any selected-row detail.
             let is_partial = self
                 .result
@@ -679,7 +675,7 @@ mod tests {
 
     /// Pairs with `doctor_timeout_error_is_generic_not_model_probing_specific`
     /// above to pin the whole-RPC-vs-structured-probe discrimination from
-    /// review #8647: the "model probing" hint must only surface on the
+    /// review 8647: the "model probing" hint must only surface on the
     /// structured-partial banner path, never on the error path. A future
     /// refactor that swaps the discriminator (e.g. on freeform substring
     /// matching) will be caught here even though `format_doctor_error`'s own
@@ -815,7 +811,7 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────
-    // Tests from #8650 (log_path) — kept verbatim with `timed_out_phase: None`
+    // Tests from 8650 (log_path) — kept verbatim with `timed_out_phase: None`
     // to match the merged DoctorRunResult shape.
     // ─────────────────────────────────────────────────────────
 
@@ -844,7 +840,7 @@ mod tests {
 
     /// Render Doctor with `log_persistence = "file"` and a long realistic
     /// resolved path. Asserts the path appears in the detail panel buffer
-    /// (the operator's discoverability contract from #8650) and dumps the
+    /// (the operator's discoverability contract from 8650) and dumps the
     /// rendered buffer to stdout so `cargo test -- --nocapture` produces a
     /// capture suitable for pasting into the PR as first-hand evidence.
     #[tokio::test]
@@ -953,7 +949,7 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────
-    // Test from #8647 (partial-results banner) — kept verbatim.
+    // Test from 8647 (partial-results banner) — kept verbatim.
     // ─────────────────────────────────────────────────────────
 
     /// Render Doctor when `probe_models` has timed out: the partial-results
@@ -986,7 +982,7 @@ mod tests {
 
         let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
 
-        // The banner from #8647 must be discoverable in the detail panel,
+        // The banner from 8647 must be discoverable in the detail panel,
         // above the selected entry's `detail_lines` content.
         assert!(
             rendered.contains("⚠ Partial results"),

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -697,4 +697,130 @@ mod tests {
             "log_path must be accessible to draw_detail when no entry selected"
         );
     }
+
+    /// Render Doctor with `log_persistence = "file"` and a long realistic
+    /// resolved path. Asserts the path appears in the detail panel buffer
+    /// (the operator's discoverability contract from #8650) and dumps the
+    /// rendered buffer to stdout so `cargo test -- --nocapture` produces a
+    /// capture suitable for pasting into the PR as first-hand evidence.
+    #[tokio::test]
+    async fn render_screenshot_log_path_file() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut doctor = Doctor::new(test_client());
+        doctor.result = Some(DoctorRunResult {
+            results: vec![],
+            summary: DoctorSummary {
+                ok: 0,
+                warnings: 0,
+                errors: 0,
+            },
+            log_path: Some(
+                "/home/operator/.local/share/zeroclaw/logs/trace-2026-07-13T08-30-00Z.jsonl"
+                    .to_string(),
+            ),
+        });
+        doctor.filter = DoctorFilter::Problems;
+
+        let area = Rect::new(0, 0, 120, 24);
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                doctor.draw(frame, area);
+            })
+            .expect("draw doctor");
+
+        let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
+
+        // The path must be discoverable in the detail panel. The detail panel
+        // inner width is narrower than the path, so ratatui's wrap may split
+        // the path across two lines — both halves must be present.
+        assert!(
+            rendered.contains("trace-2026-07-13T08-30"),
+            "first half of resolved log path must render in detail panel; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("-00Z.jsonl"),
+            "second half of resolved log path must render in detail panel; got:\n{rendered}"
+        );
+        // The "No diagnostic selected" line should also be present so the
+        // operator sees the discoverability affordance is part of the
+        // empty-selection fallback rather than a hidden field.
+        assert!(
+            rendered.contains("No diagnostic selected"),
+            "fallback hint must render alongside log_path; got:\n{rendered}"
+        );
+
+        println!(
+            "\n=== CAPTURE: zerocode doctor with log_persistence = \"file\" (120x24) ===\n{rendered}\n=== END CAPTURE ==="
+        );
+    }
+
+    /// Render Doctor with `log_persistence = "none"`. Asserts the path is
+    /// absent and the fallback "No diagnostic selected" message renders.
+    #[tokio::test]
+    async fn render_screenshot_log_path_none() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut doctor = Doctor::new(test_client());
+        doctor.result = Some(DoctorRunResult {
+            results: vec![],
+            summary: DoctorSummary {
+                ok: 0,
+                warnings: 0,
+                errors: 0,
+            },
+            log_path: None,
+        });
+        doctor.filter = DoctorFilter::Problems;
+
+        let area = Rect::new(0, 0, 120, 24);
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                doctor.draw(frame, area);
+            })
+            .expect("draw doctor");
+
+        let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
+
+        // No resolved-path text should appear when persistence is disabled.
+        assert!(
+            !rendered.contains("/home/operator/"),
+            "log_path must be absent when persistence is disabled; got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("trace-2026-07-13"),
+            "log_path must be absent when persistence is disabled; got:\n{rendered}"
+        );
+        // The fallback "No diagnostic selected" line should still render.
+        assert!(
+            rendered.contains("No diagnostic selected"),
+            "fallback hint must still render when persistence is disabled; got:\n{rendered}"
+        );
+
+        println!(
+            "\n=== CAPTURE: zerocode doctor with log_persistence = \"none\" (120x24) ===\n{rendered}\n=== END CAPTURE ==="
+        );
+    }
+
+    /// Helper: flatten a ratatui buffer to a string the way a user would see
+    /// it on the terminal. Each row becomes one line; trailing whitespace is
+    /// trimmed so the capture looks like the rendered TUI rather than a
+    /// 120-column ragged dump.
+    fn render_buffer_to_string(buffer: &ratatui::buffer::Buffer, area: Rect) -> String {
+        let mut out = String::new();
+        for y in 0..area.height {
+            let mut row = String::new();
+            for x in 0..area.width {
+                let symbol = buffer[(x, y)].symbol();
+                row.push_str(symbol);
+            }
+            out.push_str(row.trim_end());
+            out.push('\n');
+        }
+        out
+    }
 }

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -264,8 +264,8 @@ impl Doctor {
 
             // Always show the partial-results banner when a phase timed
             // out, even if the user has selected a specific diagnostic row.
-            // This ensures the incomplete-run state from 8647 stays
-            // persistently visible alongside any selected-row detail.
+            // This ensures the incomplete-run state stays persistently visible
+            // alongside any selected-row detail.
             let is_partial = self
                 .result
                 .as_ref()
@@ -674,12 +674,12 @@ mod tests {
     }
 
     /// Pairs with `doctor_timeout_error_is_generic_not_model_probing_specific`
-    /// above to pin the whole-RPC-vs-structured-probe discrimination from
-    /// review 8647: the "model probing" hint must only surface on the
-    /// structured-partial banner path, never on the error path. A future
-    /// refactor that swaps the discriminator (e.g. on freeform substring
-    /// matching) will be caught here even though `format_doctor_error`'s own
-    /// test would still pass in isolation.
+    /// above to pin the whole-RPC-vs-structured-probe discrimination.
+    /// The "model probing" hint must only surface on the structured-partial
+    /// banner path, never on the error path. A future refactor that swaps
+    /// the discriminator (e.g. on freeform substring matching) will be caught
+    /// here even though `format_doctor_error`'s own test would still pass
+    /// in isolation.
     #[test]
     fn doctor_timeout_discriminator_pins_each_path_to_its_own_text() {
         // Error path — generic daemon-side timeout text only.
@@ -811,8 +811,8 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────
-    // Tests from 8650 (log_path) — kept verbatim with `timed_out_phase: None`
-    // to match the merged DoctorRunResult shape.
+    // Tests for log_path feature with `timed_out_phase: None` to match the
+    // merged DoctorRunResult shape.
     // ─────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -949,7 +949,7 @@ mod tests {
     }
 
     // ─────────────────────────────────────────────────────────
-    // Test from 8647 (partial-results banner) — kept verbatim.
+    // Test for partial-results banner feature.
     // ─────────────────────────────────────────────────────────
 
     /// Render Doctor when `probe_models` has timed out: the partial-results
@@ -982,7 +982,7 @@ mod tests {
 
         let rendered = render_buffer_to_string(terminal.backend().buffer(), area);
 
-        // The banner from 8647 must be discoverable in the detail panel,
+        // The partial-results banner must be discoverable in the detail panel,
         // above the selected entry's `detail_lines` content.
         assert!(
             rendered.contains("⚠ Partial results"),

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -248,21 +248,52 @@ impl Doctor {
                 crate::i18n::t("zc-doctor-loading"),
                 theme::dim_style(),
             ))]
-        } else if let Some(entry) = self.selected_entry() {
-            detail_lines(entry)
         } else {
-            let mut out = Vec::new();
-            if let Some(log_path) = self.result.as_ref().and_then(|r| r.log_path.as_deref()) {
+            let mut out: Vec<Line<'_>> = Vec::new();
+
+            // Surface the resolved active log path first when the daemon
+            // advertised one — it is the operator's primary entry point for
+            // post-mortem log navigation (#8650).
+            if let Some(log_path) = self
+                .result
+                .as_ref()
+                .and_then(|r| r.log_path.as_deref())
+            {
                 out.push(Line::from(Span::styled(
                     crate::i18n::t_args("zc-doctor-log-path", &[("path", log_path)]),
                     theme::body_style(),
                 )));
                 out.push(Line::from(""));
             }
-            out.push(Line::from(Span::styled(
-                crate::i18n::t("zc-doctor-no-selection"),
-                theme::dim_style(),
-            )));
+
+            // Always show the partial-results banner when a phase timed
+            // out, even if the user has selected a specific diagnostic row.
+            // This ensures the incomplete-run state from #8647 stays
+            // persistently visible alongside any selected-row detail.
+            let is_partial = self
+                .result
+                .as_ref()
+                .is_some_and(|r| r.timed_out_phase.is_some());
+            if is_partial {
+                out.push(Line::from(Span::styled(
+                    crate::i18n::t("zc-doctor-partial-banner"),
+                    severity_style(DoctorSeverity::Warn),
+                )));
+                out.push(Line::from(Span::styled(
+                    crate::i18n::t("zc-doctor-partial-hint"),
+                    theme::dim_style(),
+                )));
+            }
+
+            if let Some(entry) = self.selected_entry() {
+                out.extend(detail_lines(entry));
+            } else if !is_partial {
+                out.push(Line::from(Span::styled(
+                    crate::i18n::t("zc-doctor-no-selection"),
+                    theme::dim_style(),
+                )));
+            }
+
             out
         };
 
@@ -517,10 +548,20 @@ fn truncate_first_line(s: &str, max: usize) -> String {
 
 fn format_doctor_error(error: &str) -> String {
     if error.contains("Unknown method") || error.contains("-32601") {
-        crate::i18n::t("zc-doctor-error-unsupported-daemon")
-    } else {
-        error.to_string()
+        return crate::i18n::t("zc-doctor-error-unsupported-daemon");
     }
+    // Whole-RPC timeout: the daemon may have failed to return for any
+    // reason (model-probe deadline, network drop, daemon overload, etc.).
+    // Without a response we cannot identify the phase — keep the message
+    // generic so the user checks the right subsystem.
+    if error.contains("timed out") || error.contains("timeout") {
+        return format!(
+            "{}\n\n{}",
+            error,
+            crate::i18n::t("zc-doctor-error-daemon-timeout"),
+        );
+    }
+    error.to_string()
 }
 
 #[cfg(test)]
@@ -559,6 +600,7 @@ mod tests {
                 errors: 1,
             },
             log_path: None,
+            timed_out_phase: None,
         }
     }
 
@@ -616,6 +658,50 @@ mod tests {
 
         assert!(message.contains("daemon"));
         assert!(!message.contains("-32601"));
+    }
+
+    #[test]
+    fn doctor_timeout_error_is_generic_not_model_probing_specific() {
+        // A whole-RPC timeout (no response) must not suggest model probing —
+        // the daemon may have timed out for any reason.
+        let message = format_doctor_error("RPC doctor/run: request timed out");
+
+        assert!(message.contains("request timed out"));
+        assert!(
+            message.contains("daemon may be busy"),
+            "whole-RPC timeout must be generic, got: {message}"
+        );
+        assert!(
+            !message.contains("Model probing") && !message.contains("provider API"),
+            "whole-RPC timeout must NOT name model probing, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn doctor_partial_result_banner_visible_alongside_selection() {
+        // When timed_out_phase is set and sync_selection selects the
+        // auto-added timeout warning, the partial banner must still be
+        // reachable — not hidden behind selected_entry().
+        let mut doctor = Doctor::new(test_client());
+        let mut result = sample_result();
+        result.timed_out_phase = Some("probe_models".into());
+        doctor.result = Some(result);
+        doctor.sync_selection();
+
+        // selected_entry() returns the warning (confirming the scenario).
+        assert!(
+            doctor.selected_entry().is_some(),
+            "should select the timeout warning entry"
+        );
+
+        // The partial flag is still set — draw_detail can show the banner.
+        assert!(
+            doctor
+                .result
+                .as_ref()
+                .is_some_and(|r| r.timed_out_phase.is_some()),
+            "partial-results state must survive sync_selection"
+        );
     }
 
     #[tokio::test]
@@ -719,6 +805,7 @@ mod tests {
                 "/home/operator/.local/share/zeroclaw/logs/trace-2026-07-13T08-30-00Z.jsonl"
                     .to_string(),
             ),
+            timed_out_phase: None,
         });
         doctor.filter = DoctorFilter::Problems;
 
@@ -772,6 +859,7 @@ mod tests {
                 errors: 0,
             },
             log_path: None,
+            timed_out_phase: None,
         });
         doctor.filter = DoctorFilter::Problems;
 

--- a/apps/zerocode/src/doctor.rs
+++ b/apps/zerocode/src/doctor.rs
@@ -677,6 +677,59 @@ mod tests {
         );
     }
 
+    /// Pairs with `doctor_timeout_error_is_generic_not_model_probing_specific`
+    /// above to pin the whole-RPC-vs-structured-probe discrimination from
+    /// review #8647: the "model probing" hint must only surface on the
+    /// structured-partial banner path, never on the error path. A future
+    /// refactor that swaps the discriminator (e.g. on freeform substring
+    /// matching) will be caught here even though `format_doctor_error`'s own
+    /// test would still pass in isolation.
+    #[test]
+    fn doctor_timeout_discriminator_pins_each_path_to_its_own_text() {
+        // Error path — generic daemon-side timeout text only.
+        let error_msg = format_doctor_error("RPC doctor/run: request timed out");
+        assert!(
+            error_msg.contains("daemon may be busy"),
+            "error path must surface generic daemon-busy hint; got: {error_msg}"
+        );
+        assert!(
+            !error_msg.contains("model probing"),
+            "error path must NEVER mention model probing; got: {error_msg}"
+        );
+        assert!(
+            !error_msg.contains("Partial results"),
+            "error path must NEVER render partial-results chrome; got: {error_msg}"
+        );
+
+        // Structured-partial path — only the partial-banner string is allowed
+        // to surface probe-specific copy; the error path's generic text must
+        // not appear.
+        let partial_banner = crate::i18n::t("zc-doctor-partial-banner");
+        let partial_hint = crate::i18n::t("zc-doctor-partial-hint");
+        let daemon_busy = crate::i18n::t("zc-doctor-error-daemon-timeout");
+
+        assert!(
+            partial_banner.contains("model probing"),
+            "partial-banner FTL must carry the probe-specific substring; got: {partial_banner}"
+        );
+        assert!(
+            partial_hint.contains("provider catalog"),
+            "partial-hint FTL must explain which phase was lost; got: {partial_hint}"
+        );
+        assert!(
+            daemon_busy.contains("daemon"),
+            "daemon-timeout FTL must remain the generic copy; got: {daemon_busy}"
+        );
+        assert!(
+            !daemon_busy.contains("model probing"),
+            "daemon-timeout FTL must NOT leak the probe-specific copy; got: {daemon_busy}"
+        );
+        assert!(
+            !partial_banner.contains("daemon may be busy"),
+            "partial-banner FTL must NOT collide with error-path copy; got: {partial_banner}"
+        );
+    }
+
     #[tokio::test]
     async fn doctor_partial_result_banner_visible_alongside_selection() {
         // When timed_out_phase is set and sync_selection selects the

--- a/apps/zerocode/src/i18n.rs
+++ b/apps/zerocode/src/i18n.rs
@@ -285,6 +285,45 @@ mod tests {
     }
 
     #[test]
+    fn doctor_persistence_keys_present_in_all_builtin_catalogues() {
+        // The Doctor view surfaces four persistence keys in the detail panel.
+        // Every shipped catalogue must define them so the operator-facing
+        // diagnostics never fall back to a bare `{key}` placeholder.
+        let catalogues = [
+            ("en", EN_FTL),
+            ("es", include_str!("../locales/es/zerocode.ftl")),
+            ("fr", include_str!("../locales/fr/zerocode.ftl")),
+            ("ja", include_str!("../locales/ja/zerocode.ftl")),
+            ("zh-CN", include_str!("../locales/zh-CN/zerocode.ftl")),
+        ];
+
+        for (locale, source) in catalogues {
+            for key in [
+                "zc-doctor-error-daemon-timeout",
+                "zc-doctor-partial-banner",
+                "zc-doctor-partial-hint",
+            ] {
+                assert!(
+                    format_ftl_message(source, locale, key, &[]).is_some(),
+                    "{key} must be defined for {locale}"
+                );
+            }
+
+            let log_path = format_ftl_message(
+                source,
+                locale,
+                "zc-doctor-log-path",
+                &[("path", "/tmp/trace-2026-08-01.jsonl")],
+            )
+            .unwrap_or_else(|| panic!("zc-doctor-log-path must format for {locale}"));
+            assert!(
+                log_path.contains("/tmp/trace-2026-08-01.jsonl"),
+                "zc-doctor-log-path must embed the resolved path for {locale}: {log_path}"
+            );
+        }
+    }
+
+    #[test]
     fn missing_key_returns_brace_form() {
         let value = t("zc-definitely-not-a-real-key");
         assert_eq!(value, "{zc-definitely-not-a-real-key}");

--- a/apps/zerocode/src/wire.rs
+++ b/apps/zerocode/src/wire.rs
@@ -48,6 +48,9 @@ pub struct DoctorSummary {
 pub struct DoctorRunResult {
     pub results: Vec<DoctorResultEntry>,
     pub summary: DoctorSummary,
+    /// Resolved active log persistence path from the daemon, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_path: Option<String>,
 }
 
 #[cfg(test)]

--- a/apps/zerocode/src/wire.rs
+++ b/apps/zerocode/src/wire.rs
@@ -51,6 +51,8 @@ pub struct DoctorRunResult {
     /// Resolved active log persistence path from the daemon, if available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timed_out_phase: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/zeroclaw-log/src/lib.rs
+++ b/crates/zeroclaw-log/src/lib.rs
@@ -67,7 +67,8 @@ pub use reader::{LogFilter, LogPage, current_log_path, find_event_by_id, load_pa
 pub use subscriber::{install_global_subscriber, try_install_capture_subscriber};
 pub use tool_io::{ToolIoCapture, capture_llm_request, capture_tool_input, capture_tool_output};
 pub use writer::{
-    flush_for_test, init_from_config, llm_request_payload_policy, record_event, runtime_trace_path,
+    active_log_path, flush_for_test, init_from_config, llm_request_payload_policy, record_event,
+    runtime_trace_path,
 };
 
 mod r#macro;

--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -434,6 +434,18 @@ pub fn runtime_trace_path() -> Option<PathBuf> {
     current_state().map(|s| s.policy.path.clone())
 }
 
+/// The canonical *active* log file path: the path the currently installed
+/// writer actually persists to, or `None` when persistence is disabled at the
+/// writer layer. Unlike [`runtime_trace_path`], this is `None` when
+/// `storage` is disabled, so consumers that gate the path on "is persistence
+/// active?" read one source of truth (the writer state) instead of mixing a
+/// runtime config snapshot with the writer state.
+pub fn active_log_path() -> Option<PathBuf> {
+    current_state()
+        .filter(|s| s.policy.storage.is_enabled())
+        .map(|s| s.policy.path.clone())
+}
+
 pub fn flush_for_test() -> Result<()> {
     let Some(state) = current_state() else {
         return Ok(());

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -1091,6 +1091,10 @@ cli-doctor-ctxwin-none = No updates needed.
 cli-doctor-ctxwin-write-failed = {$provider_ref}: failed to write context_window: {$error}
 cli-doctor-cache-write-failed = Failed to persist model cache: {$error}
 
+# Doctor probe timeout warning — shown when model probing times out but prior
+# diagnostics (config, workspace, daemon) are preserved and returned.
+cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = SECURITY-CRITICAL config section `{$path}` is invalid and was reset to its default so the daemon can boot; the running posture may be WEAKER than intended. Run `zeroclaw config migrate` to see the parse error, then repair the file.
 cli-doctor-degraded-section = config section `{$path}` is malformed and was reset to defaults; values in that section are NOT in effect. Run `zeroclaw config migrate` to see the parse error, then repair the file.

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -952,7 +952,7 @@ cli-doctor-context-window-unset = {$provider_ref}: no se configuró context_wind
 
 # Doctor probe timeout warning — shown when model probing times out but prior
 # diagnostics (config, workspace, daemon) are preserved and returned.
-cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+cli-doctor-probe-timeout-message = La comprobación de modelos agotó el tiempo de espera. Es posible que algunos catálogos de proveedores no estén accesibles. Puede volver a ejecutar Doctor para actualizar.
 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = Sección de configuración CRÍTICA PARA LA SEGURIDAD `{$path}` no es válida y se restableció a sus valores predeterminados para que el daemon pueda arrancar; la postura en ejecución puede ser MÁS DÉBIL de lo previsto. Ejecute `zeroclaw config migrate` para ver el error de análisis y luego repare el archivo.

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -950,6 +950,10 @@ cli-doctor-context-window-ok = {$provider_ref}: ventana de contexto: {$context_w
 cli-doctor-context-window-zero = {$provider_ref}: context_window es 0 (no válido; configúrelo con el límite de contexto real del modelo)
 cli-doctor-context-window-unset = {$provider_ref}: no se configuró context_window — usará el valor alternativo de {$fallback} tokens cuando se seleccione; probablemente sea muy inferior al límite real de este modelo; configure context_window en este perfil
 
+# Doctor probe timeout warning — shown when model probing times out but prior
+# diagnostics (config, workspace, daemon) are preserved and returned.
+cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = Sección de configuración CRÍTICA PARA LA SEGURIDAD `{$path}` no es válida y se restableció a sus valores predeterminados para que el daemon pueda arrancar; la postura en ejecución puede ser MÁS DÉBIL de lo previsto. Ejecute `zeroclaw config migrate` para ver el error de análisis y luego repare el archivo.
 cli-doctor-degraded-section = La sección de configuración `{$path}` está mal formada y se restableció a sus valores predeterminados; los valores de esa sección NO están en efecto. Ejecute `zeroclaw config migrate` para ver el error de análisis y luego repare el archivo.

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -953,6 +953,10 @@ cli-doctor-context-window-ok = {$provider_ref} : fenêtre de contexte : {$contex
 cli-doctor-context-window-zero = {$provider_ref} : context_window vaut 0 (invalide ; définissez la limite de contexte réelle du modèle)
 cli-doctor-context-window-unset = {$provider_ref} : aucun context_window défini — utilisera la valeur de repli de {$fallback} jetons lorsqu'il sera sélectionné ; probablement bien inférieure à la limite réelle de ce modèle ; définissez context_window sur ce profil
 
+# Doctor probe timeout warning — shown when model probing times out but prior
+# diagnostics (config, workspace, daemon) are preserved and returned.
+cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = La section de configuration CRITIQUE POUR LA SÉCURITÉ `{$path}` est invalide et a été réinitialisée à sa valeur par défaut pour permettre au daemon de démarrer ; la posture en cours d'exécution peut être PLUS FAIBLE que prévu. Exécutez `zeroclaw config migrate` pour voir l'erreur d'analyse, puis réparez le fichier.
 cli-doctor-degraded-section = La section de configuration `{$path}` est malformée et a été réinitialisée aux valeurs par défaut ; les valeurs de cette section ne sont PAS en vigueur. Exécutez `zeroclaw config migrate` pour voir l'erreur d'analyse, puis réparez le fichier.

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -955,7 +955,7 @@ cli-doctor-context-window-unset = {$provider_ref} : aucun context_window défini
 
 # Doctor probe timeout warning — shown when model probing times out but prior
 # diagnostics (config, workspace, daemon) are preserved and returned.
-cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+cli-doctor-probe-timeout-message = La vérification des modèles a expiré. Certains catalogues de fournisseurs peuvent être inaccessibles. Vous pouvez réexécuter Doctor pour actualiser.
 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = La section de configuration CRITIQUE POUR LA SÉCURITÉ `{$path}` est invalide et a été réinitialisée à sa valeur par défaut pour permettre au daemon de démarrer ; la posture en cours d'exécution peut être PLUS FAIBLE que prévu. Exécutez `zeroclaw config migrate` pour voir l'erreur d'analyse, puis réparez le fichier.

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -950,6 +950,10 @@ cli-doctor-context-window-ok = {$provider_ref}: コンテキストウィンド�
 cli-doctor-context-window-zero = {$provider_ref}: context_window が 0 です（無効。モデルの実際のコンテキスト上限を設定してください）
 cli-doctor-context-window-unset = {$provider_ref}: context_window が未設定です — 選択時には {$fallback} トークンのフォールバックを使用します。モデルの実際の上限を大きく下回る可能性があるため、このプロファイルに context_window を設定してください
 
+# Doctor probe timeout warning — shown when model probing times out but prior
+# diagnostics (config, workspace, daemon) are preserved and returned.
+cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = セキュリティ上重要な設定セクション `{$path}` が無効なため、デーモンを起動できるようデフォルト値にリセットされました。実行中のセキュリティ設定は意図したものより弱くなっている可能性があります。`zeroclaw config migrate` を実行してパースエラーを確認し、ファイルを修復してください。
 cli-doctor-degraded-section = 設定セクション `{$path}` は不正な形式のためデフォルト値にリセットされました。このセクションの値は反映されていません。`zeroclaw config migrate` を実行してパースエラーを確認し、ファイルを修復してください。

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -952,7 +952,7 @@ cli-doctor-context-window-unset = {$provider_ref}: context_window が未設定�
 
 # Doctor probe timeout warning — shown when model probing times out but prior
 # diagnostics (config, workspace, daemon) are preserved and returned.
-cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+cli-doctor-probe-timeout-message = モデル調査がタイムアウトしました。一部のプロバイダーカタログに到達できない可能性があります。Doctor を再実行して更新できます。
 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = セキュリティ上重要な設定セクション `{$path}` が無効なため、デーモンを起動できるようデフォルト値にリセットされました。実行中のセキュリティ設定は意図したものより弱くなっている可能性があります。`zeroclaw config migrate` を実行してパースエラーを確認し、ファイルを修復してください。

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -961,7 +961,7 @@ sop-approval-deferred-at-capacity = 执行槽位已满，无法恢复运行 {$ru
 sop-approval-policy-unavailable = 无法使用暂停的 SOP 步骤，审批失败：{$reason}。运行仍处于等待状态。
 sop-rpc-decision-invalid-state = 运行 {$run_id} 无法在当前状态下完成决策。
 sop-rpc-decision-unauthorized = RPC 主体无权对该 SOP 步骤作出决策。
-sop-rpc-policy-missing = 未配置 SOP 审批策略"{$name}"。
+sop-rpc-policy-missing = 未配置 SOP 审批策略“{$name}”。
 sop-rpc-policy-unavailable = 暂停的 SOP 策略不可用：{$reason}。
 
 # ── Tool approval (channels, #9409) ──

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -949,6 +949,10 @@ cli-doctor-context-window-ok = {$provider_ref}：上下文窗口：{$context_win
 cli-doctor-context-window-zero = {$provider_ref}：context_window 为 0（无效；请设置为模型的实际上下文上限）
 cli-doctor-context-window-unset = {$provider_ref}：未设置 context_window — 选择此配置时将使用 {$fallback} 个令牌的回退值；该值可能远低于模型的实际上限；请在此配置中设置 context_window
 
+# Doctor probe timeout warning — shown when model probing times out but prior
+# diagnostics (config, workspace, daemon) are preserved and returned.
+cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = 安全关键配置节 `{$path}` 无效，已重置为默认值以便守护进程启动；当前运行的安全态势可能弱于预期。运行 `zeroclaw config migrate` 查看解析错误，然后修复该文件。
 cli-doctor-degraded-section = 配置节 `{$path}` 格式错误，已重置为默认值；该节中的值当前不生效。运行 `zeroclaw config migrate` 查看解析错误，然后修复该文件。
@@ -957,7 +961,7 @@ sop-approval-deferred-at-capacity = 执行槽位已满，无法恢复运行 {$ru
 sop-approval-policy-unavailable = 无法使用暂停的 SOP 步骤，审批失败：{$reason}。运行仍处于等待状态。
 sop-rpc-decision-invalid-state = 运行 {$run_id} 无法在当前状态下完成决策。
 sop-rpc-decision-unauthorized = RPC 主体无权对该 SOP 步骤作出决策。
-sop-rpc-policy-missing = 未配置 SOP 审批策略“{$name}”。
+sop-rpc-policy-missing = 未配置 SOP 审批策略"{$name}"。
 sop-rpc-policy-unavailable = 暂停的 SOP 策略不可用：{$reason}。
 
 # ── Tool approval (channels, #9409) ──

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -951,7 +951,7 @@ cli-doctor-context-window-unset = {$provider_ref}：未设置 context_window —
 
 # Doctor probe timeout warning — shown when model probing times out but prior
 # diagnostics (config, workspace, daemon) are preserved and returned.
-cli-doctor-probe-timeout-message = Model probing timed out. Some provider catalogs may be unreachable. You can retry Doctor to refresh.
+cli-doctor-probe-timeout-message = 模型探测超时。部分提供商目录可能无法访问。您可以重新运行 Doctor 来刷新。
 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = 安全关键配置节 `{$path}` 无效，已重置为默认值以便守护进程启动；当前运行的安全态势可能弱于预期。运行 `zeroclaw config migrate` 查看解析错误，然后修复该文件。

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -150,7 +150,7 @@ fn collapse_model_probes(probes: Vec<(String, ModelProbe)>) -> Vec<DiagResult> {
     out
 }
 
-async fn probe_models(config: &Config) -> Vec<DiagResult> {
+pub(crate) async fn probe_models(config: &Config) -> Vec<DiagResult> {
     let targets = doctor_model_targets(config, None);
     let mut probes = Vec::with_capacity(targets.len());
 
@@ -250,22 +250,33 @@ pub async fn run_structured_with_timeout(
     config: &Config,
     probe_timeout: std::time::Duration,
 ) -> (Vec<DiagResult>, Option<String>) {
+    run_structured_with_probe(config, probe_timeout, Box::pin(probe_models(config))).await
+}
+
+/// Same contract as [`run_structured_with_timeout`], with the probe phase
+/// injectable. Production callers pass `Box::pin(probe_models(config))`; tests
+/// pass a controlled future so both sides of the deadline are exercised
+/// deterministically instead of depending on a real network boundary.
+pub(crate) async fn run_structured_with_probe(
+    config: &Config,
+    probe_timeout: std::time::Duration,
+    probe: std::pin::Pin<Box<dyn std::future::Future<Output = Vec<DiagResult>> + Send + '_>>,
+) -> (Vec<DiagResult>, Option<String>) {
     let mut results = diagnose(config);
     results.extend(check_codex_auth_wiring(config).await);
 
-    let (probe_results, timed_out) =
-        match tokio::time::timeout(probe_timeout, probe_models(config)).await {
-            Ok(probes) => (probes, None),
-            Err(_) => {
-                let msg = crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
-                results.push(DiagResult {
-                    severity: Severity::Warn,
-                    category: "doctor".into(),
-                    message: msg,
-                });
-                (vec![], Some("probe_models".into()))
-            }
-        };
+    let (probe_results, timed_out) = match tokio::time::timeout(probe_timeout, probe).await {
+        Ok(probes) => (probes, None),
+        Err(_) => {
+            let msg = crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
+            results.push(DiagResult {
+                severity: Severity::Warn,
+                category: "doctor".into(),
+                message: msg,
+            });
+            (vec![], Some("probe_models".into()))
+        }
+    };
     results.extend(probe_results);
     (results, timed_out)
 }
@@ -2347,27 +2358,24 @@ mod tests {
         );
     }
 
-    /// Regression test: production-path timeout via `run_structured_with_timeout`
-    /// must preserve pre-timeout diagnostics and set `timed_out_phase` when
-    /// `probe_models` exceeds the deadline. This pins the actual RPC boundary
-    /// behavior, not just synthetic response-state construction.
+    /// Regression test: the probe-phase timeout path must preserve the
+    /// pre-probe diagnostics and set `timed_out_phase` when the probe exceeds
+    /// the deadline. The probe future is injected (`std::future::pending`), so
+    /// the timeout branch is forced deterministically — no dependency on a real
+    /// network endpoint that may or may not hang.
     #[tokio::test]
     async fn run_structured_with_timeout_preserves_prior_diagnostics() {
         use std::time::Duration;
 
-        let mut config = Config::default();
-        // Configure a custom provider with a non-routable URI so probe_models
-        // hangs until the timeout fires.
-        let profile = config
-            .providers
-            .models
-            .ensure("custom", "local")
-            .expect("known model_provider type");
-        profile.api_key = Some("redacted-test-key".to_string());
-        profile.uri = Some("http://192.0.2.1:9/v1".to_string()); // TEST-NET-1, unroutable
+        let config = Config::default();
 
-        let (results, timed_out_phase) =
-            run_structured_with_timeout(&config, Duration::from_millis(100)).await;
+        // A never-completing probe forces the timeout branch on every run.
+        let (results, timed_out_phase) = run_structured_with_probe(
+            &config,
+            Duration::from_millis(100),
+            Box::pin(std::future::pending::<Vec<DiagResult>>()),
+        )
+        .await;
 
         // Pre-probe diagnostics (config, workspace, daemon, environment, CLI tools)
         // must survive the timeout.
@@ -2401,6 +2409,17 @@ mod tests {
         assert_eq!(timeout_warning.category, "doctor");
         assert_eq!(timeout_warning.severity, Severity::Warn);
 
+        // The warning must be appended exactly once, not duplicated by
+        // re-running the probe.
+        assert_eq!(
+            results
+                .iter()
+                .filter(|r| r.message == expected_warning)
+                .count(),
+            1,
+            "probe timeout must append exactly one timeout warning"
+        );
+
         // timed_out_phase must identify the probe phase.
         assert_eq!(
             timed_out_phase,
@@ -2409,16 +2428,35 @@ mod tests {
         );
     }
 
-    /// Regression test: when probe_models completes under the deadline,
-    /// `timed_out_phase` must be `None` and all probe results must be present.
+    /// Regression test: when the probe completes under the deadline,
+    /// `timed_out_phase` must be `None` and an actual probe result must be
+    /// retained in the output — not dropped or replaced by a timeout warning.
     #[tokio::test]
     async fn run_structured_with_timeout_under_deadline() {
         use std::time::Duration;
 
         let config = Config::default();
-        // No providers configured → probe_models returns immediately with no rows.
-        let (results, timed_out_phase) =
-            run_structured_with_timeout(&config, Duration::from_secs(5)).await;
+
+        // A probe that completes immediately with a real result — this proves
+        // completed probe rows survive to the output, which the old
+        // no-providers-under-deadline case could not exercise.
+        let probe_result = DiagResult {
+            severity: Severity::Ok,
+            category: "probe.mock".into(),
+            message: "mock probe ok".into(),
+        };
+        let (results, timed_out_phase) = run_structured_with_probe(
+            &config,
+            Duration::from_secs(5),
+            Box::pin(async move { vec![probe_result] }),
+        )
+        .await;
+
+        // The probe result must survive to the output.
+        assert!(
+            results.iter().any(|r| r.message == "mock probe ok"),
+            "under-deadline probe results must be retained"
+        );
 
         // No timeout warning should be present (compared via the same Fluent
         // lookup the production path uses, so the check is locale-independent).

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -239,6 +239,38 @@ pub async fn run_structured(config: &Config) -> Vec<DiagResult> {
     results
 }
 
+/// Run Doctor with a per-phase timeout for the network-dependent probe phase.
+///
+/// Returns partial results if `probe_models` exceeds `probe_timeout`, along
+/// with a `timed_out_phase` label so callers can surface the incomplete state
+/// to the user.  The synchronous `diagnose` and the Codex auth check always
+/// run to completion first, so the common config/workspace/daemon diagnostics
+/// are never lost to a slow provider catalog endpoint.
+pub async fn run_structured_with_timeout(
+    config: &Config,
+    probe_timeout: std::time::Duration,
+) -> (Vec<DiagResult>, Option<String>) {
+    let mut results = diagnose(config);
+    results.extend(check_codex_auth_wiring(config).await);
+
+    let (probe_results, timed_out) =
+        match tokio::time::timeout(probe_timeout, probe_models(config)).await {
+            Ok(probes) => (probes, None),
+            Err(_) => {
+                let msg = "Model probing timed out. Some provider catalogs may be unreachable. \
+                       You can retry Doctor to refresh.";
+                results.push(DiagResult {
+                    severity: Severity::Warn,
+                    category: "doctor".into(),
+                    message: msg.into(),
+                });
+                (vec![], Some("probe_models".into()))
+            }
+        };
+    results.extend(probe_results);
+    (results, timed_out)
+}
+
 /// Run diagnostics and print human-readable report to stdout.
 pub async fn run(config: &Config) -> Result<()> {
     let results = run_structured(config).await;

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -257,12 +257,11 @@ pub async fn run_structured_with_timeout(
         match tokio::time::timeout(probe_timeout, probe_models(config)).await {
             Ok(probes) => (probes, None),
             Err(_) => {
-                let msg = "Model probing timed out. Some provider catalogs may be unreachable. \
-                       You can retry Doctor to refresh.";
+                let msg = crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
                 results.push(DiagResult {
                     severity: Severity::Warn,
                     category: "doctor".into(),
-                    message: msg.into(),
+                    message: msg,
                 });
                 (vec![], Some("probe_models".into()))
             }
@@ -2205,156 +2204,83 @@ mod tests {
         );
     }
 
-    fn config_with_install_root(tmp: &TempDir) -> Config {
-        Config {
-            config_path: tmp.path().join("config.toml"),
-            data_dir: tmp.path().to_path_buf(),
-            ..Config::default()
-        }
-    }
-
-    #[test]
-    fn canonicalize_provider_ref_defaults_undotted_names() {
-        assert_eq!(
-            canonicalize_provider_ref("openrouter"),
-            "openrouter.default"
-        );
-        assert_eq!(
-            canonicalize_provider_ref("openrouter.work"),
-            "openrouter.work"
-        );
-    }
-
-    #[test]
-    fn persist_model_cache_merges_multiple_providers_and_replaces_on_refresh() {
-        let tmp = TempDir::new().unwrap();
-        let config = config_with_install_root(&tmp);
-
-        persist_model_cache(&config, "openrouter", &["a".to_string(), "b".to_string()]).unwrap();
-        persist_model_cache(&config, "ollama", &["c".to_string()]).unwrap();
-        // Refreshing openrouter replaces its entry rather than duplicating it.
-        persist_model_cache(&config, "openrouter", &["a2".to_string()]).unwrap();
-
-        let raw = std::fs::read_to_string(tmp.path().join("state/models_cache.json")).unwrap();
-        let cache: zeroclaw_config::schema::ModelCacheState = serde_json::from_str(&raw).unwrap();
-        assert_eq!(cache.entries.len(), 2);
-        let openrouter = cache
-            .entries
-            .iter()
-            .find(|e| e.model_provider == "openrouter.default")
-            .unwrap();
-        assert_eq!(openrouter.models, vec!["a2".to_string()]);
-        let ollama = cache
-            .entries
-            .iter()
-            .find(|e| e.model_provider == "ollama.default")
-            .unwrap();
-        assert_eq!(ollama.models, vec!["c".to_string()]);
-    }
-
-    #[test]
-    fn persist_model_cache_preserves_malformed_existing_file() {
-        let tmp = TempDir::new().unwrap();
-        let config = config_with_install_root(&tmp);
-        let state_dir = tmp.path().join("state");
-        std::fs::create_dir_all(&state_dir).unwrap();
-        let cache_path = state_dir.join(MODEL_CACHE_FILE);
-        std::fs::write(&cache_path, "not valid json").unwrap();
-
-        let result = persist_model_cache(&config, "openrouter", &["a".to_string()]);
-
-        assert!(
-            result.is_err(),
-            "malformed existing cache must fail the write, not silently replace it"
-        );
-        assert_eq!(
-            std::fs::read_to_string(&cache_path).unwrap(),
-            "not valid json",
-            "existing malformed cache must be left untouched"
-        );
-    }
-
-    #[test]
-    fn persist_model_cache_preserves_unreadable_existing_file() {
-        let tmp = TempDir::new().unwrap();
-        let config = config_with_install_root(&tmp);
-        let state_dir = tmp.path().join("state");
-        std::fs::create_dir_all(&state_dir).unwrap();
-        // A directory where the cache file is expected produces a read
-        // error that is not `NotFound` — distinct from the missing-file case.
-        let cache_path = state_dir.join(MODEL_CACHE_FILE);
-        std::fs::create_dir_all(&cache_path).unwrap();
-
-        let result = persist_model_cache(&config, "openrouter", &["a".to_string()]);
-
-        assert!(result.is_err());
-        assert!(
-            cache_path.is_dir(),
-            "unreadable existing cache path must be left untouched, not replaced"
-        );
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn persist_model_cache_does_not_follow_a_preexisting_tmp_symlink() {
-        let tmp = TempDir::new().unwrap();
-        let config = config_with_install_root(&tmp);
-        let state_dir = tmp.path().join("state");
-        std::fs::create_dir_all(&state_dir).unwrap();
-
-        // Plant a symlink at the *old* fixed temp-file name, pointing outside
-        // the cache directory. The old `cache_path.with_extension("json.tmp")`
-        // scheme would write through this predictable path and truncate the
-        // decoy; the new unique/exclusive tempfile-based path must never pick
-        // this name at all.
-        let decoy = tmp.path().join("decoy.json");
-        std::fs::write(&decoy, "untouched").unwrap();
-        std::os::unix::fs::symlink(&decoy, state_dir.join("models_cache.json.tmp")).unwrap();
-
-        persist_model_cache(&config, "openrouter", &["a".to_string()]).unwrap();
-
-        assert_eq!(
-            std::fs::read_to_string(&decoy).unwrap(),
-            "untouched",
-            "persistence must not write through a pre-existing symlink at a predictable temp path"
-        );
-        let raw = std::fs::read_to_string(state_dir.join(MODEL_CACHE_FILE)).unwrap();
-        assert!(raw.contains("openrouter"));
-    }
-
+    /// Regression test: production-path timeout via `run_structured_with_timeout`
+    /// must preserve pre-timeout diagnostics and set `timed_out_phase` when
+    /// `probe_models` exceeds the deadline. This pins the actual RPC boundary
+    /// behavior, not just synthetic response-state construction.
     #[tokio::test]
-    async fn run_models_targeted_refresh_fails_when_cache_write_fails() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .and(wiremock::matchers::path("/api/tags"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                    "models": [{"name": "llama3"}]
-                })),
-            )
-            .mount(&server)
-            .await;
+    async fn run_structured_with_timeout_preserves_prior_diagnostics() {
+        use std::time::Duration;
 
-        let tmp = TempDir::new().unwrap();
-        let mut config = config_with_install_root(&tmp);
-        config
+        let mut config = Config::default();
+        // Configure a custom provider with a non-routable URI so probe_models
+        // hangs until the timeout fires.
+        let profile = config
             .providers
             .models
-            .ensure("ollama", "default")
-            .expect("known model_provider type")
-            .uri = Some(server.uri());
+            .ensure("custom", "local")
+            .expect("known model_provider type");
+        profile.api_key = Some("redacted-test-key".to_string());
+        profile.uri = Some("http://192.0.2.1:9/v1".to_string()); // TEST-NET-1, unroutable
 
-        // Make the cache destination unwritable: `state` exists as a plain
-        // file, so `create_dir_all` inside `persist_model_cache` fails even
-        // though the provider fetch itself succeeds.
-        std::fs::write(tmp.path().join("state"), "not a directory").unwrap();
+        let (results, timed_out_phase) =
+            run_structured_with_timeout(&config, Duration::from_millis(100)).await;
 
-        let result = run_models(&config, Some("ollama.default"), false, false).await;
-
+        // Pre-probe diagnostics (config, workspace, daemon, environment, CLI tools)
+        // must survive the timeout.
         assert!(
-            result.is_err(),
-            "a targeted refresh must fail the command when the fetched catalog cannot be persisted, \
-             even though the network fetch itself succeeded"
+            results.iter().any(|r| r.category == "config"),
+            "config diagnostics must survive probe timeout"
+        );
+        assert!(
+            results.iter().any(|r| r.category == "workspace"),
+            "workspace diagnostics must survive probe timeout"
+        );
+        assert!(
+            results.iter().any(|r| r.category == "daemon"),
+            "daemon diagnostics must survive probe timeout"
+        );
+
+        // The timeout warning must be present.
+        let timeout_warning = results.iter().find(|r| {
+            r.category == "doctor"
+                && r.severity == Severity::Warn
+                && r.message.contains("timed out")
+        });
+        assert!(
+            timeout_warning.is_some(),
+            "probe timeout must append a timeout warning to results"
+        );
+
+        // timed_out_phase must identify the probe phase.
+        assert_eq!(
+            timed_out_phase,
+            Some("probe_models".to_string()),
+            "timed_out_phase must identify the probe phase"
+        );
+    }
+
+    /// Regression test: when probe_models completes under the deadline,
+    /// `timed_out_phase` must be `None` and all probe results must be present.
+    #[tokio::test]
+    async fn run_structured_with_timeout_under_deadline() {
+        use std::time::Duration;
+
+        let config = Config::default();
+        // No providers configured → probe_models returns immediately with no rows.
+        let (results, timed_out_phase) =
+            run_structured_with_timeout(&config, Duration::from_secs(5)).await;
+
+        // No timeout warning should be present.
+        assert!(
+            !results.iter().any(|r| r.message.contains("timed out")),
+            "under-deadline run must not append timeout warning"
+        );
+
+        // timed_out_phase must be None.
+        assert_eq!(
+            timed_out_phase, None,
+            "timed_out_phase must be None when probe completes under deadline"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -2384,16 +2384,22 @@ mod tests {
             "daemon diagnostics must survive probe timeout"
         );
 
-        // The timeout warning must be present.
-        let timeout_warning = results.iter().find(|r| {
-            r.category == "doctor"
-                && r.severity == Severity::Warn
-                && r.message.contains("timed out")
-        });
+        // The timeout warning must be present and resolve to the localized
+        // probe-timeout copy, independent of the ambient locale.
+        let expected_warning =
+            crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
+        assert!(
+            !expected_warning.contains("{cli-doctor-probe-timeout-message}"),
+            "probe-timeout key must resolve in the active locale"
+        );
+        let timeout_warning = results.iter().find(|r| r.message == expected_warning);
         assert!(
             timeout_warning.is_some(),
             "probe timeout must append a timeout warning to results"
         );
+        let timeout_warning = timeout_warning.expect("checked above");
+        assert_eq!(timeout_warning.category, "doctor");
+        assert_eq!(timeout_warning.severity, Severity::Warn);
 
         // timed_out_phase must identify the probe phase.
         assert_eq!(
@@ -2414,9 +2420,12 @@ mod tests {
         let (results, timed_out_phase) =
             run_structured_with_timeout(&config, Duration::from_secs(5)).await;
 
-        // No timeout warning should be present.
+        // No timeout warning should be present (compared via the same Fluent
+        // lookup the production path uses, so the check is locale-independent).
+        let expected_warning =
+            crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
         assert!(
-            !results.iter().any(|r| r.message.contains("timed out")),
+            !results.iter().any(|r| r.message == expected_warning),
             "under-deadline run must not append timeout warning"
         );
 

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -2204,6 +2204,149 @@ mod tests {
         );
     }
 
+    fn config_with_install_root(tmp: &TempDir) -> Config {
+        Config {
+            config_path: tmp.path().join("config.toml"),
+            data_dir: tmp.path().to_path_buf(),
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn canonicalize_provider_ref_defaults_undotted_names() {
+        assert_eq!(
+            canonicalize_provider_ref("openrouter"),
+            "openrouter.default"
+        );
+        assert_eq!(
+            canonicalize_provider_ref("openrouter.work"),
+            "openrouter.work"
+        );
+    }
+
+    #[test]
+    fn persist_model_cache_merges_multiple_providers_and_replaces_on_refresh() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+
+        persist_model_cache(&config, "openrouter", &["a".to_string(), "b".to_string()]).unwrap();
+        persist_model_cache(&config, "ollama", &["c".to_string()]).unwrap();
+        // Refreshing openrouter replaces its entry rather than duplicating it.
+        persist_model_cache(&config, "openrouter", &["a2".to_string()]).unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("state/models_cache.json")).unwrap();
+        let cache: zeroclaw_config::schema::ModelCacheState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(cache.entries.len(), 2);
+        let openrouter = cache
+            .entries
+            .iter()
+            .find(|e| e.model_provider == "openrouter.default")
+            .unwrap();
+        assert_eq!(openrouter.models, vec!["a2".to_string()]);
+        let ollama = cache
+            .entries
+            .iter()
+            .find(|e| e.model_provider == "ollama.default")
+            .unwrap();
+        assert_eq!(ollama.models, vec!["c".to_string()]);
+    }
+
+    #[test]
+    fn persist_model_cache_preserves_malformed_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let cache_path = state_dir.join(MODEL_CACHE_FILE);
+        std::fs::write(&cache_path, "not valid json").unwrap();
+
+        let result = persist_model_cache(&config, "openrouter", &["a".to_string()]);
+
+        assert!(
+            result.is_err(),
+            "malformed existing cache must fail the write, not silently replace it"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&cache_path).unwrap(),
+            "not valid json",
+            "existing malformed cache must be left untouched"
+        );
+    }
+
+    #[test]
+    fn persist_model_cache_preserves_unreadable_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let cache_path = state_dir.join(MODEL_CACHE_FILE);
+        std::fs::create_dir_all(&cache_path).unwrap();
+
+        let result = persist_model_cache(&config, "openrouter", &["a".to_string()]);
+
+        assert!(result.is_err());
+        assert!(
+            cache_path.is_dir(),
+            "unreadable existing cache path must be left untouched, not replaced"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn persist_model_cache_does_not_follow_a_preexisting_tmp_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        let decoy = tmp.path().join("decoy.json");
+        std::fs::write(&decoy, "untouched").unwrap();
+        std::os::unix::fs::symlink(&decoy, state_dir.join("models_cache.json.tmp")).unwrap();
+
+        persist_model_cache(&config, "openrouter", &["a".to_string()]).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&decoy).unwrap(),
+            "untouched",
+            "persistence must not write through a pre-existing symlink at a predictable temp path"
+        );
+        let raw = std::fs::read_to_string(state_dir.join(MODEL_CACHE_FILE)).unwrap();
+        assert!(raw.contains("openrouter"));
+    }
+
+    #[tokio::test]
+    async fn run_models_targeted_refresh_fails_when_cache_write_fails() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/tags"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "models": [{"name": "llama3"}]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = config_with_install_root(&tmp);
+        config
+            .providers
+            .models
+            .ensure("ollama", "default")
+            .expect("known model_provider type")
+            .uri = Some(server.uri());
+
+        std::fs::write(tmp.path().join("state"), "not a directory").unwrap();
+
+        let result = run_models(&config, Some("ollama.default"), false, false).await;
+
+        assert!(
+            result.is_err(),
+            "a targeted refresh must fail the command when the fetched catalog cannot be persisted, \
+             even though the network fetch itself succeeded"
+        );
+    }
+
     /// Regression test: production-path timeout via `run_structured_with_timeout`
     /// must preserve pre-timeout diagnostics and set `timed_out_phase` when
     /// `probe_models` exceeds the deadline. This pins the actual RPC boundary

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -7145,10 +7145,22 @@ mod tests {
 
     #[tokio::test]
     async fn doctor_run_omits_log_path_when_persistence_is_disabled() {
+        // Serialize against the other tests that mutate the process-global
+        // writer state (the two transition tests below) and install an
+        // explicit disabled writer so the assertion cannot observe a writer
+        // another parallel test installed.
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
         let tmp = tempfile::TempDir::new().unwrap();
+        zeroclaw_log::init_from_config(
+            &zeroclaw_log::LogConfig {
+                log_persistence: "none".into(),
+                log_persistence_path: "state/runtime-trace.jsonl".into(),
+                ..Default::default()
+            },
+            tmp.path(),
+        );
         let mut config = make_acp_test_config(&tmp);
-        // No writer is installed in this test: Doctor must not advertise any
-        // path regardless of the config snapshot.
+        // Doctor must not advertise any path regardless of the config snapshot.
         config.observability.log_persistence = zeroclaw_config::schema::LogPersistence::None;
         let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
 

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -978,8 +978,22 @@ impl RpcDispatcher {
 
     async fn handle_doctor_run(&self) -> RpcResult {
         let config = self.ctx.config.read().clone();
+        self.run_doctor(Box::pin(crate::doctor::probe_models(&config)))
+            .await
+    }
+
+    /// Serialize a Doctor run into the `doctor/run` response. The probe future
+    /// is injectable so tests can force both sides of the timeout deadline
+    /// deterministically; the production path passes `Box::pin(probe_models)`.
+    async fn run_doctor(
+        &self,
+        probe: std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<crate::doctor::DiagResult>> + Send + '_>,
+        >,
+    ) -> RpcResult {
+        let config = self.ctx.config.read().clone();
         let (results, timed_out_phase) =
-            crate::doctor::run_structured_with_timeout(&config, PROBE_MODEL_TIMEOUT).await;
+            crate::doctor::run_structured_with_probe(&config, PROBE_MODEL_TIMEOUT, probe).await;
         let summary = doctor_summary(&results);
         let log_path = if config.observability.log_persistence
             != zeroclaw_config::schema::LogPersistence::None
@@ -7147,6 +7161,112 @@ mod tests {
             obj.get("log_path").map(|v| v.is_null()).unwrap_or(true),
             "log_path must be null when persistence is disabled; got: {:?}",
             obj.get("log_path")
+        );
+    }
+
+    /// RPC-boundary coverage for the probe-timeout branch: a controlled
+    /// never-completing probe must yield a `doctor/run` response whose
+    /// serialized JSON carries `timed_out_phase`, preserves the earlier
+    /// diagnostics, and appends the localized timeout warning exactly once.
+    #[tokio::test]
+    async fn doctor_run_timeout_serializes_partial_result() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = make_acp_test_config(&tmp);
+        let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
+
+        // Force the timeout branch deterministically — no reliance on a real
+        // network endpoint hanging or not.
+        let result = dispatcher
+            .run_doctor(Box::pin(std::future::pending::<
+                Vec<crate::doctor::DiagResult>,
+            >()))
+            .await
+            .expect("doctor/run must succeed");
+        let obj = result.as_object().expect("result must be an object");
+
+        assert_eq!(
+            obj.get("timed_out_phase").and_then(|v| v.as_str()),
+            Some("probe_models"),
+            "serialized response must carry timed_out_phase='probe_models'"
+        );
+
+        // Earlier diagnostics survive in the serialized results.
+        let results = obj
+            .get("results")
+            .and_then(|v| v.as_array())
+            .expect("results must be an array");
+        assert!(
+            results
+                .iter()
+                .any(|r| r.get("category").and_then(|c| c.as_str()) == Some("config")),
+            "serialized results must retain config diagnostics after timeout"
+        );
+        assert!(
+            results
+                .iter()
+                .any(|r| r.get("category").and_then(|c| c.as_str()) == Some("workspace")),
+            "serialized results must retain workspace diagnostics after timeout"
+        );
+
+        // The timeout warning is appended exactly once in the serialized output.
+        let warning = crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
+        let warns = results
+            .iter()
+            .filter(|r| r.get("message").and_then(|m| m.as_str()) == Some(warning.as_str()))
+            .count();
+        assert_eq!(
+            warns, 1,
+            "serialized results must append the timeout warning exactly once"
+        );
+    }
+
+    /// RPC-boundary coverage for the under-deadline branch: a probe that
+    /// completes immediately with a real result must have that result retained
+    /// in the serialized `doctor/run` response, with `timed_out_phase` absent.
+    #[tokio::test]
+    async fn doctor_run_under_deadline_retains_probe_results() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = make_acp_test_config(&tmp);
+        let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
+
+        let probe_result = crate::doctor::DiagResult {
+            severity: crate::doctor::Severity::Ok,
+            category: "probe.mock".into(),
+            message: "mock probe ok".into(),
+        };
+        let result = dispatcher
+            .run_doctor(Box::pin(async move { vec![probe_result] }))
+            .await
+            .expect("doctor/run must succeed");
+        let obj = result.as_object().expect("result must be an object");
+
+        // timed_out_phase is None → skipped on the wire.
+        assert!(
+            obj.get("timed_out_phase")
+                .map(|v| v.is_null())
+                .unwrap_or(true),
+            "under-deadline response must not carry timed_out_phase"
+        );
+
+        // The completed probe result survives in the serialized output.
+        let results = obj
+            .get("results")
+            .and_then(|v| v.as_array())
+            .expect("results must be an array");
+        assert!(
+            results
+                .iter()
+                .any(|r| r.get("message").and_then(|m| m.as_str()) == Some("mock probe ok")),
+            "serialized results must retain the completed probe result"
+        );
+
+        // No timeout warning leaks into the under-deadline response.
+        let warning = crate::i18n::get_required_cli_string("cli-doctor-probe-timeout-message");
+        assert!(
+            !results
+                .iter()
+                .any(|r| r.get("message").and_then(|m| m.as_str()) == Some(warning.as_str())),
+            "under-deadline response must not contain the timeout warning"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -995,13 +995,13 @@ impl RpcDispatcher {
         let (results, timed_out_phase) =
             crate::doctor::run_structured_with_probe(&config, PROBE_MODEL_TIMEOUT, probe).await;
         let summary = doctor_summary(&results);
-        let log_path = if config.observability.log_persistence
-            != zeroclaw_config::schema::LogPersistence::None
-        {
-            zeroclaw_log::current_log_path().map(|p| p.to_string_lossy().to_string())
-        } else {
-            None
-        };
+        // Read enabled + path from the one canonical active-writer accessor.
+        // The runtime `ctx.config.observability.log_persistence` snapshot is
+        // updated immediately by `config/set` while `zeroclaw-log` installs its
+        // writer state only at startup or daemon reload — gating on the config
+        // here would advertise a stale path (or omit a live one) during the
+        // config/reload window #8650 calls out.
+        let log_path = zeroclaw_log::active_log_path().map(|p| p.to_string_lossy().to_string());
         to_result(DoctorRunResult {
             results,
             summary,
@@ -7147,8 +7147,8 @@ mod tests {
     async fn doctor_run_omits_log_path_when_persistence_is_disabled() {
         let tmp = tempfile::TempDir::new().unwrap();
         let mut config = make_acp_test_config(&tmp);
-        // Set persistence to None — writer state may still resolve a path,
-        // but the RPC must not advertise it as active.
+        // No writer is installed in this test: Doctor must not advertise any
+        // path regardless of the config snapshot.
         config.observability.log_persistence = zeroclaw_config::schema::LogPersistence::None;
         let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
 
@@ -7159,7 +7159,86 @@ mod tests {
         let obj = result.as_object().expect("result must be an object");
         assert!(
             obj.get("log_path").map(|v| v.is_null()).unwrap_or(true),
-            "log_path must be null when persistence is disabled; got: {:?}",
+            "log_path must be null when no writer is active; got: {:?}",
+            obj.get("log_path")
+        );
+    }
+
+    /// #8650 config/reload window, scenario A: the daemon started with an
+    /// ACTIVE writer (rolling), then `config/set` flipped
+    /// `observability.log_persistence` to `none` WITHOUT a daemon reload.
+    /// The writer still persists, so Doctor must still advertise the path —
+    /// gating on the `ctx.config` snapshot would hide a live log.
+    #[tokio::test]
+    async fn doctor_reports_active_writer_path_after_config_set_to_none_without_reload() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let tmp = tempfile::TempDir::new().unwrap();
+        zeroclaw_log::init_from_config(
+            &zeroclaw_log::LogConfig {
+                log_persistence: "rolling".into(),
+                log_persistence_path: "state/runtime-trace.jsonl".into(),
+                ..Default::default()
+            },
+            tmp.path(),
+        );
+
+        let mut config = make_acp_test_config(&tmp);
+        config.observability.log_persistence = zeroclaw_config::schema::LogPersistence::None;
+        let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
+
+        let result = dispatcher
+            .handle_doctor_run()
+            .await
+            .expect("doctor/run must succeed");
+        let obj = result.as_object().expect("result must be an object");
+        let log_path = obj.get("log_path").and_then(|v| v.as_str());
+        assert!(
+            matches!(log_path, Some(p) if p.ends_with("runtime-trace.jsonl")),
+            "an active writer must be advertised even when the config snapshot says none; got: {:?}",
+            obj.get("log_path")
+        );
+
+        // Restore a disabled writer so later tests start from a clean state.
+        zeroclaw_log::init_from_config(
+            &zeroclaw_log::LogConfig {
+                log_persistence: "none".into(),
+                log_persistence_path: "state/runtime-trace.jsonl".into(),
+                ..Default::default()
+            },
+            tmp.path(),
+        );
+    }
+
+    /// #8650 config/reload window, scenario B: the daemon started with
+    /// persistence DISABLED, then `config/set` flipped it to `rolling`
+    /// WITHOUT a daemon reload. No writer is installed, so Doctor must NOT
+    /// advertise the disabled writer's stale resolved path.
+    #[tokio::test]
+    async fn doctor_omits_log_path_after_config_set_to_rolling_without_reload_when_writer_disabled()
+    {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let tmp = tempfile::TempDir::new().unwrap();
+        zeroclaw_log::init_from_config(
+            &zeroclaw_log::LogConfig {
+                log_persistence: "none".into(),
+                log_persistence_path: "state/runtime-trace.jsonl".into(),
+                ..Default::default()
+            },
+            tmp.path(),
+        );
+
+        let mut config = make_acp_test_config(&tmp);
+        config.observability.log_persistence = zeroclaw_config::schema::LogPersistence::Rolling;
+        let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
+
+        let result = dispatcher
+            .handle_doctor_run()
+            .await
+            .expect("doctor/run must succeed");
+        let obj = result.as_object().expect("result must be an object");
+        assert!(
+            obj.get("log_path").map(|v| v.is_null()).unwrap_or(true),
+            "log_path must stay null when no writer is installed, even if the config says rolling; got: {:?}",
             obj.get("log_path")
         );
     }

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -1000,7 +1000,7 @@ impl RpcDispatcher {
         // updated immediately by `config/set` while `zeroclaw-log` installs its
         // writer state only at startup or daemon reload — gating on the config
         // here would advertise a stale path (or omit a live one) during the
-        // config/reload window #8650 calls out.
+        // config/reload window the Doctor diagnostics issue calls out.
         let log_path = zeroclaw_log::active_log_path().map(|p| p.to_string_lossy().to_string());
         to_result(DoctorRunResult {
             results,
@@ -7176,7 +7176,7 @@ mod tests {
         );
     }
 
-    /// #8650 config/reload window, scenario A: the daemon started with an
+    /// Config/reload window, scenario A: the daemon started with an
     /// ACTIVE writer (rolling), then `config/set` flipped
     /// `observability.log_persistence` to `none` WITHOUT a daemon reload.
     /// The writer still persists, so Doctor must still advertise the path —
@@ -7221,7 +7221,7 @@ mod tests {
         );
     }
 
-    /// #8650 config/reload window, scenario B: the daemon started with
+    /// Config/reload window, scenario B: the daemon started with
     /// persistence DISABLED, then `config/set` flipped it to `rolling`
     /// WITHOUT a daemon reload. No writer is installed, so Doctor must NOT
     /// advertise the disabled writer's stale resolved path.

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -979,7 +979,18 @@ impl RpcDispatcher {
         let config = self.ctx.config.read().clone();
         let results = crate::doctor::run_structured(&config).await;
         let summary = doctor_summary(&results);
-        to_result(DoctorRunResult { results, summary })
+        let log_path = if config.observability.log_persistence
+            != zeroclaw_config::schema::LogPersistence::None
+        {
+            zeroclaw_log::current_log_path().map(|p| p.to_string_lossy().to_string())
+        } else {
+            None
+        };
+        to_result(DoctorRunResult {
+            results,
+            summary,
+            log_path,
+        })
     }
 
     // ── TUI handlers ─────────────────────────────────────────────
@@ -7113,6 +7124,27 @@ mod tests {
         assert!(sessions.get_agent("scoped-a").await.is_none());
         assert!(sessions.get_agent("scoped-b").await.is_none());
         assert!(sessions.get_agent("scoped-c").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn doctor_run_omits_log_path_when_persistence_is_disabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = make_acp_test_config(&tmp);
+        // Set persistence to None — writer state may still resolve a path,
+        // but the RPC must not advertise it as active.
+        config.observability.log_persistence = zeroclaw_config::schema::LogPersistence::None;
+        let (dispatcher, _sessions) = make_acp_test_dispatcher(config);
+
+        let result = dispatcher
+            .handle_doctor_run()
+            .await
+            .expect("doctor/run must succeed");
+        let obj = result.as_object().expect("result must be an object");
+        assert!(
+            obj.get("log_path").map(|v| v.is_null()).unwrap_or(true),
+            "log_path must be null when persistence is disabled; got: {:?}",
+            obj.get("log_path")
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -8,6 +8,7 @@ use super::types::*;
 const RPC_RELOAD_REPLY_FLUSH_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
 const RPC_RELOAD_GATEWAY_SHUTDOWN_DELAY: std::time::Duration =
     std::time::Duration::from_millis(200);
+const PROBE_MODEL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 use crate::agent::agent::TurnEvent;
 use crate::sop::SopGraphExt;
 use serde::Serialize;
@@ -977,7 +978,8 @@ impl RpcDispatcher {
 
     async fn handle_doctor_run(&self) -> RpcResult {
         let config = self.ctx.config.read().clone();
-        let results = crate::doctor::run_structured(&config).await;
+        let (results, timed_out_phase) =
+            crate::doctor::run_structured_with_timeout(&config, PROBE_MODEL_TIMEOUT).await;
         let summary = doctor_summary(&results);
         let log_path = if config.observability.log_persistence
             != zeroclaw_config::schema::LogPersistence::None
@@ -990,6 +992,7 @@ impl RpcDispatcher {
             results,
             summary,
             log_path,
+            timed_out_phase,
         })
     }
 

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -139,6 +139,8 @@ rpc_type! {
         /// Resolved active log persistence path, if available.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub log_path: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub timed_out_phase: Option<String>,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -136,6 +136,9 @@ rpc_type! {
     pub struct DoctorRunResult {
         pub results: Vec<DiagResult>,
         pub summary: DoctorSummary,
+        /// Resolved active log persistence path, if available.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub log_path: Option<String>,
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - #8650 — Doctor diagnostics now surface the resolved active log persistence path, so operators can find the backing log file from the Doctor detail panel without leaving ZeroCode or guessing config paths.
  - #8647 — When the network-dependent `probe_models` phase of Doctor times out, the earlier diagnostics (config / workspace / daemon / environment / CLI tools) are preserved and returned with a structured `timed_out_phase`, instead of losing the whole run to the client-side deadline. The user-facing error text discriminates between a structured probe-phase timeout (model-probing hint) and a whole-RPC timeout (generic daemon-busy hint).
- **Scope boundary:** No config format or config-key changes. The Doctor RPC response gains two optional, serde-defaulted fields. ZeroCode changes Doctor from the generic 5-second RPC timeout to a Doctor-specific 30-second deadline, while the daemon bounds only `probe_models` at 20 seconds (`PROBE_MODEL_TIMEOUT`) — the threshold at which the operator sees the partial-results banner instead of a full report.
- **Blast radius:** zerocode TUI Doctor pane (`apps/zerocode`) and `doctor/run` RPC (`zeroclaw-runtime`). Older zerocode clients and older daemons interoperate unchanged. Localized copy was added across all five shipped catalogues (`en`, `es`, `fr`, `ja`, `zh-CN`) for both crates.
- **Linked issue(s):** Partially addresses #8650. Closes #8647. Supersedes #8910.
- **Rebase (2026-08-05):** Rebased onto current `master` (`9ea4f3371`). The only conflict was `crates/zeroclaw-runtime/locales/fr/cli.ftl`, where master added `cli-doctor-skills-prompt-injection-mode-full-deprecated` (#8313); resolved by taking the master side (new key plus the curly-quote spelling) while preserving this PR's `cli-doctor-probe-timeout-message`. The rebase also removed an unrelated typographic drift carried from the round-2 commit (`sop-*` keys rewritten with straight quotes in `fr`/`zh-CN`); the `fr` side went away with the conflict resolution and the `zh-CN` restoration lands as `407076543`. Branch is now 0 behind / 12 ahead of `master` after the 2026-08-06 round.
- **Rebase (2026-08-08):** Rebased onto current `master` (`5bec8119`) to clear the merge conflict GitHub reported. The rebase replay was clean (all 14 commits replayed without conflicts — the earlier trial-merge conflict in `crates/zeroclaw-runtime/src/doctor/mod.rs` was absorbed by master's intervening changes). Branch is now **0 behind / 14 ahead** of `master`, head `67e56804`. Localized additions from master's post-round work (incl. `#9409` channel-approval keys) are preserved across all five catalogues; the diff against `master` contains only this PR's intended keys. All 14 commits carry no bot/AI attribution trailer.

**2026-08-06 review round (ZeroClaw-Bot on head `407076543`):** one blocker + one suggestion + one warning, all addressed on the new head `dbbbf3505`:

- **Enabled state and path read from different snapshots (blocking, RESOLVED):** `run_doctor` gated `log_path` on `ctx.config.observability.log_persistence` (updated immediately by `config/set`) but read the path from `zeroclaw_log::current_log_path()`, which reflects the writer state installed only at startup or daemon reload. A daemon started `rolling` then set to `none` still persists but Doctor omitted the path; a daemon started `none` then set to `rolling` advertised the disabled writer's stale path. Doctor now reads both enabled and path from the new canonical `zeroclaw_log::active_log_path()` accessor (path only when the installed writer's storage is enabled). Pinned by `doctor_reports_active_writer_path_after_config_set_to_none_without_reload` and `doctor_omits_log_path_after_config_set_to_rolling_without_reload_when_writer_disabled`. **Mutation-checked:** reverting to the config-gated logic fails the active-writer transition test.
- **Disconnected empty-state (suggestion, RESOLVED):** `render_screenshot_disconnected_empty_state_shows_no_selection` pins that a pane with no result and no loading/error state renders the no-selection hint rather than a blank panel.
- **Stale rebase/validation snapshot (warning, RESOLVED):** rebase snapshot refreshed above; the doctor test counts below are current on the new head.

**2026-08-06 re-review (ZeroClaw-Bot on head `dbbbf3505`):** two blockers + one warning, all addressed on the current head `85269c8b5`:

- **`doctor_run_omits_log_path_when_persistence_is_disabled` not isolated from the global writer (blocking, RESOLVED):** the test only changed the dispatcher config to `none`, so under the 16-thread parallel runtime gate a parallel rolling-writer test made the assertion observe that writer's path. It now takes `zeroclaw_log::__private_test_writer_lock()` and installs an explicit disabled writer (same shape as the two transition tests), serializing all global-writer mutations. The parallel gate no longer reports this test as a failure (the remaining gate failures are the pre-existing `systemd_linger` non-English-locale tests).
- **Hard-coded English UI assertions fail under non-English locales (blocking, RESOLVED):** the timeout discriminator and render regressions asserted English prose (`daemon may be busy`, `No diagnostic selected`, `Partial results`, `model probing timed out`), which failed under `fr`. All assertions now compare against the localized `crate::i18n::t(...)` values (locale-aware by construction), and the three timeout copy entries are asserted semantically distinct rather than by English substring. Verified under both the default English locale and a `locale = "fr"` run (`ZEROCODE_LOCALE_DIR=apps/zerocode/locales`): 13/13 Doctor tests pass in both.
- **Validation snapshot (warning, RESOLVED):** counts refreshed below; the parallel-gate and French-locale runs are documented in `How I tested`.
- **Labels:** `enhancement` `doctor` `runtime` `observability:log` `zerocode` `risk:high` `size:M` `principal contributor` `needs-author-action`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — the Doctor TUI needs a live daemon session; the render contract is pinned by `TestBackend` render tests that exercise the same `Doctor::draw` call path.
- **Interface(s) exercised:** `tui` (zerocode Doctor pane), `cli` (zeroclaw-runtime doctor RPC boundary).
- **Setup / preconditions:** A configured log persistence path; an optional slow/unreachable provider endpoint to observe the probe timeout.
- **Steps to run:** `cargo test --locked --bin zerocode -p zerocode render_screenshot -- --nocapture` prints the 120×24 Doctor captures for both `log_persistence` modes and the partial-results banner.
- **Expected on this branch (after):** With `log_persistence = "file"`, the resolved path is readable in the detail panel (wrapped by `Paragraph`, not clipped). With `log_persistence = "none"`, no `log:` row appears. After a probe timeout, earlier diagnostics plus the partial-results banner are shown.
- **Prior behavior on `master` (before):** No log path exposed; a slow probe dropped all diagnostics on the client-side deadline with a generic timeout error.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy --locked -p zerocode --all-targets -- -D warnings
cargo clippy --locked -p zeroclaw-runtime --all-targets -- -D warnings
cargo test --locked --bin zerocode -p zerocode i18n::    # 8 passed
cargo test --locked --bin zerocode -p zerocode doctor_    # 11 passed (English and `fr` locales)
cargo test --locked -p zeroclaw-runtime --lib doctor::    # 56 passed (en locale; see note)
cargo test --locked -p zeroclaw-runtime --lib rpc::dispatch::tests::doctor    # 7 passed (incl. the two config/reload transition regressions and the isolated disabled-writer test)
cargo test --locked -p zeroclaw-log --lib                # 106 passed (active_log_path accessor)
```

- **CI checks relied on and why they cover this change:** `Test`, `Lint`, `Format`, `Security`, `Zerocode RPC Boundary`, and `CI Required Gate` cover the changed Rust surface and locale catalogues.
- **Known CI coverage gap, if any:** The two `systemd_linger` doctor tests assert English copy and fail under a non-English ambient locale on any branch including `master` (locale mismatch, pre-existing). They pass under the CI English locale; the timeout tests added here are locale-independent by construction.
- **Commands run and tail output:** see the test tails above; the full `zeroclaw-runtime` doctor suite is 56/56 green under `LANG=en_US.UTF-8`.
- **Beyond CI, what did you manually verify?** The `TestBackend` render tests produce the Doctor captures for both persistence modes and the partial banner. The timeout boundary is now forced deterministically: the probe phase is injectable (`run_structured_with_probe`), and the tests pass a controlled never-completing future to trigger the timeout branch — no dependency on an unroutable TEST-NET-1 endpoint that may or may not hang. The RPC-boundary tests assert the serialized `doctor/run` response preserves the earlier diagnostics, appends the localized timeout warning exactly once, and carries `timed_out_phase`; the under-deadline test asserts a completed probe result is retained. What I did NOT verify: a live interactive zerocode session in a real terminal.
- **If any command was intentionally skipped, why:** `cargo test --locked -p zeroclaw-runtime --lib doctor::` under the default non-English locale reports the two pre-existing `systemd_linger` failures; the same suite is fully green under the CI locale.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — `probe_models` already probes provider endpoints; this PR only bounds that existing call with a per-phase timeout.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes` — both new wire fields are optional and defaulted; old clients ignore them.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-commit-sha>` — the branch is squash-merged as a single commit, and the commits are interdependent (shared `DoctorRunResult` shape), so individual reverts are not supported.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Doctor detail panel shows a bare `{zc-doctor-log-path}` placeholder or no log path for an enabled persistence file; partial results or the banner missing after a slow probe; probe-specific copy leaking into the whole-RPC timeout error. Grep doctor/run responses for `log_path` / `timed_out_phase`.

