### PR TITLE
fix(desktop): embed dashboard in macOS release sidecar

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -372,13 +372,18 @@ jobs:
 
   build-desktop:
     name: Build Desktop App (macOS Universal)
-    needs: [validate]
+    needs: [validate, web]
     runs-on: macos-14
     # Two kernel release builds (arm64 + x86_64) feed the universal sidecar,
     # then the universal app build on top.
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: web-dist
+          path: web/dist/
 
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
@@ -409,7 +414,69 @@ jobs:
           echo "Tauri version set to: $VERSION"
 
       - name: Stage bundled kernel sidecar (universal)
-        run: scripts/desktop/prepare-kernel.sh --target universal-apple-darwin
+        run: scripts/desktop/prepare-kernel.sh --target universal-apple-darwin --features embedded-web
+
+      - name: Smoke test embedded dashboard from an empty directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          kernel="$GITHUB_WORKSPACE/apps/tauri/binaries/zeroclaw-universal-apple-darwin"
+          smoke_root="$RUNNER_TEMP/zeroclaw-desktop-smoke"
+          smoke_cwd="$smoke_root/cwd"
+          smoke_home="$smoke_root/home"
+          xdg_data_home="$smoke_root/xdg-data"
+          config_dir="$smoke_root/config"
+          daemon_log="$smoke_root/daemon.log"
+          host="127.0.0.1"
+          port="42618"
+          origin="http://$host:$port"
+          rm -rf "$smoke_root"
+          mkdir -p "$smoke_cwd" "$smoke_home" "$xdg_data_home" "$config_dir"
+
+          daemon_pid=""
+          cleanup() {
+            exit_code=$?
+            if [[ -n "$daemon_pid" ]]; then
+              kill "$daemon_pid" 2>/dev/null || true
+              wait "$daemon_pid" 2>/dev/null || true
+            fi
+            if [[ "$exit_code" -ne 0 ]]; then
+              echo "::group::Embedded dashboard daemon log"
+              cat "$daemon_log" || true
+              echo "::endgroup::"
+            fi
+            exit "$exit_code"
+          }
+          trap cleanup EXIT
+
+          cd "$smoke_cwd"
+          HOME="$smoke_home" XDG_DATA_HOME="$xdg_data_home" \
+            "$kernel" --config-dir "$config_dir" daemon \
+            --host "$host" --port "$port" >"$daemon_log" 2>&1 &
+          daemon_pid=$!
+
+          dashboard=""
+          ready=false
+          for _ in {1..60}; do
+            if dashboard="$(curl --fail --silent --connect-timeout 1 --max-time 2 "$origin/")"; then
+              ready=true
+              break
+            fi
+            if ! kill -0 "$daemon_pid" 2>/dev/null; then
+              echo "::error::Embedded dashboard daemon exited before serving the SPA."
+              exit 1
+            fi
+            sleep 1
+          done
+
+          if [[ "$ready" != true ]]; then
+            echo "::error::Embedded dashboard did not become ready within 60 seconds."
+            exit 1
+          fi
+          if ! grep -Fq 'id="root"' <<<"$dashboard"; then
+            echo "::error::Gateway root did not return the embedded dashboard."
+            exit 1
+          fi
 
       # Code-signing + notarization are optional: when the APPLE_* secrets are
       # configured the Tauri bundler picks them up from the environment and

--- a/apps/tauri/TESTING.md
+++ b/apps/tauri/TESTING.md
@@ -40,15 +40,18 @@ with nothing pre-installed and get a running agent — bundle the kernel as a
 sidecar:
 
 ```sh
-# 1. Build (or reuse) the kernel and stage it for the bundler.
-scripts/desktop/prepare-kernel.sh                          # host triple
-scripts/desktop/prepare-kernel.sh --target universal-apple-darwin  # mac universal
-# Reuse an existing kernel instead of rebuilding (single-target only):
-ZEROCLAW_KERNEL_PATH=~/.cargo/bin/zeroclaw scripts/desktop/prepare-kernel.sh
+# 1. Build the dashboard, then embed it in the staged kernel.
+cargo web build
+scripts/desktop/prepare-kernel.sh --features embedded-web
+scripts/desktop/prepare-kernel.sh --target universal-apple-darwin --features embedded-web
 
 # 2. Bundle with the sidecar overlay (adds bundle.externalBin).
 cd apps/tauri && cargo tauri build --config tauri.bundled.conf.json
 ```
