### PR TITLE
fix(channels/slack): track assistant threads in polling mode

### DIFF
--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -523,6 +523,17 @@ impl SlackChannel {
         Ok(ts)
     }
 
+    fn record_active_assistant_thread(&self, channel_id: &str, thread_ts: Option<&str>) -> bool {
+        let Some(thread_ts) = thread_ts.map(str::trim).filter(|ts| !ts.is_empty()) else {
+            return false;
+        };
+        let Ok(mut map) = self.active_assistant_thread.lock() else {
+            return false;
+        };
+        map.insert(channel_id.to_string(), thread_ts.to_string());
+        true
+    }
+
     /// Set the Assistants API status bar text for a channel's active thread.
     async fn set_assistant_status(&self, channel_id: &str, status: &str) {
         let thread_ts = {
@@ -3706,11 +3717,8 @@ impl SlackChannel {
                             .get("thread_ts")
                             .and_then(|v| v.as_str())
                             .unwrap_or_default();
-                        if !ch.is_empty()
-                            && !tts.is_empty()
-                            && let Ok(mut map) = self.active_assistant_thread.lock()
-                        {
-                            map.insert(ch.to_string(), tts.to_string());
+                        if !ch.is_empty() {
+                            self.record_active_assistant_thread(ch, Some(tts));
                         }
                     }
                     continue;
@@ -3891,11 +3899,7 @@ impl SlackChannel {
                 };
 
                 // Track thread context so start_typing can set assistant status.
-                if let Some(ref tts) = channel_msg.thread_ts
-                    && let Ok(mut map) = self.active_assistant_thread.lock()
-                {
-                    map.insert(channel_id.clone(), tts.clone());
-                }
+                self.record_active_assistant_thread(&channel_id, channel_msg.thread_ts.as_deref());
 
                 if tx.send(channel_msg).await.is_err() {
                     return Ok(());
@@ -5078,6 +5082,11 @@ impl Channel for SlackChannel {
                             ..Default::default()
                         };
 
+                        self.record_active_assistant_thread(
+                            &channel_id,
+                            channel_msg.thread_ts.as_deref(),
+                        );
+
                         if tx.send(channel_msg).await.is_err() {
                             return Ok(());
                         }
@@ -5180,6 +5189,11 @@ impl Channel for SlackChannel {
 
                         ..Default::default()
                     };
+
+                    self.record_active_assistant_thread(
+                        &thread_channel_id,
+                        channel_msg.thread_ts.as_deref(),
+                    );
 
                     if tx.send(channel_msg).await.is_err() {
                         return Ok(());
@@ -6837,7 +6851,7 @@ mod tests {
     }
 
     #[test]
-    fn assistant_thread_tracking() {
+    fn assistant_thread_tracking_records_only_real_threads() {
         let ch = SlackChannel::new(
             "xoxb-fake".into(),
             None,
@@ -6846,24 +6860,14 @@ mod tests {
             Arc::new(Vec::new),
         );
 
-        // Initially empty.
-        {
-            let map = ch.active_assistant_thread.lock().unwrap();
-            assert!(map.is_empty());
-        }
+        assert!(!ch.record_active_assistant_thread("C123", None));
+        assert!(!ch.record_active_assistant_thread("C123", Some("")));
+        assert!(!ch.record_active_assistant_thread("C123", Some("   ")));
+        assert!(ch.record_active_assistant_thread("C123", Some("1741234567.000100")));
 
-        // Simulate storing a thread_ts (as listen_socket_mode would).
-        {
-            let mut map = ch.active_assistant_thread.lock().unwrap();
-            map.insert("C123".to_string(), "1741234567.000100".to_string());
-        }
-
-        // Verify retrieval.
-        {
-            let map = ch.active_assistant_thread.lock().unwrap();
-            assert_eq!(map.get("C123"), Some(&"1741234567.000100".to_string()),);
-            assert_eq!(map.get("C999"), None);
-        }
+        let map = ch.active_assistant_thread.lock().unwrap();
+        assert_eq!(map.get("C123"), Some(&"1741234567.000100".to_string()),);
+        assert_eq!(map.get("C999"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Fixes Slack polling mode so discovered inbound thread replies record the active assistant thread for status updates.
  - Reuses the same active-thread tracking helper for Socket Mode assistant-thread events and message events.
  - Preserves the existing behavior that blank or absent `thread_ts` values do not create a status target.
- **Scope boundary:** Does not change Slack DM status behavior, Slack configuration, thread routing, message session keys, or the Assistants API payload shape.
- **Blast radius:** Slack channel only; affects the in-memory status-thread map used by `start_typing`, `stop_typing`, and draft progress status updates.
- **Linked issue(s):** N/A
- **Labels:** Current GitHub labels: `channel`, `channel:slack`. Suggested maintainer labels: `bug`, `risk:medium`, `size:XS`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** channel=slack
- **Setup / preconditions:** Configure Slack without Socket Mode so inbound messages are read via `conversations.history`; enable `stream_drafts = true`; use a Slack thread reply.
- **Steps to run:**
  1. Start ZeroClaw from this branch with the Slack channel enabled in polling mode.
  2. In Slack, reply to an existing thread and mention/address the bot as your config requires.
  3. Ask for a tool-using response that runs long enough to show progress.
- **Expected on this branch (after):** The Slack thread receives the same live assistant status/progress behavior as Socket Mode because the polling path records the thread id before dispatching the inbound message.
- **Prior behavior on `master` (before):** Polling-mode thread replies are dispatched, but the Slack channel does not record the active assistant thread on that path, so later status updates have no thread target and are silently skipped.

### How I tested

- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# no output

cargo clippy -p zeroclaw-channels --features channel-slack --all-targets -- -D warnings
# no output

cargo test -p zeroclaw-channels --features channel-slack
# test result: ok. 1337 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 3.74s
# test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
# test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.01s
# test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
```

- **Beyond CI, what did you manually verify?** I inspected both Slack inbound paths and verified the polling path now mirrors the Socket Mode active-thread recording before dispatching the channel message. I did not perform live Slack API testing.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` was not run because this PR is a focused Slack channel patch; the channel crate with `channel-slack` feature was run instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** Existing Slack `stream_drafts = false` disables draft/status streaming behavior.
- **Observable failure symptoms:** Slack threaded turns in polling mode stop showing live status/progress; debug logs around Slack `assistant.threads.setStatus` may be absent because no active thread target is recorded.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A

