### PR TITLE
feat(container): add multi-arch Alpine/musl image via cargo-zigbuild

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,267 @@
+# syntax=docker/dockerfile:1.7-labs
+
+# Dockerfile.alpine — Alpine/musl variant of the ZeroClaw container.
+#
+# Produces a small statically-linked image with a shell (busybox), suitable for
+# x86_64 (Intel/AMD linux, Proxmox LXC), aarch64 (Apple Silicon, Graviton), and
+# anywhere a minimal musl image is preferable to glibc. The builder cross-
+# compiles both musl targets via cargo-zigbuild, so rustc always runs native
+# (pinned to $BUILDPLATFORM) and never under QEMU emulation.
+#
+# Build for the local platform only (fastest smoke test):
+#   docker build -f Dockerfile.alpine -t zeroclaw:alpine .
+#
+# Multi-arch build (both amd64 + arm64, no QEMU for rustc):
+#   docker buildx build -f Dockerfile.alpine \
+#     --platform linux/amd64,linux/arm64 -t zeroclaw:alpine --load .
+#
+# Or with docker compose:
+#   docker compose -f docker-compose.alpine.yml up --build
+
+# ── Stage 0: Frontend build ─────────────────────────────────────
+# The web dashboard bundle is architecture-independent (JS/WASM), so the
+# frontend tooling stages are pinned to the native build platform. On a
+# multi-platform build this keeps node and `cargo web build` running natively
+# instead of under QEMU emulation.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS web-node
+
+FROM --platform=$BUILDPLATFORM rust:1.94-alpine AS web-builder
+WORKDIR /app
+COPY --from=web-node /usr/local/bin/node /usr/local/bin/node
+COPY --from=web-node /usr/local/lib/node_modules /usr/local/lib/node_modules
+# node:alpine installs npm into /usr/local/lib/node_modules; symlink the CLIs.
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && apk add --no-cache pkgconfig g++
+COPY web/package.json web/package-lock.json web/
+RUN cd web && npm ci --ignore-scripts
+COPY . .
+# Stub apps/tauri so `cargo web build` (which resolves the full workspace)
+# does not trip on its build.rs before the real source arrives via `COPY . .`.
+RUN mkdir -p apps/tauri/src \
+    && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && echo "fn main() {}" > apps/tauri/build.rs
+RUN --mount=type=cache,id=zeroclaw-cargo-registry-alpine,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git-alpine,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-web-target-alpine,target=/app/target,sharing=locked \
+    cargo web build
+
+# ── Stage 1: Build (Alpine/musl, cross-compiled via zigbuild) ───
+# Pinned to the native build platform; rustc runs on the host arch and cross-
+# compiles to $TARGETARCH so it never runs under QEMU. cargo-zigbuild provides
+# a symmetric C cross toolchain for both musl targets from either host arch —
+# unlike Alpine's apk cross-gcc packages, which only cover amd64→aarch64 (there
+# is no gcc-x86_64 musl cross package for aarch64 hosts). Zig also handles the
+# CC/CXX/linker/AR plumbing that ring needs, eliminating manual env-var setup.
+FROM --platform=$BUILDPLATFORM rust:1.94-alpine AS builder
+
+WORKDIR /app
+ARG TARGETARCH
+# >>> generated:docker-features-arg by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-amqp,channel-bluesky,channel-clawdtalk,channel-dingtalk,channel-discord,channel-email,channel-filesystem,channel-git,channel-imessage,channel-irc,channel-lark,channel-linq,channel-mattermost,channel-mochat,channel-mqtt,channel-nextcloud,channel-notion,channel-qq,channel-reddit,channel-signal,channel-slack,channel-telegram,channel-twitch,channel-twitter,channel-voice-call,channel-wati,channel-webhook,channel-wecom,channel-wecom-ws,channel-whatsapp-cloud,gateway,observability-prometheus,schema-export"
+# >>> end generated:docker-features-arg <<<
+
+# Install Alpine build dependencies.
+#   build-base — gcc, musl-dev, binutils (strip), make
+#   perl       — ring crate assembly preprocessing
+#   pkgconfig  — crate build scripts (e.g. flate2 zlib detection)
+#   zig        — symmetric C cross-compiler for both musl targets
+RUN apk add --no-cache \
+        build-base \
+        perl \
+        pkgconfig \
+        zig \
+    && cargo install --locked cargo-zigbuild
+
+# 1. Copy manifests to cache dependencies.
+COPY Cargo.toml Cargo.lock ./
+# Copy every workspace-member manifest in one glob — adding or removing a crate
+# no longer requires editing this file. --parents preserves the
+# crates/<name>/Cargo.toml directory structure.
+COPY --parents crates/*/Cargo.toml ./
+# zeroclaw-macros is a proc-macro crate, compiled for the host even on a cross
+# build. If only a stub lib.rs is present during the pre-fetch, its host-cached
+# artifact is reused in the real build under the target-triple dir, leaving
+# `zeroclaw_macros::Configurable` unresolved. Copy its real source now so the
+# proc-macro is built from the genuine implementation during the pre-fetch.
+COPY --parents crates/zeroclaw-macros/src/ ./
+# apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
+COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# apps/zerocode: TUI app shipped in the image; copy only its manifest so Cargo
+# can resolve the workspace, then stub its src/main.rs and build.rs below. Its
+# real build.rs reads web/src/contexts/themes.json and would panic in this
+# pre-fetch stage, so it is stubbed exactly like apps/tauri.
+COPY apps/zerocode/Cargo.toml apps/zerocode/Cargo.toml
+# tools/fill-translations and xtask are dev/build tools; copy manifests only so
+# Cargo can resolve the workspace, then stub their entry points so the
+# dependency pre-fetch step succeeds without building them into the image.
+COPY tools/fill-translations/Cargo.toml tools/fill-translations/Cargo.toml
+COPY xtask/Cargo.toml xtask/Cargo.toml
+# Create dummy targets for all workspace members so manifest parsing succeeds.
+# `src/bin/zeroclaw-acp-bridge.rs` is required because the `acp-bridge` feature
+# is in the root crate's default set; cargo selects the bin target during the
+# pre-fetch build even with only the workspace lib stubbed.
+RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-translations/src xtask/src/bin \
+    && echo "fn main() {}" > src/main.rs \
+    && echo "" > src/lib.rs \
+    && echo "fn main() {}" > src/bin/zeroclaw-acp-bridge.rs \
+    && echo "fn main() {}" > benches/agent_benchmarks.rs \
+    && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && echo "fn main() {}" > apps/tauri/build.rs \
+    && echo "fn main() {}" > apps/zerocode/src/main.rs \
+    && echo "fn main() {}" > apps/zerocode/build.rs \
+    && echo "fn main() {}" > tools/fill-translations/src/main.rs \
+    && echo "" > xtask/src/lib.rs \
+    && echo "fn main() {}" > xtask/src/bin/mdbook.rs \
+    && echo "fn main() {}" > xtask/src/bin/fluent.rs \
+    && echo "fn main() {}" > xtask/src/bin/web.rs \
+    && mkdir -p crates/zeroclaw-hardware/examples \
+    && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
+    && for d in crates/*/; do [ "$d" = "crates/zeroclaw-macros/" ] && continue; mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
+RUN --mount=type=cache,id=zeroclaw-cargo-registry-alpine,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git-alpine,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-target-alpine,target=/app/target,sharing=locked \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      export RUST_TARGET=aarch64-unknown-linux-musl; \
+    else \
+      export RUST_TARGET=x86_64-unknown-linux-musl; \
+    fi && \
+    rustup target add "$RUST_TARGET" && \
+    if [ -n "$ZEROCLAW_CARGO_FLAGS" ]; then \
+      cargo zigbuild --release --locked --target "$RUST_TARGET" -p zeroclawlabs -p zerocode $ZEROCLAW_CARGO_FLAGS; \
+    else \
+      cargo zigbuild --release --locked --target "$RUST_TARGET" -p zeroclawlabs -p zerocode; \
+    fi
+RUN rm -rf src benches crates xtask tools/fill-translations
+
+# 2. Copy real source and rebuild
+COPY src/ src/
+COPY benches/ benches/
+COPY crates/ crates/
+COPY xtask/ xtask/
+COPY tools/fill-translations/ tools/fill-translations/
+# apps/zerocode ships in the image; copy its real source. Its build.rs reads the
+# dashboard theme registry under web/src/contexts, so that path must be present.
+COPY apps/zerocode/ apps/zerocode/
+COPY web/src/ web/src/
+# locales.toml lives at repo root and is embedded by zeroclaw-runtime via
+# include_str!("../../../locales.toml"); the real build needs it present.
+COPY locales.toml .
+COPY *.rs .
+RUN touch src/main.rs apps/zerocode/src/main.rs
+# Bust the stubbed workspace crates so the real sources rebuild. zerocode is
+# purged from BOTH the target tree and the host tree (target/release/): with
+# --target, build scripts compile in the host tree, so its real build.rs (which
+# generates theme_presets.rs into OUT_DIR) must replace the no-op stub compiled
+# during the dependency pre-fetch, otherwise the include! finds no file.
+RUN --mount=type=cache,id=zeroclaw-cargo-registry-alpine,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git-alpine,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-target-alpine,target=/app/target,sharing=locked \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      export RUST_TARGET=aarch64-unknown-linux-musl; \
+    else \
+      export RUST_TARGET=x86_64-unknown-linux-musl; \
+    fi && \
+    rm -rf target/"$RUST_TARGET"/release/.fingerprint/zeroclawlabs-* \
+           target/"$RUST_TARGET"/release/deps/zeroclawlabs-* \
+           target/"$RUST_TARGET"/release/incremental/zeroclawlabs-* \
+           target/"$RUST_TARGET"/release/.fingerprint/zeroclaw-* \
+           target/"$RUST_TARGET"/release/deps/zeroclaw_* \
+           target/"$RUST_TARGET"/release/incremental/zeroclaw_* \
+           target/"$RUST_TARGET"/release/.fingerprint/xtask-* \
+           target/"$RUST_TARGET"/release/deps/xtask-* \
+           target/"$RUST_TARGET"/release/.fingerprint/fill-translations-* \
+           target/"$RUST_TARGET"/release/deps/fill_translations-* \
+           target/"$RUST_TARGET"/release/.fingerprint/zerocode-* \
+           target/"$RUST_TARGET"/release/deps/zerocode-* \
+           target/"$RUST_TARGET"/release/incremental/zerocode-* \
+           target/"$RUST_TARGET"/release/build/zerocode-* \
+           target/release/.fingerprint/zerocode-* \
+           target/release/build/zerocode-* && \
+    if [ -n "$ZEROCLAW_CARGO_FLAGS" ]; then \
+      cargo zigbuild --release --locked --target "$RUST_TARGET" -p zeroclawlabs -p zerocode $ZEROCLAW_CARGO_FLAGS; \
+    else \
+      cargo zigbuild --release --locked --target "$RUST_TARGET" -p zeroclawlabs -p zerocode; \
+    fi && \
+    cp target/"$RUST_TARGET"/release/zeroclaw /app/zeroclaw && \
+    cp target/"$RUST_TARGET"/release/zerocode /app/zerocode && \
+    # The builder runs on the native build arch and cross-compiles to the
+    # target triple, so the host `strip` only understands same-arch ELFs.
+    # Try to strip; if the host binutils can't parse the foreign ELF, keep
+    # the unstripped binary (strip is a size optimization, not correctness).
+    strip /app/zeroclaw /app/zerocode 2>/dev/null || \
+        echo "note: host strip cannot parse foreign-arch ELF; shipping unstripped"
+RUN for b in zeroclaw zerocode; do \
+      size=$(stat -c%s "/app/$b") && \
+      if [ "$size" -lt 1000000 ]; then echo "ERROR: $b too small (${size} bytes), likely dummy build artifact" && exit 1; fi; \
+    done
+
+# Prepare runtime directory structure and default config inline.
+# Dashboard assets live at /usr/share/zeroclawlabs/web/dist (outside the
+# documented /zeroclaw-data mount point) so a bind mount on /zeroclaw-data
+# cannot shadow them (#6400).
+RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/data && \
+    printf '%s\n' \
+        'api_key = ""' \
+        'default_provider = "openrouter"' \
+        'default_model = "anthropic/claude-sonnet-4-20250514"' \
+        'default_temperature = 0.7' \
+        '' \
+        '[gateway]' \
+        'port = 42617' \
+        'host = "[::]"' \
+        'allow_public_bind = true' \
+        'require_pairing = false' \
+        'web_dist_dir = "/usr/share/zeroclawlabs/web/dist"' \
+        '' \
+        '[risk_profiles.default]' \
+        'level = "supervised"' \
+        'auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory_store", "web_search_tool", "web_fetch", "calculator", "glob_search", "content_search", "image_info", "weather", "git_operations"]' \
+        > /zeroclaw-data/.zeroclaw/config.toml && \
+    chown -R 65534:65534 /zeroclaw-data
+
+# ── Stage 2: Runtime (Alpine with shell) ──────────────────────
+FROM alpine:3.21 AS runtime
+
+# Install runtime dependencies.
+# Alpine base already includes busybox sh, but we add:
+#   ca-certificates — TLS root certificates
+#   curl            — health checks and agent HTTP
+#   bash            — full shell for agent tool execution
+#   git             — agent git operations
+#   tzdata          — timezone data (small, avoids panics in chrono code paths)
+RUN apk add --no-cache \
+        ca-certificates \
+        curl \
+        bash \
+        git \
+        tzdata
+
+COPY --from=builder /zeroclaw-data /zeroclaw-data
+COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=builder /app/zerocode /usr/local/bin/zerocode
+# Install the dashboard at /usr/share/zeroclawlabs/web/dist (outside the
+# documented /zeroclaw-data mount) so user volumes do not shadow it (#6400).
+COPY --from=web-builder /app/web/dist /usr/share/zeroclawlabs/web/dist
+
+# Overwrite minimal config with DEV template (Ollama defaults)
+COPY dev/config.template.toml /zeroclaw-data/.zeroclaw/config.toml
+RUN chown 65534:65534 /zeroclaw-data/.zeroclaw/config.toml
+
+# Environment setup
+# Ensure UTF-8 locale so CJK / multibyte input is handled correctly
+ENV LANG=C.UTF-8
+# Bootstrap: decides where the config file and state databases live.
+ENV ZEROCLAW_DATA_DIR=/zeroclaw-data/data
+ENV HOME=/zeroclaw-data
+# V0.8.0 env-var grammar: `ZEROCLAW_<dotted_path_with_double_underscores>=<value>`
+# mirrors the TOML config 1:1; `__` is the path separator.
+ENV ZEROCLAW_gateway__port=42617
+
+WORKDIR /zeroclaw-data
+USER 65534:65534
+EXPOSE 42617
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=10s \
+    CMD ["zeroclaw", "status", "--format=exit-code"]
+ENTRYPOINT ["zeroclaw"]
+CMD ["daemon"]

