### PR TITLE
fix(channels): relax Matrix marker path instructions from absolute to workspace-relative

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -884,8 +884,10 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
             "When responding on Matrix:\n\
              - Use Markdown formatting (bold, italic, code blocks)\n\
              - Be concise and direct\n\
-             - For media attachments use markers: [IMAGE:<absolute-path>], [DOCUMENT:<absolute-path>], [VIDEO:<absolute-path>], [AUDIO:<absolute-path>], or [VOICE:<absolute-path>]\n\
-             - Paths inside markers MUST be absolute (starting with /). Never use relative paths.\n\
+             - For media attachments use markers: [IMAGE:<path-or-url>], [DOCUMENT:<path-or-url>], [VIDEO:<path-or-url>], [AUDIO:<path-or-url>], or [VOICE:<path-or-url>]\n\
+             - Local marker paths may be workspace-relative or absolute, but they must resolve inside the configured workspace directory.\n\
+             - Copy paths returned by file tools exactly into markers. Do not add or remove a leading slash.\n\
+             - Remote media is also accepted via http:// or https:// URLs in the same marker form.\n\
              - Keep normal text outside markers and never wrap markers in code fences.\n\
              - When you receive a [Voice message], the user spoke to you. Respond naturally as in conversation.\n\
              - Your text reply will automatically be converted to audio and sent back as a voice message.\n",
@@ -21879,6 +21881,36 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             block.contains("[IMAGE:<absolute-path>]"),
             "discord block must show the absolute-path marker form"
+        );
+    }
+
+    #[test]
+    fn channel_delivery_instructions_for_matrix_match_marker_contract() {
+        let block = channel_delivery_instructions("matrix")
+            .expect("matrix channel must have a delivery-instructions block");
+        assert!(
+            block.contains("When responding on Matrix:"),
+            "matrix block must identify itself"
+        );
+        assert!(
+            block.contains("[IMAGE:<path-or-url>]"),
+            "matrix block must describe local path or URL marker syntax"
+        );
+        assert!(
+            block.contains("workspace-relative or absolute"),
+            "matrix block must match the validator's local path contract"
+        );
+        assert!(
+            block.contains("Copy paths returned by file tools exactly"),
+            "matrix block must prevent rewriting relative tool paths into unrelated absolute paths"
+        );
+        assert!(
+            block.contains("http:// or https:// URLs"),
+            "matrix block must describe supported remote marker targets"
+        );
+        assert!(
+            !block.contains("Never use relative paths"),
+            "matrix block must not contradict the workspace-relative marker contract"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The Matrix channel delivery instructions told the model that marker paths MUST be absolute. The sender-side validator accepts both absolute and workspace-relative local paths when they resolve inside the configured workspace directory, as well as `http://` and `https://` remote URLs.
  - Updated the prompt to match the full marker contract: `<path-or-url>` syntax, workspace-relative or absolute local paths, exact file-tool path copying guidance, and explicit `http://` / `https://` remote URL support.
  - Added a regression test asserting the updated wording and verifying the old "MUST be absolute" constraint is removed.
- **Scope boundary:** Single Matrix delivery-instructions string in `orchestrator/mod.rs` + one regression test.
- **Blast radius:** Only Matrix channel prompt text. No functional code changes.
- **Linked issue(s):** Supersedes #8889 by @drbparadise
- **Labels:** `bug`, `channel`, `channel:core`, `risk:medium`, `size:XS`

## Validation Evidence

```bash
$ cargo test -p zeroclaw-channels --lib channel_delivery_instructions_for_matrix_match_marker_contract
running 1 test
test orchestrator::tests::channel_delivery_instructions_for_matrix_match_marker_contract ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```bash
$ cargo clippy -p zeroclaw-channels -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.51s
```

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility

- Backward compatible? (`Yes` — prompt-only change; does not alter any API, config, or behavior contract)
- Config / env / CLI surface changed? (`No`)


## Supersede Attribution

This PR carries forward the Matrix marker prompt/test work from #8889 by @drbparadise.
The prompt contract, regression test shape, and <path-or-url> formulation are based on
the approved #8889 diff. Attribution is recorded here per the contribution contract.

## Rollback

- Low-risk PR: `git revert 766af1b46` is the plan.