### PR TITLE
fix(providers): drop redundant refs in gemini_oauth format args

### DIFF
--- a/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
@@ -244,7 +244,7 @@ pub async fn start_device_code_flow(client: &Client, client_id: &str) -> Result<
 
     Ok(DeviceCodeStart {
         device_code: device_response.device_code,
-        verification_uri_complete: Some(format!("{}?user_code={}", &verification_url, &user_code)),
+        verification_uri_complete: Some(format!("{verification_url}?user_code={user_code}")),
         user_code,
         verification_uri: verification_url,
         expires_in: device_response.expires_in.unwrap_or(1800),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** clippy's `useless_borrows_in_formatting` lint (tightened in Rust 1.97) flags the two `&` references in the `format!` call at `crates/zeroclaw-providers/src/auth/gemini_oauth.rs` as redundant, which fails `clippy -D warnings` on newer toolchains. The identifiers are inlined into the format string instead.
- **Scope boundary:** No logic change. `format!` already borrows its arguments, so dropping the `&` neither changes the formatted output nor moves `verification_url` / `user_code`, both of which are still used in the surrounding `DeviceCodeStart` struct.
- **Blast radius:** `crates/zeroclaw-providers` only; a single expression in the Gemini OAuth device-code flow.
- **Linked issue(s):** None (lint cleanup)
- **Labels:** `provider`, `provider:gemini`, `risk:low`, `size:XS`, `type:refactor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — mechanical lint fix with no user-visible behavior change; covered by clippy and the existing gemini_oauth unit tests.

### How I tested

- **CI checks relied on and why they cover this change:** The workspace clippy/test legs of `ci.yml` cover `zeroclaw-providers`.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```sh
cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
# Finished (0 errors; the two useless_borrows_in_formatting errors are gone)

cargo fmt -p zeroclaw-providers -- --check
# (clean)

cargo test -p zeroclaw-providers --lib gemini_oauth
# test result: ok. 5 passed; 0 failed; 0 ignored
```

- **Beyond CI, what did you manually verify?** Confirmed the same crate produced two `useless_borrows_in_formatting` errors under Rust 1.97 before the change and zero after.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No — inline format-argument capture is stable since Rust 1.58, well below the workspace MSRV.

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` is the plan.