### PR TITLE
fix(auth): accept legacy provider key in auth profiles

### DIFF
--- a/crates/zeroclaw-providers/src/auth/profiles.rs
+++ b/crates/zeroclaw-providers/src/auth/profiles.rs
@@ -604,6 +604,7 @@ impl Default for PersistedAuthProfiles {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct PersistedAuthProfile {
+    #[serde(alias = "provider")]
     model_provider: String,
     profile_name: String,
     kind: String,
@@ -685,6 +686,31 @@ mod tests {
             profile_id("openai-codex", "default"),
             "openai-codex:default"
         );
+    }
+
+    #[test]
+    fn persisted_profile_accepts_legacy_provider_key() {
+        let raw = r#"{
+            "schema_version": 2,
+            "updated_at": "2026-07-11T00:00:00Z",
+            "active_profiles": {
+                "openai-codex": "openai-codex:default"
+            },
+            "profiles": {
+                "openai-codex:default": {
+                    "provider": "openai-codex",
+                    "profile_name": "default",
+                    "kind": "oauth",
+                    "access_token": "access-token"
+                }
+            }
+        }"#;
+
+        let parsed: PersistedAuthProfiles = serde_json::from_str(raw).unwrap();
+        let profile = parsed.profiles.get("openai-codex:default").unwrap();
+
+        assert_eq!(profile.model_provider, "openai-codex");
+        assert_eq!(profile.profile_name, "default");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Accepts the legacy persisted auth-profile key `provider` as a read-time serde alias for the canonical `model_provider` field.
  - Adds a regression test covering old auth-profile JSON so users with existing files are not blocked from repairing or reimporting auth.
  - Keeps new writes canonical: the profile writer still emits `model_provider`, so this is compatibility-only and does not introduce duplicate persisted state.
- **Scope boundary:** This PR does not migrate files in place, does not write the legacy `provider` key, and does not change token refresh or quickstart behavior.
- **Blast radius:** Auth profile deserialization for persisted provider credentials.
- **Linked issue(s):** None.
- **Labels:** `bug`, `provider`, `security:secrets`, `rust`, `risk:medium`, `size:XS`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings -- not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:**

`cargo fmt --all -- --check`

```text
(no stdout; exited 0)
```

`DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo clippy --all-targets -- -D warnings`

```text
    Checking zeroclaw-channels v0.8.2
    Checking zeroclaw-eval v0.8.2
    Checking zeroclawlabs v0.8.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 56.53s
```

`DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo test`

```text
test result: ok. 0 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/test_system.rs (target/debug/deps/system-4721fcdacbc0b185)

running 9 tests
test system::multi_agent_e2e::peer_group_dotted_channel_refs_remain_alias_scoped_for_dispatch ... ok
test system::multi_agent_e2e::peer_group_routes_messages_only_within_resolved_peer_set ... ok
test system::multi_agent_e2e::legacy_install_upgrades_cleanly_with_backup ... ok
test system::multi_agent_e2e::two_sqlite_agents_on_one_install_have_isolated_memory ... ok
test system::full_stack::system_parallel_tool_execution ... ok
test system::full_stack::system_simple_text_response ... ok
test system::full_stack::system_tool_arguments_passed_correctly ... ok
test system::full_stack::system_tool_execution_flow ... ok
test system::full_stack::system_multi_turn_conversation ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s

   Doc-tests zeroclaw

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- **Beyond CI -- what did you manually verify?** The added regression test exercises the legacy `provider` key. I did not mutate a real auth-profile file in place because this PR intentionally only changes read compatibility.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1-2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`Yes`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: Auth-profile parsing now accepts an older metadata key so existing credential files remain readable. The writer still emits only the canonical `model_provider` key, and the test fixture uses fake placeholder token material.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: No upgrade steps are required. Existing auth-profile files using either `model_provider` or legacy `provider` deserialize; new writes remain canonical.

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert ccc80e85b`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Old auth-profile files fail to load with a missing `model_provider` parse error, preventing auth repair or reimport flows.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`No`)
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR is declared.
