### PR TITLE
docs(maintainers): fix dashboard workflow link

### DIFF
--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -27,7 +27,7 @@ The Project board is an automated planning board, not the authoritative PR revie
 
 Use the board for issue readiness, routing evidence, roadmap grouping, dependencies, blocker state, and stale-exemption reasons. Those signals move slowly enough that a board field or planning lane can stay useful.
 
-The current automation is manual and report-only. [`project-dashboard-plan.yml`](../../../../.github/workflows/project-dashboard-plan.yml) runs on `workflow_dispatch` for a single issue number, reads the issue payload, and writes a step summary proposing the existing Project Status value that best matches the issue's live labels and state. It does not write Project fields, edit issues, add labels, post comments, or run automatically on issue events.
+The current automation is manual and report-only. [`project-dashboard-plan.yml`](https://github.com/zeroclaw-labs/zeroclaw/blob/master/.github/workflows/project-dashboard-plan.yml) runs on `workflow_dispatch` for a single issue number, reads the issue payload, and writes a step summary proposing the existing Project Status value that best matches the issue's live labels and state. It does not write Project fields, edit issues, add labels, post comments, or run automatically on issue events.
 
 A JSON summary of this planning split lives in [`project-board-contract.json`](./project-board-contract.json). Treat it as the contract for the report-only planner and future board refresh automation, not as approval for automatic issue-event runs or active GitHub Project mutation yet. Live ProjectV2 writes need an approved field mapping, a project-scoped credential or app installation, and readback that compares planned status with live Project state before maintainers rely on it.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace the repository-relative link to `project-dashboard-plan.yml` with its public GitHub URL. The relative target exists in the source tree but is absent from the generated mdBook site, causing the docs deployment's internal-link check to fail.
- **Scope boundary:** This PR does not change the dashboard planner workflow or project-board behavior.
- **Blast radius:** Maintainer documentation and the mdBook deployment link check only.
- **Linked issue(s):** Related #8914
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A. This docs-only repair has no branch preview; the public target and link-checker classification were verified directly.
- **Interface(s) exercised:** N/A
- **Setup / preconditions:** N/A
- **Steps to run:** N/A
- **Expected on this branch (after):** N/A
- **Prior behavior on `master` (before):** N/A

### How I tested

- **Commands run and tail output:**

```text
$ git diff --check
(no output; exit 0)

$ DOCS_FILES='docs/book/src/maintainers/pr-workflow.md' BASE_SHA=__invalid__ scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting: 1 file(s)
Summary: 0 error(s)

$ curl -I -L --max-time 20 https://github.com/zeroclaw-labs/zeroclaw/blob/master/.github/workflows/project-dashboard-plan.yml
HTTP/2 200
```

- **Beyond CI, what did you manually verify?** Confirmed that the mdBook internal-link checker excludes absolute HTTP(S) URLs and that the public workflow URL resolves successfully. The [failing master deployment](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/29172752554) reported `maintainers/pr-workflow.html -> ../../../../.github/workflows/project-dashboard-plan.yml` as a dead link.
- **If any command was intentionally skipped, why:** `cargo mdbook build` was not run locally because it builds generated references, workspace rustdoc, and every documentation locale. I verified the checker's external-URL classification and the target's reachability directly instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No. There are no application or workflow behavior changes; the documentation link points to the repository's public workflow source.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- If `No` or `Yes` to either: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: `git revert <landed-sha>`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
