### PR TITLE
fix(zerocode): apply fill_style() to queue sidebar and session picker overlays

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -3085,7 +3085,8 @@ fn render_queue_sidebar(f: &mut Frame, state: &mut ChatState, area: Rect) {
     );
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(Span::styled(format!(" {title} "), theme::title_style()));
+        .title(Span::styled(format!(" {title} "), theme::title_style()))
+        .style(theme::fill_style());
     let inner = block.inner(area);
     f.render_widget(Clear, area);
     f.render_widget(block, area);
@@ -3860,11 +3861,12 @@ fn render_session_list_overlay(
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_style(theme::overlay_border_style())
         .title(Span::styled(
             " Sessions (Enter=switch, Esc=close) ",
             theme::overlay_border_style(),
         ))
-        .style(theme::overlay_border_style());
+        .style(theme::fill_style());
 
     let inner = block.inner(overlay_area);
     f.render_widget(block, overlay_area);


### PR DESCRIPTION
## Summary

- Apply `theme::fill_style()` to the queue sidebar block in `render_queue_sidebar()` so the overlay interior repaints with the active ZeroCode theme background after `Clear`, instead of inheriting the terminal default background.
- Apply `theme::fill_style()` to the session picker block in `render_session_list_overlay()` and explicitly set `border_style(overlay_border_style())` separately, so the block interior uses the theme background while preserving the existing accent border/title styling.

Closes #8765

## Problem

Both `render_queue_sidebar()` and `render_session_list_overlay()` call `Clear` to erase the underlying content, then render a `Block` on top. The queue sidebar block had no `.style()` at all, and the session picker block used `.style(overlay_border_style())` which only sets the foreground color — neither applied the theme background. This means the overlay interior inherits the terminal's default background color, which is visibly wrong when the terminal profile uses a light background while ZeroCode uses a dark theme.

Every other overlay in the codebase (approval, elicitation, file explorer, help modal, quit confirm, quickstart wizard, etc.) already calls `.style(theme::fill_style())` on its block after `Clear`. These two were the only outliers.

## Risk

Low — UI-only rendering change. Both functions already call `Clear` before the block; this ensures the cleared area is repainted with the correct theme background. No logic, state, or API changes.

## Testing

- Verified that all other overlay rendering functions in `apps/zerocode/src/chat.rs` and `apps/zerocode/src/app.rs` already use `fill_style()` on their blocks after `Clear`, confirming this is the established pattern.
- The `render_session_list_overlay` change also separates `border_style` from the block `style`, which matches how other overlays (e.g., `render_approval_overlay`, `render_elicitation_overlay`) handle border vs interior styling.