### PR TITLE
feat(lark): save non-inlineable inbound files to the channel workspace

### DIFF
--- a/crates/zeroclaw-channels/src/lark.rs
+++ b/crates/zeroclaw-channels/src/lark.rs
@@ -223,6 +223,10 @@ const LARK_IMAGE_MAX_BYTES: usize = 10 * 1024 * 1024;
 /// Maximum file size we will download and present as text (512 KiB).
 const LARK_FILE_MAX_BYTES: usize = 512 * 1024;
 
+/// Maximum file size we will download and save into the channel workspace
+/// (inbound files that are neither inline-able images nor text, e.g. PDFs).
+const LARK_ATTACHMENT_SAVE_MAX_BYTES: usize = 20 * 1024 * 1024;
+
 /// Image MIME types we support for inline base64 encoding.
 const LARK_SUPPORTED_IMAGE_MIMES: &[&str] = &[
     "image/png",
@@ -1875,7 +1879,7 @@ impl LarkChannel {
         }
 
         if let Some(cl) = resp.content_length()
-            && cl > LARK_FILE_MAX_BYTES as u64
+            && cl > LARK_ATTACHMENT_SAVE_MAX_BYTES as u64
         {
             ::zeroclaw_log::record!(
                 WARN,
@@ -1885,7 +1889,7 @@ impl LarkChannel {
                 "file too large for : bytes exceeds limit"
             );
             return Some(format!(
-                "[ATTACHMENT:{file_name} | size={cl} bytes | too large to inline]"
+                "[ATTACHMENT:{file_name} | size={cl} bytes | too large to save]"
             ));
         }
 
@@ -1950,10 +1954,73 @@ impl LarkChannel {
             return Some(format!("[FILE:{file_name}]\n```{ext}\n{truncated}\n```"));
         }
 
-        Some(format!(
-            "[ATTACHMENT:{file_name} | mime={content_type} | size={} bytes]",
-            bytes.len()
-        ))
+        // Oversized bodies without a Content-Length header are caught here.
+        if bytes.len() > LARK_ATTACHMENT_SAVE_MAX_BYTES {
+            return Some(format!(
+                "[ATTACHMENT:{file_name} | mime={content_type} | size={} bytes | too large to save]",
+                bytes.len()
+            ));
+        }
+
+        // Binary, non-inlineable file (e.g. PDF): save into the channel
+        // workspace so the agent can access it with file tools.
+        match self.save_attachment_to_workspace(file_name, &bytes).await {
+            Some(local_path) => Some(format!(
+                "[ATTACHMENT:{file_name} | mime={content_type} | size={} bytes | saved: {}]",
+                bytes.len(),
+                local_path.display()
+            )),
+            None => Some(format!(
+                "[ATTACHMENT:{file_name} | mime={content_type} | size={} bytes]",
+                bytes.len()
+            )),
+        }
+    }
+
+    /// Save a non-inlineable inbound attachment (e.g. PDF) under
+    /// `<workspace>/lark_files/` so the agent can reach it with file tools.
+    /// Returns the local path, or `None` when the channel has no workspace or
+    /// the write fails — callers fall back to a metadata-only marker.
+    async fn save_attachment_to_workspace(
+        &self,
+        file_name: &str,
+        bytes: &[u8],
+    ) -> Option<std::path::PathBuf> {
+        let Some(workspace) = self.workspace_dir.as_ref() else {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                "lark: inbound attachment not saved (channel has no workspace_dir)"
+            );
+            return None;
+        };
+        let file_name = lark_sanitize_attachment_filename(file_name)?;
+        let save_dir = workspace.join("lark_files");
+        if let Err(err) = tokio::fs::create_dir_all(&save_dir).await {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": format!("{}", err)})),
+                "lark: failed to create attachment dir"
+            );
+            return None;
+        }
+        let local_path = save_dir.join(&file_name);
+        if let Err(err) = tokio::fs::write(&local_path, bytes).await {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": format!("{}", err)})),
+                &format!(
+                    "lark: failed to save attachment to {}",
+                    local_path.display()
+                )
+            );
+            return None;
+        }
+        Some(local_path)
     }
 
     async fn fetch_bot_open_id_with_token(
@@ -3890,6 +3957,20 @@ fn lark_detect_image_mime(content_type: Option<&str>, bytes: &[u8]) -> Option<St
 }
 
 /// Check if a filename looks like a text file based on extension.
