### PR TITLE
fix(tools): gate execute_pipeline sub-tools by per-agent access policy

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10221,6 +10221,10 @@ pub async fn start_channels(
         // still applies to them.
         let before_policy_filter_ch = built_tools.len();
         apply_policy_tool_filter(&mut built_tools, Some(security.as_ref()), None);
+        tools::sync_pipeline_access_policy(
+            all_tools_result_ch.pipeline_policy_handle.as_ref(),
+            mcp_tool_access_policy(security.as_ref(), None),
+        );
         if built_tools.len() != before_policy_filter_ch {
             ::zeroclaw_log::record!(
                 INFO,

--- a/crates/zeroclaw-runtime/src/agent/parity.rs
+++ b/crates/zeroclaw-runtime/src/agent/parity.rs
@@ -282,6 +282,7 @@ fn built_with(tools: Vec<Box<dyn Tool>>) -> AllToolsResult {
         poll_handle: None,
         escalate_handle: None,
         channel_room_handle: None,
+        pipeline_policy_handle: None,
         unfiltered_tool_arcs: Vec::new(),
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -108,7 +108,9 @@ pub use zeroclaw_tools::microsoft365::Microsoft365Tool;
 pub use zeroclaw_tools::model_routing_config::ModelRoutingConfigTool;
 pub use zeroclaw_tools::notion_tool::NotionTool;
 pub use zeroclaw_tools::opencode_cli::OpenCodeCliTool;
-pub use zeroclaw_tools::pipeline::PipelineTool;
+pub use zeroclaw_tools::pipeline::{
+    PipelineAccessPolicyHandle, PipelineTool, sync_pipeline_access_policy,
+};
 pub use zeroclaw_tools::poll::PollTool;
 pub use zeroclaw_tools::project_intel::ProjectIntelTool;
 pub use zeroclaw_tools::proxy_config::ProxyConfigTool;
@@ -510,6 +512,8 @@ pub struct AllToolsResult {
     pub reaction_handle: PerToolChannelHandle,
     pub poll_handle: Option<PerToolChannelHandle>,
     pub escalate_handle: Option<PerToolChannelHandle>,
+    /// Handle for the per-agent access policy applied to `execute_pipeline` sub-tools.
+    pub pipeline_policy_handle: Option<zeroclaw_tools::pipeline::PipelineAccessPolicyHandle>,
     /// Pre-boxed Arcs of every tool (before policy filter). Used by
     /// skill-scoped builtin elevation to resolve targets at registration.
     pub unfiltered_tool_arcs: Vec<Arc<dyn Tool>>,
@@ -1401,6 +1405,7 @@ pub fn all_tools_with_runtime(
                     reaction_handle,
                     poll_handle: Some(poll_handle),
                     escalate_handle,
+                    pipeline_policy_handle: None,
                 };
             }
 
@@ -1623,12 +1628,13 @@ pub fn all_tools_with_runtime(
     }
 
     // Pipeline tool (execute_pipeline) — multi-step tool chaining.
+    let mut pipeline_policy_handle = None;
     if root_config.pipeline.enabled {
         let pipeline_tools: Vec<Arc<dyn Tool>> = tool_arcs.clone();
-        tool_arcs.push(Arc::new(PipelineTool::new(
-            root_config.pipeline.clone(),
-            pipeline_tools,
-        )));
+        let (pipeline_tool, handle) =
+            PipelineTool::new(root_config.pipeline.clone(), pipeline_tools);
+        pipeline_policy_handle = Some(handle);
+        tool_arcs.push(Arc::new(pipeline_tool));
     }
 
     AllToolsResult {
@@ -1640,6 +1646,7 @@ pub fn all_tools_with_runtime(
         reaction_handle,
         poll_handle: Some(poll_handle),
         escalate_handle,
+        pipeline_policy_handle,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/tools/scoped.rs
+++ b/crates/zeroclaw-runtime/src/tools/scoped.rs
@@ -237,6 +237,7 @@ impl ScopedToolRegistry {
             poll_handle,
             escalate_handle,
             channel_room_handle,
+            pipeline_policy_handle,
             unfiltered_tool_arcs,
         } = built;
 
@@ -262,6 +263,10 @@ impl ScopedToolRegistry {
         //    `caller_allowed` narrows on top of the policy, for the `run` path only.
         let before_filter = tools_registry.len();
         apply_policy_tool_filter(&mut tools_registry, Some(security.as_ref()), caller_allowed);
+        crate::tools::sync_pipeline_access_policy(
+            pipeline_policy_handle.as_ref(),
+            mcp_tool_access_policy(security.as_ref(), caller_allowed),
+        );
         if emit_assembly_logs && tools_registry.len() != before_filter {
             ::zeroclaw_log::record!(
                 INFO,
@@ -634,6 +639,7 @@ mod tests {
             poll_handle: None,
             escalate_handle: None,
             channel_room_handle: None,
+            pipeline_policy_handle: None,
             unfiltered_tool_arcs: Vec::new(),
         }
     }

--- a/crates/zeroclaw-tools/src/pipeline.rs
+++ b/crates/zeroclaw-tools/src/pipeline.rs
@@ -8,9 +8,27 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult};
 use zeroclaw_config::schema::PipelineConfig;
+
+use crate::tool_search::ToolAccessPolicy;
+
+/// Live per-agent access policy for pipeline sub-tool steps. Updated whenever
+/// the caller's tool registry is policy-filtered.
+pub type PipelineAccessPolicyHandle = Arc<RwLock<Option<ToolAccessPolicy>>>;
+
+/// Set the active access policy on a pipeline handle built at registry time.
+pub fn sync_pipeline_access_policy(
+    handle: Option<&PipelineAccessPolicyHandle>,
+    policy: Option<ToolAccessPolicy>,
+) {
+    if let Some(handle) = handle
+        && let Ok(mut guard) = handle.write()
+    {
+        *guard = policy;
+    }
+}
 
 /// Errors specific to pipeline execution.
 #[derive(Debug, Clone, Serialize, thiserror::Error)]
@@ -74,16 +92,37 @@ pub struct PipelineTool {
     config: PipelineConfig,
     tools: Vec<Arc<dyn Tool>>,
     allowed_set: HashSet<String>,
+    access_policy: PipelineAccessPolicyHandle,
 }
 
 impl PipelineTool {
-    pub fn new(config: PipelineConfig, tools: Vec<Arc<dyn Tool>>) -> Self {
+    pub fn new(
+        config: PipelineConfig,
+        tools: Vec<Arc<dyn Tool>>,
+    ) -> (Self, PipelineAccessPolicyHandle) {
         let allowed_set: HashSet<String> = config.allowed_tools.iter().cloned().collect();
-        Self {
-            config,
-            tools,
-            allowed_set,
+        let access_policy = Arc::new(RwLock::new(None));
+        let handle = Arc::clone(&access_policy);
+        (
+            Self {
+                config,
+                tools,
+                allowed_set,
+                access_policy,
+            },
+            handle,
+        )
+    }
+
+    fn is_step_allowed(&self, name: &str) -> bool {
+        if !self.allowed_set.contains(name) {
+            return false;
         }
+        self.access_policy
+            .read()
+            .ok()
+            .and_then(|guard| guard.as_ref().cloned())
+            .is_none_or(|policy| policy.is_tool_allowed(name))
     }
 
     /// Find a tool by name in the registry.
@@ -100,9 +139,10 @@ impl PipelineTool {
             return Err(PipelineError::TooManySteps(self.config.max_steps));
         }
 
-        // Check all tools are on the allowlist before executing any.
+        // Check all tools are on the pipeline allowlist and the caller's access
+        // policy before executing any.
         for step in &request.steps {
-            if !self.allowed_set.contains(&step.tool) {
+            if !self.is_step_allowed(&step.tool) {
                 return Err(PipelineError::UnknownTool(step.tool.clone()));
             }
         }
@@ -537,7 +577,7 @@ mod tests {
             max_steps: 2,
             allowed_tools: vec!["shell".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let (tool, _) = PipelineTool::new(config, vec![]);
 
         let request = PipelineRequest {
             steps: vec![
@@ -569,7 +609,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec!["shell".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let (tool, _) = PipelineTool::new(config, vec![]);
 
         let request = PipelineRequest {
             steps: vec![PipelineStep {
@@ -591,7 +631,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec!["shell".to_string(), "file_read".to_string()],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let (tool, _) = PipelineTool::new(config, vec![]);
 
         let request = PipelineRequest {
             steps: vec![
@@ -618,7 +658,7 @@ mod tests {
             max_steps: 20,
             allowed_tools: vec![],
         };
-        let tool = PipelineTool::new(config, vec![]);
+        let (tool, _) = PipelineTool::new(config, vec![]);
 
         let request = PipelineRequest {
             steps: vec![],
@@ -702,7 +742,39 @@ mod tests {
                 output: "final answer".into(),
             }),
         ];
-        PipelineTool::new(config, tools)
+        PipelineTool::new(config, tools).0
+    }
+
+    #[test]
+    fn validate_rejects_pipeline_step_denied_by_access_policy() {
+        let config = PipelineConfig {
+            enabled: true,
+            max_steps: 20,
+            allowed_tools: vec!["shell".to_string(), "file_read".to_string()],
+        };
+        let (tool, handle) = PipelineTool::new(config, vec![]);
+        sync_pipeline_access_policy(
+            Some(&handle),
+            Some(ToolAccessPolicy {
+                allowed: Some(vec![
+                    "file_read".to_string(),
+                    "execute_pipeline".to_string(),
+                ]),
+                ..ToolAccessPolicy::default()
+            }),
+        );
+
+        let request = PipelineRequest {
+            steps: vec![PipelineStep {
+                tool: "shell".into(),
+                args: serde_json::json!({}),
+            }],
+            parallel: false,
+            result: PipelineResultMode::default(),
+        };
+
+        let err = tool.validate(&request).unwrap_err();
+        assert!(matches!(err, PipelineError::UnknownTool(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **What changed and why:** `execute_pipeline` sub-tool steps are now gated by the intersection of global `[pipeline].allowed_tools` and the calling agent's `ToolAccessPolicy` (same construction as MCP/built-in filtering). Prevents a read-only agent with `execute_pipeline` from invoking `shell` / `file_write` / etc. when those tools are globally pipeline-allowed but denied on the agent profile (confused deputy, #7947).
- **Scope boundary:** Does not change `[pipeline].allowed_tools` config semantics or skill-scoped elevation wrappers; only adds the missing per-agent ceiling on pipeline step execution.
- **Blast radius:** Agents using `execute_pipeline` with steps that were already denied by their allowlist; unrestricted agents unchanged.
- **Linked issue(s):** Fixes #7947
- **Labels:** `type:bug`, `risk:high`, `size:S`

## Testing (required)

- **Reviewer testing requested?** N/A — unit test covers policy intersection at validate time.
- **Commands run:**
```sh
cargo test -p zeroclaw-tools validate_rejects_pipeline_step_denied --lib
cargo check -p zeroclaw-runtime -p zeroclaw-channels
```

## Security & Privacy Impact

- New permissions: No (tightens existing policy)
- New external network calls: No
- Secrets changed: No
- PII in diff: No
- Prompt injection surface: No

## Compatibility

- Backward compatible: Yes for agents without restrictive allowlists; agents that relied on the bypass lose illicit sub-tool access (intended fix)
- Config/CLI changed: No
- MSRV changed: No
