### PR TITLE
fix(wechat): surface iLink sendmessage body errors instead of silently dropping messages

### DIFF
--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -440,6 +440,33 @@ fn https_base_url(
     Ok(url)
 }
 
+/// Interpret an iLink `sendmessage` response body, returning a description
+/// of the failure when the API reported one.
+///
+/// The iLink API reports send failures as HTTP 200 with a non-zero
+/// `ret`/`errcode` in the JSON body — the same envelope the getUpdates
+/// sync loop parses. Checking only the HTTP status treats those failures
+/// (e.g. an expired or missing `context_token`) as success, so the message
+/// is silently dropped (zeroclaw-labs/zeroclaw#8967).
+///
+/// An empty or non-JSON 2xx body carries no envelope to inspect and is
+/// treated as success, preserving the pre-check behavior for those shapes.
+fn sendmessage_body_error(body: &str) -> Option<String> {
+    if body.trim().is_empty() {
+        return None;
+    }
+    let Ok(data) = serde_json::from_str::<serde_json::Value>(body) else {
+        return None;
+    };
+    let ret = data.get("ret").and_then(|v| v.as_i64()).unwrap_or(0);
+    let errcode = data.get("errcode").and_then(|v| v.as_i64()).unwrap_or(0);
+    if ret == 0 && errcode == 0 {
+        return None;
+    }
+    let errmsg = data.get("errmsg").and_then(|v| v.as_str()).unwrap_or("");
+    Some(format!("ret={ret}, errcode={errcode}, errmsg={errmsg:?}"))
+}
+
 /// WeChat iLink Bot channel — long-polls the iLink Bot API for updates.
 pub struct WeChatChannel {
     /// Bot token obtained via QR-code login; `None` until first login.
@@ -1928,6 +1955,13 @@ impl WeChatChannel {
             anyhow::bail!("sendMessage failed ({status}): {err}");
         }
 
+        // The API reports failures as HTTP 200 with a non-zero ret/errcode
+        // in the body; a status check alone silently drops the message.
+        let body = resp.text().await.unwrap_or_default();
+        if let Some(err) = sendmessage_body_error(&body) {
+            anyhow::bail!("sendMessage failed ({err})");
+        }
+
         Ok(())
     }
 