+/// Strip any path components from an inbound attachment filename so a
+/// sender-controlled name cannot escape the save directory (mirrors the
+/// WeChat channel's sanitizer).
+fn lark_sanitize_attachment_filename(file_name: &str) -> Option<String> {
+    let cleaned = Path::new(file_name)
+        .file_name()
+        .and_then(|name| name.to_str())?
+        .trim();
+    if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
+        return None;
+    }
+    Some(cleaned.to_string())
+}
+
 fn lark_is_text_filename(name: &str) -> bool {
     let ext = name.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
     matches!(
@@ -5287,6 +5368,25 @@ mod tests {
 
         // No info at all should return None
         assert_eq!(lark_detect_image_mime(None, &unknown), None);
+    }
+
+    #[test]
+    fn lark_sanitize_attachment_filename_strips_path_components() {
+        assert_eq!(
+            lark_sanitize_attachment_filename("order.pdf"),
+            Some("order.pdf".to_string())
+        );
+        assert_eq!(
+            lark_sanitize_attachment_filename("../../etc/passwd"),
+            Some("passwd".to_string())
+        );
+        assert_eq!(
+            lark_sanitize_attachment_filename("/tmp/evil.sh"),
+            Some("evil.sh".to_string())
+        );
+        assert_eq!(lark_sanitize_attachment_filename(""), None);
+        assert_eq!(lark_sanitize_attachment_filename(".."), None);
+        assert_eq!(lark_sanitize_attachment_filename("."), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Inbound Feishu file messages that are neither inline-able images nor text (PDF, docx, zip, …) were downloaded and then discarded — the agent only ever saw the `[ATTACHMENT:…]` metadata marker and could never access the file itself.
  - Save such files under `<workspace>/lark_files/` (mirroring the WeChat channel's inbound-attachment behavior) and append the local path to the marker so the agent can reach the file with its file tools.
  - Raise the non-inline download cap to 20 MiB (`LARK_ATTACHMENT_SAVE_MAX_BYTES`); inline limits are unchanged (text 512 KiB, images 10 MiB). Previously any file over 512 KiB was rejected before download.
  - Sanitize sender-controlled filenames to a bare file name (`lark_sanitize_attachment_filename`) so a crafted name cannot escape the save directory.
- **Scope boundary:** does not change image/text inlining behavior, outbound attachments, or any other channel; adds no PDF/document parsing — how the saved file is consumed is left to the agent.
- **Blast radius:** lark channel inbound file handling only; a `lark_files/` directory appears in channel workspaces.
- **Linked issue(s):** None
- **Labels:** left to the path labeler / maintainers

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** channel `lark` (Feishu)
- **Setup / preconditions:** a Feishu bot configured with `receive_mode = "websocket"` and an agent with a workspace
- **Steps to run:** DM the bot any PDF file (>512 KiB makes the delta most visible), then inspect the inbound marker and the channel workspace
- **Expected on this branch (after):** marker reads `[ATTACHMENT:<name> | mime=application/pdf | size=<n> bytes | saved: <workspace>/lark_files/<name>]`, the file exists on disk, and the agent can read it with file tools
- **Prior behavior on `master` (before):** files over 512 KiB are rejected before download (`… | too large to inline`); smaller binary files produce a metadata-only marker and the downloaded bytes are discarded

### How I tested

- **CI checks relied on and why they cover this change:** the required Linux fmt/clippy/test jobs cover this single-crate change; local runs below were done on aarch64 as an extra platform data point
- **Known CI coverage gap, if any:** the workspace-save path is exercised end-to-end manually (below), not by an automated integration test
- **Commands run and tail output:**

  ```
  $ cargo fmt --all -- --check
  (clean, exit 0)

  $ cargo clippy -p zeroclaw-channels --features channel-lark --all-targets -- -D warnings
      Checking zeroclaw-channels v0.8.2
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 53s

  $ cargo test -p zeroclaw-channels --features channel-lark lark_sanitize
  running 1 test
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1333 filtered out
  ```

- **Beyond CI, what did you manually verify?** Deployed a release build (`channels-full`) on a production aarch64 instance: sent two real PDFs (1.4 MB and 1.9 MB) via Feishu DM — both were saved into `lark_files/` with their original (CJK) filenames, the marker carried the local path, and the agent read the files and extracted their content. Pre-patch behavior was confirmed on the same instance (>512 KiB files rejected as "too large to inline"). The filename sanitizer's traversal cases (`../../etc/passwd` → `passwd`, absolute paths, empty/`.`/`..` rejected) are covered by the new unit test. Not manually verified: the workspace-less channel fallback (unit-level behavior only).
- **If any command was intentionally skipped, why:** full-workspace `cargo test` was not rerun locally (aarch64 SBC; required CI covers it) — the touched crate's lint and the new test ran locally as shown.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes**
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? **Yes**
- If any `Yes`, describe the risk and mitigation: the channel now writes inbound files into the agent workspace; the filename is sender-controlled, mitigated by sanitizing to a bare file name, confining writes to the fixed `lark_files/` subdirectory, and capping downloads at 20 MiB (same exposure class as the existing WeChat channel behavior). The saved file's content is untrusted input the agent can now read via its file tools — that is the intended capability, gated by the agent's existing file-tool policy and workspace scoping; the marker itself only adds the sanitized name and local path, and the filename was already model-visible on `master`.

## Compatibility (required)

- Backward compatible? Yes — the marker gains a trailing ` | saved: …` field; when the channel has no workspace or the write fails, the previous metadata-only marker is emitted unchanged
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.