### PR TITLE
test(config): cover typed value object shapes

### DIFF
--- a/crates/zeroclaw-config/src/typed_value.rs
+++ b/crates/zeroclaw-config/src/typed_value.rs
@@ -340,4 +340,44 @@ mod tests {
             "[\"a\",\"b\"]"
         );
     }
+
+    #[test]
+    fn object_field_accepts_object_and_rejects_other_shapes() {
+        let value = serde_json::json!({"model": "gpt-4.1", "limit": 1024});
+        let coerced = coerce_for_set_prop(&value, Some(PropKind::Object)).unwrap();
+        let reparsed: serde_json::Value = serde_json::from_str(&coerced).unwrap();
+        assert_eq!(reparsed, value);
+
+        let err = coerce_for_set_prop(
+            &serde_json::json!(["not", "object"]),
+            Some(PropKind::Object),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ConfigApiCode::ValueTypeMismatch);
+        assert!(err.message.contains("JSON object"));
+    }
+
+    #[test]
+    fn object_array_field_accepts_array_and_rejects_other_shapes() {
+        let value = serde_json::json!([
+            {"name": "alpha"},
+            {"name": "beta", "enabled": true}
+        ]);
+        let coerced = coerce_for_set_prop(&value, Some(PropKind::ObjectArray)).unwrap();
+        let reparsed: serde_json::Value = serde_json::from_str(&coerced).unwrap();
+        assert_eq!(reparsed, value);
+
+        let scalar_items = serde_json::json!(["alpha", 42]);
+        let coerced = coerce_for_set_prop(&scalar_items, Some(PropKind::ObjectArray)).unwrap();
+        let reparsed: serde_json::Value = serde_json::from_str(&coerced).unwrap();
+        assert_eq!(reparsed, scalar_items);
+
+        let err = coerce_for_set_prop(
+            &serde_json::json!({"name": "alpha"}),
+            Some(PropKind::ObjectArray),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, ConfigApiCode::ValueTypeMismatch);
+        assert!(err.message.contains("JSON array"));
+    }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Typed config value coercion had no direct tests for object and object-array `PropKind` shapes.
- Why it matters: Gateway and CLI callers depend on consistent shape validation before values reach `Config::set_prop`.
- What changed: Added focused unit tests for object acceptance/rejection and object-array array-shape handling, including the existing pass-through behavior for scalar array elements before serde validation.
- What did **not** change (scope boundary): No runtime logic, config schema, API behavior, or error wording changed.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `config`, `tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): N/A (no matching module label exists)
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed/read-only
- If any auto-label is incorrect, note requested correction: None.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No superseded PR or external contributor work incorporated.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
git diff --check
cargo fmt --all -- --check
cargo test -p zeroclaw-config typed_value::tests --lib
cargo clippy -p zeroclaw-config --tests -- -D warnings
```

- Evidence provided (test/log/trace/screenshot/perf): `git diff --check` passed; `cargo fmt --all -- --check` passed; typed value tests reported `test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 1086 filtered out; finished in 0.00s`; clippy reported `Finished dev profile` with `-D warnings`.
- If any command is intentionally skipped, explain why: Full workspace `cargo test` and `cargo clippy --all-targets` were not run locally; this is a one-file tests-only config change, so validation used the affected package tests plus package test clippy. CI should cover the full workspace matrix.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: Test data is synthetic and contains no secrets, credentials, or personal data.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Uses project-native test naming only.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: Test-only change; no user-facing wording.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Object` accepts JSON objects and rejects arrays; `ObjectArray` accepts JSON arrays and rejects non-arrays.
- Edge cases checked: Object-array pass-through for scalar array elements, which documents the current contract that serde performs later element validation.
- What was not verified: End-to-end CLI/gateway patch flows, because no runtime code changed.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `zeroclaw-config` unit tests for typed value coercion.
- Potential unintended effects: None expected; tests-only addition.
- Guardrails/monitoring for early detection: Unit test failure if object or object-array shape coercion regresses.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): AI-assisted local diff review and validation.
- Workflow/plan summary (if any): Added focused tests around existing object and object-array coercion boundaries.
- Verification focus: Shape validation and existing pass-through behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes.

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit.
- Feature flags or config toggles (if any): N/A
- Observable failure symptoms: Unit test failure in `typed_value::tests`.

## Risks and Mitigations

- Risk: Object-array test could be mistaken for full element validation.
  - Mitigation: The PR summary and test explicitly document that this layer validates array shape while serde validates element shape later.