--- a/docker-compose.alpine.yml
+++ b/docker-compose.alpine.yml
@@ -1,0 +1,56 @@
+# ZeroClaw Docker Compose — Alpine variant
+#
+# Quick start:
+#   1. Set your API key: export ZEROCLAW_providers__models__openrouter__default__api_key=sk-or-...
+#      (V0.8 env-var grammar: ZEROCLAW_<dotted.toml.path.with.double.underscores>=value)
+#   2. Run: docker compose -f docker-compose.alpine.yml up -d
+#   3. Access gateway at http://localhost:42617
+#
+# Build for local platform (fastest):
+#   docker compose -f docker-compose.alpine.yml up --build
+#
+# Multi-arch build (x86_64 + aarch64, rustc runs native, no QEMU):
+#   docker buildx build -f Dockerfile.alpine \
+#     --platform linux/amd64,linux/arm64 -t zeroclaw:alpine --load .
+
+services:
+  zeroclaw:
+    build:
+      context: .
+      dockerfile: Dockerfile.alpine
+    image: zeroclaw:alpine
+    container_name: zeroclaw-alpine
+    restart: unless-stopped
+
+    environment:
+      # V0.8 env-var grammar. Provide credentials here, or bind-mount your own
+      # config.toml over /zeroclaw-data/.zeroclaw/config.toml. The default
+      # baked config (Ollama at host.docker.internal:11434) needs no key.
+      - ZEROCLAW_providers__models__openrouter__default__api_key=${OPENROUTER_API_KEY:-}
+      - ZEROCLAW_ALLOW_PUBLIC_BIND=true
+      - ZEROCLAW_gateway__port=${ZEROCLAW_GATEWAY_PORT:-42617}
+
+    volumes:
+      - zeroclaw-data-alpine:/zeroclaw-data
+
+    ports:
+      - "${HOST_PORT:-42617}:${ZEROCLAW_GATEWAY_PORT:-42617}"
+
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 32M
+
+    healthcheck:
+      test: ["CMD", "zeroclaw", "status", "--format=exit-code"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  zeroclaw-data-alpine:

--- a/docs/book/src/setup/container.md
+++ b/docs/book/src/setup/container.md
@@ -14,6 +14,45 @@ Multi-arch: `linux/amd64`, `linux/arm64`.
 
 > **Note on shell access:** The default `latest` image is intentionally distroless and does not include `sh`, `ash`, or `bash`. Use the `debian` tag if you need a shell inside the container (for example, to run `docker exec` for debugging).
 
+## Alpine image (local build)
+
+A third variant, `Dockerfile.alpine`, builds a small **statically-linked musl** image from source. It is not published to `ghcr.io` — build it locally when you want:
+
+- a smaller image footprint than the Debian/glibc variants,
+- a fully static binary (no glibc dependency), well-suited to Proxmox LXC/VM guests and other minimal kernels,
+- the same multi-arch coverage (`linux/amd64`, `linux/arm64`) as the official images.
+
+The builder cross-compiles both musl targets via `cargo-zigbuild` with rustc pinned to the native build platform, so `docker buildx --platform linux/amd64,linux/arm64` runs the compiler natively (no QEMU emulation) and can produce either arch from either an Apple Silicon or an x86-64 host. It carries the same shell tools (`bash`, `git`, `curl`) and the dashboard as the Debian image, installed at the same `/usr/share/zeroclawlabs/web/dist` path.
+
+<div class="os-tabs-src">
+
+#### sh
+
+```sh
+# Local platform only (fastest smoke test):
+docker build -f Dockerfile.alpine -t zeroclaw:alpine .
+
+# Multi-arch (both amd64 + arm64, rustc runs native on each build platform):
+docker buildx build -f Dockerfile.alpine \
+  --platform linux/amd64,linux/arm64 -t zeroclaw:alpine --load .
+```
+
+</div>
+
+Or with the bundled Compose file (single-platform build):
+
+<div class="os-tabs-src">
+
+#### sh
+
+```sh
+docker compose -f docker-compose.alpine.yml up --build
+```
+
+</div>
+
+The alpine image uses the same baked config, `/zeroclaw-data` data mount, and V0.8 env-var grammar as the official images — see [Config inside containers](#config-inside-containers) and the Compose section below.
+
 ## Minimum run
 
 <div class="os-tabs-src">

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -58,6 +58,11 @@ fn registry() -> Vec<Surface> {
             render: |root, cur| render_docker_arg(root, cur),
         },
         Surface {
+            name: "dockerfile-alpine",
+            file: "Dockerfile.alpine",
+            render: |root, cur| render_docker_arg(root, cur),
+        },
+        Surface {
             name: "pkgbuild",
             file: "dist/aur/PKGBUILD",
             render: |root, cur| packaging::render_pkgbuild(root, cur),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds `Dockerfile.alpine` + `docker-compose.alpine.yml` producing a small statically-linked musl image that builds and runs on Apple Silicon (arm64), x86-64 Linux, and Proxmox VMs/LXC. The builder cross-compiles both `linux/amd64` and `linux/arm64` musl targets via `cargo-zigbuild` with rustc pinned to `$BUILDPLATFORM`, so `docker buildx --platform linux/amd64,linux/arm64` runs the compiler natively (no QEMU emulation). cargo-zigbuild is the forced choice: Alpine ships `gcc-aarch64` (amd64→aarch64) but no `gcc-x86_64` musl cross package, so the apk route cannot produce amd64 from an arm host; Zig is symmetric and also removes the manual CC/AR/linker plumbing that breaks `ring` under musl.
- **Scope boundary:** Build infra + docs only. Adds `Dockerfile.alpine`, `docker-compose.alpine.yml`, one generator-registry row in `xtask`, and a docs section. No runtime, security, CI, or release-workflow changes. `Dockerfile`, `Dockerfile.debian`, `Containerfile` untouched.
- **Blast radius:** New opt-in image; nothing existing changes. The xtask `Surface` row extends `cargo generate installers` to drift-check the new file's feature zone alongside the others.
- **Linked issue(s):** None tracked.
- **Labels:** `type:feat`, `risk:medium`, `size:M` (suggested)

The `Dockerfile.alpine` feature set is generated (not hand-typed) via the same `Selection::Dist` generator as the other Dockerfiles, satisfying the single-source-of-truth rule. `cargo generate installers --check` reports `dockerfile-alpine in sync`.

Related: #8953 (fixes the baked Ollama config template this image COPYs). The alpine image benefits from that fix landing; until then operators point at Ollama via the V0.8 env-var grammar.

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo generate installers --check`:
    ```
    ok: dockerfile in sync
    ok: dockerfile-debian in sync
    ok: dockerfile-alpine in sync
    ```
  - `cargo fmt --all -- --check`: clean (exit 0)
  - `cargo clippy -p xtask --all-targets -- -D warnings`: `CLIPPY PASS`
- **Beyond CI — what did I manually verify?**
  - **arm64 build** (`docker build -f Dockerfile.alpine -t zeroclaw:alpine .`): 88 MB, stripped, statically linked. `zeroclaw --version` → `0.8.2`; `zerocode --version` → `0.8.2`. Dashboard present at `/usr/share/zeroclawlabs/web/dist/index.html` (outside `/zeroclaw-data`, #6400 fix). Config path consistent.
  - **amd64 cross-build** from arm mac via buildx + zigbuild: 97 MB, genuine x86-64 ELF (header `7f 45 4c 46 02 01`). `ring v0.17.14` compiled for both musl targets (the crate that breaks under manual musl cross-compile).
  - **Daemon runtime**: container starts healthy; `GET /health`, `/metrics`, `/` (dashboard) all HTTP 200; `POST /webhook` routes through the full agent loop. With a host Ollama + the V0.8 env-var override for `uri`, returned real model responses (`{"response":"pong"}`, `{"response":"Paris"}`).
- **If any command was intentionally skipped, why:** Full `cargo test` not run — no Rust production logic changed (only an xtask registry row, which clippy covers). Multi-arch `buildx --load` with two platforms simultaneously not tested (OrbStack's docker driver doesn't support multi-platform `--load`); verified each arch separately instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — new opt-in image.
- Config / env / CLI surface changed? **No** (uses the same baked config, `/zeroclaw-data` mount, and V0.8 env-var grammar as the other images).
- Upgrade steps: none. Operators who want the alpine variant build it locally; existing image users are unaffected.

## Rollback

Medium-risk; `git revert <sha>`. The new files are additive (no existing behavior depends on them); revert removes the alpine variant with no side effects.