### PR TITLE
docs(firmware): fix ESP32 hardware design link

### DIFF
--- a/firmware/esp32-ui/README.md
+++ b/firmware/esp32-ui/README.md
@@ -103,4 +103,4 @@ MIT - See root `LICENSE`
 
 - [Slint ESP32 Documentation](https://slint.dev/esp32)
 - [ESP-IDF Rust Book](https://esp-rs.github.io/book/)
-- [ZeroClaw Hardware Design](../../docs/hardware/hardware-peripherals-design.md)
+- [ZeroClaw Hardware Design](../../docs/book/src/hardware/hardware-peripherals-design.md)


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The ESP32 UI README linked to a hardware design document path that no longer exists.
- Why it matters: Readers following the firmware README should land on the current hardware design documentation.
- What changed: Updated the relative link to `docs/book/src/hardware/hardware-peripherals-design.md`.
- What did **not** change (scope boundary): No firmware, build, runtime, or documentation wording changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `docs`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `firmware: esp32-ui`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed/read-only
- If any auto-label is incorrect, note requested correction: None.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `docs`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `docs`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No superseded PR or external contributor work incorporated.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
git diff --check
BASE_SHA=upstream/master DOCS_FILES=firmware/esp32-ui/README.md bash scripts/ci/docs_quality_gate.sh
BASE_SHA=upstream/master DOCS_FILES=firmware/esp32-ui/README.md bash scripts/ci/docs_links_gate.sh
```

- Evidence provided (test/log/trace/screenshot/perf): `git diff --check` passed; docs quality gate reported `No prose em-dashes in changed docs files.`; markdown lint reported `Summary: 0 error(s)`; docs link gate reported `Collected 0 added link(s) from 1 docs file(s).` and `No added links detected in changed docs lines.` Manual check confirmed the new relative target exists.
- If any command is intentionally skipped, explain why: Cargo checks skipped because this is a README-only link fix with no Rust or firmware code changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No secrets, personal data, or identity-like examples added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Uses existing project-native documentation labels only.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: Link target only; no new user-facing copy or navigation entry.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: The README link now resolves to the current hardware design document path.
- Edge cases checked: Checked from the `firmware/esp32-ui/` relative path context.
- What was not verified: Firmware build was not run because no firmware code changed.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: ESP32 UI README documentation link.
- Potential unintended effects: Link could break if docs are reorganized again.
- Guardrails/monitoring for early detection: Docs link checks and reviewer click-through.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): AI-assisted local diff review and validation.
- Workflow/plan summary (if any): Scoped docs-only fix after checking for open duplicate PRs.
- Verification focus: Relative path correctness and docs lint/link gates.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes.

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit.
- Feature flags or config toggles (if any): N/A
- Observable failure symptoms: README link no longer resolves.

## Risks and Mitigations

- Risk: The docs path could move again.
  - Mitigation: Keep the change to one link and rely on docs link checks/review.