### PR TITLE
fix(channels): log typed transcription registration failures

### DIFF
--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -1027,19 +1027,15 @@ impl TranscriptionManager {
                     transcription_providers.insert(dotted, provider);
                 }
                 Err(e) => {
-                    let message = if family == "local_whisper" {
-                        "typed local_whisper config invalid, provider skipped"
-                    } else {
-                        "typed transcription provider skipped (config error)"
-                    };
+                    let config_path = format!("[providers.transcription.{dotted}]");
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(
-                                ::serde_json::json!({"error": format!("{}", e), "provider": dotted})
+                                ::serde_json::json!({"error": e.to_string(), "config_path": config_path})
                             ),
-                        message
+                        "typed transcription provider skipped (config error)"
                     );
                 }
             }
@@ -1513,46 +1509,39 @@ mod tests {
 
         let assert_events = |entry_point: &str, events: Vec<serde_json::Value>| {
             let expected = [
-                (
-                    "groq.invalid",
-                    "typed transcription provider skipped (config error)",
-                    "[providers.transcription.groq.invalid]",
-                ),
-                (
-                    "openai.invalid",
-                    "typed transcription provider skipped (config error)",
-                    "[providers.transcription.openai.invalid]",
-                ),
+                ("groq.invalid", "[providers.transcription.groq.invalid]"),
+                ("openai.invalid", "[providers.transcription.openai.invalid]"),
                 (
                     "deepgram.invalid",
-                    "typed transcription provider skipped (config error)",
                     "[providers.transcription.deepgram.invalid]",
                 ),
                 (
                     "assemblyai.invalid",
-                    "typed transcription provider skipped (config error)",
                     "[providers.transcription.assemblyai.invalid]",
                 ),
-                (
-                    "google.invalid",
-                    "typed transcription provider skipped (config error)",
-                    "[providers.transcription.google.invalid]",
-                ),
+                ("google.invalid", "[providers.transcription.google.invalid]"),
                 (
                     "local_whisper.invalid",
-                    "typed local_whisper config invalid, provider skipped",
                     "local_whisper: `url` must not be empty",
                 ),
             ];
 
-            for (provider, message, error_fragment) in expected {
+            for (provider, error_fragment) in expected {
+                let config_path = format!("[providers.transcription.{provider}]");
                 let event = events
                     .iter()
-                    .find(|value| value["attributes"]["provider"] == provider)
+                    .find(|value| value["attributes"]["config_path"] == config_path)
                     .unwrap_or_else(|| {
                         panic!("{entry_point} should log a warning for {provider}: {events:?}")
                     });
-                assert_eq!(event["message"], message, "provider: {provider}");
+                assert_eq!(
+                    event["message"], "typed transcription provider skipped (config error)",
+                    "provider: {provider}"
+                );
+                assert!(
+                    event["attributes"].get("provider").is_none(),
+                    "{entry_point} must not emit provider attribution as a call-site attribute: {event}"
+                );
                 assert!(
                     event["attributes"]["error"]
                         .as_str()

--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -4,11 +4,8 @@ use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use reqwest::multipart::{Form, Part};
 
-use zeroclaw_config::providers::TranscriptionProviderEntry;
-use zeroclaw_config::schema::{
-    AssemblyAiSttConfig, Config, DeepgramSttConfig, GoogleSttConfig, LocalWhisperConfig,
-    OpenAiSttConfig, TranscriptionConfig,
-};
+use zeroclaw_config::providers::{TranscriptionProviderEntry, TranscriptionProviders};
+use zeroclaw_config::schema::{Config, TranscriptionConfig};
 
 /// Maximum upload size accepted by most Whisper-compatible APIs (25 MB).
 const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
@@ -157,6 +154,7 @@ impl GroqProvider {
             model: cfg
                 .model
                 .clone()
+                .filter(|model| !model.trim().is_empty())
                 .unwrap_or_else(|| "whisper-large-v3-turbo".to_string()),
             api_key,
             language: cfg.base.language.clone(),
@@ -250,7 +248,11 @@ impl OpenAiWhisperProvider {
         Ok(Self {
             alias: alias.to_string(),
             api_key,
-            model: cfg.model.clone().unwrap_or_else(|| "whisper-1".to_string()),
+            model: cfg
+                .model
+                .clone()
+                .filter(|model| !model.trim().is_empty())
+                .unwrap_or_else(|| "whisper-1".to_string()),
         })
     }
 }
@@ -337,7 +339,11 @@ impl DeepgramProvider {
         Ok(Self {
             alias: alias.to_string(),
             api_key,
-            model: cfg.model.clone().unwrap_or_else(|| "nova-2".to_string()),
+            model: cfg
+                .model
+                .clone()
+                .filter(|model| !model.trim().is_empty())
+                .unwrap_or_else(|| "nova-2".to_string()),
         })
     }
 }
@@ -617,6 +623,7 @@ impl GoogleSttProvider {
                 .base
                 .language
                 .clone()
+                .filter(|language| !language.trim().is_empty())
                 .unwrap_or_else(|| "en-US".to_string()),
         })
     }
@@ -901,7 +908,10 @@ impl TranscriptionManager {
             HashMap::new();
 
         Self::register_legacy_providers(&mut transcription_providers, &config.transcription);
-        Self::register_typed_providers(&mut transcription_providers, config);
+        Self::register_typed_providers(
+            &mut transcription_providers,
+            &config.providers.transcription,
+        );
 
         if config.transcription.enabled && transcription_providers.is_empty() {
             bail!(
@@ -978,179 +988,67 @@ impl TranscriptionManager {
 
     fn register_typed_providers(
         transcription_providers: &mut HashMap<String, Box<dyn TranscriptionProvider>>,
-        config: &Config,
+        typed: &TranscriptionProviders,
     ) {
-        for (family, alias, entry) in config.providers.transcription.iter_entries() {
+        for (family, alias, entry) in typed.iter_entries() {
             let dotted = format!("{family}.{alias}");
-            let (log_invalid_config, result): (bool, Result<Box<dyn TranscriptionProvider>>) =
-                match entry {
-                    TranscriptionProviderEntry::Groq(provider_config) => {
-                        let groq_config = TranscriptionConfig {
-                            enabled: config.transcription.enabled,
-                            api_key: provider_config.base.api_key.clone(),
-                            api_url: "https://api.groq.com/openai/v1/audio/transcriptions"
-                                .to_string(),
-                            model: provider_config
-                                .model
-                                .clone()
-                                .filter(|model| !model.trim().is_empty())
-                                .unwrap_or_else(|| "whisper-large-v3-turbo".to_string()),
-                            language: provider_config.base.language.clone(),
-                            initial_prompt: provider_config.base.initial_prompt.clone(),
-                            max_audio_bytes: config.transcription.max_audio_bytes,
-                            max_duration_secs: config.transcription.max_duration_secs,
-                            openai: None,
-                            deepgram: None,
-                            assemblyai: None,
-                            google: None,
-                            local_whisper: None,
-                            transcribe_non_ptt_audio: config.transcription.transcribe_non_ptt_audio,
-                        };
-                        (
-                            false,
-                            GroqProvider::from_config(alias, &groq_config)
-                                .map(|p| Box::new(p) as _),
-                        )
-                    }
-                    TranscriptionProviderEntry::OpenAi(provider_config) => {
-                        let openai_config = OpenAiSttConfig {
-                            api_key: provider_config.base.api_key.clone(),
-                            model: provider_config
-                                .model
-                                .clone()
-                                .filter(|model| !model.trim().is_empty())
-                                .unwrap_or_else(|| "whisper-1".to_string()),
-                        };
-                        (
-                            false,
-                            OpenAiWhisperProvider::from_config(alias, &openai_config)
-                                .map(|p| Box::new(p) as _),
-                        )
-                    }
-                    TranscriptionProviderEntry::Deepgram(provider_config) => {
-                        let deepgram_config = DeepgramSttConfig {
-                            api_key: provider_config.base.api_key.clone(),
-                            model: provider_config
-                                .model
-                                .clone()
-                                .filter(|model| !model.trim().is_empty())
-                                .unwrap_or_else(|| "nova-2".to_string()),
-                        };
-                        (
-                            false,
-                            DeepgramProvider::from_config(alias, &deepgram_config)
-                                .map(|p| Box::new(p) as _),
-                        )
-                    }
-                    TranscriptionProviderEntry::AssemblyAi(provider_config) => {
-                        let assemblyai_config = AssemblyAiSttConfig {
-                            api_key: provider_config.base.api_key.clone(),
-                        };
-                        (
-                            false,
-                            AssemblyAiProvider::from_config(alias, &assemblyai_config)
-                                .map(|p| Box::new(p) as _),
-                        )
-                    }
-                    TranscriptionProviderEntry::Google(provider_config) => {
-                        let google_config = GoogleSttConfig {
-                            api_key: provider_config.base.api_key.clone(),
-                            language_code: provider_config
-                                .base
-                                .language
-                                .clone()
-                                .filter(|language| !language.trim().is_empty())
-                                .unwrap_or_else(|| "en-US".to_string()),
-                        };
-                        (
-                            false,
-                            GoogleSttProvider::from_config(alias, &google_config)
-                                .map(|p| Box::new(p) as _),
-                        )
-                    }
-                    TranscriptionProviderEntry::LocalWhisper(provider_config) => {
-                        let local_config = LocalWhisperConfig {
-                            url: provider_config.uri.clone(),
-                            bearer_token: provider_config.bearer_token.clone(),
-                            max_audio_bytes: provider_config.max_audio_bytes,
-                            timeout_secs: provider_config.timeout_secs,
-                        };
-                        (
-                            true,
-                            LocalWhisperProvider::from_config(alias, &local_config)
-                                .map(|p| Box::new(p) as _),
-                        )
-                    }
-                };
+            if transcription_providers.contains_key(&dotted) {
+                continue;
+            }
+            let result: Result<Box<dyn TranscriptionProvider>> = match entry {
+                TranscriptionProviderEntry::Groq(provider_config) => {
+                    GroqProvider::from_typed_config(alias, provider_config)
+                        .map(|provider| Box::new(provider) as _)
+                }
+                TranscriptionProviderEntry::OpenAi(provider_config) => {
+                    OpenAiWhisperProvider::from_typed_config(alias, provider_config)
+                        .map(|provider| Box::new(provider) as _)
+                }
+                TranscriptionProviderEntry::Deepgram(provider_config) => {
+                    DeepgramProvider::from_typed_config(alias, provider_config)
+                        .map(|provider| Box::new(provider) as _)
+                }
+                TranscriptionProviderEntry::AssemblyAi(provider_config) => {
+                    AssemblyAiProvider::from_typed_config(alias, provider_config)
+                        .map(|provider| Box::new(provider) as _)
+                }
+                TranscriptionProviderEntry::Google(provider_config) => {
+                    GoogleSttProvider::from_typed_config(alias, provider_config)
+                        .map(|provider| Box::new(provider) as _)
+                }
+                TranscriptionProviderEntry::LocalWhisper(provider_config) => {
+                    LocalWhisperProvider::from_typed_config(alias, provider_config)
+                        .map(|provider| Box::new(provider) as _)
+                }
+            };
 
             match result {
                 Ok(provider) => {
                     transcription_providers.insert(dotted, provider);
                 }
-                Err(e) if log_invalid_config => {
+                Err(e) => {
+                    let message = if family == "local_whisper" {
+                        "typed local_whisper config invalid, provider skipped"
+                    } else {
+                        "typed transcription provider skipped (config error)"
+                    };
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(
-                                ::serde_json::json!({"error": format!("{}", e), "dotted": dotted})
+                                ::serde_json::json!({"error": format!("{}", e), "provider": dotted})
                             ),
-                        "typed local_whisper config invalid, provider skipped"
+                        message
                     );
                 }
-                Err(_) => {}
             }
         }
     }
 
     #[must_use]
-    pub fn with_typed_providers(
-        mut self,
-        typed: &zeroclaw_config::providers::TranscriptionProviders,
-    ) -> Self {
-        macro_rules! register_typed {
-            ($family:ident, $family_str:literal, $from_typed:path) => {
-                for (alias, cfg) in &typed.$family {
-                    let key = format!("{}.{}", $family_str, alias);
-                    if !self.transcription_providers.contains_key(&key) {
-                        match $from_typed(alias, cfg) {
-                            Ok(p) => {
-                                self.transcription_providers.insert(key, Box::new(p));
-                            }
-                            Err(e) => {
-                                ::zeroclaw_log::record!(
-                                    WARN,
-                                    ::zeroclaw_log::Event::new(
-                                        module_path!(),
-                                        ::zeroclaw_log::Action::Note,
-                                    )
-                                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                                    .with_attrs(::serde_json::json!({
-                                        "provider": format!("{}.{}", $family_str, alias),
-                                        "error": format!("{e}"),
-                                    })),
-                                    "typed transcription provider skipped (config error)"
-                                );
-                            }
-                        }
-                    }
-                }
-            };
-        }
-        register_typed!(groq, "groq", GroqProvider::from_typed_config);
-        register_typed!(openai, "openai", OpenAiWhisperProvider::from_typed_config);
-        register_typed!(deepgram, "deepgram", DeepgramProvider::from_typed_config);
-        register_typed!(
-            assemblyai,
-            "assemblyai",
-            AssemblyAiProvider::from_typed_config
-        );
-        register_typed!(google, "google", GoogleSttProvider::from_typed_config);
-        register_typed!(
-            local_whisper,
-            "local_whisper",
-            LocalWhisperProvider::from_typed_config
-        );
+    pub fn with_typed_providers(mut self, typed: &TranscriptionProviders) -> Self {
+        Self::register_typed_providers(&mut self.transcription_providers, typed);
         self
     }
 
@@ -1577,6 +1475,128 @@ mod tests {
 
         assert_eq!(manager.agent_transcription_provider, "groq.default");
         assert!(manager.available_providers().contains(&"groq.default"));
+    }
+
+    #[test]
+    fn typed_registration_logs_non_local_config_errors() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.providers.transcription.groq.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::GroqTranscriptionProviderConfig::default(),
+        );
+        config.providers.transcription.local_whisper.insert(
+            "local".to_string(),
+            zeroclaw_config::schema::LocalWhisperTranscriptionProviderConfig::default(),
+        );
+
+        TranscriptionManager::from_config_for_agent(&config, None)
+            .expect("invalid typed providers should be skipped when transcription is disabled");
+
+        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let event = events
+            .iter()
+            .find(|value| {
+                value.get("message").and_then(serde_json::Value::as_str)
+                    == Some("typed transcription provider skipped (config error)")
+            })
+            .expect("typed Groq registration failure should emit a warning");
+        assert_eq!(event["attributes"]["provider"], "groq.default");
+        assert!(
+            event["attributes"]["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("[providers.transcription.groq.default]")),
+            "warning should include the provider registration error: {event}"
+        );
+
+        let local_event = events
+            .iter()
+            .find(|value| {
+                value.get("message").and_then(serde_json::Value::as_str)
+                    == Some("typed local_whisper config invalid, provider skipped")
+            })
+            .expect("typed local Whisper registration failure should preserve its warning");
+        assert_eq!(local_event["attributes"]["provider"], "local_whisper.local");
+    }
+
+    #[test]
+    fn typed_registration_builder_uses_same_error_contract() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let mut typed = zeroclaw_config::providers::TranscriptionProviders::default();
+        typed.local_whisper.insert(
+            "local".to_string(),
+            zeroclaw_config::schema::LocalWhisperTranscriptionProviderConfig::default(),
+        );
+
+        let _manager = TranscriptionManager::empty().with_typed_providers(&typed);
+
+        let event = std::iter::from_fn(|| rx.try_recv().ok())
+            .find(|value| {
+                value.get("message").and_then(serde_json::Value::as_str)
+                    == Some("typed local_whisper config invalid, provider skipped")
+            })
+            .expect("builder path should preserve the local Whisper warning");
+        assert_eq!(event["attributes"]["provider"], "local_whisper.local");
+    }
+
+    #[test]
+    fn typed_registration_defaults_blank_optional_values() {
+        let base = zeroclaw_config::schema::TranscriptionProviderConfig {
+            api_key: Some("test-key".to_string()),
+            ..zeroclaw_config::schema::TranscriptionProviderConfig::default()
+        };
+
+        let groq = GroqProvider::from_typed_config(
+            "default",
+            &zeroclaw_config::schema::GroqTranscriptionProviderConfig {
+                base: base.clone(),
+                model: Some("   ".to_string()),
+            },
+        )
+        .unwrap();
+        assert_eq!(groq.model, "whisper-large-v3-turbo");
+
+        let openai = OpenAiWhisperProvider::from_typed_config(
+            "default",
+            &zeroclaw_config::schema::OpenAiTranscriptionProviderConfig {
+                base: base.clone(),
+                model: Some(String::new()),
+            },
+        )
+        .unwrap();
+        assert_eq!(openai.model, "whisper-1");
+
+        let deepgram = DeepgramProvider::from_typed_config(
+            "default",
+            &zeroclaw_config::schema::DeepgramTranscriptionProviderConfig {
+                base: base.clone(),
+                model: Some("\t".to_string()),
+            },
+        )
+        .unwrap();
+        assert_eq!(deepgram.model, "nova-2");
+
+        let google = GoogleSttProvider::from_typed_config(
+            "default",
+            &zeroclaw_config::schema::GoogleTranscriptionProviderConfig {
+                base: zeroclaw_config::schema::TranscriptionProviderConfig {
+                    language: Some("  ".to_string()),
+                    ..base
+                },
+            },
+        )
+        .unwrap();
+        assert_eq!(google.language_code, "en-US");
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -1478,75 +1478,104 @@ mod tests {
     }
 
     #[test]
-    fn typed_registration_logs_non_local_config_errors() {
+    fn typed_registration_logs_all_family_errors_across_entry_points() {
         let _writer_guard = zeroclaw_log::__private_test_writer_lock();
         let _hook_guard = zeroclaw_log::__private_test_hook_lock();
         zeroclaw_log::try_install_capture_subscriber();
         let mut rx = zeroclaw_log::subscribe_or_install();
         while rx.try_recv().is_ok() {}
 
-        let mut config = zeroclaw_config::schema::Config::default();
-        config.providers.transcription.groq.insert(
-            "default".to_string(),
+        let mut typed = TranscriptionProviders::default();
+        typed.groq.insert(
+            "invalid".to_string(),
             zeroclaw_config::schema::GroqTranscriptionProviderConfig::default(),
         );
-        config.providers.transcription.local_whisper.insert(
-            "local".to_string(),
+        typed.openai.insert(
+            "invalid".to_string(),
+            zeroclaw_config::schema::OpenAiTranscriptionProviderConfig::default(),
+        );
+        typed.deepgram.insert(
+            "invalid".to_string(),
+            zeroclaw_config::schema::DeepgramTranscriptionProviderConfig::default(),
+        );
+        typed.assemblyai.insert(
+            "invalid".to_string(),
+            zeroclaw_config::schema::AssemblyAiTranscriptionProviderConfig::default(),
+        );
+        typed.google.insert(
+            "invalid".to_string(),
+            zeroclaw_config::schema::GoogleTranscriptionProviderConfig::default(),
+        );
+        typed.local_whisper.insert(
+            "invalid".to_string(),
             zeroclaw_config::schema::LocalWhisperTranscriptionProviderConfig::default(),
         );
 
+        let assert_events = |entry_point: &str, events: Vec<serde_json::Value>| {
+            let expected = [
+                (
+                    "groq.invalid",
+                    "typed transcription provider skipped (config error)",
+                    "[providers.transcription.groq.invalid]",
+                ),
+                (
+                    "openai.invalid",
+                    "typed transcription provider skipped (config error)",
+                    "[providers.transcription.openai.invalid]",
+                ),
+                (
+                    "deepgram.invalid",
+                    "typed transcription provider skipped (config error)",
+                    "[providers.transcription.deepgram.invalid]",
+                ),
+                (
+                    "assemblyai.invalid",
+                    "typed transcription provider skipped (config error)",
+                    "[providers.transcription.assemblyai.invalid]",
+                ),
+                (
+                    "google.invalid",
+                    "typed transcription provider skipped (config error)",
+                    "[providers.transcription.google.invalid]",
+                ),
+                (
+                    "local_whisper.invalid",
+                    "typed local_whisper config invalid, provider skipped",
+                    "local_whisper: `url` must not be empty",
+                ),
+            ];
+
+            for (provider, message, error_fragment) in expected {
+                let event = events
+                    .iter()
+                    .find(|value| value["attributes"]["provider"] == provider)
+                    .unwrap_or_else(|| {
+                        panic!("{entry_point} should log a warning for {provider}: {events:?}")
+                    });
+                assert_eq!(event["message"], message, "provider: {provider}");
+                assert!(
+                    event["attributes"]["error"]
+                        .as_str()
+                        .is_some_and(|error| error.contains(error_fragment)),
+                    "{entry_point} should include the remediation error for {provider}: {event}"
+                );
+            }
+        };
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.providers.transcription = typed.clone();
         TranscriptionManager::from_config_for_agent(&config, None)
             .expect("invalid typed providers should be skipped when transcription is disabled");
-
-        let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
-        let event = events
-            .iter()
-            .find(|value| {
-                value.get("message").and_then(serde_json::Value::as_str)
-                    == Some("typed transcription provider skipped (config error)")
-            })
-            .expect("typed Groq registration failure should emit a warning");
-        assert_eq!(event["attributes"]["provider"], "groq.default");
-        assert!(
-            event["attributes"]["error"]
-                .as_str()
-                .is_some_and(|error| error.contains("[providers.transcription.groq.default]")),
-            "warning should include the provider registration error: {event}"
-        );
-
-        let local_event = events
-            .iter()
-            .find(|value| {
-                value.get("message").and_then(serde_json::Value::as_str)
-                    == Some("typed local_whisper config invalid, provider skipped")
-            })
-            .expect("typed local Whisper registration failure should preserve its warning");
-        assert_eq!(local_event["attributes"]["provider"], "local_whisper.local");
-    }
-
-    #[test]
-    fn typed_registration_builder_uses_same_error_contract() {
-        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
-        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
-        zeroclaw_log::try_install_capture_subscriber();
-        let mut rx = zeroclaw_log::subscribe_or_install();
-        while rx.try_recv().is_ok() {}
-
-        let mut typed = zeroclaw_config::providers::TranscriptionProviders::default();
-        typed.local_whisper.insert(
-            "local".to_string(),
-            zeroclaw_config::schema::LocalWhisperTranscriptionProviderConfig::default(),
+        assert_events(
+            "config manager",
+            std::iter::from_fn(|| rx.try_recv().ok()).collect(),
         );
 
         let _manager = TranscriptionManager::empty().with_typed_providers(&typed);
-
-        let event = std::iter::from_fn(|| rx.try_recv().ok())
-            .find(|value| {
-                value.get("message").and_then(serde_json::Value::as_str)
-                    == Some("typed local_whisper config invalid, provider skipped")
-            })
-            .expect("builder path should preserve the local Whisper warning");
-        assert_eq!(event["attributes"]["provider"], "local_whisper.local");
+        assert_events(
+            "builder",
+            std::iter::from_fn(|| rx.try_recv().ok()).collect(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Log typed transcription provider registration failures for every provider family instead of silently dropping non-local errors.
  - Reuse one typed registration path for manager construction and builder registration so warnings and collision behavior stay consistent.
  - Emit one literal warning message with `config_path` and `error` metadata, leaving provider identity to the existing attribution span.
  - Treat blank optional model and language values as omitted, preserving each provider's documented default.
- **Scope boundary:** This PR does not change transcription configuration schemas, provider selection, audio processing, or network behavior.
- **Blast radius:** Typed transcription provider initialization and its startup diagnostics in the channels crate.
- **Linked issue(s):** None. This is a narrow maintenance fix identified during code review.
- **Labels:** `bug`, `channel`, `risk:medium`, `size:M`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A; deterministic log-capture tests cover all six provider families through both typed registration entry points.

### How I tested

- **CI checks relied on and why they cover this change:** Current-head `Format` covers Rust formatting; `Lint` and the platform checks compile the changed channels code; `Test` runs the channels unit tests, including the focused regression cases.
- **Known CI coverage gap, if any:** No live transcription provider network call was made. The changed behavior occurs during local provider construction and is covered by deterministic log-capture tests.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(passed with no output)

$ cargo test -p zeroclaw-channels transcription::tests::typed_registration_ -- --nocapture
running 2 tests
test transcription::tests::typed_registration_defaults_blank_optional_values ... ok
test transcription::tests::typed_registration_logs_all_family_errors_across_entry_points ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1244 filtered out
```

- **Beyond CI, what did you manually verify?** The warning matrix asserts one literal message, the provider-specific `config_path`, the remediation error, and the absence of a call-site `provider` attribute for all six provider families through both typed registration entry points. The default-value test covers blank model fallbacks for Groq, OpenAI, and Deepgram plus the blank Google language fallback. No live provider call was made.
- **If any command was intentionally skipped, why:** Broader local Clippy and workspace tests were not rerun because fresh required CI provides the broader compile, lint, and test coverage for the current head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade steps are required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Missing `typed transcription provider skipped (config error)` warnings, missing `config_path` or `error` metadata, or unexpected typed-provider initialization behavior.
