### PR TITLE
docs(install): align first-run guidance with installer behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ cd zeroclaw
 ./install.sh
 ```
 
-The installer asks whether you want a prebuilt binary (fast, ~seconds) or a source build (slower, customisable). Both end the same way: `zeroclaw quickstart` kicks off automatically.
+The piped installer uses a prebuilt binary when one is available and falls back to a source build otherwise. It skips interactive setup and prints `zeroclaw quickstart` as the next step.
+
+Running `./install.sh` from a clone in an interactive terminal offers prebuilt or source installation. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based Quickstart. Use `--skip-quickstart` when you only want to install.
 
 > **Working on the docs?** The translated documentation catalogues live in a
 > git submodule (`docs/book/po`). The Rust build does not need it, but building

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd zeroclaw
 
 The piped installer uses a prebuilt binary when one is available and falls back to a source build otherwise. It skips interactive setup and prints `zeroclaw quickstart` as the next step.
 
-Running `./install.sh` from a clone in an interactive terminal offers prebuilt or source installation. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based Quickstart. Use `--skip-quickstart` when you only want to install.
+When the platform maps to a supported prebuilt target, running `./install.sh` from a clone in an interactive terminal offers prebuilt or source installation; other platforms build from source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based Quickstart. Use `--skip-quickstart` when you only want to install.
 
 > **Working on the docs?** The translated documentation catalogues live in a
 > git submodule (`docs/book/po`). The Rust build does not need it, but building

--- a/docs/book/src/_snippets/install.md
+++ b/docs/book/src/_snippets/install.md
@@ -17,7 +17,7 @@ The piped path chooses a prebuilt binary when one is available and falls back to
 ./install.sh
 ```
 
-Run this path in an interactive terminal to choose prebuilt or source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based setup.
+When the platform maps to a supported prebuilt target, run this path in an interactive terminal to choose prebuilt or source; other platforms build from source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based setup.
 
 **Homebrew (Linuxbrew):**
 
@@ -43,7 +43,7 @@ The piped path chooses a prebuilt binary when one is available and falls back to
 ./install.sh
 ```
 
-Run this path in an interactive terminal to choose prebuilt or source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based setup.
+When the platform maps to a supported prebuilt target, run this path in an interactive terminal to choose prebuilt or source; other platforms build from source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based setup.
 
 **Homebrew:**
 

--- a/docs/book/src/_snippets/install.md
+++ b/docs/book/src/_snippets/install.md
@@ -3,17 +3,21 @@
 <!-- ANCHOR: linux -->
 ### Linux
 
-**One-liner (`install.sh` via curl):**
+**Piped noninteractive install (`install.sh` via curl):**
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh | sh
 ```
 
-**From a clone:**
+The piped path chooses a prebuilt binary when one is available and falls back to a source build otherwise. It skips the setup prompt and prints `zeroclaw quickstart` as the next step.
+
+**Guided install from a clone:**
 
 ```sh
 ./install.sh
 ```
+
+Run this path in an interactive terminal to choose prebuilt or source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based setup.
 
 **Homebrew (Linuxbrew):**
 
@@ -25,17 +29,21 @@ brew install zeroclaw
 <!-- ANCHOR: macos -->
 ### macOS
 
-**One-liner (`install.sh` via curl):**
+**Piped noninteractive install (`install.sh` via curl):**
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh | sh
 ```
 
-**From a clone:**
+The piped path chooses a prebuilt binary when one is available and falls back to a source build otherwise. It skips the setup prompt and prints `zeroclaw quickstart` as the next step.
+
+**Guided install from a clone:**
 
 ```sh
 ./install.sh
 ```
+
+Run this path in an interactive terminal to choose prebuilt or source. The source path also lets you select apps and optional features. For an unconfigured install, the installer then offers CLI or browser-based setup.
 
 **Homebrew:**
 
@@ -47,16 +55,14 @@ brew install zeroclaw
 <!-- ANCHOR: windows -->
 ### Windows
 
-**`setup.bat` (from a release):**
+**Prebuilt binary (recommended):**
+
+Download the latest `zeroclaw-x86_64-pc-windows-msvc.zip`, extract it, add its directory to `PATH`, and run `zeroclaw quickstart`. The [Windows setup guide](../setup/windows.md) provides an idempotent PowerShell installation block.
+
+**`setup.bat` (currently checks for Rust before its prebuilt path):**
 
 ```cmd
