### PR TITLE
fix(config): put Ollama endpoint in uri, not api_key, in dev templates

### DIFF
--- a/dev/config.harness-test.toml
+++ b/dev/config.harness-test.toml
@@ -1,10 +1,20 @@
-workspace_dir = "/zeroclaw-data/workspace"
-config_path = "/zeroclaw-data/.zeroclaw/config.toml"
-# API key: set via .env or environment variable at runtime
-api_key = "http://host.docker.internal:11434"
-default_provider = "ollama"
-default_model = "llama3.2"
-default_temperature = 0.7
+schema_version = 3
+
+# Ollama running on the host. The endpoint belongs in `uri` under the
+# provider alias, NOT in a top-level `api_key` (which is a secret bearer
+# token, not a URL).
+[providers.models.ollama.default]
+model = "llama3.2"
+uri = "http://host.docker.internal:11434"
+
+[agents.default]
+enabled = true
+model_provider = "ollama.default"
+risk_profile = "default"
+
+[risk_profiles.default]
+level = "supervised"
+auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory_store", "web_search_tool", "web_fetch", "calculator", "glob_search", "content_search", "image_info", "git_operations"]
 
 [gateway]
 port = 42617
@@ -12,14 +22,15 @@ host = "[::]"
 allow_public_bind = true
 require_pairing = false
 
-[agent]
+# Iteration/context caps live on the runtime profile in V3 (previously the
+# V1 `[agent]` block), and the agent references the profile by alias.
+[runtime_profiles.default]
 max_tool_iterations = 50
-max_tool_result_chars = 50000
 max_context_tokens = 32000
+max_tool_result_chars = 50000
 
-[agent.context_compression]
+[runtime_profiles.default.context_compression]
 enabled = true
-tool_result_retrim_chars = 2000
 
 [memory]
 backend = "sqlite"
@@ -28,7 +39,3 @@ hygiene_enabled = true
 archive_after_days = 7
 purge_after_days = 30
 embedding_provider = "none"
-
-[autonomy]
-level = "supervised"
-auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory_store", "web_search_tool", "web_fetch", "calculator", "glob_search", "content_search", "image_info", "git_operations"]

--- a/dev/config.template.toml
+++ b/dev/config.template.toml
@@ -1,10 +1,23 @@
-workspace_dir = "/zeroclaw-data/workspace"
-config_path = "/zeroclaw-data/.zeroclaw/config.toml"
-# This is the Ollama Base URL, not a secret key
-api_key = "http://host.docker.internal:11434"
-default_provider = "ollama"
-default_model = "llama3.2"
-default_temperature = 0.7
+schema_version = 3
+
+# Ollama running on the host. The endpoint belongs in `uri` under the
+# provider alias, NOT in a top-level `api_key` (which is a secret bearer
+# token, not a URL). `host.docker.internal` resolves to the Docker host on
+# Docker Desktop / OrbStack; on Linux add `--add-host=host.docker.internal:host-gateway`.
+[providers.models.ollama.default]
+model = "llama3.2"
+uri = "http://host.docker.internal:11434"
+
+# A V3 config needs at least one dispatchable agent pointing at a provider
+# alias, or the gateway stays in `needs_quickstart` mode (503 on chat).
+[agents.default]
+enabled = true
+model_provider = "ollama.default"
+risk_profile = "default"
+
+[risk_profiles.default]
+level = "supervised"
+auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory_store", "web_search_tool", "web_fetch", "calculator", "glob_search", "content_search", "image_info", "weather", "git_operations"]
 
 [gateway]
 port = 42617


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `dev/config.template.toml` and `dev/config.harness-test.toml` (baked into every Docker image via `COPY`) stored the Ollama base URL in the top-level `api_key` field with a comment claiming it was "not a secret key." ZeroClaw treats `api_key` as a bearer token and sends it as `Authorization: Bearer <url>`; the actual endpoint field is `uri` on the provider alias. With `uri` unset, the provider fell back to `http://localhost:11434/v1`, so every container using the baked Ollama config could not reach a host-side Ollama and chat returned HTTP 500 "LLM request failed."
- **Scope boundary:** Only the two dev config templates. No Dockerfile, runtime, provider, or schema code changes. The inline configs in the Dockerfiles (`api_key = ""` for OpenRouter) are unaffected.
- **Blast radius:** Affects the baked default config of the alpine, debian, and main Docker images (all COPY `dev/config.template.toml`). Operators who override via env vars or bind-mount their own config are unaffected.
- **Linked issue(s):** None tracked.
- **Labels:** `bug`, `config`, `provider`, `dev`, `provider:ollama`, `risk:medium`, `size:XS`

The templates are rewritten as `schema_version = 3` (the current schema version). A `schema_version = 2` declaration triggers the V2→V3 migration, which restructures the providers table and drops fields; V3 loads natively. A native V3 config also needs an explicit `[agents.default]` + `[risk_profiles.default]` block to be dispatchable, so those are added.

## Validation Evidence (required)

- **Commands run and tail output:**
  - Schema parse + field-resolution test (both templates):
    ```
    running 2 tests
    test dev_template_ollama_provider_resolves_uri_and_model ... ok
    test harness_test_template_ollama_provider_resolves_uri_and_model ... ok
    test result: ok. 2 passed; 0 failed
    ```
- **Beyond CI — what did I manually verify?** End-to-end runtime test: fresh Docker volume (no persisted quickstart state), the fixed template as the baked config with **zero env-var overrides**, model swapped to a locally-available `gemma4:latest`:
  ```
  POST /webhook {"message":"Reply with exactly the word pong and nothing else."}
  → {"model":"gemma4:latest","response":"pong"}  HTTP 200

  POST /webhook {"message":"What is the capital of France? One word."}
  → {"model":"gemma4:latest","response":"Paris"}  HTTP 200
  ```
  The daemon's resolved config (via `/api/config`) confirmed `ollama.default` carried both `uri` and `model` and no `api_key`.
- **If any command was intentionally skipped, why:** Did not run the full `cargo test` battery — this PR touches only two data files consumed at runtime; the targeted schema-parse test plus the live runtime verification covers the change. fmt/clippy are N/A (no code changed).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — corrects where an existing endpoint URL is stored; does not add calls.
- Secrets / tokens / credentials handling changed? **No** — removes a value that was incorrectly stored as a credential; no real secrets are involved.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — the baked config now works where it previously did not.
- Config / env / CLI surface changed? **Yes** (dev template only). The default model remains `llama3.2`; operators who bind-mount their own config are unaffected.
- Upgrade steps: none required. Operators using the baked Ollama default now get a reachable endpoint automatically.

## Rollback

Medium-risk; `git revert <sha>` restores the prior templates.
