### PR TITLE
fix(providers): sanitize outbound tool-call arguments to prevent 400 (#8675)

### DIFF
--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -972,4 +972,42 @@ mod tests {
         );
         assert_eq!(p.api_version, "2025-01-01");
     }
+
+    #[test]
+    fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
+        // Regression for #8675: pins that the azure_openai `convert_messages`
+        // call site of `sanitize_tool_arguments` is wired in. The helper
+        // contract itself is covered in
+        // `compatible::tests::sanitize_tool_arguments_*`.
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"trying","tool_calls":[{"id":"call_bad","name":"shell","arguments":"{\"command\":\"rm -rf"}]}"#
+                .into(),
+        }];
+
+        let native = AzureOpenAiModelProvider::convert_messages(&messages);
+        let tool_calls = native[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id.as_deref(), Some("call_bad"));
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(tool_calls[0].function.arguments, "{}");
+    }
+
+    #[test]
+    fn convert_messages_passes_through_valid_tool_arguments() {
+        // Companion regression: valid JSON must round-trip byte-for-byte.
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"using","tool_calls":[{"id":"call_ok","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#
+                .into(),
+        }];
+
+        let native = AzureOpenAiModelProvider::convert_messages(&messages);
+        let tool_calls = native[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls[0].function.arguments, r#"{"command":"pwd"}"#);
+    }
 }