+
+`ZEROCLAW_KERNEL_PATH` can reuse a prebuilt single-target kernel, but that
+binary must already have been built with `--features embedded-web`; the staging
+script cannot add embedded assets to an existing executable.
 
 The overlay keeps the default config untouched, so `cargo tauri build`
 without the staged kernel keeps working. Tauri places the sidecar next to the

--- a/scripts/desktop/prepare-kernel.sh
+++ b/scripts/desktop/prepare-kernel.sh
@@ -16,10 +16,13 @@ set -euo pipefail
 #   scripts/desktop/prepare-kernel.sh --target aarch64-apple-darwin
 #   scripts/desktop/prepare-kernel.sh --target universal-apple-darwin
 #       # builds both mac arches and fuses them with lipo
+#   scripts/desktop/prepare-kernel.sh --target universal-apple-darwin \
+#       --features embedded-web
 #
 # Environment:
 #   ZEROCLAW_KERNEL_PATH   Reuse an existing kernel binary instead of building
-#                          (single-target only; ignored for universal).
+#                          (single-target only; ignored for universal). Requested
+#                          features must already be present in that binary.
 #   CARGO_PROFILE          Cargo profile to build (default: release).
 #
 # Then bundle with the sidecar overlay:
@@ -30,10 +33,12 @@ OUT_DIR="$REPO_ROOT/apps/tauri/binaries"
 PROFILE="${CARGO_PROFILE:-release}"
 
 TARGET=""
+FEATURES=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target) TARGET="$2"; shift 2 ;;
-    -h|--help) sed -n '3,25p' "$0"; exit 0 ;;
+    --features) FEATURES="$2"; shift 2 ;;
+    -h|--help) sed -n '3,29p' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -72,8 +77,13 @@ build_kernel() {
     echo "$ZEROCLAW_KERNEL_PATH"
     return
   fi
-  echo "prepare-kernel: cargo build --profile $PROFILE --bin zeroclaw --target $triple" >&2
-  (cd "$REPO_ROOT" && cargo build --profile "$PROFILE" --bin zeroclaw --target "$triple")
+  if [[ -n "$FEATURES" ]]; then
+    echo "prepare-kernel: cargo build --profile $PROFILE --bin zeroclaw --target $triple --features $FEATURES" >&2
+    (cd "$REPO_ROOT" && cargo build --profile "$PROFILE" --bin zeroclaw --target "$triple" --features "$FEATURES")
+  else
+    echo "prepare-kernel: cargo build --profile $PROFILE --bin zeroclaw --target $triple" >&2
+    (cd "$REPO_ROOT" && cargo build --profile "$PROFILE" --bin zeroclaw --target "$triple")
+  fi
   local dir="release"
   [[ "$PROFILE" != "release" ]] && dir="$PROFILE"
   echo "$REPO_ROOT/target/$triple/$dir/zeroclaw$exe"

--- a/tests/architecture/desktop_release.rs
+++ b/tests/architecture/desktop_release.rs
@@ -1,0 +1,72 @@
+//! Release invariant: the macOS desktop sidecar must contain the dashboard.
+
+use std::{fs, path::Path};
+
+#[test]
+fn macos_desktop_sidecar_embeds_the_web_artifact() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(root.join(".github/workflows/release-stable-manual.yml"))
+        .expect("release workflow should be readable");
+    let macos_job = workflow
+        .split_once("\n  build-desktop:\n")
+        .and_then(|(_, rest)| rest.split_once("\n  build-desktop-linux:\n"))
+        .map(|(job, _)| job)
+        .expect("macOS desktop release job should exist");
+
+    assert!(
+        macos_job.contains("needs: [validate, web]"),
+        "macOS desktop release must wait for the canonical web-dist artifact"
+    );
+    assert!(
+        macos_job.contains("uses: actions/download-artifact@")
+            && macos_job.contains("name: web-dist")
+            && macos_job.contains("path: web/dist/"),
+        "macOS desktop release must restore web-dist at the embedded-web source path"
+    );
+    assert!(
+        macos_job
+            .contains("prepare-kernel.sh --target universal-apple-darwin --features embedded-web"),
+        "macOS desktop kernel must enable the existing embedded-web Cargo feature"
+    );
+    let stage_position = macos_job
+        .find("- name: Stage bundled kernel sidecar (universal)")
+        .expect("macOS desktop release should stage its sidecar");
+    let smoke_position = macos_job
+        .find("- name: Smoke test embedded dashboard from an empty directory")
+        .expect("macOS desktop release should smoke test the staged sidecar");
+    let signing_position = macos_job
+        .find("- name: Enable macOS signing")
+        .expect("macOS desktop release should configure signing");
+    assert!(
+        stage_position < smoke_position && smoke_position < signing_position,
+        "embedded dashboard smoke test must run immediately after sidecar staging"
+    );
+
+    let smoke_step = &macos_job[smoke_position..signing_position];
+    assert!(
+        smoke_step.contains("cd \"$smoke_cwd\"")
+            && smoke_step.contains("--config-dir \"$config_dir\"")
+            && smoke_step.contains("HOME=\"$smoke_home\"")
+            && smoke_step.contains("XDG_DATA_HOME=\"$xdg_data_home\"")
+            && smoke_step.contains("host=\"127.0.0.1\"")
+            && smoke_step.contains("port=\"42618\"")
+            && smoke_step.contains("origin=\"http://$host:$port\"")
+            && smoke_step.contains("--host \"$host\" --port \"$port\""),
+        "embedded dashboard smoke test must launch from an empty cwd with isolated config"
+    );
+    assert!(
+        smoke_step.contains("curl --fail --silent --connect-timeout 1 --max-time 2")
+            && smoke_step.contains("\"$origin/\"")
+            && smoke_step.contains("id=\"root\""),
+        "embedded dashboard smoke test must require a successful SPA response"
+    );
+
+    let prepare = fs::read_to_string(root.join("scripts/desktop/prepare-kernel.sh"))
+        .expect("desktop kernel preparation script should be readable");
+    assert!(
+        prepare.lines().any(|line| {
+            line.contains("cargo build") && line.contains("--features \"$FEATURES\"")
+        }),
+        "prepare-kernel.sh must forward the requested Cargo features"
+    );
+}