@@ -2557,6 +2591,43 @@ impl Channel for WeChatChannel {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn sendmessage_body_error_flags_nonzero_ret() {
+        let err = sendmessage_body_error(r#"{"ret":-1,"errmsg":"context token expired"}"#)
+            .expect("non-zero ret must be reported as an error");
+        assert!(err.contains("ret=-1"), "ret code missing from error: {err}");
+        assert!(
+            err.contains("context token expired"),
+            "errmsg missing from error: {err}"
+        );
+    }
+
+    #[test]
+    fn sendmessage_body_error_flags_nonzero_errcode() {
+        let err = sendmessage_body_error(r#"{"ret":0,"errcode":301,"errmsg":"session expired"}"#)
+            .expect("non-zero errcode must be reported as an error");
+        assert!(err.contains("errcode=301"), "errcode missing: {err}");
+    }
+
+    #[test]
+    fn sendmessage_body_error_accepts_success_envelope() {
+        assert_eq!(
+            sendmessage_body_error(r#"{"ret":0,"errcode":0,"errmsg":""}"#),
+            None
+        );
+        // Fields absent entirely also means success (defaults are 0).
+        assert_eq!(sendmessage_body_error(r#"{"msg_id":"abc"}"#), None);
+    }
+
+    #[test]
+    fn sendmessage_body_error_preserves_legacy_success_for_empty_or_non_json() {
+        // An empty 2xx body was success before this check existed; keep it so.
+        assert_eq!(sendmessage_body_error(""), None);
+        assert_eq!(sendmessage_body_error("   "), None);
+        // A non-JSON 2xx body has no envelope to inspect; do not invent failures.
+        assert_eq!(sendmessage_body_error("OK"), None);
+    }
 
     #[test]
     fn wechat_channel_name() {

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -447,7 +447,7 @@ fn https_base_url(
 /// `ret`/`errcode` in the JSON body — the same envelope the getUpdates
 /// sync loop parses. Checking only the HTTP status treats those failures
 /// (e.g. an expired or missing `context_token`) as success, so the message
-/// is silently dropped (zeroclaw-labs/zeroclaw#8967).
+/// is silently dropped.
 ///
 /// An empty or non-JSON 2xx body carries no envelope to inspect and is
 /// treated as success, preserving the pre-check behavior for those shapes.
@@ -1957,7 +1957,10 @@ impl WeChatChannel {
 
         // The API reports failures as HTTP 200 with a non-zero ret/errcode
         // in the body; a status check alone silently drops the message.
-        let body = resp.text().await.unwrap_or_default();
+        let body = resp
+            .text()
+            .await
+            .context("failed to read sendMessage response body")?;
         if let Some(err) = sendmessage_body_error(&body) {
             anyhow::bail!("sendMessage failed ({err})");
         }
@@ -2591,6 +2594,86 @@ impl Channel for WeChatChannel {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    fn test_wechat_channel_for_api(api_base_url: String, state_dir: &Path) -> WeChatChannel {
+        let mut channel = WeChatChannel::new(
+            "wechat_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            None,
+            None,
+            Some(state_dir.to_path_buf()),
+        )
+        .unwrap();
+        channel.api_base_url = api_base_url;
+        *channel.bot_token.write().unwrap() = Some("test-token".into());
+        channel
+    }
+
+    #[tokio::test]
+    async fn send_text_reports_2xx_error_envelope() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ilink/bot/sendmessage"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ret": -1,
+                "errcode": 301,
+                "errmsg": "context token expired"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let state = tempdir().unwrap();
+        let channel = test_wechat_channel_for_api(server.uri(), state.path());
+        let err = channel
+            .send_text("recipient", "hello", None)
+            .await
+            .expect_err("a 2xx iLink error envelope must fail the send");
+
+        let message = err.to_string();
+        assert!(message.contains("sendMessage failed"), "{message}");
+        assert!(message.contains("errcode=301"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn send_text_propagates_2xx_body_read_failure() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = zeroclaw_spawn::spawn!(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 64\r\nConnection: close\r\n\r\n{}")
+                .await
+                .unwrap();
+        });
+
+        let state = tempdir().unwrap();
+        let channel = test_wechat_channel_for_api(format!("http://{address}"), state.path());
+        let err = tokio::time::timeout(
+            Duration::from_secs(5),
+            channel.send_text("recipient", "hello", None),
+        )
+        .await
+        .expect("the local truncated-body request must complete")
+        .expect_err("a truncated 2xx response body must fail the send");
+        tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("the local truncated-body server must complete")
+            .unwrap();
+
+        assert!(
+            err.to_string()
+                .contains("failed to read sendMessage response body"),
+            "{err:#}"
+        );
+    }
 
     #[test]
     fn sendmessage_body_error_flags_nonzero_ret() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Treat non-zero `ret` or `errcode` values in successful iLink `sendMessage` response bodies as send failures instead of silently reporting delivery success.
  - Preserve legacy success behavior for empty, non-JSON, and zero-valued response envelopes.
  - Propagate failures while reading a 2xx response body so a truncated or otherwise unreadable response cannot become a false success.
  - Exercise both failure modes through the real WeChat `send_text` HTTP boundary.
- **Scope boundary:** This PR does not add re-login, token refresh, retry behavior, or config changes, and it does not alter the `getUpdates` sync path.
- **Blast radius:** WeChat outbound text and attachment sends share the updated `send_message_items` boundary, while the added HTTP-boundary regressions exercise the text path. Callers that previously received `Ok(())` for an iLink body-reported failure now receive an error.
- **Linked issue(s):** Fixes #8967
- **Labels:** `bug`, `channel`, `channel:wechat`, `domain:channels`, `priority:p1`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** WeChat channel
- **Setup / preconditions:** Configure a WeChat channel with a recipient whose reply window is cold or whose `context_token` is expired or missing.
- **Steps to run:** Send once with the cold reply window, then have the recipient message the bot to refresh the token and send again.
- **Expected on this branch (after):** The first `send_text` call returns an error instead of reporting delivery success; the second send succeeds after the token is refreshed.
- **Prior behavior on `master` (before):** The first send can return success even though the recipient receives nothing; the second send succeeds after the token is refreshed.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed on the published head and covers the aggregate current-master result. The default CI feature set does not compile the feature-gated WeChat module, so focused local validation covers that gap.
- **Known CI coverage gap, if any:** The default workspace test and `ci-all` feature sets do not include `channel-wechat`; the focused commands below compile and exercise it directly.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
clean

cargo test --locked -p zeroclaw-channels --lib --features channel-wechat wechat
test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 1362 filtered out

cargo test --locked -p zeroclaw-channels --lib --features channel-wechat send_text_
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1414 filtered out

cargo clippy --locked -p zeroclaw-channels --all-targets --features channel-wechat -- -D warnings
Finished successfully with no Clippy warnings

bash scripts/ci/comment_hygiene_gate.sh
passed
```

- **Beyond CI, what did you manually verify?** The contributor reproduced the original silent drop on v0.8.2 with a cold WeChat reply window and verified that the same delivery succeeded after the recipient refreshed the token. The repair was not rerun against a live iLink endpoint; focused HTTP-boundary regressions cover a non-zero response envelope and a truncated 2xx response body.
- **If any command was intentionally skipped, why:** A full local workspace test was not repeated because required CI covers the aggregate workspace result after publication, while the feature-gated WeChat behavior is covered by the focused commands above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No; the code now reads and validates the body of an existing response.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes. Successful empty, non-JSON, and zero-valued response bodies keep their previous behavior; responses that report or encounter a failure now return an error.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the two PR commits.
- **Feature flags or config toggles:** The behavior remains isolated behind the existing `channel-wechat` feature; there is no dedicated runtime toggle.
- **Observable failure symptoms:** Unexpected send failures containing `sendMessage failed (ret=` or `failed to read sendMessage response body`.