--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -272,13 +272,19 @@ impl AzureOpenAiModelProvider {
                 {
                     let tool_calls = parsed_calls
                         .into_iter()
-                        .map(|tc| NativeToolCall {
-                            id: Some(tc.id),
-                            kind: Some("function".to_string()),
-                            function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
-                            },
+                        .map(|tc| {
+                            let name = tc.name;
+                            NativeToolCall {
+                                id: Some(tc.id),
+                                kind: Some("function".to_string()),
+                                function: NativeFunctionCall {
+                                    arguments: crate::compatible::sanitize_tool_arguments(
+                                        &name,
+                                        &tc.arguments,
+                                    ),
+                                    name,
+                                },
+                            }
                         })
                         .collect::<Vec<_>>();
                     let content = crate::request_payload::non_empty_string_field(&value, "content");

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -101,6 +101,38 @@ pub enum AuthStyle {
     ZhipuJwt,
 }
 
+/// Sanitize a tool-call `arguments` string before it is re-serialized into an
+/// outbound OpenAI-compatible chat-completions request.
+///
+/// Several strict upstream providers (Cohere, OpenInference, Nvidia …,
+/// surfaced most often through OpenRouter) reject requests where
+/// `tool_calls[].function.arguments` is not well-formed JSON. Smaller /
+/// reasoning models sometimes emit a malformed arguments string; when that
+/// happens the whole turn fails with HTTP 400 and the user receives the
+/// generic fallback instead of the agent's response. #8675.
+///
+/// Contract (kept identical to the existing in-line normalization in
+/// `ToolCall::into_provider_tool_call`):
+/// - empty / whitespace-only → `"{}"` (every upstream accepts this)
+/// - valid JSON → returned unchanged
+/// - invalid JSON → WARN-logged, then `"{}"`
+pub fn sanitize_tool_arguments(function_name: &str, arguments: &str) -> String {
+    if arguments.trim().is_empty() {
+        return "{}".to_string();
+    }
+    if serde_json::from_str::<serde_json::Value>(arguments).is_ok() {
+        return arguments.to_string();
+    }
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({"function": function_name, "arguments": arguments})),
+        "Invalid JSON in tool-call arguments being sent to upstream provider, dropping to empty object"
+    );
+    "{}".to_string()
+}
+
 /// Generate a Zhipu JWT from an `id.secret` API key.
 /// Returns `Authorization: Bearer <jwt>` value. Token is valid for 3.5 minutes.
 fn zhipu_jwt_bearer(credential: &str) -> Result<String, String> {
@@ -3498,6 +3530,37 @@ impl ::zeroclaw_api::attribution::Attributable for OpenAiCompatibleModelProvider
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Empty / whitespace arguments must collapse to `"{}"` so OpenAI-style
+    /// providers never see an invalid `tool_calls[].function.arguments`.
+    #[test]
+    fn sanitize_tool_arguments_empty_or_whitespace_becomes_empty_object() {
+        assert_eq!(sanitize_tool_arguments("f", ""), "{}");
+        assert_eq!(sanitize_tool_arguments("f", "   \n\t  "), "{}");
+    }
+
+    /// Well-formed JSON returns untouched — we never want to mutate valid input.
+    #[test]
+    fn sanitize_tool_arguments_valid_json_is_passthrough() {
+        let args = r#"{"path":"/tmp/x","recursive":true}"#;
+        assert_eq!(sanitize_tool_arguments("file_read", args), args);
+        // Bare JSON arrays / null are also "valid JSON" and pass through.
+        assert_eq!(sanitize_tool_arguments("f", "null"), "null");
+        assert_eq!(sanitize_tool_arguments("f", "[]"), "[]");
+    }
+
+    /// Malformed arguments are dropped to `"{}"` so strict upstreams (Cohere,
+    /// OpenInference, Nvidia via OpenRouter) no longer reject the whole request
+    /// with HTTP 400 just because the model emitted junk arguments.
+    #[test]
+    fn sanitize_tool_arguments_invalid_json_becomes_empty_object() {
+        // Unterminated string
+        assert_eq!(sanitize_tool_arguments("f", r#"{"path":"/tmp"#), "{}");
+        // Trailing junk
+        assert_eq!(sanitize_tool_arguments("f", r#"{"x":1}garbage"#), "{}");
+        // Truncated (the actual observed failure case from #8675)
+        assert_eq!(sanitize_tool_arguments("f", ""), "{}");
+    }
 
     fn make_model_provider(
         name: &str,

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -125,12 +125,31 @@ pub enum AuthStyle {
 /// normalization contract. The streaming accumulator's
 /// `StreamToolCallAccumulator::into_provider_tool_call` and all typed
 /// providers' outbound `convert_messages` paths route through here.
-pub fn sanitize_tool_arguments(function_name: &str, arguments: &str) -> String {
+pub(crate) fn sanitize_tool_arguments(function_name: &str, arguments: &str) -> String {
     if arguments.trim().is_empty() {
         return "{}".to_string();
     }
-    if serde_json::from_str::<serde_json::Value>(arguments).is_ok() {
-        return arguments.to_string();
+    match serde_json::from_str::<serde_json::Value>(arguments) {
+        Ok(serde_json::Value::Object(_)) => return arguments.to_string(),
+        Ok(_non_object) => {
+            // Accept only JSON objects; null, arrays, strings, numbers, and
+            // booleans do not satisfy a strict-provider function-arguments
+            // contract (reported by Cohere, tracked by OpenRouter's
+            // auto-exacto validator).
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "function": function_name,
+                        "payload_len": arguments.len(),
+                        "error_key": "tool_args_not_object",
+                    })),
+                "Non-object tool-call arguments being sent to strict upstream provider, dropping to empty object"
+            );
+            return "{}".to_string();
+        }
+        Err(_) => {}
     }
     ::zeroclaw_log::record!(
         WARN,
@@ -3539,14 +3558,24 @@ mod tests {
         assert_eq!(sanitize_tool_arguments("f", "   \n\t  "), "{}");
     }
 
-    /// Well-formed JSON returns untouched — we never want to mutate valid input.
+    /// Well-formed JSON object returns untouched — only object-shaped arguments
+    /// satisfy the strict-provider function-arguments contract.
     #[test]
     fn sanitize_tool_arguments_valid_json_is_passthrough() {
         let args = r#"{"path":"/tmp/x","recursive":true}"#;
         assert_eq!(sanitize_tool_arguments("file_read", args), args);
-        // Bare JSON arrays / null are also "valid JSON" and pass through.
-        assert_eq!(sanitize_tool_arguments("f", "null"), "null");
-        assert_eq!(sanitize_tool_arguments("f", "[]"), "[]");
+    }
+
+    /// Non-object JSON values (null, array, string, number, boolean) are
+    /// rejected to `"{}"` because strict providers require a JSON object for
+    /// tool-call arguments.
+    #[test]
+    fn sanitize_tool_arguments_non_object_becomes_empty_object() {
+        assert_eq!(sanitize_tool_arguments("f", "null"), "{}");
+        assert_eq!(sanitize_tool_arguments("f", "[]"), "{}");
+        assert_eq!(sanitize_tool_arguments("f", "42"), "{}");
+        assert_eq!(sanitize_tool_arguments("f", "\"hello\""), "{}");
+        assert_eq!(sanitize_tool_arguments("f", "true"), "{}");
     }
 
     /// Malformed arguments are dropped to `"{}"` so strict upstreams (Cohere,

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -111,11 +111,20 @@ pub enum AuthStyle {
 /// happens the whole turn fails with HTTP 400 and the user receives the
 /// generic fallback instead of the agent's response. #8675.
 ///
-/// Contract (kept identical to the existing in-line normalization in
-/// `ToolCall::into_provider_tool_call`):
+/// Contract:
 /// - empty / whitespace-only → `"{}"` (every upstream accepts this)
 /// - valid JSON → returned unchanged
-/// - invalid JSON → WARN-logged, then `"{}"`
+/// - invalid JSON → WARN-logged with **safe metadata only** (function name,
+///   payload length, stable error key), then `"{}"`. The raw arguments
+///   string is **never** recorded, because tool-call arguments can contain
+///   commands, URLs, credentials, file paths, or user content and WARN
+///   events enter the broadcast and rolling-persistence path regardless of
+///   the tool/LLM content-capture policy.
+///
+/// This is the single source of truth for the tool-call arguments
+/// normalization contract. The streaming accumulator's
+/// `StreamToolCallAccumulator::into_provider_tool_call` and all typed
+/// providers' outbound `convert_messages` paths route through here.
 pub fn sanitize_tool_arguments(function_name: &str, arguments: &str) -> String {
     if arguments.trim().is_empty() {
         return "{}".to_string();
@@ -127,7 +136,11 @@ pub fn sanitize_tool_arguments(function_name: &str, arguments: &str) -> String {
         WARN,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-            .with_attrs(::serde_json::json!({"function": function_name, "arguments": arguments})),
+            .with_attrs(::serde_json::json!({
+                "function": function_name,
+                "payload_len": arguments.len(),
+                "error_key": "tool_args_invalid_json",
+            })),
         "Invalid JSON in tool-call arguments being sent to upstream provider, dropping to empty object"
     );
     "{}".to_string()
@@ -1410,24 +1423,11 @@ impl StreamToolCallAccumulator {
         used_tool_call_ids: &mut std::collections::HashSet<String>,
     ) -> Option<ProviderToolCall> {
         let name = self.name?;
-        let arguments = if self.arguments.trim().is_empty() {
-            "{}".to_string()
-        } else {
-            self.arguments
-        };
-        let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments).is_ok()
-        {
-            arguments
-        } else {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"function": name, "arguments": arguments})),
-                "Invalid JSON in streamed native tool-call arguments, using empty object"
-            );
-            "{}".to_string()
-        };
+        // Route through the shared `sanitize_tool_arguments` helper so the
+        // normalization contract (empty/whitespace → "{}", invalid JSON →
+        // WARN + "{}", valid JSON → passthrough) has a single source of
+        // truth. #8675.
+        let normalized_arguments = sanitize_tool_arguments(&name, &self.arguments);
 
         Some(ProviderToolCall {
             id: reserve_tool_call_id_for_contract(

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -323,13 +323,19 @@ impl CopilotModelProvider {
                 {
                     let tool_calls = parsed_calls
                         .into_iter()
-                        .map(|tool_call| NativeToolCall {
-                            id: Some(tool_call.id),
-                            kind: Some("function".to_string()),
-                            function: NativeFunctionCall {
-                                name: tool_call.name,
-                                arguments: tool_call.arguments,
-                            },
+                        .map(|tool_call| {
+                            let name = tool_call.name;
+                            NativeToolCall {
+                                id: Some(tool_call.id),
+                                kind: Some("function".to_string()),
+                                function: NativeFunctionCall {
+                                    arguments: crate::compatible::sanitize_tool_arguments(
+                                        &name,
+                                        &tool_call.arguments,
+                                    ),
+                                    name,
+                                },
+                            }
                         })
                         .collect::<Vec<_>>();
 

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -879,4 +879,42 @@ mod tests {
         let result = CopilotModelProvider::to_api_content("assistant", "sure").unwrap();
         assert!(matches!(result, ApiContent::Text(ref s) if s == "sure"));
     }
+
+    #[test]
+    fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
+        // Regression for #8675: pins that the copilot `convert_messages` call
+        // site of `sanitize_tool_arguments` is wired in. The helper contract
+        // itself is covered in `compatible::tests::sanitize_tool_arguments_*`.
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"trying","tool_calls":[{"id":"call_bad","name":"shell","arguments":"{\"command\":\"rm -rf"}]}"#
+                .into(),
+        }];
+
+        let api_messages = CopilotModelProvider::convert_messages(&messages);
+        assert_eq!(api_messages.len(), 1);
+        let tool_calls = api_messages[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id.as_deref(), Some("call_bad"));
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(tool_calls[0].function.arguments, "{}");
+    }
+
+    #[test]
+    fn convert_messages_passes_through_valid_tool_arguments() {
+        // Companion regression: valid JSON must round-trip byte-for-byte.
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"using","tool_calls":[{"id":"call_ok","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#
+                .into(),
+        }];
+
+        let api_messages = CopilotModelProvider::convert_messages(&messages);
+        let tool_calls = api_messages[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls[0].function.arguments, r#"{"command":"pwd"}"#);
+    }
 }

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -1551,6 +1551,39 @@ mod tests {
     }
 
     #[test]
+    fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
+        // Regression for #8675: pins that the openai `convert_messages` call
+        // site of `sanitize_tool_arguments` is wired in. The helper contract
+        // itself is covered in `compatible::tests::sanitize_tool_arguments_*`.
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let messages = vec![ChatMessage::assistant(
+            r#"{"content":"trying","tool_calls":[{"id":"call_bad","name":"shell","arguments":"{\"command\":\"rm -rf"}]}"#.to_string(),
+        )];
+
+        let native = OpenAiModelProvider::convert_messages(&messages);
+        let tool_calls = native[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id.as_deref(), Some("call_bad"));
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(tool_calls[0].function.arguments, "{}");
+    }
+
+    #[test]
+    fn convert_messages_passes_through_valid_tool_arguments() {
+        // Companion regression: valid JSON must round-trip byte-for-byte.
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let messages = vec![ChatMessage::assistant(
+            r#"{"content":"using","tool_calls":[{"id":"call_ok","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#.to_string(),
+        )];
+
+        let native = OpenAiModelProvider::convert_messages(&messages);
+        let tool_calls = native[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls[0].function.arguments, r#"{"command":"pwd"}"#);
+    }
+
+    #[test]
     fn native_message_omits_reasoning_content_when_none() {
         let msg = NativeMessage {
             role: "assistant".to_string(),

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -295,13 +295,19 @@ impl OpenAiModelProvider {
                 {
                     let tool_calls = parsed_calls
                         .into_iter()
-                        .map(|tc| NativeToolCall {
-                            id: Some(tc.id),
-                            kind: Some("function".to_string()),
-                            function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
-                            },
+                        .map(|tc| {
+                            let name = tc.name;
+                            NativeToolCall {
+                                id: Some(tc.id),
+                                kind: Some("function".to_string()),
+                                function: NativeFunctionCall {
+                                    arguments: crate::compatible::sanitize_tool_arguments(
+                                        &name,
+                                        &tc.arguments,
+                                    ),
+                                    name,
+                                },
+                            }
                         })
                         .collect::<Vec<_>>();
                     let content = crate::request_payload::non_empty_string_field(&value, "content");

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -422,11 +422,15 @@ pub(crate) fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<Va
                     }
 
                     for call in parsed_calls {
+                        let name = call.name;
                         input.push(serde_json::json!({
                             "type": "function_call",
                             "call_id": call.id,
-                            "name": call.name,
-                            "arguments": call.arguments,
+                            "name": name,
+                            "arguments": crate::compatible::sanitize_tool_arguments(
+                                &name,
+                                &call.arguments,
+                            ),
                         }));
                     }
                 } else if !msg.content.trim().is_empty() {

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -338,6 +338,22 @@ fn decode_responses_history_items(reasoning_content: &str) -> Option<Vec<Value>>
     (!items.is_empty()).then_some(items)
 }
 
+/// Build a single Responses-API `function_call` input item from a parsed
+/// `ProviderToolCall`. The `arguments` field is routed through the shared
+/// `sanitize_tool_arguments` helper so the openai_codex call site inherits
+/// the same malformed-JSON → `"{}"` contract as the other four typed
+/// providers. Factored out so the call-site behavior is testable without
+/// running the full input builder. #8675.
+pub(crate) fn build_function_call_item(call: ProviderToolCall) -> Value {
+    let name = call.name;
+    serde_json::json!({
+        "type": "function_call",
+        "call_id": call.id,
+        "name": name,
+        "arguments": crate::compatible::sanitize_tool_arguments(&name, &call.arguments),
+    })
+}
+
 pub(crate) fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<Value>) {
     let mut system_parts: Vec<&str> = Vec::new();
     let mut input: Vec<Value> = Vec::new();
@@ -422,16 +438,7 @@ pub(crate) fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<Va
                     }
 
                     for call in parsed_calls {
-                        let name = call.name;
-                        input.push(serde_json::json!({
-                            "type": "function_call",
-                            "call_id": call.id,
-                            "name": name,
-                            "arguments": crate::compatible::sanitize_tool_arguments(
-                                &name,
-                                &call.arguments,
-                            ),
-                        }));
+                        input.push(build_function_call_item(call));
                     }
                 } else if !msg.content.trim().is_empty() {
                     input.push(response_message_item(
@@ -2540,5 +2547,38 @@ data: [DONE]
 
         assert!(provider.supports_streaming());
         assert!(provider.supports_streaming_tool_events());
+    }
+
+    #[test]
+    fn build_function_call_item_sanitizes_invalid_arguments_to_empty_object() {
+        // Regression for #8675: pins that the openai_codex call site of
+        // `sanitize_tool_arguments` is wired in. The helper contract itself
+        // is covered in `compatible::tests::sanitize_tool_arguments_*`.
+        let call = ProviderToolCall {
+            id: "call_bad".to_string(),
+            name: "shell".to_string(),
+            arguments: r#"{"command":"rm -rf"#.to_string(),
+            extra_content: None,
+        };
+
+        let item = build_function_call_item(call);
+        assert_eq!(item["type"], "function_call");
+        assert_eq!(item["call_id"], "call_bad");
+        assert_eq!(item["name"], "shell");
+        assert_eq!(item["arguments"], "{}");
+    }
+
+    #[test]
+    fn build_function_call_item_passes_through_valid_arguments() {
+        // Companion regression: valid JSON must round-trip byte-for-byte.
+        let call = ProviderToolCall {
+            id: "call_ok".to_string(),
+            name: "shell".to_string(),
+            arguments: r#"{"command":"pwd"}"#.to_string(),
+            extra_content: None,
+        };
+
+        let item = build_function_call_item(call);
+        assert_eq!(item["arguments"], r#"{"command":"pwd"}"#);
     }
 }

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -1877,7 +1877,11 @@ mod tests {
         let tool_calls = converted[0].tool_calls.as_ref().unwrap();
         assert_eq!(tool_calls.len(), 3);
         for tc in tool_calls {
-            assert_eq!(tc.function.arguments, "{}", "non-object arg for {} must normalize to empty object", tc.function.name);
+            assert_eq!(
+                tc.function.arguments, "{}",
+                "non-object arg for {} must normalize to empty object",
+                tc.function.name
+            );
         }
     }
 

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -260,13 +260,19 @@ impl OpenRouterModelProvider {
                 {
                     let tool_calls = parsed_calls
                         .into_iter()
-                        .map(|tc| NativeToolCall {
-                            id: Some(tc.id),
-                            kind: Some("function".to_string()),
-                            function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
-                            },
+                        .map(|tc| {
+                            let name = tc.name;
+                            NativeToolCall {
+                                id: Some(tc.id),
+                                kind: Some("function".to_string()),
+                                function: NativeFunctionCall {
+                                    arguments: crate::compatible::sanitize_tool_arguments(
+                                        &name,
+                                        &tc.arguments,
+                                    ),
+                                    name,
+                                },
+                            }
                         })
                         .collect::<Vec<_>>();
                     let content = crate::request_payload::non_empty_string_field(&value, "content")

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -1848,8 +1848,8 @@ mod tests {
 
     #[test]
     fn convert_messages_passes_through_valid_tool_arguments() {
-        // Companion regression: valid JSON must round-trip byte-for-byte so
-        // the openrouter call site cannot accidentally re-encode or strip
+        // Companion regression: valid JSON object must round-trip byte-for-byte
+        // so the openrouter call site cannot accidentally re-encode or strip
         // good payloads.
         let messages = vec![ChatMessage {
             role: "assistant".into(),
@@ -1860,6 +1860,25 @@ mod tests {
         let converted = OpenRouterModelProvider::convert_messages(&messages);
         let tool_calls = converted[0].tool_calls.as_ref().unwrap();
         assert_eq!(tool_calls[0].function.arguments, r#"{"command":"pwd"}"#);
+    }
+
+    #[test]
+    fn convert_messages_rejects_non_object_tool_arguments() {
+        // Strict providers (Cohere, OpenRouter auto-exacto) require a JSON
+        // object for tool-call arguments. Null, arrays, strings, numbers, and
+        // booleans are valid JSON but must not reach the upstream.
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"testing","tool_calls":[{"id":"c1","name":"f","arguments":"null"},{"id":"c2","name":"g","arguments":"[]"},{"id":"c3","name":"h","arguments":"42"}]}"#
+                .into(),
+        }];
+
+        let converted = OpenRouterModelProvider::convert_messages(&messages);
+        let tool_calls = converted[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 3);
+        for tc in tool_calls {
+            assert_eq!(tc.function.arguments, "{}", "non-object arg for {} must normalize to empty object", tc.function.name);
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -1825,6 +1825,44 @@ mod tests {
     }
 
     #[test]
+    fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
+        // Regression for #8675: a malformed arguments string in the assistant
+        // history must be normalized to "{}" so the outbound chat-completions
+        // request doesn't 400 on strict upstreams. This test pins that the
+        // openrouter call site of `sanitize_tool_arguments` is wired in; the
+        // helper contract itself is covered in
+        // `compatible::tests::sanitize_tool_arguments_*`.
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"trying","tool_calls":[{"id":"call_bad","name":"shell","arguments":"{\"command\":\"rm -rf"}]}"#
+                .into(),
+        }];
+
+        let converted = OpenRouterModelProvider::convert_messages(&messages);
+        let tool_calls = converted[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id.as_deref(), Some("call_bad"));
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(tool_calls[0].function.arguments, "{}");
+    }
+
+    #[test]
+    fn convert_messages_passes_through_valid_tool_arguments() {
+        // Companion regression: valid JSON must round-trip byte-for-byte so
+        // the openrouter call site cannot accidentally re-encode or strip
+        // good payloads.
+        let messages = vec![ChatMessage {
+            role: "assistant".into(),
+            content: r#"{"content":"using","tool_calls":[{"id":"call_ok","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#
+                .into(),
+        }];
+
+        let converted = OpenRouterModelProvider::convert_messages(&messages);
+        let tool_calls = converted[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls[0].function.arguments, r#"{"command":"pwd"}"#);
+    }
+
+    #[test]
     fn native_message_omits_reasoning_content_when_none() {
         let msg = NativeMessage {
             role: "assistant".to_string(),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** #8675 reports that on OpenRouter-routed upstreams (Cohere, OpenInference, Nvidia …) a single malformed `tool_calls[].function.arguments` string from a smaller / reasoning model causes a HTTP 400 on the whole chat-completions request, the runtime classifies it non-retryable, the turn's final text is empty, and the user only sees the generic `"I couldn't produce a visible reply for that message. Please try again."` fallback. `compatible.rs` already guards this with `ToolCall::into_provider_tool_call`, but the five typed providers — `openrouter`, `openai`, `azure_openai`, `copilot`, `openai_codex` — re-serialize the parsed history verbatim (`convert_messages` / `build_responses_input`) without that check, so a malformed assistant tool-call from one turn poisons every subsequent turn's outbound request. This PR lifts the same normalization contract out as a small shared `sanitize_tool_arguments` helper in `crate::compatible` and routes all five outbound paths and the streaming accumulator through it.
- **Round-2 follow-up:** the new helper and the existing in-line normalization inside `StreamToolCallAccumulator::into_provider_tool_call` are now collapsed to a single source of truth — the inline implementation is gone, the accumulator calls `sanitize_tool_arguments`. The malformed-arguments WARN event records only safe metadata (`function`, `payload_len`, `error_key = "tool_args_invalid_json"`); the raw arguments string is no longer logged because tool-call payloads can carry commands, URLs, credentials, paths, or user content and WARN events enter the broadcast/rolling-persistence path regardless of the tool/LLM content-capture policy.
- **Round-3 follow-up:** the helper now enforces the strict-provider **object contract**: only JSON objects (e.g. `{"key": "value"}`) pass through; non-object values (`null`, `[]`, `42`, `"hello"`) are normalized to `"{}"`, closing the gap where syntactically valid JSON that is not a function-arguments object could still trigger a 400 on strict providers (Cohere, OpenRouter). The helper visibility is `pub(crate)` — it is an internal normalization contract, not a public API surface.
- **Round-4 follow-up:** `cargo fmt` applied to the OpenRouter non-object regression test that was added in round 3; no behavioral change.
- **Scope boundary:** Only the five typed providers' outbound `convert_messages` / `build_responses_input` paths and the streaming accumulator's `into_provider_tool_call` are touched. The **inbound** parse paths that translate upstream responses into `ProviderChatResponse` are unchanged: malformed arguments on the wire are still observable to the model and to the runtime — only the **re-serialization** is sanitized. Provider selection, default routing, and fallback behavior are explicitly out of scope.
- **Blast radius:** Six files in `zeroclaw-providers`, one `pub(crate)` helper consumed by six call sites (five typed providers + streaming accumulator). All call sites are pure additive on the diff line; no provider selection, default, or routing behavior is touched. The only observable behavior change is in the malformed-arguments failure mode that #8675 itself documents — those calls now serialize `"{}"` upstream instead of a 400, and the WARN event no longer carries the raw arguments string.
- **Linked issue(s):** Fixes #8675. Supersedes #8748. Supersedes #8749.

## Supersede Attribution

Both #8748 and #8749 were earlier attempts at the same fix by the same author (`wangmiao0668000666`). #8931 carries forward:

- the shared-helper contract from #8748 (lifted into `compatible::sanitize_tool_arguments`);
- the per-provider call-site coverage from #8749 (five typed providers + `openai_codex`), expanded with 10 per-call-site regression tests;
- the streaming-accumulator consolidation and WARN-event data minimisation added in round 2;
- the object-contract enforcement and `pub(crate)` visibility restriction added in round 3.

No additional `Co-authored-by` trailer is needed — the four commits on this branch (`731112bb3`, `a1ce6f4d6`, `956dab74e`, `a45f257ca`) already carry the same author as both predecessor PRs. Both #8748 and #8749 were closed unmerged and explicitly name #8931 as their replacement; this PR is the canonical fix.

## Changes

- `crates/zeroclaw-providers/src/compatible.rs` — `pub(crate) fn sanitize_tool_arguments(function_name: &str, arguments: &str) -> String`. Enforces the JSON object contract: only `serde_json::Value::Object(_)` passes through; non-object values (`null`, `[]`, strings, numbers, booleans) are normalized to `"{}"`, closing the strict-provider object-shaped-arguments rejection path. Four unit tests (`sanitize_tool_arguments_empty_or_whitespace_becomes_empty_object`, `…_valid_json_is_passthrough`, `…_invalid_json_becomes_empty_object`, `…_non_object_becomes_empty_object`). The WARN event records `function` / `payload_len` / `error_key` only — the raw arguments string is no longer captured. The streaming `StreamToolCallAccumulator::into_provider_tool_call` delegates to `sanitize_tool_arguments`; the duplicate inline JSON-parse + WARN path is removed.
- `crates/zeroclaw-providers/src/openrouter.rs` — outbound `convert_messages` `NativeFunctionCall.arguments` calls the helper. Three regression tests (`convert_messages_sanitizes_invalid_tool_arguments_to_empty_object`, `convert_messages_passes_through_valid_tool_arguments`, `convert_messages_rejects_non_object_tool_arguments`) pin the call-site behavior including the non-object rejection path.
- `crates/zeroclaw-providers/src/openai.rs` — same change in `convert_messages` plus the two regression tests.
- `crates/zeroclaw-providers/src/azure_openai.rs` — same change in `convert_messages` plus the two regression tests.
- `crates/zeroclaw-providers/src/copilot.rs` — same change in `convert_messages` plus the two regression tests.
- `crates/zeroclaw-providers/src/openai_codex.rs` — outbound `function_call` `arguments` field is now built through a `pub(crate) fn build_function_call_item(call: ProviderToolCall) -> Value` helper that calls `sanitize_tool_arguments`. Two regression tests (`build_function_call_item_sanitizes_invalid_arguments_to_empty_object`, `…_passes_through_valid_arguments`) pin the helper.

## Testing (required)

### How you can test

**Reviewer testing requested?** N/A — this is a deterministic data-normalization change at the outbound serialization boundary. The per-provider regression tests prove each call site routes through the shared helper, and the helper-contract tests cover all four input branches (empty/whitespace, valid object JSON, invalid JSON, non-object JSON). No environment-specific behavior to verify by hand.

### How I tested

**Commands that ran on the current head (`a45f257ca`):**

```text
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 57s
(no warnings)

$ cargo test --locked -p zeroclaw-providers --lib -- sanitize_tool_arguments convert_messages build_function_call_item
test compatible::tests::sanitize_tool_arguments_empty_or_whitespace_becomes_empty_object ... ok
test compatible::tests::sanitize_tool_arguments_valid_json_is_passthrough ... ok
test compatible::tests::sanitize_tool_arguments_invalid_json_becomes_empty_object ... ok
test compatible::tests::sanitize_tool_arguments_non_object_becomes_empty_object ... ok
test openrouter::tests::convert_messages_sanitizes_invalid_tool_arguments_to_empty_object ... ok
test openrouter::tests::convert_messages_passes_through_valid_tool_arguments ... ok
test openrouter::tests::convert_messages_rejects_non_object_tool_arguments ... ok
test openai::tests::convert_messages_sanitizes_invalid_tool_arguments_to_empty_object ... ok
test openai::tests::convert_messages_passes_through_valid_tool_arguments ... ok
test azure_openai::tests::convert_messages_sanitizes_invalid_tool_arguments_to_empty_object ... ok
test azure_openai::tests::convert_messages_passes_through_valid_tool_arguments ... ok
test copilot::tests::convert_messages_sanitizes_invalid_tool_arguments_to_empty_object ... ok
test copilot::tests::convert_messages_passes_through_valid_tool_arguments ... ok
test openai_codex::tests::build_function_call_item_sanitizes_invalid_arguments_to_empty_object ... ok
test openai_codex::tests::build_function_call_item_passes_through_valid_arguments ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 1083 filtered out; finished in 0.00s
```

15 new tests across 4 rounds: 4 helper-contract tests in `compatible.rs` (empty/whitespace, valid JSON, invalid JSON, non-object), + 3 in `openrouter.rs` (sanitize, passthrough, reject-non-object), + 2 each in `openai.rs`, `azure_openai.rs`, `copilot.rs`, and `openai_codex.rs`.

Full crate test suite: `cargo test --locked -p zeroclaw-providers --lib` — 1098 passed, 0 failed.

**CI evidence (separate from local validation):** GitHub Actions run on the current head includes `cargo fmt --all -- --check`, `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`, `cargo test --locked -p zeroclaw-providers --lib`, plus the cross-platform matrix (`aarch64-apple-darwin`, `x86_64-pc-windows-msvc`). All green.

**Skipped commands (with reason):**

- `cargo clippy --all-targets -- -D warnings` (full workspace) — **skipped locally** because it is already exercised on every PR by the GitHub `Lint` job; running it locally duplicates CI coverage without adding reviewer-relevant signal. The crate-scoped `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` above is the authoritative clippy pass for this PR's diff surface.
- `cargo test --locked` (full workspace) — **skipped locally** for the same reason; the GitHub `Test` job exercises the full workspace. The crate-scoped `cargo test --locked -p zeroclaw-providers --lib` is the authoritative regression pass for this PR's diff surface (1098 / 1098 passed).
- `cargo test --locked -p zeroclaw-providers --lib --test '*'` (full integration tests) — **skipped**: integration tests under `tests/` are covered by the same GitHub `Test` job and the diff does not touch any integration-test surface.

## Real behavior proof

- **Behavior addressed:** A malformed `tool_calls[].function.arguments` JSON string (or a non-object JSON value) in the assistant history turns into a 400 on strict upstreams (Cohere, OpenInference, Nvidia via OpenRouter) and the user sees the generic fallback instead of the agent's reply.
- **Real environment tested:** Linux x86_64, Rust stable via `rust-toolchain.toml`, `zeroclaw-providers` crate only.
- **Exact steps run after this patch:**
  - `cargo fmt --all -- --check` — clean
  - `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` — clean
  - `cargo test --locked -p zeroclaw-providers --lib` — 1098 / 1098 passed
- **Evidence after fix:** every per-call-site regression confirms malformed arguments round-trip to `"{}"` in the outbound payload; the matching `*_passes_through_valid_arguments` test confirms valid object JSON is preserved byte-for-byte; the `non_object` test confirms `null`, `[]`, `42`, and `"hello"` are all normalized to `"{}"`; the `rejects_non_object_tool_arguments` regression confirms the OpenRouter call site rejects non-object values at the serialization boundary.
- **Observed result after fix:** the malformed-JSON → 400 and non-object-JSON → 400 failure modes are now closed through the re-serialization path; the helper guarantees `tool_calls[].function.arguments` is either a valid JSON object or `"{}"` before serialization. Schema/shape rejection on valid objects (where the JSON object fails the provider's tool-schema validation) is a separate upstream concern outside this PR's normalization boundary.
- **What was not tested:** Live HTTP against Cohere / OpenInference / Nvidia / OpenRouter — the regression suite only pins the boundary contracts, not the upstream status code. Schema/shape rejection (where a structurally valid JSON object fails the provider's tool-schema validation) is a separate failure class not covered by this sanitization path.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — changes only the outbound payload shape; does not add or remove endpoints.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — the round-2 change removed raw tool-call arguments from WARN events so that commands, URLs, credentials, paths, or user content no longer enter the broadcast/rolling-persistence path through this WARN. Tests use synthetic payloads only.
- Prompt injection or untrusted model-visible text introduced/changed? `Yes`, narrowing only — the entire change is a defense-in-depth sanitization of untrusted model-output tool-call arguments at the outbound serialization boundary. Invalid and non-object JSON arguments are normalized to `"{}"` before the next outbound request, closing the #8675 400 path without introducing new prompt-injection surface.

- **Deny-by-default posture:** Yes. Invalid and non-object JSON arguments are rendered as `"{}"` before serialization; empty/whitespace arguments receive the same treatment.

## Compatibility (required)

- Backward compatible? `Yes` — valid object JSON round-trips byte-for-byte; only previously-400-producing payloads change (from malformed/non-object JSON to `"{}"`), which is a strict improvement on #8675's reproducer.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

- **Wire protocol change:** Yes, narrowing only (see backward-compatible above).
- **Public API breakage:** No. `sanitize_tool_arguments` is `pub(crate)`; no external API surface is added or changed.
- **CLI / FTL / localization change:** No.
- **DB / state-file change:** No.

## Rollback

- **Rollback path:** `git revert <squash-merge-commit>` after this PR lands. Reverting the eventual squash-merge commit restores pre-8931 behavior where each provider path independently re-serializes verbatim history and the streaming accumulator carries a duplicate inline normalization. This rollback undoes the entire `#8675` fix in a single revert; the predecessor PRs (#8748, #8749) were closed unmerged so there is no stacked history to unwind.
- **Feature toggle:** None (not gated by a config flag).
- **Observable failure after rollback:** Malformed or non-object tool-call arguments from assisted/reasoning models resume causing HTTP 400 on strict providers (Cohere, OpenInference, Nvidia via OpenRouter), and the raw arguments string resumes appearing in the malformed-arguments WARN event.

## Label snapshot

- **Live labels on this PR:** `bug`, `priority:p1`, `provider`, `provider:azure-openai`, `provider:compatible`, `provider:copilot`, `provider:openai`, `provider:openrouter`, `risk:medium`, `size:M`
- **Milestone:** `Provider Transport: Wire-Protocol Hardening`

## Risk

Medium. This is a behavioral change in `crates/zeroclaw-providers/src/**` that replaces malformed and non-object tool-call arguments with `"{}"` at the outbound serialization boundary. Valid object JSON round-trips byte-for-byte (verified by 5 paired `*_passes_through_valid_arguments` tests). The only changed observable behavior is on the malformed/non-object input failure mode that #8675 documents — those calls now serialize `"{}"` instead of triggering a 400 — and on the WARN event that records the failure, which now logs only safe metadata. A bug in the helper would affect all provider outbound paths equally, but the 4 helper-contract tests + 11 per-call-site regressions provide deterministic coverage of empty/whitespace, valid object, invalid JSON, and non-object branches.

## Manual verification

None beyond `cargo test`. The change is a pure-data normalization contract — no environment-specific behavior to verify by hand.

