### PR TITLE
docs(contributing): clarify contribution maintenance expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ For the full mechanics — code style, testing levels, PR template requirements,
 
 ## Keep contributions moving
 
-Submitting an issue or pull request starts a conversation. Contributors are not expected to respond immediately; the policies below explain how inactive work is handled.
+Contributors are not expected to respond instantly, but should remain in contact throughout the review process to avoid their contributions becoming inactive. The policies below explain contributor expectations and how inactive work is handled.
 
 **Pull requests:** Respond to actionable review feedback. Resolve conflicts or update your branch when a maintainer asks, or leave a comment explaining what is blocking you. A PR that remains unresponsive after a documented author-action request and follow-up period may be closed for backlog hygiene. Closing the PR does not reject the underlying bug or idea. If the work remains valuable, maintainers may carry it forward through a takeover or superseding PR while preserving contributor attribution. See [PR backlog pruning](docs/book/src/maintainers/reviewer-playbook.md#pr-backlog-pruning) and [Superseding PRs](docs/book/src/maintainers/superseding.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,11 @@ For the full mechanics — code style, testing levels, PR template requirements,
 
 ## Keep contributions moving
 
-Submitting an issue or pull request starts a conversation. You do not need to be constantly available, but please say when you need to pause so maintainers know whether to wait, help, or make another plan.
+Submitting an issue or pull request starts a conversation. Contributors are not expected to respond immediately; the policies below explain how inactive work is handled.
 
 **Pull requests:** Respond to actionable review feedback. Resolve conflicts or update your branch when a maintainer asks, or leave a comment explaining what is blocking you. A PR that remains unresponsive after a documented author-action request and follow-up period may be closed for backlog hygiene. Closing the PR does not reject the underlying bug or idea. If the work remains valuable, maintainers may carry it forward through a takeover or superseding PR while preserving contributor attribution. See [PR backlog pruning](docs/book/src/maintainers/reviewer-playbook.md#pr-backlog-pruning) and [Superseding PRs](docs/book/src/maintainers/superseding.md).
 
-**Issues:** The original reporter is not the only person who can show that an issue remains relevant. A substantive update from any participant, such as a current reproduction, logs, or a concrete affected use case, can keep the issue active; a generic `+1` cannot. Issues without current evidence may close for backlog hygiene, but updated evidence can support reopening the issue or filing a new one. See the [issue stale policy](docs/book/src/maintainers/labels.md#issue-stale-policy) for the canonical rules.
+**Issues:** If you open an issue, follow the discussion when you can and add new details as they become available. Other participants may also provide evidence that the issue remains relevant. A substantive update, such as a current reproduction, logs, or a concrete affected use case, can keep it active; a generic `+1` cannot. Issues without current evidence may close for backlog hygiene, but updated evidence can support reopening the issue or filing a new one. See the [issue stale policy](docs/book/src/maintainers/labels.md#issue-stale-policy) for the canonical rules.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,10 @@ Contributors are not expected to respond instantly, but should remain in contact
 
 **Pull requests:** Respond to actionable review feedback. Resolve conflicts or update your branch when a maintainer asks, or leave a comment explaining what is blocking you. A PR that remains unresponsive after a documented author-action request and follow-up period may be closed for backlog hygiene. Closing the PR does not reject the underlying bug or idea. If the work remains valuable, maintainers may carry it forward through a takeover or superseding PR while preserving contributor attribution. See [PR backlog pruning](docs/book/src/maintainers/reviewer-playbook.md#pr-backlog-pruning) and [Superseding PRs](docs/book/src/maintainers/superseding.md).
 
+Before requesting or re-requesting review, inspect the current PR state yourself. Relevant checks should pass, obvious failures and conflicts should be resolved, prior review findings should be addressed, and the PR description and validation evidence should match the current head. Perform a focused self-review of the production and user-visible paths changed by the PR.
+
+Do not rely on maintainers to check the test status or determine whether you have addressed every review finding. When the PR is ready, post one concise comment summarizing what changed and requesting re-review, and also use GitHub's re-request review control so the appropriate reviewers are formally requested again.
+
 **Issues:** If you open an issue, follow the discussion when you can and add new details as they become available. Other participants may also provide evidence that the issue remains relevant. A substantive update, such as a current reproduction, logs, or a concrete affected use case, can keep it active; a generic `+1` cannot. Issues without current evidence may close for backlog hygiene, but updated evidence can support reopening the issue or filing a new one. See the [issue stale policy](docs/book/src/maintainers/labels.md#issue-stale-policy) for the canonical rules.
 
 ## Development setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,14 @@ All PRs target **`master`**. PRs targeting `main` will be rejected.
 
 For the full mechanics — code style, testing levels, PR template requirements, review process — see **[How to contribute](docs/book/src/contributing/how-to.md)**. For non-trivial architecture, workflow, config, security, or agent-assisted changes, use the **[Architecture and contribution map](docs/book/src/contributing/architecture-map.md)** to find the right foundation and architecture context before implementing.
 
+## Keep contributions moving
+
+Submitting an issue or pull request starts a conversation. You do not need to be constantly available, but please say when you need to pause so maintainers know whether to wait, help, or make another plan.
+
+**Pull requests:** Respond to actionable review feedback. Resolve conflicts or update your branch when a maintainer asks, or leave a comment explaining what is blocking you. A PR that remains unresponsive after a documented author-action request and follow-up period may be closed for backlog hygiene. Closing the PR does not reject the underlying bug or idea. If the work remains valuable, maintainers may carry it forward through a takeover or superseding PR while preserving contributor attribution. See [PR backlog pruning](docs/book/src/maintainers/reviewer-playbook.md#pr-backlog-pruning) and [Superseding PRs](docs/book/src/maintainers/superseding.md).
+
+**Issues:** The original reporter is not the only person who can show that an issue remains relevant. A substantive update from any participant, such as a current reproduction, logs, or a concrete affected use case, can keep the issue active; a generic `+1` cannot. Issues without current evidence may close for backlog hygiene, but updated evidence can support reopening the issue or filing a new one. See the [issue stale policy](docs/book/src/maintainers/labels.md#issue-stale-policy) for the canonical rules.
+
 ## Development setup
 
 ```bash


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #8989. The linked issue-stale policy and its anchor are not available on `master` until that PR lands. Refresh this branch and rerun link validation afterward.

## Summary

- **Base branch:** `master`
- **What changed and why:** Added contributor-facing guidance for staying engaged with pull request feedback, preserving attribution when valuable work is carried forward, and allowing substantive issue evidence from participants other than the original reporter.
- **Scope boundary:** This PR does not define stale timing, exclusions, or maintainer procedures. Those rules remain in the linked maintainer documentation.
- **Blast radius:** Documentation-only contributor guidance; no runtime, configuration, CI automation, or API behavior changes.
- **Linked issue(s):** Depends on #8989. Related #5615.
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a documentation-only change with no useful manual runtime path.

### How I tested

- **CI checks relied on and why they cover this change:** None. The local Markdown lint result covers the changed file; GitHub checks are not used as validation evidence here.
- **Known CI coverage gap, if any:** The `#issue-stale-policy` link target is introduced by #8989, so link-integrity validation must be repeated after that dependency lands.
- **Commands run and tail output:**

  ```text
  $ npm_config_cache="$(mktemp -d)" npx --yes markdownlint-cli2 CONTRIBUTING.md
  Summary: 0 error(s)

  $ git diff --check
  # no output
  ```

- **Beyond CI, what did you manually verify?** Compared the contributor wording with the PR backlog-pruning and superseding rules, and verified the pending issue-policy anchor in #8989.
- **If any command was intentionally skipped, why:** The full docs quality script does not include root-level `CONTRIBUTING.md` by default, so I ran its Markdown linter directly against the changed file. The repository link-integrity check is deferred until #8989 supplies the linked anchor on the base branch.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low risk: revert the documentation commit.
