### PR TITLE
fix(sop): advance to linear next step when when-guard is false

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -211,7 +211,9 @@ mod tests {
         run.current_step = 1;
         run.total_steps = 3;
         let mut run_data = RunData::default();
-        run_data.outputs.insert(1, serde_json::json!({"remaining": 0}));
+        run_data
+            .outputs
+            .insert(1, serde_json::json!({"remaining": 0}));
         let ctx = RouteCtx {
             sop: &sop,
             run: &run,
@@ -231,7 +233,9 @@ mod tests {
         let mut run = run();
         run.current_step = 2;
         let mut run_data = RunData::default();
-        run_data.outputs.insert(2, serde_json::json!({"remaining": 0}));
+        run_data
+            .outputs
+            .insert(2, serde_json::json!({"remaining": 0}));
         let ctx = RouteCtx {
             sop: &sop,
             run: &run,

--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -37,10 +37,28 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
         return NextStep::Complete;
     };
 
-    if let Some(when) = current.routing.when.as_deref()
-        && !evaluate_condition(when, Some(&ctx.run_data.to_payload().to_string()))
-    {
-        return NextStep::Complete;
+    let when_holds = if let Some(when) = current.routing.when.as_deref() {
+        evaluate_condition(when, Some(&ctx.run_data.to_payload().to_string()))
+    } else {
+        true
+    };
+
+    if !when_holds {
+        let linear_next = ctx.run.current_step.saturating_add(1);
+        if linear_next > ctx.run.total_steps {
+            return NextStep::Complete;
+        }
+        let Some(step) = ctx.sop.steps.iter().find(|s| s.number == linear_next) else {
+            return NextStep::Complete;
+        };
+        if !guard::within_visit_bound(ctx.run, linear_next, ctx.max_step_visits) {
+            return NextStep::Fail(format!("step {linear_next} visit limit reached"));
+        }
+        return if eligible(step, ctx.run_data) {
+            NextStep::Step(linear_next)
+        } else {
+            NextStep::Wait(linear_next)
+        };
     }
 
     let explicit_next = current.routing.next;
@@ -167,5 +185,61 @@ mod tests {
         };
 
         assert_eq!(resolve_next(&ctx), NextStep::Wait(2));
+    }
+
+    #[test]
+    fn when_false_advances_to_linear_next() {
+        let mut sop = sop();
+        sop.steps[0].routing.when = Some("$.steps.1.remaining > 0".into());
+        sop.steps[0].routing.next = Some(1);
+        sop.steps.push(SopStep {
+            number: 3,
+            title: "Review".into(),
+            body: String::new(),
+            suggested_tools: Vec::new(),
+            requires_confirmation: false,
+            kind: SopStepKind::Execute,
+            schema: None,
+            scope: None,
+            routing: StepRouting::default(),
+            on_failure: Default::default(),
+            mode: None,
+            capability: None,
+            capability_input: None,
+        });
+        let mut run = run();
+        run.current_step = 1;
+        run.total_steps = 3;
+        let mut run_data = RunData::default();
+        run_data.outputs.insert(1, serde_json::json!({"remaining": 0}));
+        let ctx = RouteCtx {
+            sop: &sop,
+            run: &run,
+            run_data: &run_data,
+            last_status: SopStepStatus::Completed,
+            max_step_visits: 256,
+        };
+
+        assert_eq!(resolve_next(&ctx), NextStep::Step(2));
+    }
+
+    #[test]
+    fn when_false_on_last_step_completes() {
+        let mut sop = sop();
+        sop.steps[1].routing.when = Some("$.steps.2.remaining > 0".into());
+        sop.steps[1].routing.next = Some(2);
+        let mut run = run();
+        run.current_step = 2;
+        let mut run_data = RunData::default();
+        run_data.outputs.insert(2, serde_json::json!({"remaining": 0}));
+        let ctx = RouteCtx {
+            sop: &sop,
+            run: &run,
+            run_data: &run_data,
+            last_status: SopStepStatus::Completed,
+            max_step_visits: 256,
+        };
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 }


### PR DESCRIPTION
## Summary

- Change `resolve_next` so that a false `when` guard advances to the linear next step (`current_step + 1`) instead of completing the run. This enables multi-phase SOPs where a self-looping step is followed by a finalize/review step.
- When `when` is false and the linear next step exceeds `total_steps`, the run still completes (backward compatible for tail-loop SOPs).
- Add two unit tests: `when_false_advances_to_linear_next` and `when_false_on_last_step_completes`.

Closes #8719

## Problem

`route::resolve_next` treats a false `when` as run completion. This makes a self-looping step (e.g., `when: $.steps.N.remaining > 0`, `next: N`) effectively terminal: the moment the condition clears, the run ends. There is no way to express a loop followed by a finalize step.

## Proposed behavior

- `when` true: follow the explicit `next` (the loop back-edge), as today.
- `when` false: advance to `current_step + 1` instead of `Complete`.
- No `when`: follow `next`/`current_step + 1`, as today.

This is backward compatible: for existing tail-loop SOPs where the looping step is the last step, `current_step + 1` exceeds `total_steps` and the run still completes.

## Risk

Medium — changes SOP routing behavior, but the change is backward compatible for all existing SOPs where a loop step is the last step. Only SOPs that place a step after a loop gain the new behavior (they now reach it instead of ending). The fix is confined to a single function (`resolve_next`).

## Testing

- `when_false_advances_to_linear_next`: step 1 has `when: $.steps.1.remaining > 0` and `next: 1`; when `remaining == 0`, `resolve_next` returns `Step(2)` instead of `Complete`.
- `when_false_on_last_step_completes`: step 2 (last) has `when: $.steps.2.remaining > 0` and `next: 2`; when `remaining == 0`, `resolve_next` returns `Complete` (backward compatible).
- Existing tests `linear_default_routes_to_next_step` and `dependency_without_output_waits` continue to pass unchanged.