### PR TITLE
docs(contributing): compact coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,13 @@ Prefer borrowed config, getters, resolver closures over live config, on-demand m
 1. Read the owning module, factory wiring, adjacent tests, and relevant docs before editing.
 2. For architecture, config, security, workflow, governance, CI, release, or agent-assisted changes, start with `docs/book/src/contributing/architecture-map.md`.
 3. Name the source of truth before introducing state.
-4. Keep one concern per PR and avoid unrelated cleanup.
-5. Add the smallest useful implementation and tests at the real behavior boundary.
-6. Validate at the change's risk level and report commands actually run.
-7. Use a non-`master` branch, open a PR to `master`, and never push directly to `master`.
-8. Use conventional commits and the full PR template. Do not add bot or AI attribution footers.
+4. Keep one concern per PR. Avoid unrelated cleanup and do not mix broad formatting changes with functional changes.
+5. Do not add heavy dependencies for minor convenience, speculative abstractions, or config keys and feature flags without a concrete use case.
+6. Add the smallest useful implementation and tests at the real behavior boundary.
+7. Validate at the change's risk level, report commands actually run, and document behavior, risk, side effects, and rollback.
+8. Use a non-`master` branch, open a PR to `master`, and never push directly to `master`.
+9. Use conventional commits and the full PR template. Prefer small PRs and do not add bot or AI attribution footers.
+10. Declare stacked work with `Depends on #...` and replacement work with `Supersedes #...`.
 
 Subagents must set their working directory to the repository root before shell or filesystem work. Do not assume an inherited working directory.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,72 +1,47 @@
-# AGENTS.md — ZeroClaw
+# AGENTS.md - ZeroClaw
 
-Cross-tool agent instructions for any AI coding assistant working on this repository.
+Core instructions for AI coding assistants working in this repository. Use `docs/book/src/contributing/architecture-map.md` to load only the references needed for a non-trivial task.
 
-## ABSOLUTE RULE — SINGLE SOURCE OF TRUTH (NO DRY VIOLATIONS)
+## Single Source Of Truth
 
-**No piece of state lives in two places. Ever. Anywhere in this codebase.**
+Do not duplicate state. Before adding a struct field, config entry, schema field, runtime cache, or parallel lookup table, identify the canonical source:
 
-This is not a guideline. It is not a preference. It is not deferrable to a
-follow-up PR. If a fact already lives somewhere in this codebase, you do NOT
-copy it into a new field, struct, config block, schema entry, runtime cache,
-or anywhere else. You reference it. You resolve it from its source on demand.
+1. If the new field creates the fact, state that explicitly.
+2. If the fact already exists, resolve it from that source at use time.
 
-**Why this matters more than anything else you're tempted to ship:** every
-duplicate state breeds a drift bug whose symptoms surface months later in
-production — operator edits the canonical location, the cached copy serves
-stale data, the agent silently misbehaves. The previous incarnation of this
-codebase had channel `allowed_users` Vec fields cached inside channel handles
-while the truth lived in config TOML; reloading config didn't refresh the
-channels; an authorized user couldn't talk to the bot until daemon restart.
-Every such field is now banned by this rule.
+Prefer borrowed config, getters, resolver closures over live config, on-demand materialized views, or generated surfaces from one input. Do not snapshot live policy into long-lived handles. A restart-only snapshot is not a substitute for resolving canonical state.
 
-### Forcing mechanism — what happens when you violate
+## Safety And Privacy
 
-Adding a duplicate state field is an automatic-revert-on-detect change. The
-pre-push gate runs `dev/ci.sh dry-check`. If it fires, the maintainer will
-`git reset --hard` your branch back to the prior good state, and the time you
-spent is wasted. Save yourself the burn: do not write the duplicate in the
-first place.
+- Never commit secrets, tokens, credentials, personal data, or real identities.
+- Do not weaken permissions, allowlists, sandboxing, approvals, or other trust boundaries without making the behavior and risk explicit.
+- New external surfaces default closed. Prefer allowlists to blocklists.
+- Do not hide behavior changes inside refactors or bypass failing checks.
+- Production paths must propagate errors. Avoid `unwrap()` and `expect()` unless a documented invariant makes panic impossible.
+- Do not suppress unused production code with underscore names or `#[allow(dead_code)]`; remove it, connect it, or track it. Underscore names remain valid for required but intentionally unused API, trait, or callback parameters.
 
-### Pre-edit ritual — before any new struct field, channel/handle field, schema field, config entry
+## Working Rules
 
-State, in your response text, the source of truth for the new data BEFORE you
-write the field. Two valid answers:
+1. Read the owning module, factory wiring, adjacent tests, and relevant docs before editing.
+2. For architecture, config, security, workflow, governance, CI, release, or agent-assisted changes, start with `docs/book/src/contributing/architecture-map.md`.
+3. Name the source of truth before introducing state.
+4. Keep one concern per PR and avoid unrelated cleanup.
+5. Add the smallest useful implementation and tests at the real behavior boundary.
+6. Validate at the change's risk level and report commands actually run.
+7. Use a non-`master` branch, open a PR to `master`, and never push directly to `master`.
+8. Use conventional commits and the full PR template. Do not add bot or AI attribution footers.
 