--- a/tests/test_architecture.rs
+++ b/tests/test_architecture.rs
@@ -11,3 +11,6 @@ mod config_save_isolation;
 
 #[path = "architecture/cli_fluent_coverage.rs"]
 mod cli_fluent_coverage;
+
+#[path = "architecture/desktop_release.rs"]
+mod desktop_release;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Make the macOS desktop release job wait for the canonical `web-dist` artifact and restore it at `web/dist/`.
  - Build the bundled kernel sidecar with the existing `embedded-web` feature so the dashboard is compiled into the executable.
  - Launch the staged sidecar from an empty working directory with isolated config, home, and data directories; use bounded loopback requests and require `/` to return the dashboard root marker before packaging continues.
  - Add an architecture regression guard and document the self-contained build contract.
- **Scope boundary:** This changes only the required macOS desktop release path. Linux and Windows desktop jobs, dashboard source code, Tauri permissions, signing, notarization, DMG collection, and plugin-host sidecar bundling are unchanged.
- **Blast radius:** The macOS desktop job now depends on the web build artifact, its sidecar is larger because it contains the dashboard, and release packaging fails early when the staged sidecar cannot serve the SPA. `prepare-kernel.sh` gains an additive optional `--features` argument.
- **Linked issue(s):** Related #9031 (release-note heredoc/actionlint repair; recommended landing order for clean workflow lint, not a functional desktop prerequisite). Related #6465. Related #9014 (complementary DMG notarization change; no dependency). Related #8661 (non-conflicting ordering hazard only; plugin-host bundling remains out of scope here).
- **Labels:** `bug`, `ci`, `type:ci`, `desktop`, `tauri`, `docs`, `scripts`, `tests`, `release-gate`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the release job now contains the isolated runtime smoke itself; repeating it manually would not exercise the universal sidecar and artifact handoff produced by GitHub Actions.

### How I tested