-setup.bat
-```
-
-**Scoop:**
-
-```cmd
-scoop install zeroclaw
+setup.bat --prebuilt
 ```
 
 **From source:**
@@ -66,7 +72,7 @@ cargo install --locked --path .
 ```
 
 On WSL2, follow the Linux path; `install.sh` runs unchanged. See
-[Setup → Windows](../setup/windows.md) for the full walkthrough.
+[Setup → Windows](../setup/windows.md) for the full walkthrough and current Scoop status.
 <!-- ANCHOR_END: windows -->
 
 </div>

--- a/docs/book/src/getting-started/quickstart.md
+++ b/docs/book/src/getting-started/quickstart.md
@@ -10,14 +10,12 @@ where you are.
 
 {{#include ../_snippets/install.md}}
 
-This builds and installs both `zeroclaw` and the `zerocode` terminal interface.
-Run it with no flags for an interactive picker that lets you choose the build
-type, which apps to install, and which optional features to compile in.
+Every installation includes `zeroclaw`. A release archive or selected source apps may also include the `zerocode` terminal interface. For a source install, pass `--apps zerocode` when it is not already selected. Without `zerocode`, use the CLI or web Quickstart paths below.
 
 ## The steps
 
 > **Important:** if any of these terms are unfamiliar, read
-> [Getting Started → Concepts](./index.md#concepts) first. It defines model
+> [Getting Started → Concepts](./concepts.md) first. It defines model
 > provider, risk profile, alias, and the rest in one place.
 
 {{#include ../_snippets/quickstart-steps.md}}

--- a/docs/book/src/setup/linux.md
+++ b/docs/book/src/setup/linux.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 </div>
 
-When the platform maps to a supported prebuilt target, an interactive run offers prebuilt or source installation; other platforms build from source. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
+When the platform maps to a supported prebuilt target, an interactive run offers prebuilt or source installation; other platforms build from source. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to Cargo's bin directory, usually `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
 
 ### Homebrew (Linuxbrew)
 

--- a/docs/book/src/setup/linux.md
+++ b/docs/book/src/setup/linux.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 </div>
 
-The installer detects your distribution and architecture, picks a prebuilt binary or builds from source (interactive by default; non-interactive shells take the prebuilt when available), installs to `~/.cargo/bin/zeroclaw`, and offers to run [`zeroclaw quickstart`](../getting-started/quickstart.md) for first-time setup. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
+When run from an interactive terminal, the installer offers prebuilt or source installation. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
 
 ### Homebrew (Linuxbrew)
 

--- a/docs/book/src/setup/linux.md
+++ b/docs/book/src/setup/linux.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 </div>
 
-When run from an interactive terminal, the installer offers prebuilt or source installation. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
+When the platform maps to a supported prebuilt target, an interactive run offers prebuilt or source installation; other platforms build from source. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
 
 ### Homebrew (Linuxbrew)
 

--- a/docs/book/src/setup/macos.md
+++ b/docs/book/src/setup/macos.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 </div>
 
-When the platform maps to a supported prebuilt target, an interactive run offers prebuilt or source installation; other platforms build from source. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
+When the platform maps to a supported prebuilt target, an interactive run offers prebuilt or source installation; other platforms build from source. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to Cargo's bin directory, usually `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
 
 ### Homebrew
 

--- a/docs/book/src/setup/macos.md
+++ b/docs/book/src/setup/macos.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 </div>
 
-When run from an interactive terminal, the installer offers prebuilt or source installation. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
+When the platform maps to a supported prebuilt target, an interactive run offers prebuilt or source installation; other platforms build from source. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
 
 ### Homebrew
 

--- a/docs/book/src/setup/macos.md
+++ b/docs/book/src/setup/macos.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 </div>
 
-The installer picks a prebuilt binary or builds from source (interactive by default), installs to `~/.cargo/bin/zeroclaw`, and offers to run [`zeroclaw quickstart`](../getting-started/quickstart.md) for first-time setup. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
+When run from an interactive terminal, the installer offers prebuilt or source installation. Source installs also offer app and optional-feature choices. For an unconfigured install, the installer then offers CLI or browser-based setup. The piped `curl | bash` path is noninteractive: it selects a prebuilt binary when available, falls back to a source build otherwise, skips the setup prompt, and prints [`zeroclaw quickstart`](../getting-started/quickstart.md) as the next step. Both paths install to `~/.cargo/bin/zeroclaw`. Pass `--help` for the full flag reference, or `--skip-quickstart` to install only.
 
 ### Homebrew
 
@@ -187,7 +187,7 @@ rm -rf ~/.zeroclaw ~/.config/zeroclaw
 
 - **Homebrew config path mismatch.** The `brew services` daemon reads config from `$HOMEBREW_PREFIX/var/zeroclaw/`, not `~/.zeroclaw/`. If your service is reading stale config, check which one the daemon sees and set `ZEROCLAW_WORKSPACE` accordingly.
 - **First launch of the browser tool** downloads Chromium (~150 MB) via Playwright.
-- **Apple Silicon** and **Intel** builds are both released. The bootstrap script auto-detects. Homebrew auto-selects.
+- **Apple Silicon and Intel:** the bootstrap script detects the architecture and uses a matching prebuilt release artifact when one is available. If the release has no matching artifact, it falls back to a source build. Homebrew selects the appropriate package for the host.
 
 ## Next
 

--- a/docs/book/src/setup/windows.md
+++ b/docs/book/src/setup/windows.md
@@ -82,12 +82,12 @@ cargo install --locked --path .
 zeroclaw quickstart
 ```
 
-### Option 4: Scoop (currently stale)
+### Option 4: Scoop (verify before use)
 
-> ⚠️ **The Scoop manifest in the repo is pinned to v0.5.9** (23 patch releases behind master). Until a release-time CI hook bumps it, prefer Option 1 or 3. If you do use Scoop and hit issues, please open a PR against `dist/scoop/zeroclaw.json`.
+> ⚠️ **Verify the Scoop manifest before use.** The checked-in manifest can declare the current package version while retaining an older static download URL. Until release automation keeps both fields aligned, prefer the manual prebuilt path above or build from source.
 
 ```
-scoop install zeroclaw     # currently installs an older release; see warning above
+scoop install zeroclaw     # verify the resolved release URL first; see warning above
 zeroclaw quickstart
 ```
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Separate piped noninteractive Unix installation from the guided clone path so each path matches current installer behavior.
  - Correct first-run and `zerocode` availability claims, and fix the Quickstart Concepts link.
  - Make the macOS and Windows guidance resilient to release-asset drift.
- **Scope boundary:** Documentation only. This PR does not change installer, Quickstart behavior, runtime, package-manager, or release behavior. Generating installation prose from the canonical install spec remains tracked in Related #9039.
- **Blast radius:** The README and English mdBook installation, Quickstart, Linux, macOS, and Windows pages. The shared installation snippet also feeds its existing Linux anchor consumer.
- **Linked issue(s):** Related #9039
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A. This docs-only change is covered by source lint plus full mdBook rendering and link checks.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` checks changed Markdown lines. The local full mdBook build additionally covers snippet expansion, locale rendering, and internal links.
- **Known CI coverage gap, if any:** Fresh required CI passed. Platform installer smoke was not run because no installer or runtime code changed.
- **Commands run and tail output:** The mdBook command below was invoked through a local validation wrapper.

```text
$ DOCS_FILES=$'docs/book/src/_snippets/install.md\ndocs/book/src/getting-started/quickstart.md\ndocs/book/src/setup/linux.md\ndocs/book/src/setup/macos.md' BASE_SHA=missing scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Summary: 0 error(s)

$ npx --yes markdownlint-cli2@0.20.0 README.md
Summary: 0 error(s)

$ cargo mdbook build
HTML book written for en, fr, ja, es, and zh-CN.
Internal link check passed.
Exit 0 in 55.74s.

$ git diff --check
(no output; exit 0)
```

- **Beyond CI, what did you manually verify?** Compared the claims with `install.sh`, `setup.bat`, the stable release workflow, and the checked-in Scoop manifest. Confirmed that the rendered English Quickstart and platform pages contain the corrected guidance and that the Concepts target exists.
- **If any command was intentionally skipped, why:** Full-file lint for `docs/book/src/setup/windows.md` still reports two pre-existing `MD049` findings on unchanged line 154; the edited lines are clean. Fresh Unix and Windows installations were not executed because this PR does not change installation behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: `git revert <landed-sha>`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
