### PR TITLE
feat(channels/slack): show draft progress in direct messages

### DIFF
--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -493,7 +493,7 @@ impl SlackChannel {
 
         let resp = self
             .http_client()
-            .post("https://slack.com/api/chat.postMessage")
+            .post(self.slack_api_url("chat.postMessage"))
             .bearer_auth(&self.bot_token)
             .json(&body)
             .send()
@@ -523,17 +523,17 @@ impl SlackChannel {
         Ok(ts)
     }
 
+    fn active_assistant_thread_ts(&self, channel_id: &str) -> Option<String> {
+        self.active_assistant_thread
+            .lock()
+            .ok()
+            .and_then(|map| map.get(channel_id).cloned())
+    }
+
     /// Set the Assistants API status bar text for a channel's active thread.
     async fn set_assistant_status(&self, channel_id: &str, status: &str) {
-        let thread_ts = {
-            let map = match self.active_assistant_thread.lock() {
-                Ok(m) => m,
-                Err(_) => return,
-            };
-            match map.get(channel_id) {
-                Some(ts) => ts.clone(),
-                None => return,
-            }
+        let Some(thread_ts) = self.active_assistant_thread_ts(channel_id) else {
+            return;
         };
 
         let body = serde_json::json!({
@@ -544,7 +544,7 @@ impl SlackChannel {
 
         let _ = self
             .http_client()
-            .post("https://slack.com/api/assistant.threads.setStatus")
+            .post(self.slack_api_url("assistant.threads.setStatus"))
             .bearer_auth(&self.bot_token)
             .json(&body)
             .send()
@@ -839,7 +839,7 @@ impl SlackChannel {
 
         let resp = self
             .http_client()
-            .post("https://slack.com/api/chat.update")
+            .post(self.slack_api_url("chat.update"))
             .bearer_auth(&self.bot_token)
             .json(&body)
             .send()
@@ -4582,6 +4582,7 @@ impl Channel for SlackChannel {
         let client = self.http_client();
         let token = self.bot_token.clone();
         let channel = recipient.to_string();
+        let update_url = self.slack_api_url("chat.update");
         zeroclaw_spawn::spawn!(async move {
             let mut body = serde_json::json!({
                 "channel": channel,
@@ -4595,7 +4596,7 @@ impl Channel for SlackChannel {
                 }]);
             }
             match client
-                .post("https://slack.com/api/chat.update")
+                .post(update_url)
                 .bearer_auth(&token)
                 .json(&body)
                 .send()
@@ -4637,16 +4638,30 @@ impl Channel for SlackChannel {
     async fn update_draft_progress(
         &self,
         recipient: &str,
-        _message_id: &str,
+        message_id: &str,
         text: &str,
     ) -> anyhow::Result<()> {
         let status_line = text.trim().lines().last().unwrap_or("").trim();
-        // Skip "Thinking..." — the typing indicator already conveys that.
-        // Only show tool-related progress in the status bar.
-        if status_line.is_empty() || status_line.starts_with("\u{1f914}") {
+        if status_line.is_empty() {
             return Ok(());
         }
-        self.set_assistant_status(recipient, status_line).await;
+
+        if self.active_assistant_thread_ts(recipient).is_some() {
+            // Skip "Thinking..." in assistant threads — the Slack status bar
+            // is reserved for concrete tool progress there.
+            if !status_line.starts_with("\u{1f914}") {
+                self.set_assistant_status(recipient, status_line).await;
+            }
+            return Ok(());
+        }
+
+        // Slack assistant-thread status is unavailable in ordinary IM/DM
+        // conversations. Surface the same ephemeral progress by editing the
+        // in-flight draft body; the final response later replaces it.
+        if !Self::is_group_channel_id(recipient) {
+            self.update_draft(recipient, message_id, status_line)
+                .await?;
+        }
         Ok(())
     }
 
@@ -4705,7 +4720,7 @@ impl Channel for SlackChannel {
 
         let resp = self
             .http_client()
-            .post("https://slack.com/api/chat.update")
+            .post(self.slack_api_url("chat.update"))
             .bearer_auth(&self.bot_token)
             .json(&body)
             .send()
@@ -6027,6 +6042,78 @@ mod tests {
         )
         .with_workspace_dir(workspace.to_path_buf())
         .with_api_base_url(server.uri())
+    }
+
+    fn test_streaming_slack_channel(
+        server: &wiremock::MockServer,
+        workspace: &Path,
+    ) -> SlackChannel {
+        test_slack_channel(server, workspace).with_streaming(true, 1)
+    }
+
+    #[tokio::test]
+    async fn update_draft_progress_in_dm_materializes_visible_draft_status() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let tmp = tempfile::tempdir().unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/chat.postMessage"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "ts": "1710000000.000100",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/chat.update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ch = test_streaming_slack_channel(&server, tmp.path());
+        let draft_id = ch
+            .send_draft(&SendMessage::new("...", "D123"))
+            .await
+            .unwrap()
+            .expect("streaming Slack returns a lazy draft id");
+
+        ch.update_draft_progress(
+            "D123",
+            &draft_id,
+            "⏳ shell: cargo test
+",
+        )
+        .await
+        .unwrap();
+        ch.finalize_draft("D123", &draft_id, "final answer", false)
+            .await
+            .unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        let post = requests
+            .iter()
+            .find(|req| req.url.path() == "/chat.postMessage")
+            .expect("progress should materialize the lazy draft in a DM");
+        let post_body: serde_json::Value = serde_json::from_slice(&post.body).unwrap();
+        assert_eq!(post_body["channel"], "D123");
+        assert_eq!(post_body["text"], "⏳ shell: cargo test");
+        assert!(post_body.get("thread_ts").is_none());
+
+        let update = requests
+            .iter()
+            .find(|req| req.url.path() == "/chat.update")
+            .expect("finalize should replace the progress draft with the final answer");
+        let update_body: serde_json::Value = serde_json::from_slice(&update.body).unwrap();
+        assert_eq!(update_body["channel"], "D123");
+        assert_eq!(update_body["ts"], "1710000000.000100");
+        assert_eq!(update_body["text"], "final answer");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a Slack DM fallback for draft progress/status updates when there is no Slack assistant-thread status surface.
  - Keeps existing Slack thread behavior unchanged: concrete tool progress still goes to `assistant.threads.setStatus` when a thread target is known.
  - Routes draft post/update helpers through the existing testable Slack API base URL so DM progress streaming can be covered without live Slack calls.
- **Scope boundary:** Does not change Slack config, session keys, mention policy, final answer rendering, or group/channel-root progress behavior.
- **Blast radius:** Slack channel draft streaming only; affects intermediate draft edits in IM/DM conversations and test URL routing for Slack post/update helpers.
- **Linked issue(s):** N/A
- **Labels:** Current GitHub labels: `channel`, `channel:slack`. Suggested maintainer labels: `Improvement`, `risk:medium`, `size:S`, `rust`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** channel=slack
- **Setup / preconditions:** Configure Slack with `stream_drafts = true`; send a direct message to the bot; use a request that produces tool progress before final text.
- **Steps to run:**
  1. Start ZeroClaw from this branch with Slack enabled.
  2. DM the bot a tool-heavy request, such as a code inspection or local validation task.
  3. Watch the initial Slack draft while the tool runs.
- **Expected on this branch (after):** The Slack DM draft visibly updates with the current progress/status line before the final response replaces it.
- **Prior behavior on `master` (before):** DM progress/status updates call the Slack assistant-thread status path without an active thread target, so they no-op and the DM remains silent until final text or streamed answer text arrives.

### How I tested

- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# no output

cargo test -p zeroclaw-channels --features channel-slack update_draft_progress_in_dm_materializes_visible_draft_status
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1338 filtered out; finished in 0.05s

cargo clippy -p zeroclaw-channels --features channel-slack --all-targets -- -D warnings
# Finished `dev` profile [unoptimized] target(s) in 27.69s
# Finished `test` profile [unoptimized] target(s) in 0.46s

cargo test -p zeroclaw-channels --features channel-slack -- --test-threads=1
# test result: ok. 1338 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 24.58s
# test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
# test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.01s
# test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

- **Beyond CI, what did you manually verify?** I inspected the Slack draft-progress path and verified that thread-capable conversations still prefer `assistant.threads.setStatus`, while direct messages fall back to editing the lazy draft. I did not perform live Slack API testing.
- **If any command was intentionally skipped, why:** Full workspace `cargo test` was not run because this is scoped to Slack channel streaming; the channel crate with `channel-slack` feature was run instead. One initial parallel `cargo test -p zeroclaw-channels --features channel-slack` run failed in an existing order-sensitive orchestrator test; rerunning the crate serially passed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** Existing Slack `stream_drafts = false` disables draft/status streaming behavior.
- **Observable failure symptoms:** Slack DMs may show intermediate progress lines in the draft body while a turn is running; if Slack rejects draft edits, logs contain `chat.update (draft) failed` or `chat.postMessage (lazy draft) failed`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A

