### PR TITLE
fix(providers): surface cause-specific provider failure diagnostics (#9001)

### DIFF
--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -406,6 +406,74 @@ struct ProviderErrorDiagnostic {
     endpoint: Option<String>,
 }
 
+/// A structured, locale-neutral failure lead for the owning presentation layer
+/// to render. The provider edge crate intentionally does not format
+/// product text: it exposes the cause `kind`, the provider name, and the
+/// sanitized endpoint, leaving each consuming surface (CLI/runtime/ZeroCode)
+/// to render through its own Fluent catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFailureLead {
+    pub provider: String,
+    pub kind: &'static str,
+    pub endpoint: Option<String>,
+}
+
+impl ProviderFailureLead {
+    /// Stable machine-readable encoding used as the concise lead of the
+    /// `bail!` message, so downstream surfaces can re-parse it without the
+    /// retry envelope. Format: `provider-failure|kind=..|provider=..|endpoint=..`
+    fn encode(&self) -> String {
+        let mut s = format!(
+            "provider-failure|kind={}|provider={}",
+            self.kind, self.provider
+        );
+        if let Some(endpoint) = &self.endpoint {
+            s.push_str(&format!("|endpoint={endpoint}"));
+        }
+        s
+    }
+
+    /// Parse the encoded lead out of a larger error message. Returns `None`
+    /// when the message does not carry a provider-failure lead (e.g. a
+    /// non-provider error), so callers can fall back to a generic message.
+    pub fn extract_from(message: &str) -> Option<ProviderFailureLeadView> {
+        let marker = "provider-failure|";
+        let start = message.find(marker)?;
+        let tail = &message[start + marker.len()..];
+        // Stop at the first newline; the retry envelope follows.
+        let segment = tail.split('\n').next()?;
+        let mut kind = None;
+        let mut provider = None;
+        let mut endpoint = None;
+        for part in segment.split('|') {
+            let Some((k, v)) = part.split_once('=') else {
+                continue;
+            };
+            match k {
+                "kind" => kind = Some(v),
+                "provider" => provider = Some(v),
+                "endpoint" => endpoint = Some(v.to_string()),
+                _ => {}
+            }
+        }
+        Some(ProviderFailureLeadView {
+            kind: kind.unwrap_or("provider_error").to_string(),
+            provider: provider.unwrap_or("unknown").to_string(),
+            endpoint,
+        })
+    }
+}
+
+/// Owned, locale-neutral view of a provider-failure lead, returned by
+/// [`ProviderFailureLead::extract_from`] for downstream surfaces to render
+/// through their own Fluent catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFailureLeadView {
+    pub kind: String,
+    pub provider: String,
+    pub endpoint: Option<String>,
+}
+
 fn sanitized_url_endpoint(mut url: reqwest::Url) -> String {
     let _ = url.set_username("");
     let _ = url.set_password(None);
@@ -424,6 +492,110 @@ fn endpoint_from_error_text(text: &str) -> Option<String> {
         .or_else(|_| reqwest::Url::parse(raw.trim_end_matches([':', '.'])))
         .ok()?;
     Some(sanitized_url_endpoint(url))
+}
+
+/// A display-only auth classifier that distinguishes `auth_missing` (no
+/// credential configured) from `auth_rejected` (a credential was sent and
+/// refused), falling back to the ambiguous `auth`.
+///
+/// This is intentionally separate from the public `is_auth_error` predicate,
+/// which keeps its existing semantics (rejections / real 401-403) so the
+/// orchestrator's cache-eviction control flow is unchanged. Missing-key
+/// detection here is best-effort: providers phrase their pre-flight "no key
+/// configured" check differently, and some (local / OpenAI-compatible) never
+/// emit one, so we only claim it on a positive match.
+fn classify_auth_kind(err: &anyhow::Error, lower: &str) -> &'static str {
+    // A real 401/403 is authoritative: the request reached the provider and
+    // was refused, so this is a rejection regardless of any other wording.
+    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
+        && let Some(status) = reqwest_err.status()
+        && (status.as_u16() == 401 || status.as_u16() == 403)
+    {
+        return "auth_rejected";
+    }
+
+    let missing = [
+        "not set",
+        "not configured",
+        "no api key",
+        "no credentials",
+        "missing api key",
+        "credentials not found",
+        "credentials required",
+    ];
+    if missing.iter().any(|hint| lower.contains(hint)) {
+        return "auth_missing";
+    }
+
+    let rejected = [
+        "401",
+        "403",
+        "unauthorized",
+        "forbidden",
+        "invalid api key",
+        "incorrect api key",
+        "invalid token",
+        "token expired",
+        "expired",
+        "rejected",
+        "access denied",
+        "permission denied",
+    ];
+    if rejected.iter().any(|hint| lower.contains(hint)) {
+        return "auth_rejected";
+    }
+
+    "auth"
+}
+
+/// Whether a sanitized endpoint refers to a loopback / local address, so the
+/// owning catalog can choose "start its local server" guidance only when it is
+/// actually local. Remote endpoints must not be told to start a local
+/// server.
+pub fn is_localhost_endpoint(endpoint: Option<&str>) -> bool {
+    let Some(endpoint) = endpoint else {
+        return false;
+    };
+    let Some(host) = endpoint
+        .strip_prefix("http://")
+        .or_else(|| endpoint.strip_prefix("https://"))
+    else {
+        return false;
+    };
+    // Strip the path first, then the port, so IPv6 literals like `[::1]` keep
+    // their brackets until the final comparison.
+    let host = host.split('/').next().unwrap_or(host);
+    let host = host.rsplit_once(':').map(|(h, _)| h).unwrap_or(host);
+    let host = host.to_lowercase();
+    matches!(
+        host.as_str(),
+        "localhost" | "127.0.0.1" | "0.0.0.0" | "[::1]"
+    ) || host.ends_with(".localhost")
+}
+
+/// Rank a diagnostic `kind` by how actionable it is as a user-facing lead.
+/// Clear configuration/process causes (auth, unreachable endpoint, unknown
+/// model, oversized context) outrank transient/ambiguous ones so that, across
+/// several failing providers, the most useful cause leads the message.
+fn lead_priority(kind: &str) -> u8 {
+    match kind {
+        "auth" | "auth_missing" | "auth_rejected" | "connect" | "dns" | "model_not_found"
+        | "context_window" => 3,
+        "rate_limited" | "timeout" | "connect_timeout" | "provider_server" => 2,
+        _ => 1,
+    }
+}
+
+/// Decide whether `candidate` should become the user-facing lead diagnostic,
+/// keeping the first-seen one on ties.
+fn should_replace_lead(
+    current: Option<&ProviderFailureLead>,
+    candidate: &ProviderErrorDiagnostic,
+) -> bool {
+    match current {
+        None => true,
+        Some(existing) => lead_priority(candidate.kind) > lead_priority(existing.kind),
+    }
 }
 
 fn provider_error_diagnostic(err: &anyhow::Error) -> ProviderErrorDiagnostic {
@@ -445,7 +617,30 @@ fn provider_error_diagnostic(err: &anyhow::Error) -> ProviderErrorDiagnostic {
 
     if is_auth_error(err) {
         return ProviderErrorDiagnostic {
-            kind: "auth",
+            kind: classify_auth_kind(err, &lower),
+            phase: "http_response",
+            hint: "check provider credentials",
+            endpoint,
+        };
+    }
+
+    // Missing/unconfigured credentials do not always surface as a typed
+    // reqwest 401/403 — some providers emit a pre-flight "no key" error that
+    // `is_auth_error` does not cover. Recognize it here as a display-only
+    // `auth_missing` classification without widening the public predicate's
+    // semantics; the public predicate is unchanged so cache-eviction control
+    // flow is not widened.
+    if lower.contains("credentials not set")
+        || lower.contains("credentials not found")
+        || lower.contains("credentials required")
+        || lower.contains("no credentials")
+        || lower.contains("missing api key")
+        || lower.contains("api key not set")
+        || lower.contains("no api key")
+        || lower.contains("api key is not configured")
+    {
+        return ProviderErrorDiagnostic {
+            kind: "auth_missing",
             phase: "http_response",
             hint: "check provider credentials",
             endpoint,
@@ -544,6 +739,24 @@ fn provider_error_diagnostic(err: &anyhow::Error) -> ProviderErrorDiagnostic {
             kind: "dns",
             phase: "dns",
             hint: "DNS resolution failed; check network or provider host",
+            endpoint,
+        };
+    }
+
+    // Stringified connection failures (e.g. a local LM Studio/Ollama server
+    // not running) do not always survive as a typed `reqwest::Error`, so
+    // recognize them by text too.
+    if lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("failed to connect")
+        || lower.contains("could not connect")
+        || lower.contains("couldn't connect")
+        || lower.contains("client error (connect)")
+    {
+        return ProviderErrorDiagnostic {
+            kind: "connect",
+            phase: "connect",
+            hint: "could not open provider connection; check network, VPN, or firewall",
             endpoint,
         };
     }
@@ -1039,6 +1252,7 @@ impl ModelProvider for ReliableModelProvider {
     ) -> anyhow::Result<String> {
         let models = self.model_chain(model);
         let mut failures = Vec::new();
+        let mut lead: Option<ProviderFailureLead> = None;
 
         // Outer: model fallback chain. Middle: model_provider priority. Inner: retries.
         // Each iteration: attempt one (model_provider, model) call. On success, return
@@ -1129,6 +1343,13 @@ impl ModelProvider for ReliableModelProvider {
                             let diagnostic = provider_error_diagnostic(&e);
                             last_error_detail = Some(error_detail.clone());
                             last_diagnostic = Some(diagnostic.clone());
+                            if should_replace_lead(lead.as_ref(), &diagnostic) {
+                                lead = Some(ProviderFailureLead {
+                                    provider: provider_name.to_string(),
+                                    kind: diagnostic.kind,
+                                    endpoint: diagnostic.endpoint.clone(),
+                                });
+                            }
 
                             push_failure(
                                 &mut failures,
@@ -1227,7 +1448,10 @@ impl ModelProvider for ReliableModelProvider {
         }
 
         anyhow::bail!(
-            "All model_providers/models failed. Attempts:\n{}",
+            "{}\nAll model_providers/models failed. Attempts:\n{}",
+            lead.as_ref().map(|l| l.encode()).unwrap_or_else(|| {
+                "provider-failure|kind=provider_error|provider=unknown".to_string()
+            }),
             failures.join("\n")
         )
     }
@@ -1240,6 +1464,7 @@ impl ModelProvider for ReliableModelProvider {
     ) -> anyhow::Result<String> {
         let models = self.model_chain(model);
         let mut failures = Vec::new();
+        let mut lead: Option<ProviderFailureLead> = None;
         let mut effective_messages = messages.to_vec();
         let mut context_truncated = false;
 
@@ -1340,6 +1565,13 @@ impl ModelProvider for ReliableModelProvider {
                             let diagnostic = provider_error_diagnostic(&e);
                             last_error_detail = Some(error_detail.clone());
                             last_diagnostic = Some(diagnostic.clone());
+                            if should_replace_lead(lead.as_ref(), &diagnostic) {
+                                lead = Some(ProviderFailureLead {
+                                    provider: provider_name.to_string(),
+                                    kind: diagnostic.kind,
+                                    endpoint: diagnostic.endpoint.clone(),
+                                });
+                            }
 
                             push_failure(
                                 &mut failures,
@@ -1432,7 +1664,10 @@ impl ModelProvider for ReliableModelProvider {
         }
 
         anyhow::bail!(
-            "All model_providers/models failed. Attempts:\n{}",
+            "{}\nAll model_providers/models failed. Attempts:\n{}",
+            lead.as_ref().map(|l| l.encode()).unwrap_or_else(|| {
+                "provider-failure|kind=provider_error|provider=unknown".to_string()
+            }),
             failures.join("\n")
         )
     }
@@ -1489,6 +1724,7 @@ impl ModelProvider for ReliableModelProvider {
     ) -> anyhow::Result<ChatResponse> {
         let models = self.model_chain(model);
         let mut failures = Vec::new();
+        let mut lead: Option<ProviderFailureLead> = None;
         let mut effective_messages = messages.to_vec();
         let mut context_truncated = false;
 
@@ -1590,6 +1826,13 @@ impl ModelProvider for ReliableModelProvider {
                             let diagnostic = provider_error_diagnostic(&e);
                             last_error_detail = Some(error_detail.clone());
                             last_diagnostic = Some(diagnostic.clone());
+                            if should_replace_lead(lead.as_ref(), &diagnostic) {
+                                lead = Some(ProviderFailureLead {
+                                    provider: provider_name.to_string(),
+                                    kind: diagnostic.kind,
+                                    endpoint: diagnostic.endpoint.clone(),
+                                });
+                            }
 
                             push_failure(
                                 &mut failures,
@@ -1682,7 +1925,10 @@ impl ModelProvider for ReliableModelProvider {
         }
 
         anyhow::bail!(
-            "All model_providers/models failed. Attempts:\n{}",
+            "{}\nAll model_providers/models failed. Attempts:\n{}",
+            lead.as_ref().map(|l| l.encode()).unwrap_or_else(|| {
+                "provider-failure|kind=provider_error|provider=unknown".to_string()
+            }),
             failures.join("\n")
         )
     }
@@ -1695,6 +1941,7 @@ impl ModelProvider for ReliableModelProvider {
     ) -> anyhow::Result<ChatResponse> {
         let models = self.model_chain(model);
         let mut failures = Vec::new();
+        let mut lead: Option<ProviderFailureLead> = None;
         let mut effective_messages = request.messages.to_vec();
         let mut context_truncated = false;
 
@@ -1801,6 +2048,13 @@ impl ModelProvider for ReliableModelProvider {
                             let diagnostic = provider_error_diagnostic(&e);
                             last_error_detail = Some(error_detail.clone());
                             last_diagnostic = Some(diagnostic.clone());
+                            if should_replace_lead(lead.as_ref(), &diagnostic) {
+                                lead = Some(ProviderFailureLead {
+                                    provider: provider_name.to_string(),
+                                    kind: diagnostic.kind,
+                                    endpoint: diagnostic.endpoint.clone(),
+                                });
+                            }
 
                             push_failure(
                                 &mut failures,
@@ -1897,7 +2151,10 @@ impl ModelProvider for ReliableModelProvider {
         }
 
         anyhow::bail!(
-            "All model_providers/models failed. Attempts:\n{}",
+            "{}\nAll model_providers/models failed. Attempts:\n{}",
+            lead.as_ref().map(|l| l.encode()).unwrap_or_else(|| {
+                "provider-failure|kind=provider_error|provider=unknown".to_string()
+            }),
             failures.join("\n")
         )
     }
@@ -2165,7 +2422,7 @@ impl ::zeroclaw_api::attribution::Attributable for ReliableModelProvider {
 
     fn alias(&self) -> &str {
         // Delegate to the primary inner provider for the same reason
-        // as `role()`. Falls back to the wrapper's own configured alias
+        // as `role`. Falls back to the wrapper's own configured alias
         // when no inner provider is registered.
         match self.model_providers.first() {
             Some(entry) => ::zeroclaw_api::attribution::Attributable::alias(entry.provider()),
@@ -2842,7 +3099,7 @@ mod tests {
             ),
             (
                 "401 Unauthorized: invalid api key",
-                "auth",
+                "auth_rejected",
                 "http_response",
                 "credentials",
             ),
@@ -2886,6 +3143,135 @@ mod tests {
             assert_eq!(diagnostic.phase, expected_phase, "{message}");
             assert!(diagnostic.hint.contains(expected_hint), "{message}");
         }
+    }
+
+    // --- cause-specific provider diagnostics ---------------------------
+
+    #[test]
+    fn missing_key_is_classified_as_auth_missing_without_widening_is_auth_error() {
+        // A missing/unconfigured key must read as `auth_missing` for display,
+        // but the public `is_auth_error` predicate must NOT widen to it (W1:
+        // that predicate drives orchestrator cache eviction).
+        for msg in [
+            "missing api key",
+            "api key not set",
+            "no api key",
+            "api key is not configured",
+            // Anthropic's real missing-credential wording.
+            "Anthropic credentials not set. Set ANTHROPIC_API_KEY or ANTHROPIC_OAUTH_TOKEN.",
+            "credentials not found",
+            "credentials required",
+            "no credentials",
+        ] {
+            let err = anyhow::Error::msg(msg);
+            // Display classification is cause-specific:
+            assert_eq!(
+                provider_error_diagnostic(&err).kind,
+                "auth_missing",
+                "kind for: {msg}"
+            );
+            // But the control-flow predicate is unchanged (no eviction side effect):
+            assert!(
+                !is_auth_error(&err),
+                "is_auth_error must not match missing-key wording: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejected_credentials_classified_as_auth_rejected() {
+        for msg in [
+            "401 Unauthorized",
+            "403 Forbidden",
+            "invalid api key provided",
+            "token expired",
+        ] {
+            let err = anyhow::Error::msg(msg);
+            assert_eq!(
+                provider_error_diagnostic(&err).kind,
+                "auth_rejected",
+                "kind for: {msg}"
+            );
+            assert!(is_auth_error(&err), "is_auth_error should match: {msg}");
+        }
+    }
+
+    #[test]
+    fn text_connection_failure_is_classified_as_connect() {
+        // Stringified connection failures do not always survive as a typed
+        // reqwest::Error, so recognize them by text too.
+        for msg in [
+            "error sending request: client error (Connect): tcp connect error: connection refused",
+            "connection reset by peer",
+            "failed to connect to host",
+            "could not connect",
+        ] {
+            let err = anyhow::Error::msg(msg);
+            assert_eq!(provider_error_diagnostic(&err).kind, "connect", "{msg}");
+        }
+    }
+
+    #[test]
+    fn lead_priority_prefers_actionable_cause() {
+        let auth = ProviderErrorDiagnostic {
+            kind: "auth_missing",
+            phase: "http_response",
+            hint: "",
+            endpoint: None,
+        };
+        let generic = ProviderErrorDiagnostic {
+            kind: "provider_error",
+            phase: "unknown",
+            hint: "",
+            endpoint: None,
+        };
+        // A generic cause never displaces an already-recorded actionable one.
+        assert!(should_replace_lead(None, &generic));
+        assert!(should_replace_lead(
+            Some(&ProviderFailureLead {
+                provider: "p".into(),
+                kind: "provider_error",
+                endpoint: None,
+            }),
+            &auth
+        ));
+        assert!(!should_replace_lead(
+            Some(&ProviderFailureLead {
+                provider: "p".into(),
+                kind: "auth_missing",
+                endpoint: None,
+            }),
+            &generic
+        ));
+    }
+
+    #[test]
+    fn failure_lead_round_trips_through_encode_extract() {
+        let lead = ProviderFailureLead {
+            provider: "anthropic".into(),
+            kind: "auth_missing",
+            endpoint: Some("https://api.anthropic.com/v1/messages".into()),
+        };
+        let encoded = lead.encode();
+        let message = format!("{encoded}\nAll model_providers/models failed. Attempts:\n...");
+        let view = ProviderFailureLead::extract_from(&message).expect("should parse");
+        assert_eq!(view.kind, "auth_missing");
+        assert_eq!(view.provider, "anthropic");
+        assert_eq!(
+            view.endpoint.as_deref(),
+            Some("https://api.anthropic.com/v1/messages")
+        );
+    }
+
+    #[test]
+    fn is_localhost_endpoint_distinguishes_loopback() {
+        assert!(is_localhost_endpoint(Some("http://127.0.0.1:8080/v1")));
+        assert!(is_localhost_endpoint(Some("http://localhost:8080/v1")));
+        assert!(is_localhost_endpoint(Some("http://[::1]:8080/v1")));
+        assert!(!is_localhost_endpoint(Some(
+            "https://api.openai.com/v1/chat/completions"
+        )));
+        assert!(!is_localhost_endpoint(None));
     }
 
     #[test]
@@ -3656,7 +4042,7 @@ mod tests {
 
     // Arc<ModelAwareMock> ModelProvider impl provided by blanket impl in zeroclaw-types.
 
-    /// Mock model_provider that implements `chat()` with native tool support.
+    /// Mock model_provider that implements `chat` with native tool support.
     struct NativeToolMock {
         calls: Arc<AtomicUsize>,
         fail_until_attempt: usize,
@@ -3822,7 +4208,7 @@ mod tests {
         );
     }
 
-    // ── Gap 2-4: Parity tests for chat() ────────────────────────
+    // ── Gap 2-4: Parity tests for chat ────────────────────────
 
     #[tokio::test]
     async fn chat_returns_aggregated_error_when_all_providers_fail() {
@@ -3874,7 +4260,7 @@ mod tests {
     }
 
     /// Mock that records model names and can fail specific models,
-    /// implementing `chat()` for native tool calling parity tests.
+    /// implementing `chat` for native tool calling parity tests.
     struct NativeModelAwareMock {
         calls: Arc<AtomicUsize>,
         models_seen: parking_lot::Mutex<Vec<String>>,
@@ -5399,11 +5785,11 @@ mod tests {
     #[test]
     fn capabilities_vision_matches_supports_vision_on_final_wrapped_reliable() {
         // Regression: the final wrapped ReliableModelProvider must report the SAME
-        // `vision` on `capabilities().vision` and `supports_vision()`. Wrap the
+        // `vision` on `capabilities.vision` and `supports_vision`. Wrap the
         // config `vision` decorator forcing vision ON over a non-vision inner; the
-        // outer surface must reflect it on BOTH accessors. Before `capabilities()`
+        // outer surface must reflect it on BOTH accessors. Before `capabilities`
         // delegated to the primary, the outer returned the trait default
-        // (vision=false) and disagreed with the delegated `supports_vision()`.
+        // (vision=false) and disagreed with the delegated `supports_vision`.
         struct PlainMock;
         #[async_trait]
         impl ModelProvider for PlainMock {

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -1088,6 +1088,22 @@ cli-doctor-ctxwin-none = No updates needed.
 cli-doctor-ctxwin-write-failed = {$provider_ref}: failed to write context_window: {$error}
 cli-doctor-cache-write-failed = Failed to persist model cache: {$error}
 
+# ── Provider failure leads (#9001) ───────────────────────────────────
+# Concise, actionable cause rendered at the user-facing boundary. The full
+# retry envelope stays in structured logs only. Rendered from the structured
+# ProviderFailureLead, not formatted inside the provider edge crate.
+provider-fail-auth-missing = No API key is configured for {$provider}. Add credentials for the selected provider.
+provider-fail-auth-rejected = The configured credentials for {$provider} were rejected.
+provider-fail-auth = The configured credentials for {$provider} were rejected or missing. Add or check the API key for the selected provider.
+provider-fail-connect-local = {$provider} is not reachable{$at_endpoint}. Start its local server or update the endpoint.
+provider-fail-connect-remote = {$provider} is not reachable{$at_endpoint}. Check the network, VPN, or firewall, or update the endpoint.
+provider-fail-timeout = {$provider} did not respond in time{$at_endpoint}. Retry, check the network, or switch provider.
+provider-fail-rate-limited = {$provider} rate-limited the request. Wait, change key/quota, or switch provider.
+provider-fail-model-not-found = The configured model was not found by {$provider}. Check the model id for the selected provider.
+provider-fail-context-window = The request exceeds the context window for {$provider}. Reduce context or use a larger-context model.
+provider-fail-provider-server = {$provider} returned a server error. Retry or switch provider.
+provider-fail-generic = The request to {$provider} failed. See the logs for details.
+
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = SECURITY-CRITICAL config section `{$path}` is invalid and was reset to its default so the daemon can boot; the running posture may be WEAKER than intended. Run `zeroclaw config migrate` to see the parse error, then repair the file.
 cli-doctor-degraded-section = config section `{$path}` is malformed and was reset to defaults; values in that section are NOT in effect. Run `zeroclaw config migrate` to see the parse error, then repair the file.

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -988,3 +988,16 @@ channel-approval-opt-allow-once = Permitir una vez
 channel-approval-opt-allow-always = Permitir siempre
 channel-approval-opt-reject = Rechazar
 channel-approval-opt-reject-with-edit = Rechazar con edición
+
+# ── Provider failure leads (#9001) ───────────────────────────────────
+provider-fail-auth-missing = No hay una clave de API configurada para {$provider}. Añade credenciales para el proveedor seleccionado.
+provider-fail-auth-rejected = Las credenciales configuradas para {$provider} fueron rechazadas.
+provider-fail-auth = Las credenciales configuradas para {$provider} fueron rechazadas o faltan. Añade o revisa la clave de API del proveedor seleccionado.
+provider-fail-connect-local = {$provider} no es accesible{$at_endpoint}. Inicia su servidor local o actualiza el endpoint.
+provider-fail-connect-remote = {$provider} no es accesible{$at_endpoint}. Revisa la red, VPN o firewall, o actualiza el endpoint.
+provider-fail-timeout = {$provider} no respondió a tiempo{$at_endpoint}. Reintenta, revisa la red o cambia de proveedor.
+provider-fail-rate-limited = {$provider} limitó la solicitud. Espera, cambia la clave/cuota o cambia de proveedor.
+provider-fail-model-not-found = El modelo configurado no fue encontrado por {$provider}. Revisa el id del modelo del proveedor seleccionado.
+provider-fail-context-window = La solicitud supera la ventana de contexto de {$provider}. Reduce el contexto o usa un modelo con más contexto.
+provider-fail-provider-server = {$provider} devolvió un error de servidor. Reintenta o cambia de proveedor.
+provider-fail-generic = La solicitud a {$provider} falló. Consulta los registros.

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -991,3 +991,16 @@ channel-approval-opt-allow-once = Autoriser une fois
 channel-approval-opt-allow-always = Toujours autoriser
 channel-approval-opt-reject = Rejeter
 channel-approval-opt-reject-with-edit = Rejeter avec modification
+
+# ── Provider failure leads (#9001) ───────────────────────────────────
+provider-fail-auth-missing = Aucune clé d'API configurée pour {$provider}. Ajoutez des identifiants pour le fournisseur sélectionné.
+provider-fail-auth-rejected = Les identifiants configurés pour {$provider} ont été refusés.
+provider-fail-auth = Les identifiants configurés pour {$provider} ont été refusés ou sont manquants. Ajoutez ou vérifiez la clé d'API du fournisseur sélectionné.
+provider-fail-connect-local = {$provider} est injoignable{$at_endpoint}. Démarrez son serveur local ou mettez à jour l'endpoint.
+provider-fail-connect-remote = {$provider} est injoignable{$at_endpoint}. Vérifiez le réseau, le VPN ou le pare-feu, ou mettez à jour l'endpoint.
+provider-fail-timeout = {$provider} n'a pas répondu à temps{$at_endpoint}. Réessayez, vérifiez le réseau ou changez de fournisseur.
+provider-fail-rate-limited = {$provider} a limité la requête. Attendez, changez de clé/quota ou de fournisseur.
+provider-fail-model-not-found = Le modèle configuré est introuvable pour {$provider}. Vérifiez l'id du modèle du fournisseur sélectionné.
+provider-fail-context-window = La requête dépasse la fenêtre de contexte de {$provider}. Réduisez le contexte ou utilisez un modèle à plus grand contexte.
+provider-fail-provider-server = {$provider} a renvoyé une erreur serveur. Réessayez ou changez de fournisseur.
+provider-fail-generic = La requête vers {$provider} a échoué. Consultez les journaux.

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -988,3 +988,16 @@ channel-approval-opt-allow-once = 今回のみ許可
 channel-approval-opt-allow-always = 常に許可
 channel-approval-opt-reject = 拒否
 channel-approval-opt-reject-with-edit = 編集して拒否
+
+# ── Provider failure leads (#9001) ───────────────────────────────────
+provider-fail-auth-missing = {$provider} に API キーが設定されていません。選択したプロバイダーの認証情報を追加してください。
+provider-fail-auth-rejected = {$provider} の認証情報が拒否されました。
+provider-fail-auth = {$provider} の認証情報が拒否されたか不足しています。選択したプロバイダーの API キーを追加または確認してください。
+provider-fail-connect-local = {$provider} に到達できません{$at_endpoint}。ローカルサーバーを起動するかエンドポイントを更新してください。
+provider-fail-connect-remote = {$provider} に到達できません{$at_endpoint}。ネットワーク、VPN、ファイアウォールを確認するかエンドポイントを更新してください。
+provider-fail-timeout = {$provider} が時間内に応答しませんでした{$at_endpoint}。再試行、ネットワーク確認、またはプロバイダー切り替えを行ってください。
+provider-fail-rate-limited = {$provider} がリクエストをレート制限しました。待機、キー/クォータの変更、またはプロバイダー切り替えを行ってください。
+provider-fail-model-not-found = 設定されたモデルが {$provider} で見つかりませんでした。選択したプロバイダーのモデル id を確認してください。
+provider-fail-context-window = リクエストが {$provider} のコンテキストウィンドウを超えています。コンテキストを減らすか、より大きいコンテキストのモデルを使用してください。
+provider-fail-provider-server = {$provider} がサーバーエラーを返しました。再試行またはプロバイダーを切り替えてください。
+provider-fail-generic = {$provider} へのリクエストが失敗しました。ログを確認してください。

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -987,3 +987,16 @@ channel-approval-opt-allow-once = 仅本次允许
 channel-approval-opt-allow-always = 始终允许
 channel-approval-opt-reject = 拒绝
 channel-approval-opt-reject-with-edit = 编辑后拒绝
+
+# ── Provider failure leads (#9001) ───────────────────────────────────
+provider-fail-auth-missing = 未为 {$provider} 配置 API 密钥。请为所选 provider 添加凭据。
+provider-fail-auth-rejected = {$provider} 的凭据被拒绝。
+provider-fail-auth = {$provider} 的凭据被拒绝或缺失。请添加或检查所选 provider 的 API 密钥。
+provider-fail-connect-local = 无法连接到 {$provider}{$at_endpoint}。请启动其本地服务或更新端点。
+provider-fail-connect-remote = 无法连接到 {$provider}{$at_endpoint}。请检查网络、VPN 或防火墙，或更新端点。
+provider-fail-timeout = {$provider} 未在规定时间内响应{$at_endpoint}。请重试、检查网络或更换 provider。
+provider-fail-rate-limited = {$provider} 对请求限流。请等待、更换密钥/配额或更换 provider。
+provider-fail-model-not-found = {$provider} 未找到所配置的模型。请检查所选 provider 的模型 id。
+provider-fail-context-window = 请求超出 {$provider} 的上下文窗口。请减少上下文或使用更大上下文的模型。
+provider-fail-provider-server = {$provider} 返回服务器错误。请重试或更换 provider。
+provider-fail-generic = 向 {$provider} 的请求失败。详见日志。

--- a/crates/zeroclaw-runtime/src/i18n.rs
+++ b/crates/zeroclaw-runtime/src/i18n.rs
@@ -351,6 +351,53 @@ pub fn normalize_locale(raw: &str) -> String {
     raw.split('.').next().unwrap_or(raw).replace('_', "-")
 }
 
+/// Render a structured provider-failure lead into a concise, localized,
+/// user-facing sentence. The provider edge crate emits only the
+/// structured `ProviderFailureLeadView`; this function projects it through
+/// the runtime's Fluent catalog so the owning presentation surface (CLI /
+/// ZeroCode / gateway) does not receive English hard-coded below its
+/// localization boundary. The full retry envelope stays in structured logs.
+///
+/// Returns `None` only when `lead` is `None` (no provider failure to render).
+pub fn render_provider_failure_lead(
+    lead: Option<&zeroclaw_providers::reliable::ProviderFailureLeadView>,
+) -> Option<String> {
+    let lead = lead?;
+    let provider = lead.provider.as_str();
+    let at_endpoint = lead
+        .endpoint
+        .as_deref()
+        .map(|endpoint| format!(" at {endpoint}"))
+        .unwrap_or_default();
+    let endpoint_str = at_endpoint.as_str();
+
+    // For connect/dns, pick local vs remote guidance by endpoint so a cloud
+    // API outage is never told to "start its local server".
+    let key = match lead.kind.as_str() {
+        "auth_missing" => "provider-fail-auth-missing",
+        "auth_rejected" => "provider-fail-auth-rejected",
+        "auth" => "provider-fail-auth",
+        "connect" | "dns" => {
+            if zeroclaw_providers::reliable::is_localhost_endpoint(lead.endpoint.as_deref()) {
+                "provider-fail-connect-local"
+            } else {
+                "provider-fail-connect-remote"
+            }
+        }
+        "connect_timeout" | "timeout" => "provider-fail-timeout",
+        "rate_limited" => "provider-fail-rate-limited",
+        "model_not_found" => "provider-fail-model-not-found",
+        "context_window" => "provider-fail-context-window",
+        "provider_server" => "provider-fail-provider-server",
+        _ => "provider-fail-generic",
+    };
+
+    Some(get_required_cli_string_with_args(
+        key,
+        &[("provider", provider), ("at_endpoint", endpoint_str)],
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1110,7 +1157,7 @@ mod tests {
 
     #[test]
     fn detect_locale_defaults_to_en_without_config() {
-        // Locale is config-only. read_config_table() is pure parsing over a
+        // Locale is config-only. read_config_table is pure parsing over a
         // string; verify the fallback contract without touching the real
         // filesystem or env. An absent/locale-less table must yield "en".
         assert_eq!(locale_from_table(None), None);
@@ -1475,5 +1522,74 @@ mod tests {
                 "{key} resolved to the missing-string sentinel"
             );
         }
+    }
+
+    // --- keep retry envelope out of user-facing turn content ---------
+
+    #[test]
+    fn provider_failure_lead_renders_without_retry_envelope() {
+        // Simulate the exact bail! shape emitted by the reliable provider:
+        // a structured lead line, then the full retry envelope below it.
+        let provider_error = format!(
+            "{}\nAll model_providers/models failed. Attempts:\n\
+             model_provider=anthropic model=claude-sonnet-4-6 attempt 1/3: retryable; \
+             error=Anthropic credentials not set.; kind=auth_missing; ...",
+            "provider-failure|kind=auth_missing|provider=anthropic"
+        );
+
+        let view = zeroclaw_providers::reliable::ProviderFailureLead::extract_from(&provider_error)
+            .expect("lead should parse from bail message");
+        let rendered = render_provider_failure_lead(Some(&view)).expect("should render a lead");
+
+        // The user-facing content must NOT carry the retry envelope.
+        assert!(
+            !rendered.contains("All model_providers/models failed"),
+            "envelope leaked into user content: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Attempts:"),
+            "attempts leaked into user content: {rendered}"
+        );
+        // It must name the provider and point at credentials (en or zh).
+        assert!(rendered.contains("anthropic"), "rendered: {rendered}");
+        assert!(
+            rendered.to_lowercase().contains("credentials")
+                || rendered.to_lowercase().contains("api key")
+                || rendered.contains("密钥")
+                || rendered.contains("凭据"),
+            "rendered should be actionable: {rendered}"
+        );
+    }
+
+    #[test]
+    fn provider_failure_lead_connect_remote_does_not_prescribe_local_server() {
+        // A remote endpoint must not be told to "start its local server".
+        let provider_error = format!(
+            "{}\nAll model_providers/models failed. Attempts:\n...",
+            "provider-failure|kind=connect|provider=custom|endpoint=https://api.openai.com/v1/chat/completions"
+        );
+        let view = zeroclaw_providers::reliable::ProviderFailureLead::extract_from(&provider_error)
+            .expect("lead should parse");
+        let rendered = render_provider_failure_lead(Some(&view)).expect("should render a lead");
+        assert!(
+            !rendered.contains("local server") && !rendered.contains("本地服务"),
+            "remote endpoint told to start a local server: {rendered}"
+        );
+        assert!(rendered.contains("api.openai.com"), "rendered: {rendered}");
+    }
+
+    #[test]
+    fn provider_failure_lead_connect_local_prescribes_local_server() {
+        let provider_error = format!(
+            "{}\nAll model_providers/models failed. Attempts:\n...",
+            "provider-failure|kind=connect|provider=custom|endpoint=http://127.0.0.1:1234/v1/chat/completions"
+        );
+        let view = zeroclaw_providers::reliable::ProviderFailureLead::extract_from(&provider_error)
+            .expect("lead should parse");
+        let rendered = render_provider_failure_lead(Some(&view)).expect("should render a lead");
+        assert!(
+            rendered.contains("local server") || rendered.contains("本地服务"),
+            "local endpoint should mention local server: {rendered}"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -1991,13 +1991,22 @@ impl RpcDispatcher {
                         })),
                     "turn failed; emitting TurnComplete so the client exits the working state"
                 );
+                // project a concise, localized provider-failure lead into
+                // the user-facing TurnComplete content AND the RPC error
+                // message; keep the full retry envelope in structured logs only
+                // (recorded above) so it does not dominate chat or leak via any
+                // surface that stringifies the RPC error.
+                let lead_view =
+                    zeroclaw_providers::reliable::ProviderFailureLead::extract_from(&e.to_string());
+                let user_message = crate::i18n::render_provider_failure_lead(lead_view.as_ref())
+                    .unwrap_or_else(|| format!("turn failed: {e}"));
                 self.emit_turn_complete(
                     &req.session_id,
                     crate::rpc::types::TurnCompletionOutcome::Failed,
-                    format!("turn failed: {e}"),
+                    user_message.clone(),
                 )
                 .await;
-                Err(rpc_err(INTERNAL_ERROR, e.to_string()))
+                Err(rpc_err(INTERNAL_ERROR, user_message))
             }
         }
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Terminal provider failures all surfaced through the generic `All model_providers/models failed` envelope followed by raw retry traces, so routine problems (a local server not running, a missing/rejected API key, an unknown model, a timeout) were indistinguishable without reading low-level output. The reliable layer already classified the underlying error into a `kind` but never promoted it to the user-facing message. The provider edge crate now emits a structured, locale-neutral `ProviderFailureLead` (cause kind + provider + sanitized endpoint) as the `bail!` lead line; the runtime renders that lead through its Fluent catalog into a concise, actionable sentence at the user-facing boundary, and the full per-attempt envelope stays in structured logs only.
- **What changed and why:** Auth is split into `auth_missing` / `auth_rejected` via a display-only `classify_auth_kind`, with a combined honest `auth` fallback. Rejection rides on the portable HTTP 401/403 contract; missing is best-effort (some providers, e.g. local/OpenAI-compatible, never emit a pre-flight "no key" error). The public `is_auth_error` predicate is intentionally left unchanged so the orchestrator's cache-eviction control flow is not widened.
- **What changed and why:** Missing-credential wording (including Anthropic's real `credentials not set`) and stringified connection failures (`connection refused`, etc., which do not always survive as a typed `reqwest::Error`) are now recognized as their true cause instead of the generic fallback.
- **What changed and why:** Connect/DNS guidance distinguishes local vs remote endpoints via `is_localhost_endpoint`, so a cloud API outage is never told to "start its local server".
- **Scope boundary:** Retry and fallback behavior is unchanged (`is_non_retryable` / retry counts untouched); `is_auth_error` semantics are unchanged. The gateway `ws.rs` `error_code` substring classifier is intentionally left for a follow-up (out of scope here).
- **Blast radius:** `crates/zeroclaw-providers` (structured lead + classifier) and `crates/zeroclaw-runtime` (Fluent rendering at `dispatch.rs` + 5 locale catalogs). ZeroCode renders the runtime-supplied `TurnComplete.content` verbatim, so it gets the concise lead for free; nothing parses the old envelope for control flow.
- **Linked issue(s):** Closes #9001
- **Labels:** `bug`, `provider`, `runtime`, `provider:reliable`, `priority:p2`, `risk:medium`, `size:M`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (`zeroclaw agent -a <alias> -m ...`); same error path feeds `tui` (zerocode) and `web` (gateway).
- **Setup / preconditions:** An isolated config dir (`ZEROCLAW_CONFIG_DIR`) with one agent and a failing provider.
- **Steps to run:**
  - Missing key: configure `[providers.models.anthropic.<alias>]` with a model but no key, then `zeroclaw agent -a <alias> -m hello`.
  - Unreachable local: configure a `custom` provider with `uri = "http://127.0.0.1:1/v1"` and any placeholder key, then send a message.
  - Unreachable remote: configure a `custom` provider with a cloud `uri` that refuses/DNS-fails, then send a message.
- **Expected on this branch (after):**
  - Missing key → `No API key is configured for anthropic. Add credentials for the selected provider.`
  - Unreachable local → `custom is not reachable at http://127.0.0.1:1/v1/chat/completions. Start its local server or update the endpoint.`
  - Unreachable remote → `custom is not reachable at https://api.example.com/.... Check the network, VPN, or firewall, or update the endpoint.`
  - The full `All model_providers/models failed. Attempts: ...` envelope is **no longer** in `TurnComplete.content`; it remains in structured logs only.
- **Prior behavior on `master` (before):** Both lead with `All model_providers/models failed. Attempts:` (unreachable) or `The request to anthropic failed. See the logs for details.` (missing key), i.e. no cause-specific lead.

### How I tested

- **CI checks relied on and why they cover this change:** The workspace Rust build/test/clippy/fmt legs of `ci.yml` cover both changed crates (`zeroclaw-providers`, `zeroclaw-runtime`). The comment hygiene gate enforces no issue refs leak into code comments.
- **Known CI coverage gap, if any:** None for the changed surface.
- **Commands run and tail output:**

```sh
cargo test -p zeroclaw-providers --lib
# test result: ok. 1187 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p zeroclaw-runtime --lib i18n::tests::provider_failure
# 3 passed; 0 failed (boundary regression: no envelope in rendered lead; local vs remote guidance)

cargo test -p zeroclaw-runtime --lib rpc::dispatch
# test result: ok. 165 passed; 0 failed

cargo clippy -p zeroclaw-providers -p zeroclaw-runtime --all-targets -- -D warnings
# clean

cargo fmt -p zeroclaw-providers -p zeroclaw-runtime -- --check
# clean
```

- **Beyond CI, what did you manually verify?** Boundary unit tests assert the rendered lead contains no `All model_providers/models failed` / `Attempts:` and that a remote endpoint is not told to start a local server (while a local endpoint is). The 12 pre-existing locale-sensitive runtime failures on `master` (zh-CN environment, English assertions in `safety_net`/`agent`/`daemon`/`doctor`/`service`/`quickstart`) are unrelated to this change — verified by reproducing one on clean `master`.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No — messages name the provider and (for connect/timeout) the sanitized endpoint via the existing `sanitize_api_error` / `sanitized_url_endpoint` paths; no credential values are surfaced.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes — error text is human-facing only; no consumer parses the envelope for control flow. `is_auth_error` semantics are unchanged, so orchestrator cache-eviction behavior is unchanged.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Provider-failure messages regress to the generic `All model_providers/models failed` lead in `TurnComplete.content`; grep logs for `error_kind` attrs to confirm classification still fires.