-  1. **"This is the source of truth — created here."** OK to write the
-     field. State what it represents.
-  2. **"Source of truth is `<path/to/canonical>` — this would be a
-     duplicate."** Do NOT write the field. Resolve from the canonical
-     location at use-time (closure, helper, `&Config` parameter, getter
-     trait, whatever fits — never a cache).
+Subagents must set their working directory to the repository root before shell or filesystem work. Do not assume an inherited working directory.
 
-Any third answer ("we'll only refresh on restart", "snapshot is fine",
-"orchestrator passes a Vec in") is a duplicate. Refuse the edit. Find the
-canonical source and resolve from there.
+## User-Facing Text
 
-### Examples of patterns that ARE duplicate state (forbidden):
+- User-facing CLI, tool, onboarding, and dashboard text uses Fluent `fl!()` keys rather than bare literals.
+- Logs, tracing fields, and panic text remain English and use stable error keys where the logging contract requires them.
+- English Markdown is the documentation source of truth. Follow the documented localization workflow instead of editing generated translations by hand.
 
-- A channel handle struct holding `Vec<String>` of "authorized users" alongside
-  `peer_groups` in `Config`.
-- A schema enum variant list duplicated across an enum and a `const &[Variant]`
-  table that aren't generated from the same macro.
-- A `ConfigSnapshot` struct that clones live `Config` fields the runtime can
-  already reach through its `Arc<RwLock<Config>>` handle.
-- Re-emitting a model-provider's API key into a runtime struct field when the
-  runtime already has the typed alias config.
+## Validation
 
