### PR TITLE
fix(ci): escape release verification Markdown

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -717,7 +717,7 @@ jobs:
               --source-digest "$GITHUB_SHA" \
               --bundle "$tmp_dir/$target" \
               --custom-trusted-root "$tmp_dir/trusted_root.jsonl"
-            printf '`%s` | `%s` | `%s`\n' "$artifact" "$digest" "$target" >> "$tmp_dir/ATTESTATION-BUNDLES.md"
+            printf "\`%s\` | \`%s\` | \`%s\`\n" "$artifact" "$digest" "$target" >> "$tmp_dir/ATTESTATION-BUNDLES.md"
             bundle_count=$((bundle_count + 1))
           done
 
@@ -726,7 +726,7 @@ jobs:
           mv "$tmp_dir"/* .
 
           echo "--- Attestation bundles ---"
-          ls -lh *.attestation.jsonl trusted_root.jsonl ATTESTATION-BUNDLES.md
+          ls -lh ./*.attestation.jsonl ./trusted_root.jsonl ./ATTESTATION-BUNDLES.md
 
       - name: Write release notes
         env:
@@ -749,27 +749,27 @@ jobs:
           Release artifacts have GitHub artifact provenance attestations.
 
           **Online**
-          ```bash
-          gh attestation verify <artifact> \
-            --repo zeroclaw-labs/zeroclaw \
-            --signer-workflow zeroclaw-labs/zeroclaw/.github/workflows/release-stable-manual.yml \
+          \`\`\`bash
+          gh attestation verify <artifact> \\
+            --repo zeroclaw-labs/zeroclaw \\
+            --signer-workflow zeroclaw-labs/zeroclaw/.github/workflows/release-stable-manual.yml \\
             --source-digest ${SOURCE_DIGEST}
-          ```
+          \`\`\`
           VERIFY_EOF
 
             if [[ "$BUNDLE_OUTCOME" == "success" ]]; then
               cat >> release-notes.md <<VERIFY_EOF
 
           **Offline**
-          Download `<artifact>`, `<artifact>.attestation.jsonl`, and `trusted_root.jsonl` from the release assets, then run:
-          ```bash
-          gh attestation verify <artifact> \
-            --repo zeroclaw-labs/zeroclaw \
-            --signer-workflow zeroclaw-labs/zeroclaw/.github/workflows/release-stable-manual.yml \
-            --source-digest ${SOURCE_DIGEST} \
-            --bundle <artifact>.attestation.jsonl \
+          Download \`<artifact>\`, \`<artifact>.attestation.jsonl\`, and \`trusted_root.jsonl\` from the release assets, then run:
+          \`\`\`bash
+          gh attestation verify <artifact> \\
+            --repo zeroclaw-labs/zeroclaw \\
+            --signer-workflow zeroclaw-labs/zeroclaw/.github/workflows/release-stable-manual.yml \\
+            --source-digest ${SOURCE_DIGEST} \\
+            --bundle <artifact>.attestation.jsonl \\
             --custom-trusted-root trusted_root.jsonl
-          ```
+          \`\`\`
           VERIFY_EOF
             else
               cat >> release-notes.md <<VERIFY_EOF


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Escapes Markdown code fences and inline-code markers inside the expandable release-note heredocs so Bash emits them literally instead of interpreting them as command substitutions.
  - Uses the same escaped-literal form for the attestation table row and prefixes the final asset-listing paths with `./`, keeping dash-leading filenames option-safe.
  - Preserves `${SOURCE_DIGEST}` and `${RUN_URL}` expansion while making the workflow fully clean under `actionlint` and ShellCheck.
  - Prevents successful attestation runs from silently publishing verification notes with missing artifact names and command blocks.
- **Scope boundary:** This does not change attestation policy, release asset selection, signing, action references, permissions, or the existing best-effort behavior.
- **Blast radius:** Limited to attestation Markdown generation and the display paths used by the final attestation-asset `ls`; published asset names and verification command arguments are unchanged, while their intended multiline formatting is restored.
- **Linked issue(s):** Related #9014 (same workflow, non-overlapping macOS DMG notarization change; no dependency).
- **Labels:** `ci`, `type:ci`, `bug`, `risk:high`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; the focused lint command exposes the before/after delta without dispatching a release.
- **Interface(s) exercised:** N/A — this is a maintainer GitHub Actions release workflow, not a product attribution surface.
- **Setup / preconditions:** `actionlint` 1.7.11 and ShellCheck 0.11.0.
- **Steps to run:**

  ```sh
  actionlint -no-color .github/workflows/release-stable-manual.yml
  ```

- **Expected on this branch (after):** No output and exit `0`.
- **Prior behavior on `master` (before):** The same workflow exits non-zero with 17 findings: 7 errors, 5 informational findings, 4 style findings, and 1 warning. These include SC1072, SC1073, SC2261, and SC2328 at the release-note step plus SC2016/SC2035 in attestation-bundle rendering.

### How I tested

- **CI checks relied on and why they cover this change:** CI for JordanTheJet/zeroclaw#17 completed successfully, including `CI Required Gate`, the full lint/test/build/security matrix, `Docker Images Build (no push)`, and all three `Dockerfile Source Build (no push)` jobs. Those checks validate the release workflow syntax and its surrounding build surfaces; the focused local `actionlint`, ShellCheck, and generated-output checks directly cover both changed workflow steps.
- **Known CI coverage gap, if any:** A signed release was not dispatched. That path requires release credentials and publishes external artifacts; the local smoke executed the same embedded Bash under GitHub's `bash -e -o pipefail` semantics instead.
- **Commands run and tail output:**

  ```text
  # actionlint comparison against master and this branch
  base actionlint: 17 findings (7 errors, 5 info, 4 style, 1 warning)
  patched actionlint exit: 0

  # focused attestation-bundle and release-note scripts
  focused shellcheck steps: clean

  # generated Markdown assertions
  gh attestation verify <artifact> ... --source-digest 0123456789abcdef
  gh attestation verify <artifact> ... --bundle <artifact>.attestation.jsonl ...
  Download `<artifact>`, `<artifact>.attestation.jsonl`, and `trusted_root.jsonl` from the release assets, then run:
  release-note smoke exit: 0

  # attestation table-row rendering
  `zeroclaw-aarch64-apple-darwin.tar.gz` | `0123456789abcdef` | `zeroclaw-aarch64-apple-darwin.tar.gz.attestation.jsonl`

  # patch hygiene
  git diff --check
  # no output; exit 0
  ```

- **Beyond CI, what did you manually verify?** Executed the extracted release-note Bash in a temporary directory and verified two literal fenced `bash` blocks, multiline verification commands with literal continuation backslashes, the three inline-code artifact names, expansion of the source digest, and the attestation table-row format. On `master`, the equivalent generated text loses the fenced commands and artifact names. I did not contact GitHub's attestation service or publish a release.
- **If any command was intentionally skipped, why:** No full release dispatch because it requires secrets, approvals, and external publication. Cargo checks were not run because the patch changes only workflow heredoc text and no Rust or dependency surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 8d0796174`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `actionlint` again reports SC1072/SC1073/SC2261/SC2328 at the release-note step; generated release notes omit verification command blocks and inline artifact names; workflow logs may contain `artifact: No such file or directory` or `trusted_root.jsonl: command not found` while assembling notes.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede another contribution.