- **CI checks relied on and why they cover this change:** CI for JordanTheJet/zeroclaw#18 completed successfully, including `CI Required Gate`, the full lint/test/build/security matrix, all Docker source-build jobs, and `zeroclaw-desktop` on macOS, Linux, and Windows. Those checks cover the workflow, script, architecture test, and cross-platform desktop crate surfaces; the focused local runtime smoke covers the embedded-dashboard behavior.
- **Known CI coverage gap, if any:** The production workflow's publishing jobs were intentionally not dispatched. The successful [macOS-only signed smoke](https://github.com/JordanTheJet/zeroclaw/actions/runs/29242262129) used a combined fork integration branch containing the implementations from JordanTheJet/zeroclaw#17 through JordanTheJet/zeroclaw#20, so it validates the combined stack rather than this PR in isolation. It exercised the universal sidecar, isolated embedded-dashboard smoke, Tauri packaging, Developer ID signing, notarization, stapling, and DMG upload without retaining any release, container, package-manager, website, or announcement job. Separately, combining this branch with #9031 produces a clean `actionlint` run; #9031 repairs release-note heredocs but is not required for desktop functionality.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
# exit 0

$ cargo clippy --test architecture -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 45s

$ cargo test --test architecture
running 4 tests
test desktop_release::macos_desktop_sidecar_embeds_the_web_artifact ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ bash -n scripts/desktop/prepare-kernel.sh
# exit 0

$ PATH="/opt/homebrew/opt/node@24/bin:$PATH" cargo web build
✓ built in 343ms

$ cargo build --bin zeroclaw --features embedded-web
Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.35s

$ # Run the built kernel with isolated cwd, HOME, XDG_DATA_HOME, and --config-dir
health=200 root=200 marker=id-root cwd_entries=0

$ # Validate a combined tree with #9031's workflow-lint repair
combined actionlint: clean

$ bash scripts/ci/docs_quality_gate.sh
No docs files detected; skipping docs quality gate.

$ bash scripts/ci/docs_links_gate.sh
No added links detected in changed docs lines.

$ # Signed universal macOS smoke, run 29242262129
Stage bundled kernel sidecar (universal) ... success
Smoke test embedded dashboard from an empty directory ... success
Build Tauri app (universal binary, bundled kernel) ... success
packaged sidecar dashboard smoke from mounted DMG ... ok
```

- **Beyond CI, what did you manually verify?** Before the workflow fix, the focused architecture test failed because the macOS job did not consume `web-dist`; a follow-up red run also rejected the unbounded loopback request. After both fixes, the full architecture suite passes. I built the real dashboard with Node 24, compiled a kernel with `embedded-web`, and launched it outside the checkout with isolated config/home/data paths. After the signed smoke, I also mounted the downloaded DMG and launched its packaged universal sidecar under isolated paths; `/` returned the dashboard root marker.
- **If any command was intentionally skipped, why:** A real stable release was not published because its downstream jobs create external release/package/site/announcement state. The pruned signed smoke exercised the macOS build boundary without those side effects.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`Yes`) — the macOS CI job downloads the canonical `web-dist` artifact produced by the same workflow run; product runtime networking is unchanged.
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: The artifact transfer uses the existing SHA-pinned GitHub download action and the exact `web-dist` name from the canonical web job. The release smoke binds only to loopback and writes only below its runner-temporary root; cleanup terminates the daemon and prints its log on failure.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`Yes`) — the developer-only `prepare-kernel.sh` interface gains an optional `--features` argument; product config, environment variables, and the `zeroclaw` CLI are unchanged.
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade is required. Existing script invocations retain their previous behavior; self-contained builds should pass `--features embedded-web`, and prebuilt kernels supplied through `ZEROCLAW_KERNEL_PATH` must already contain that feature.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After merge, revert the resulting squash commit with `git revert <squash commit SHA>`. The current one-commit patch head is `132181f803fc4427bf4a22bb0f949429a835a787`.
- **Feature flags or config toggles:** The existing build-time `embedded-web` Cargo feature controls asset embedding; there is no runtime toggle or new config state.
- **Observable failure symptoms:** The macOS `build-desktop` job fails in `Smoke test embedded dashboard from an empty directory`, `/` never returns HTTP success or lacks `id="root"`, and the grouped daemon log is printed. A successful but unexpectedly large sidecar or longer kernel build is also attributable to the embedded asset payload.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede another contribution.

