### PR TITLE
fix(providers): normalize malformed native tool-call arguments before outbound requests

### DIFF
--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -278,8 +278,11 @@ impl AzureOpenAiModelProvider {
                             id: Some(tc.id),
                             kind: Some("function".to_string()),
                             function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
+                                name: tc.name.clone(),
+                                arguments: crate::request_payload::normalize_native_tool_arguments(
+                                    &tc.arguments,
+                                    &tc.name,
+                                ),
                             },
                         })
                         .collect::<Vec<_>>();

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2393,11 +2393,10 @@ impl OpenAiCompatibleModelProvider {
             .into_iter()
             .filter_map(|tc| {
                 let name = tc.function_name()?;
-                let normalized_arguments =
-                    crate::request_payload::normalize_native_tool_arguments(
-                        tc.function_arguments().as_deref().unwrap_or("{}"),
-                        &name,
-                    );
+                let normalized_arguments = crate::request_payload::normalize_native_tool_arguments(
+                    tc.function_arguments().as_deref().unwrap_or("{}"),
+                    &name,
+                );
                 Some(ProviderToolCall {
                     id: self.reserve_tool_call_id(tc.id, &mut used_tool_call_ids),
                     name,

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1378,24 +1378,14 @@ impl StreamToolCallAccumulator {
         used_tool_call_ids: &mut std::collections::HashSet<String>,
     ) -> Option<ProviderToolCall> {
         let name = self.name?;
-        let arguments = if self.arguments.trim().is_empty() {
-            "{}".to_string()
-        } else {
-            self.arguments
-        };
-        let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments).is_ok()
-        {
-            arguments
-        } else {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"function": name, "arguments": arguments})),
-                "Invalid JSON in streamed native tool-call arguments, using empty object"
-            );
-            "{}".to_string()
-        };
+        let normalized_arguments = crate::request_payload::normalize_native_tool_arguments(
+            if self.arguments.trim().is_empty() {
+                "{}"
+            } else {
+                &self.arguments
+            },
+            &name,
+        );
 
         Some(ProviderToolCall {
             id: reserve_tool_call_id_for_contract(
@@ -2107,8 +2097,13 @@ impl OpenAiCompatibleModelProvider {
                                 }),
                                 kind: Some("function".to_string()),
                                 function: Some(Function {
-                                    name: Some(tc.name),
-                                    arguments: Some(tc.arguments),
+                                    name: Some(tc.name.clone()),
+                                    arguments: Some(
+                                        crate::request_payload::normalize_native_tool_arguments(
+                                            &tc.arguments,
+                                            &tc.name,
+                                        ),
+                                    ),
                                 }),
                                 name: None,
                                 arguments: None,
@@ -2398,23 +2393,11 @@ impl OpenAiCompatibleModelProvider {
             .into_iter()
             .filter_map(|tc| {
                 let name = tc.function_name()?;
-                let arguments = tc.function_arguments().unwrap_or_else(|| "{}".to_string());
-                let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments)
-                    .is_ok()
-                {
-                    arguments
-                } else {
-                    ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(
-                                ::serde_json::json!({"function": name, "arguments": arguments})
-                            ),
-                        "Invalid JSON in native tool-call arguments, using empty object"
+                let normalized_arguments =
+                    crate::request_payload::normalize_native_tool_arguments(
+                        tc.function_arguments().as_deref().unwrap_or("{}"),
+                        &name,
                     );
-                    "{}".to_string()
-                };
                 Some(ProviderToolCall {
                     id: self.reserve_tool_call_id(tc.id, &mut used_tool_call_ids),
                     name,

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -327,8 +327,11 @@ impl CopilotModelProvider {
                             id: Some(tool_call.id),
                             kind: Some("function".to_string()),
                             function: NativeFunctionCall {
-                                name: tool_call.name,
-                                arguments: tool_call.arguments,
+                                name: tool_call.name.clone(),
+                                arguments: crate::request_payload::normalize_native_tool_arguments(
+                                    &tool_call.arguments,
+                                    &tool_call.name,
+                                ),
                             },
                         })
                         .collect::<Vec<_>>();

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -302,8 +302,11 @@ impl OpenAiModelProvider {
                             id: Some(tc.id),
                             kind: Some("function".to_string()),
                             function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
+                                name: tc.name.clone(),
+                                arguments: crate::request_payload::normalize_native_tool_arguments(
+                                    &tc.arguments,
+                                    &tc.name,
+                                ),
                             },
                         })
                         .collect::<Vec<_>>();
@@ -1920,6 +1923,27 @@ mod tests {
             native[0].reasoning_content.as_deref(),
             Some("Let me think...")
         );
+    }
+
+    #[test]
+    fn convert_messages_normalizes_malformed_tool_arguments() {
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let history_json = serde_json::json!({
+            "content": "",
+            "tool_calls": [{
+                "id": "tc_1",
+                "name": "file_write",
+                "arguments": r#"{"path": "unclosed"#
+            }]
+        });
+
+        let messages = vec![ChatMessage::assistant(history_json.to_string())];
+        let native = OpenAiModelProvider::convert_messages(&messages);
+        assert_eq!(native.len(), 1);
+        let tool_calls = native[0].tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.arguments, "{}");
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -267,8 +267,11 @@ impl OpenRouterModelProvider {
                             id: Some(tc.id),
                             kind: Some("function".to_string()),
                             function: NativeFunctionCall {
-                                name: tc.name,
-                                arguments: tc.arguments,
+                                name: tc.name.clone(),
+                                arguments: crate::request_payload::normalize_native_tool_arguments(
+                                    &tc.arguments,
+                                    &tc.name,
+                                ),
                             },
                         })
                         .collect::<Vec<_>>();

--- a/crates/zeroclaw-providers/src/request_payload.rs
+++ b/crates/zeroclaw-providers/src/request_payload.rs
@@ -57,7 +57,10 @@ mod tests {
     #[test]
     fn normalize_native_tool_arguments_valid_array_passthrough() {
         let raw = r#"[1,2]"#;
-        assert_eq!(normalize_native_tool_arguments(raw, "shell"), raw.to_string());
+        assert_eq!(
+            normalize_native_tool_arguments(raw, "shell"),
+            raw.to_string()
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/request_payload.rs
+++ b/crates/zeroclaw-providers/src/request_payload.rs
@@ -5,3 +5,70 @@ pub(crate) fn non_empty_string_field(value: &serde_json::Value, field: &str) -> 
         .filter(|content| !content.trim().is_empty())
         .map(ToString::to_string)
 }
+
+/// Normalize native tool-call `arguments` for OpenAI-format wire export.
+///
+/// Providers require each `function.arguments` field to be a parseable JSON
+/// value string. Malformed model output is replaced with `{}` so the outbound
+/// request is not rejected with HTTP 400.
+pub(crate) fn normalize_native_tool_arguments(raw: &str, function_name: &str) -> String {
+    let arguments = if raw.trim().is_empty() {
+        "{}".to_string()
+    } else {
+        raw.to_string()
+    };
+
+    if serde_json::from_str::<serde_json::Value>(&arguments).is_ok() {
+        return arguments;
+    }
+
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({
+                "function": function_name,
+                "arguments": arguments,
+            })),
+        "Invalid JSON in native tool-call arguments, using empty object"
+    );
+    "{}".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_native_tool_arguments;
+
+    #[test]
+    fn normalize_native_tool_arguments_empty_to_object() {
+        assert_eq!(normalize_native_tool_arguments("", "shell"), "{}");
+        assert_eq!(normalize_native_tool_arguments("   ", "shell"), "{}");
+    }
+
+    #[test]
+    fn normalize_native_tool_arguments_valid_object_passthrough() {
+        let raw = r#"{"path":"foo.txt"}"#;
+        assert_eq!(
+            normalize_native_tool_arguments(raw, "file_read"),
+            raw.to_string()
+        );
+    }
+
+    #[test]
+    fn normalize_native_tool_arguments_valid_array_passthrough() {
+        let raw = r#"[1,2]"#;
+        assert_eq!(normalize_native_tool_arguments(raw, "shell"), raw.to_string());
+    }
+
+    #[test]
+    fn normalize_native_tool_arguments_malformed_to_empty_object() {
+        assert_eq!(
+            normalize_native_tool_arguments(r#"{"path": "unclosed"#, "file_write"),
+            "{}"
+        );
+        assert_eq!(
+            normalize_native_tool_arguments("not json at all", "shell"),
+            "{}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed and why:** OpenAI-format providers (openai, openrouter, azure_openai, copilot, compatible) now normalize `tool_calls[].function.arguments` on **outbound** message conversion. Malformed JSON is replaced with `{}` and logged, matching the existing inbound path in `compatible.rs`. Prevents provider HTTP 400 and empty replies when models emit broken argument strings (seen in production with Qwen via OpenRouter).
- **Scope boundary:** Does not add runtime repair during tool-call parsing or change inbound dedicated-provider parsers beyond DRY refactor of compatible inbound paths.
- **Blast radius:** Multi-turn history replay to OpenAI-format APIs only; valid arguments pass through unchanged.
- **Linked issue(s):** Fixes #8675
- **Labels:** `type:bug`, `risk:medium`, `size:S`

## Testing (required)

- **Reviewer testing requested?** N/A — covered by unit tests on normalization helper and `convert_messages` integration test.
- **Commands run and tail output:**
```sh
cargo test -p zeroclaw-providers normalize_native_tool_arguments --lib
cargo test -p zeroclaw-providers convert_messages_normalizes_malformed --lib
```
Both pass (4 + 1 tests).

## Security & Privacy Impact

- New permissions: No
- New external network calls: No
- Secrets changed: No
- PII in diff: No
- Prompt injection surface: No

## Compatibility

- Backward compatible: Yes (malformed args previously caused provider errors; now degrade to `{}`)
- Config/CLI changed: No
- MSRV changed: No