-### Patterns that are NOT duplicate state (allowed):
-
-- Resolver closures (`Arc<dyn Fn() -> T + Send + Sync>`) that close over
-  `Arc<RwLock<Config>>` and resolve on call.
-- `&Config` / `&AgentConfig` parameters threaded through call sites.
-- Materialized views built ON-DEMAND from canonical state (cached per-call,
-  not stored).
-- Derive macros that emit multiple surfaces from one input table (e.g.
-  enum + const list from one macro invocation — both come from the same
-  source of truth at expansion time).
-
-## Commands
+Choose checks that match the changed surface. Common code checks are:
 
 ```bash
 cargo fmt --all -- --check
@@ -74,169 +49,8 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-Full pre-PR validation (recommended):
+Use `./dev/ci.sh all` for full pre-PR validation when the scope warrants it. Docs-only changes use `scripts/ci/docs_quality_gate.sh` and `scripts/ci/docs_links_gate.sh`. Bootstrap script changes add `bash -n install.sh`.
 
-```bash
-./dev/ci.sh all
-```
+## Task References
 
-Docs-only changes: run markdown lint and link-integrity checks. If touching bootstrap scripts: `bash -n install.sh`.
-
-## Subagents
-
-Subagents (via `spawn_subagent` or cron `JobType::Agent`) inherit the parent's identity and permissions but run in isolated sessions. **Before running any shell commands or filesystem operations, subagents must explicitly set their working directory to the repository root** (the directory containing the top-level `Cargo.toml` and `AGENTS.md`). Do not assume the shell starts at repo root; always `cd` to it first (or use the equivalent in the tool's context).
-
-This guarantees consistent command behavior across parent and child runs.
-
-
-## Project Snapshot
-
-ZeroClaw is a Rust-first autonomous agent runtime optimized for performance, efficiency, stability, extensibility, sustainability, and security.
-
-Core architecture is trait-driven and modular. Extend by implementing traits and registering in factory modules.
-
-Key extension points:
-
-- `crates/zeroclaw-api/src/model_provider.rs` (`ModelProvider`)
-- `crates/zeroclaw-api/src/channel.rs` (`Channel`)
-- `crates/zeroclaw-api/src/tool.rs` (`Tool`)
-- `crates/zeroclaw-api/src/memory_traits.rs` (`Memory`)
-- `crates/zeroclaw-api/src/observability_traits.rs` (`Observer`)
-- `crates/zeroclaw-api/src/runtime_traits.rs` (`RuntimeAdapter`)
-- `crates/zeroclaw-api/src/peripherals_traits.rs` (`Peripheral`) — hardware boards (STM32, RPi GPIO)
-
-## Stability Tiers
-
-Every workspace crate carries a stability tier per the Microkernel Architecture RFC.
-
-| Crate | Tier | Notes |
-|-------|------|-------|
-| `zeroclaw-api` | Experimental | Stable at v1.0.0 (formal milestone) |
-| `zeroclaw-config` | Beta | Stable at v0.8.0 |
-| `zeroclaw-log` | Beta | Unified log emission + JSONL persistence + broadcast hook |
-| `zeroclaw-providers` | Beta | — |
-| `zeroclaw-memory` | Beta | — |
-| `zeroclaw-infra` | Beta | — |
-| `zeroclaw-commands` | Experimental | Built-in command catalogue and metadata |
-| `zeroclaw-tool-call-parser` | Beta | Stable at v0.8.0 |
-| `zeroclaw-channels` | Experimental | Plugin migration at v1.0.0 |
-| `zeroclaw-tools` | Experimental | Plugin migration at v1.0.0 |
-| `zeroclaw-runtime` | Experimental | Agent runtime (agent loop, security, cron, SOP, skills, observability) |
-| `zeroclaw-gateway` | Experimental | Separate binary at v0.9.0 |
-| `zerocode` | Experimental | TUI onboarding wizard |
-| `zeroclaw-plugins` | Experimental | WASM plugin system — foundation for v1.0.0 plugin ecosystem |
-| `zeroclaw-hardware` | Experimental | USB discovery, peripherals, serial |
-| `zeroclaw-macros` | Beta | Tightly coupled to config schema |
-| `zeroclaw-eval` | Experimental | Agent evaluation harness — Phase 0 deterministic replay of LLM trace fixtures |
-| `zeroclaw-spawn` | Beta | Attribution-propagating `tokio::spawn` wrapper layered on `zeroclaw-log` |
-| `robot-kit` | Experimental | Robot control toolkit — drive, vision, speech, sensors, safety |
-| `aardvark-sys` | Experimental | Low-level FFI bindings for Total Phase Aardvark I2C/SPI/GPIO USB adapter; only crate where `unsafe` is permitted |
-
-**Tiers**: Stable = covered by breaking-change policy. Beta = breaking changes permitted in MINOR with changelog notes. Experimental = no stability guarantee.
-
-Tiers are promoted, never demoted, through deliberate team decision.
-
-## Repository Map
-
-- `src/main.rs` — CLI entrypoint and command routing
-- `src/lib.rs` — module re-exports and CLI command enum definitions
-- `crates/zeroclaw-api/` — public trait definitions (ModelProvider, Channel, Tool, Memory, Observer, Peripheral)
-- `crates/zeroclaw-config/` — schema, config loading/merging
-- `crates/zeroclaw-log/` — unified log surface (record! macro, LogEvent schema, JSONL persistence, broadcast hook, Observer bridge)
-- `crates/zeroclaw-macros/` — Configurable derive macro
-- `crates/zeroclaw-providers/` — model providers and resilient wrapper
-- `crates/zeroclaw-channels/` — messaging platform integrations (30+ channels)
-- `crates/zeroclaw-channels/src/orchestrator/` — channel lifecycle, routing, media pipeline
-- `crates/zeroclaw-tools/` — tool execution surface (shell, file, memory, browser)
-- `crates/zeroclaw-runtime/` — agent loop, security, cron, SOP, skills, onboarding wizard, observability
-- `crates/zeroclaw-eval/` — agent evaluation harness (Phase 0 deterministic replay)
-- `crates/zeroclaw-memory/` — memory backends (markdown, sqlite, embeddings, vector merge)
-- `crates/zeroclaw-infra/` — shared infrastructure (debounce, session, stall watchdog)
-- `crates/zeroclaw-spawn/` — attribution-propagating `tokio::spawn` wrapper layered on `zeroclaw-log`
-- `crates/zeroclaw-gateway/` — webhook/gateway server (separate binary)
-- `crates/zeroclaw-hardware/` — USB discovery, peripherals, serial, GPIO
-- `crates/robot-kit/` — robot control toolkit (drive, vision, speech, sensors, safety)
-- `crates/aardvark-sys/` — Total Phase Aardvark I2C/SPI/GPIO FFI bindings
-- `apps/zerocode/` — TUI onboarding wizard
-- `crates/zeroclaw-plugins/` — WASM plugin system
-- `crates/zeroclaw-tool-call-parser/` — tool call parsing
-- `apps/tauri/` — Tauri-based desktop GUI
-- `docs/` — topic-based documentation (setup-guides, reference, ops, security, hardware, contributing, maintainers)
-- `.github/` — CI, templates, automation workflows
-
-## Risk Tiers
-
-- **Low risk**: docs/chore/tests-only changes
-- **Medium risk**: most `crates/*/src/**` behavior changes without boundary/security impact
-- **High risk**: `crates/zeroclaw-runtime/src/**` (especially `src/security/`), `crates/zeroclaw-gateway/src/**`, `crates/zeroclaw-tools/src/**`, `.github/workflows/**`, access-control boundaries
-
-When uncertain, classify as higher risk.
-
-## Workflow
-
-1. **Read before write** — inspect existing module, factory wiring, and adjacent tests before editing.
-2. **Map non-trivial changes** — before architecture, config, security, workflow, governance, CI, or agent-assisted contribution changes, read `docs/book/src/contributing/architecture-map.md` to choose the relevant architecture and foundation docs.
-3. **One concern per PR** — avoid mixed feature+refactor+infra patches.
-4. **Implement minimal patch** — no speculative abstractions, no config keys without a concrete use case.
-5. **Validate by risk tier** — docs-only: lightweight checks. Code changes: full relevant checks.
-6. **Document impact** — update PR notes for behavior, risk, side effects, and rollback.
-7. **Queue hygiene** — stacked PR: declare `Depends on #...`. Replacing old PR: declare `Supersedes #...`.
-
-Branch/commit/PR rules:
-- Work from a non-`master` branch. Open a PR to `master`; do not push directly.
-- Use conventional commit titles. Prefer small PRs (`size:XS`, `size:S`, or `size:M`).
-- Follow `.github/pull_request_template.md` fully.
-- Never commit secrets, personal data, or real identity information (see `@docs/book/src/contributing/privacy.md`).
-
-## Anti-Patterns
-
-- Do not add heavy dependencies for minor convenience.
-- Do not silently weaken security policy or access constraints.
-- Do not add speculative config/feature flags "just in case".
-- Do not mix massive formatting-only changes with functional changes.
-- Do not modify unrelated modules "while here".
-- Do not bypass failing checks without explicit explanation.
-- Do not hide behavior-changing side effects in refactor commits.
-- Do not suppress unused production code with underscore prefixes or `#[allow(dead_code)]`; delete it, wire it into behavior, or track a follow-up issue. Reserve underscore names for required but intentionally unused API, trait, or callback parameters.
-- Do not leave `unwrap()` / `expect()` in production paths; propagate errors or document the invariant that makes panic impossible.
-- Do not include personal identity or sensitive information in test data, examples, docs, or commits.
-
-## Skills
-
-AI coding assistant skills live in `.claude/skills/`. Use the right one for the job:
-
-- `.claude/skills/github-pr-review-session/SKILL.md` — PR review co-pilot; assists **you** as the human reviewer. Resolves the active reviewer from session state or `gh`, uses the RFC feedback taxonomy (🔴/🟡/✅/🔵/🟢), and formats formal review findings as H3 headings that start with the taxonomy emoji. Trigger: `review 1234`, `re-review 1234`, `go through the queue`.
-- `.claude/skills/changelog-generation/SKILL.md` — generates `CHANGELOG-next.md` between stable tags, resolves contributors via GraphQL, feeds the release workflow. Trigger: `generate changelog`, `release notes for v0.7.x`.
-- `.claude/skills/pr-architecture-check/SKILL.md` — Advisory architecture review of a PR diff; validates dependency direction, trait boundaries, extension patterns, crate placement, and core constraints against AGENTS.md and FND-001. Posts a non-blocking comment. Trigger: `arch-check #N`, `architecture check #N`.
-- `.claude/skills/github-issue-triage/SKILL.md` — Issue triage and lifecycle management; manages the backlog, labels, and stale policies. Trigger: `triage issues`, `sweep issues`, `handle issue #N`.
-- `.claude/skills/github-issue/SKILL.md` — Interactively files structured GitHub issues (bug reports or feature requests) using repo templates. Trigger: `file issue`, `report bug`, `feature request`.
-- `.claude/skills/github-pr/SKILL.md` — Opens or updates GitHub PRs, handles validation evidence, and manages PR descriptions. Trigger: `open PR`, `update PR`, `submit for review`.
-- `.claude/skills/skill-creator/SKILL.md` — Framework for creating, testing, evaluating, and optimizing new AI skills. Trigger: `create skill`, `improve skill`, `run skill evals`.
-- `.claude/skills/squash-merge/SKILL.md` — Performs conventional squash-merges into master with preserved commit history. Trigger: `squash-merge #123`, `land #789`.
-- `.claude/skills/zeroclaw/SKILL.md` — Operational guide for interacting with a ZeroClaw agent instance via CLI or API. Trigger: `check agent status`, `manage memory`, `zeroclaw config`.
-
-## Localization
-
-- All user-facing output (CLI messages, tool descriptions, onboarding prompts) must use `fl!()` / Fluent strings — never bare string literals.
-- Log messages, `tracing::` spans/events, and panic messages stay in English with stable `error_key` fields (RFC #5653 §4.6).
-- Panics and `tracing::` lines are never translated.
-- The Wiki and internal developer docs are English only.
-
-Dev-operational contracts — files consumed by AI coding skills and development tooling. Do not move or delete without updating all consuming skills and AGENTS.md:
-
-| Protected file | Consuming skill / tool |
-|---|---|
-| `docs/book/src/contributing/pr-review-protocol.md` | `github-pr-review-session` — review protocol |
-| `docs/book/src/maintainers/changelog-generation.md` | `changelog-generation` — release procedure |
-| `docs/book/src/maintainers/reviewer-playbook.md` | `github-issue-triage` — triage governance |
-| `docs/book/src/maintainers/pr-workflow.md` | `github-issue-triage` — triage discipline |
-| `docs/book/src/contributing/privacy.md` | `github-issue-triage`, PR template — privacy rules |
-| `docs/book/src/foundations/fnd-00*.md` | `github-pr-review-session` — RFC reference data; public transparency documents |
-
-## Linked References
-
-- `@docs/book/src/contributing/architecture-map.md` — start-here map for humans and coding agents before non-trivial architecture, workflow, config, security, CI, governance, or agent-assisted contribution changes
-- `@docs/book/src/developing/extension-examples.md` — adding providers, channels, tools, peripherals; tool shared-state contract; architecture boundary rules
-- `@docs/book/src/contributing/privacy.md` — privacy rules and neutral-placeholder palette
-- `@docs/book/src/maintainers/superseding.md` — superseded-PR attribution, PR/commit templates, handoff template
-- `@docs/maintainers/audit-policy.md` — `.cargo/audit.toml` / `deny.toml` ignore rationale and add/remove workflow (tracks #8519, #8059)
+The architecture map routes task-specific documentation. Consult `docs/book/src/contributing/agent-guidelines.md` only for detailed agent examples, risk and stability policy, skill discovery, and protected operational documents. Do not skip a required contract because it is no longer embedded in this bootstrap file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@ Subagents must set their working directory to the repository root before shell o
 
 ## User-Facing Text
 
-- User-facing CLI, tool, onboarding, and dashboard text uses Fluent `fl!()` keys rather than bare literals.
+- User-facing runtime CLI, tool, and onboarding text uses Fluent `fl!()` keys rather than bare literals.
+- Zerocode uses its independent Fluent catalogue through its documented `crate::i18n` helpers. Web dashboard text follows the TypeScript `web/src/lib/i18n.ts` contract, not Rust `fl!()`.
 - Logs, tracing fields, and panic text remain English and use stable error keys where the logging contract requires them.
 - English Markdown is the documentation source of truth. Follow the documented localization workflow instead of editing generated translations by hand.
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -157,6 +157,7 @@
   - [Zero compromise in practice](./foundations/fnd-006-zero-compromise-in-practice.md)
 - [Contributing](./contributing/index.md)
   - [How to contribute](./contributing/how-to.md)
+  - [Coding agent guidelines](./contributing/agent-guidelines.md)
   - [Architecture and contribution map](./contributing/architecture-map.md)
   - [RFC process](./contributing/rfcs.md)
   - [Communication](./contributing/communication.md)

--- a/docs/book/src/contributing/agent-guidelines.md
+++ b/docs/book/src/contributing/agent-guidelines.md
@@ -1,0 +1,91 @@
+# Coding Agent Guidelines
+
+The repository-root `AGENTS.md` is the compact, always-loaded contract for AI coding assistants. This page provides details that are useful for some tasks but should not consume every session's prompt budget.
+
+These rules apply regardless of model size or where the model runs. Compact prompt profiles may change how much context is loaded eagerly; they do not weaken safety, privacy, authorization, or contribution requirements.
+
+## How To Use This Page
+
+Start with the [architecture and contribution map](./architecture-map.md). Its change-path table routes each task to the current architecture, foundation, testing, security, and maintainer documentation. Return here only for the agent-specific subjects below.
+
+## Single Source Of Truth Examples
+
+No piece of state should live in two independently maintained places. If a fact already exists in config, schema, runtime state, or a generated definition, resolve or derive it from that source instead of copying it into another field.
+
+Before adding a struct field, channel or handle field, schema field, or config entry, state one of these answers:
+
+1. "This is the source of truth, created here." State what it represents.
+2. "The source of truth is `<path>`; this would duplicate it." Resolve it from that location at use time.
+
+Do not defer duplicate-state cleanup to a follow-up. A restart-only snapshot is still duplicate state.
+
+Forbidden examples:
+
+- a channel handle caching authorized users while live config owns them;
+- an enum and a separate hand-maintained variant list;
+- a config snapshot cloning fields the runtime can read from live config;
+- copying a provider credential into another runtime field.
+
+Allowed examples:
+
+- resolver closures over `Arc<RwLock<Config>>`;
+- borrowed `Config` or typed config parameters;
+- on-demand views that are not stored beyond the operation;
+- macros or generators that emit several surfaces from one input.
+
+## Architecture And Ownership
+
+ZeroClaw is a Rust-first, trait-driven agent runtime. Primary extension traits live in `crates/zeroclaw-api/src/`:
+
+- `model_provider.rs` (`ModelProvider`)
+- `channel.rs` (`Channel`)
+- `tool.rs` (`Tool`)
+- `memory_traits.rs` (`Memory`)
+- `observability_traits.rs` (`Observer`)
+- `runtime_traits.rs` (`RuntimeAdapter`)
+- `peripherals_traits.rs` (`Peripheral`)
+
+Do not maintain another crate or repository inventory here. Use [Crates](../architecture/crates.md) for ownership and dependency direction, the workspace members in the root `Cargo.toml` for current membership, and the architecture map for provider, channel, tool, plugin, runtime, and config change paths.
+
+## Stability And Risk
+
+The stability-tier definitions and versioning policy live in [FND-001](../foundations/fnd-001-intentional-architecture.md#stability-tiers). Verify a component's current tier in its own `AGENTS.md` or plugin registry manifest. Do not infer current tiers from an old aggregate list.
+
+Change-risk routing is:
+
+- **Low:** docs, chores, and tests without behavior changes.
+- **Medium:** most implementation changes without boundary or security impact.
+- **High:** `crates/zeroclaw-runtime/src/`, especially `src/security/`; `crates/zeroclaw-gateway/src/`; `crates/zeroclaw-tools/src/`; `.github/workflows/`; access control; and other trust-boundary changes.
+
+Classify uncertainty upward. Validation and rollback evidence should match the actual blast radius, not only the number of changed lines. Use [How to contribute](./how-to.md) for PR mechanics and [Testing](./testing.md) for the validation taxonomy.
+
+## Skill Discovery
+
+Repository-owned coding-assistant skills live in `.claude/skills/`. Inspect the available `*/SKILL.md` files and load only the skill matching the requested operation. Do not maintain a second skill catalog in this page; the directory is the current inventory and each skill file owns its workflow.
+
+## Protected Operational Documents
+
+These files are consumed by skills or development tooling. Do not move or delete them without updating their consumers and repository guidance.
+
+| File | Consumer |
+| --- | --- |
+| `docs/book/src/contributing/pr-review-protocol.md` | PR review skill |
+| `docs/book/src/maintainers/changelog-generation.md` | Changelog skill |
+| `docs/book/src/maintainers/reviewer-playbook.md` | Issue triage skill |
+| `docs/book/src/maintainers/pr-workflow.md` | Issue triage and maintainer workflow |
+| `docs/book/src/contributing/privacy.md` | Issue and PR privacy gates |
+| `docs/book/src/foundations/fnd-00*.md` | Review architecture references |
+
+## Localization And Privacy
+
+User-facing text and English-only logging rules remain in root `AGENTS.md`. The Wiki and internal developer documentation are also English-only. For the full contracts, use [Privacy and PII discipline](./privacy.md) and [Docs and translations](../maintainers/docs-and-translations.md).
+
+## Further Reading
+
+- [Architecture and contribution map](./architecture-map.md)
+- [How to contribute](./how-to.md)
+- [Privacy and PII discipline](./privacy.md)
+- [Testing](./testing.md)
+- [Architecture overview](../architecture/overview.md)
+- [Superseding pull requests](../maintainers/superseding.md)
+- [Audit policy](../../../maintainers/audit-policy.md)

--- a/docs/book/src/contributing/agent-guidelines.md
+++ b/docs/book/src/contributing/agent-guidelines.md
@@ -97,7 +97,7 @@ These files are consumed by skills or development tooling. Do not move or delete
 | File | Consumer |
 | --- | --- |
 | `docs/book/src/contributing/pr-review-protocol.md` | PR review skill |
-| `docs/book/src/maintainers/changelog-generation.md` | Changelog skill |
+| `.claude/skills/changelog-generation/SKILL.md` | Changelog skill loader and release runbook |
 | `docs/book/src/maintainers/reviewer-playbook.md` | Issue triage skill |
 | `docs/book/src/maintainers/pr-workflow.md` | Issue triage and maintainer workflow |
 | `docs/book/src/contributing/privacy.md` | Issue and PR privacy gates |

--- a/docs/book/src/contributing/agent-guidelines.md
+++ b/docs/book/src/contributing/agent-guidelines.md
@@ -49,7 +49,34 @@ Do not maintain another crate or repository inventory here. Use [Crates](../arch
 
 ## Stability And Risk
 
-The stability-tier definitions and versioning policy live in [FND-001](../foundations/fnd-001-intentional-architecture.md#stability-tiers). Verify a component's current tier in its own `AGENTS.md` or plugin registry manifest. Do not infer current tiers from an old aggregate list.
+The stability-tier definitions and versioning policy live in [FND-001](../foundations/fnd-001-intentional-architecture.md#stability-tiers). Component-local `AGENTS.md` files and plugin registry manifests are the target ownership model. Until every component has one, the table below is the canonical source for current assignments; do not copy it into another hand-maintained aggregate.
+
+### Current Stability Assignments
+
+| Component | Tier | Notes |
+| --- | --- | --- |
+| `zeroclaw-api` | Experimental | Stable at v1.0.0 (formal milestone) |
+| `zeroclaw-config` | Beta | Stable at v0.8.0 |
+| `zeroclaw-log` | Beta | Unified log emission, JSONL persistence, and broadcast hook |
+| `zeroclaw-providers` | Beta | |
+| `zeroclaw-memory` | Beta | |
+| `zeroclaw-infra` | Beta | |
+| `zeroclaw-commands` | Experimental | Built-in command catalog and metadata |
+| `zeroclaw-tool-call-parser` | Beta | Stable at v0.8.0 |
+| `zeroclaw-channels` | Experimental | Plugin migration at v1.0.0 |
+| `zeroclaw-tools` | Experimental | Plugin migration at v1.0.0 |
+| `zeroclaw-runtime` | Experimental | Agent runtime: agent loop, security, cron, SOP, skills, and observability |
+| `zeroclaw-gateway` | Experimental | Separate binary at v0.9.0 |
+| `zerocode` | Experimental | TUI onboarding wizard |
+| `zeroclaw-plugins` | Experimental | WASM plugin system and foundation for the v1.0.0 plugin ecosystem |
+| `zeroclaw-hardware` | Experimental | USB discovery, peripherals, and serial support |
+| `zeroclaw-macros` | Beta | Tightly coupled to the config schema |
+| `zeroclaw-eval` | Experimental | Agent evaluation harness with deterministic replay of LLM trace fixtures |
+| `zeroclaw-spawn` | Beta | Attribution-propagating `tokio::spawn` wrapper layered on `zeroclaw-log` |
+| `robot-kit` | Experimental | Robot control toolkit: drive, vision, speech, sensors, and safety |
+| `aardvark-sys` | Experimental | Low-level FFI bindings for the Total Phase Aardvark adapter; the only crate where `unsafe` is permitted |
+
+Stable components follow the breaking-change policy. Beta components may make breaking changes in a MINOR release with changelog notes. Experimental components carry no stability guarantee. Tiers are promoted, never demoted, through deliberate team decision.
 
 Change-risk routing is:
 

--- a/docs/book/src/contributing/architecture-map.md
+++ b/docs/book/src/contributing/architecture-map.md
@@ -6,10 +6,11 @@ This page is only a map. The linked files remain the source of truth.
 
 ## Start Here
 
-1. Read the repo-root `AGENTS.md` first. It contains the current risk tiers, protected files, anti-patterns, localization rules, and agent-specific workflow contracts.
-2. Read [How to contribute](./how-to.md) for the PR mechanics, validation expectations, and review process.
+1. Read the repo-root `AGENTS.md` first. It contains the compact, always-loaded safety and contribution contract.
+2. Read [How to contribute](./how-to.md) for PR mechanics, validation expectations, and the review process.
 3. Use the tables below to choose the architecture and foundation documents that match the change.
-4. If the change crosses subsystem, config, security, workflow, governance, or release boundaries, check the [RFC process](./rfcs.md) before implementing.
+4. Consult [Coding agent guidelines](./agent-guidelines.md) when an AI coding task needs detailed source-of-truth examples, risk and stability policy, skill discovery, or protected operational documents.
+5. If the change crosses subsystem, config, security, workflow, governance, or release boundaries, check the [RFC process](./rfcs.md) before implementing.
 
 ## Common Change Paths
 
@@ -44,7 +45,7 @@ This page is only a map. The linked files remain the source of truth.
 
 Coding agents should use the same public docs as humans, plus the repository-local agent contracts.
 
-- Follow the repo-root `AGENTS.md` and the matching in-repo skill listed there when one applies.
+- Follow the repo-root `AGENTS.md`. Inspect `.claude/skills/*/SKILL.md` and use the matching in-repo skill when one applies; the skill file is authoritative.
 - Treat foundation documents as decision context. They explain why a review may ask for a split, an RFC, stronger validation, or a different owner.
 - Keep private workflow mechanics out of public PR bodies, issue comments, and reviews. Public text should cite concrete behavior, source paths, commands, validation evidence, linked issues, and user-visible risk.
 - If a generated or skill-authored draft conflicts with source code, current `AGENTS.md`, or a ratified foundation document, stop and reconcile before posting or implementing.

--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -11,7 +11,7 @@ See [RFC process](./rfcs.md) for larger changes that need design discussion befo
 For anything larger than a typo fix:
 
 1. **Check the issue tracker.** Someone may already be working on it or have filed a related discussion.
-2. **Read `AGENTS.md`.** The repo's root `AGENTS.md` is the canonical source of convention: risk tiers, PR discipline, anti-patterns, and review standards live there.
+2. **Read `AGENTS.md`.** The repo root contains the compact, always-loaded contract. Use [Coding agent guidelines](./agent-guidelines.md) for detailed risk, stability, source-of-truth, and skill-discovery references.
 3. **Use the [Architecture and contribution map](./architecture-map.md)** for anything that touches architecture, config, security, workflow, governance, CI, release behavior, or AI-assisted contribution policy.
 4. **Pick a branch.** PRs target `master`. Fork the repo and branch from there; there's no develop/integration branch to go through.
 

--- a/docs/book/src/foundations/fnd-001-intentional-architecture.md
+++ b/docs/book/src/foundations/fnd-001-intentional-architecture.md
@@ -292,7 +292,7 @@ Because application crates share a unified version, the team needs a product-lev
 
 ##### Stability tiers
 
-The product version answers *"what release is this?"* A stability tier answers *"how much can I rely on this component?"* Every component, kernel, gateway, plugin crate, WIT interface, carries one of three tiers. Tiers are documented in the component's `AGENTS.md` and in its plugin registry manifest.
+The product version answers *"what release is this?"* A stability tier answers *"how much can I rely on this component?"* Every component, kernel, gateway, plugin crate, and WIT interface carries one of three tiers. Component-local `AGENTS.md` files and plugin registry manifests are the target ownership model. Until that migration is complete, the canonical current assignments live in [Coding agent guidelines](../contributing/agent-guidelines.md#current-stability-assignments).
 
 | Tier | Meaning | Implication |
 |---|---|---|

--- a/docs/book/src/foundations/fnd-002-documentation-standards.md
+++ b/docs/book/src/foundations/fnd-002-documentation-standards.md
@@ -327,7 +327,7 @@ When an AI coding assistant reads a repository, it sees the code as it is now. I
 
 ### 7.1 The Pattern
 
-The root `AGENTS.md` is the project's strongest existing contribution to AI-assisted development. It tells AI coding assistants the commands to run, the architecture to respect, the risk tiers to apply, and the anti-patterns to avoid. It works because it is specific, opinionated, and short.
+The root `AGENTS.md` is the project's compact, always-loaded contract for AI-assisted development. It owns project-wide safety, privacy, authorization, contribution, and validation policy. The architecture and contribution map routes non-trivial tasks to their relevant sources, while the coding agent guidelines hold optional detail such as examples, current stability assignments, skill discovery, and protected operational documents. This layered contract stays specific and opinionated without loading every detail into every session.
 
 As the workspace decomposes into crates (per the microkernel architecture RFC), each crate should have its own `AGENTS.md`. This is the mechanism by which architectural boundaries become enforceable at the AI-assistance layer, not just at compile time through crate dependencies, but at the reasoning layer before any code is written.
 
@@ -431,7 +431,9 @@ Implementations are registered by the binary crate, not by the kernel.
 
 ### 7.4 The AGENTS.md Hierarchy
 
-The root `AGENTS.md` sets project-wide policy. Crate-level `AGENTS.md` files narrow that policy for their specific scope. When an AI tool reads a file in `crates/zeroclaw-api/`, it should read both the root `AGENTS.md` (project policy) and `crates/zeroclaw-api/AGENTS.md` (crate policy). Crate policy is more specific and takes precedence where they conflict.
+The root `AGENTS.md` sets the compact project-wide policy. The [architecture and contribution map](../contributing/architecture-map.md) routes tasks to maintained architecture, foundation, testing, security, and maintainer sources. [Coding agent guidelines](../contributing/agent-guidelines.md) provide detailed project-wide examples and registries that are useful on demand but are not part of the always-loaded bootstrap.
+
+Crate-level `AGENTS.md` files narrow that policy for their specific scope. When an AI tool reads a file in `crates/zeroclaw-api/`, it should read the root contract, follow the architecture map for the task, and read `crates/zeroclaw-api/AGENTS.md` when present. Crate policy is more specific and takes precedence within its scope, but it cannot weaken project-wide safety, privacy, or authorization requirements.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Reduces the repository-root `AGENTS.md` from 15,565 bytes to 4,107 bytes while retaining the always-applicable source-of-truth, safety, privacy, localization, contribution, and validation contracts.
  - Moves optional agent-specific examples, risk and stability routing, skill discovery, and protected-document guidance into a linked contributor reference.
  - Makes the architecture map the task router and replaces hand-maintained crate and skill inventories with pointers to their canonical sources.
  - Routes runtime, Zerocode, and web user-facing text to the localization systems those surfaces actually use, and protects the self-contained changelog skill file referenced by the release runbook.
- **Scope boundary:** This does not change runtime prompt construction, `local_small` behavior, bootstrap truncation, skill injection, generated reference docs, or compiled behavior.
- **Blast radius:** AI coding assistants working from the repository receive a smaller always-loaded contract and load detailed guidance on demand. Contributor documentation navigation changes; runtime configuration and user-facing product behavior do not.
- **Linked issue(s):** Related #5287
- **Labels:** `docs`, `risk:low`, `size:M`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a documentation-only restructuring with no user-visible runtime behavior.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh `Docs Style`, `Format`, static-analysis, and required CI run against the corrected head. `Docs Style` covers the changed mdBook files; root `AGENTS.md` is covered by the separate full-file Markdown pass below.
- **Known CI coverage gap, if any:** `SUMMARY.md` is intentionally excluded by the repository Markdown-lint configuration, and root `AGENTS.md` is outside the docs-quality path selector. Link validation covers the new summary target, and the separate full-file pass covers `AGENTS.md`.
- **Commands run and tail output:**

```text
$ bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Summary: 0 error(s)

$ bash scripts/ci/docs_links_gate.sh
Collected 12 added link(s) from 7 docs file(s).
Checked 12 local docs link target(s).
No added HTTP(S) links detected in changed docs lines.

$ markdownlint-cli2@0.20.0 AGENTS.md <six changed mdBook files>
Linting: 6 file(s)
Summary: 0 error(s)

$ git diff --check
# no output
```

- **Beyond CI, what did you manually verify?** Compared the retained rules with the prior root contract, verified the 4,107-byte final size, checked every added local target, confirmed the runtime, Zerocode, and web localization implementations, and read the self-contained changelog skill plus its release-runbook reference.
- **If any command was intentionally skipped, why:** Cargo checks were skipped because the patch changes only Markdown and mdBook navigation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **Yes.** Repository guidance is model-visible when an assistant works from this checkout. The compact contract retains the safety, privacy, authorization, and source-of-truth requirements, routes optional detail to maintained references, and introduces no user-controlled content.
- If any `Yes`, describe the risk and mitigation: The risk is accidental loss or misrouting of an always-on contribution rule during compression. The patch keeps critical rules in root `AGENTS.md`, preserves current stability assignments in one canonical interim registry, and routes optional detail through the architecture map.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk documentation change: `git revert <squash-merge-sha>`.
