### PR TITLE
docs(governance): define Project initiative planning model

### DIFF
--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -1,8 +1,8 @@
 # FND-003: Team Organization, Project Governance, and Contribution Pipeline
 
-> Starting v0.7.0 · Type: Governance · Rev. 5
+> Starting v0.7.0 · Type: Governance · Rev. 6
 >
-> **Canonical reference** · Ratified by the team · Rev. 5
+> **Canonical reference** · Ratified by the team · Rev. 6
 > Original governance discussion: [#5577](https://github.com/zeroclaw-labs/zeroclaw/issues/5577)
 > Follow-up work-lane and label-governance policy: [#6808](https://github.com/zeroclaw-labs/zeroclaw/issues/6808)
 
@@ -23,6 +23,7 @@
 | 3 | 2026-05-24 | Added #6808 operational-label-policy pointers; current label behavior lives in maintainer docs |
 | 4 | 2026-05-24 | Added #6808 community-pickup and issue-risk/PR-risk operational pointers |
 | 5 | 2026-05-25 | Promoted #6808 feature-facing work-lane and label-governance policy into FND-003; clarified durable source boundaries, Discussions stewardship, Discord-to-GitHub handoff, and where operational gate questions live |
+| 6 | 2026-07-14 | Defined long-lived product-area Projects, bounded Initiatives, tracker hierarchy, and numbered-release milestone ownership |
 
 ---
 
@@ -97,6 +98,24 @@ Operational details intentionally live close to the workflow that uses them:
 
 ## 3. GitHub Projects: The Work Pipeline
 
+Use one long-lived GitHub Project for each ongoing product area. A Project is
+the workspace for that area, not a finite delivery batch. Within it, an
+**Initiative** is a bounded outcome with a parent tracker issue that owns the
+definition, scope, and close criteria. The Project `Initiative` field groups
+the tracker, its implementation issues, and directly linked pull requests.
+
+Keep these dimensions separate:
+
+- `Status` owns delivery workflow and remains the Kanban column field.
+- The parent tracker and native sub-issue hierarchy own issue decomposition.
+- Native pull request links and closing relationships own implementation links.
+- Native milestones own numbered release scheduling. Leave an item unmilestoned
+  until the team commits it to a release.
+- Labels classify work; they do not establish Initiative membership.
+
+An Initiative can span multiple numbered releases. Do not turn Initiatives into
+Status values or use a non-release milestone as their canonical container.
+
 ### 3.1 The Pipeline Stages
 
 The Project board has a single **Status** field with seven values. Each value is a stage in the pipeline. The sequence is linear but items can be moved back:
@@ -160,7 +179,8 @@ Create these fields in the GitHub Project settings:
 | **Size** | Single select | XS · S · M · L · XL |
 | **Risk Tier** | Single select | Low · Medium · High (mirrors `AGENTS.md` risk tiers) |
 | **Component** | Single select | Kernel · Gateway · Channels · Tools · Memory · Security · Hardware · Docs · Infrastructure |
-| **Milestone** | Milestone | v0.7.0 · v0.8.0 · v0.9.0 · v1.0.0 · Icebox |
+| **Initiative** | Single select | Bounded outcomes named by their tracker issue |
+| **Milestone** | Native milestone | A numbered release such as v0.9.0, or empty when unscheduled |
 
 **On sizing (T-shirt sizes):** Story points require calibration and historical data the team does not have yet. T-shirt sizes are immediately intuitive and good enough for a team at this stage:
 
@@ -176,36 +196,36 @@ XL items should almost always be broken down before they enter In Progress. If y
 
 ### 3.4 Views
 
-Create four named views in the Project:
+Create four baseline views in each product-area Project. Useful existing views
+can remain; do not duplicate a view that already serves the same purpose.
 
-#### View 1: Roadmap
-
-- Type: Roadmap (timeline)
-- Grouped by: Milestone
-- Visible fields: Title, Type, Size, Component, Assignee
-- Purpose: Public-facing. "Here is what is coming and when." Share this link in the README and with the community. Keep it updated.
-
-#### View 2: Board
-
-- Type: Board (Kanban)
-- Columns: Status field values
-- Filtered to: Current milestone only
-- Visible fields: Title, Assignee, Size, Risk Tier
-- Purpose: Day-to-day work visibility. What is everyone working on right now? What is blocked?
-
-#### View 3: Backlog
-
-- Type: Table
-- Sorted by: Priority (descending), then Size (ascending)
-- Filtered to: Status = Backlog OR Defined
-- Visible fields: Title, Type, Priority, Size, Component, Milestone, Risk Tier
-- Purpose: Used during grooming sessions. What needs to be worked on next? What is sized and ready to pick up?
-
-#### View 4: My Work
+#### Delivery Board
 
 - Type: Board
-- Filtered to: Assignee = @me
-- Purpose: Personal dashboard. Each contributor can see their own items without noise.
+- Columns: Status
+- Visible fields: Initiative, Milestone, Assignee, Parent issue
+- Purpose: Day-to-day delivery across all active Initiatives in the area.
+
+#### Initiatives
+
+- Type: Table or roadmap
+- Grouped by: Initiative
+- Visible fields: Title, Status, Milestone, Assignee, Parent issue, Sub-issues progress
+- Purpose: Review bounded outcomes and their tracker issues without changing the delivery workflow.
+
+#### Releases
+
+- Type: Table or board
+- Grouped by: Milestone
+- Filtered to: Numbered release milestones or no milestone
+- Purpose: Discuss committed release scope while keeping an explicit unscheduled group.
+
+#### Unscheduled Backlog
+
+- Type: Table
+- Filtered to: Open items with no milestone
+- Visible fields: Initiative, Status, Priority, Assignee
+- Purpose: Review work that is valid for the area but not yet committed to a numbered release.
 
 ### 3.5 Pinned Items
 
@@ -227,7 +247,7 @@ Use this split:
 | Surface | Owns | Does not own |
 |---|---|---|
 | Labels | durable classification: type, scope, risk, size, contributor tier, stale/triage policy | per-push review state, active CI status, personal task lists |
-| Project board | planning state: readiness, routing evidence, roadmap grouping, dependency/blocker state, stale-exemption reason when a field exists | authoritative PR review queue, mergeability, required checks |
+| Project board | planning state: readiness, Initiative membership, routing evidence, roadmap grouping, dependency/blocker state, stale-exemption reason when a field exists | authoritative PR review queue, mergeability, required checks, release commitment without a native milestone |
 | Native PR state | review decision, required checks, branch freshness, conflicts, mergeability, draft/ready state | long-term roadmap ownership |
 | Issues/RFCs | durable discussion record, acceptance state, user need, linked implementation trail | live replacement for maintainer docs after policy promotion |
 
@@ -840,9 +860,13 @@ By v1.0.0, the governance model should be self-sustaining: the team should not n
 
 **Lazy consensus**: A decision-making approach in which a proposed action proceeds unless someone objects within a defined time period. Reduces the overhead of requiring explicit approval for routine decisions.
 
+**Initiative**: A finite, bounded outcome inside a product-area Project. Its parent tracker issue owns scope and close criteria, while the Project `Initiative` field groups related issues and pull requests.
+
 **Meritocracy**: A governance model in which authority and influence are earned through demonstrated contribution, not through seniority or title. Standard in open source projects.
 
 **Milestone**: A GitHub feature that groups issues and PRs by release target. A milestone represents a version of the software.
+
+**Product-area Project**: A long-lived GitHub Project that contains planning and delivery state for one ongoing product area.
 
 **T-shirt sizing**: An estimation technique that uses abstract sizes (XS, S, M, L, XL) rather than numeric story points. Easier to use without historical calibration data and sufficient for teams at an early stage.
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -27,9 +27,37 @@ The Project board is an automated planning board, not the authoritative PR revie
 
 Use the board for issue readiness, routing evidence, roadmap grouping, dependencies, blocker state, and stale-exemption reasons. Those signals move slowly enough that a board field or planning lane can stay useful.
 
+Treat a Project as the long-lived workspace for one product area. Use a parent
+tracker issue for each finite Initiative and put the matching value in the
+Project `Initiative` field on clearly related issues and pull requests. Make
+implementation issues sub-issues of the tracker when the ownership is clear;
+pull requests keep their native linked-issue and closing relationships. Keep
+`Status` as the delivery workflow and Kanban column field.
+
+Native milestones are release commitments. Use numbered release milestones,
+and leave valid but unscheduled items without a milestone until the team makes
+that commitment. An Initiative can span more than one release. Labels remain
+classification and routing metadata; do not use them as the canonical record
+of Initiative membership.
+
 The current automation is manual and report-only. [`project-dashboard-plan.yml`](https://github.com/zeroclaw-labs/zeroclaw/blob/master/.github/workflows/project-dashboard-plan.yml) runs on `workflow_dispatch` for a single issue number, reads the issue payload, and writes a step summary proposing the existing Project Status value that best matches the issue's live labels and state. It does not write Project fields, edit issues, add labels, post comments, or run automatically on issue events.
 
 A JSON summary of this planning split lives in [`project-board-contract.json`](./project-board-contract.json). Treat it as the contract for the report-only planner and future board refresh automation, not as approval for automatic issue-event runs or active GitHub Project mutation yet. Live ProjectV2 writes need an approved field mapping, a project-scoped credential or app installation, and readback that compares planned status with live Project state before maintainers rely on it.
+
+The report-only Initiative validator accepts a transient snapshot of live
+Project, hierarchy, relationship, and milestone state:
+
+```sh
+python3 scripts/github/project_initiative_validate.py \
+  --snapshot /path/to/project-initiative-snapshot.json \
+  --format markdown
+```
+
+It reports missing or unsupported Initiative membership, tracker hierarchy
+drift, retired capability milestones, unsupported release assignments, duplicate
+or missing tracker items, and closed trackers with open sub-issues. The snapshot
+is an on-demand materialized view of GitHub's canonical state, not a file to
+commit or maintain. The command never writes to GitHub.
 
 Do not mirror native PR review state into manual board lanes. GitHub PR state owns review decision, required checks, mergeability, conflicts, stale approvals, and merge readiness. If the board later displays derived PR routing such as `DIRTY`, `BEHIND`, or `APPROVED`, treat it as a dashboard view of GitHub state, not a separate source of truth.
 

--- a/docs/book/src/maintainers/project-board-contract.json
+++ b/docs/book/src/maintainers/project-board-contract.json
@@ -2,9 +2,10 @@
   "schema_version": 1,
   "contract_name": "project-board-planning-contract",
   "status": "dry_run_planner",
-  "description": "GitHub Project board fields are planning signals. The current automation produces a report-only plan from live issue metadata; fast PR review and mergeability state is derived from native GitHub PR state.",
+  "description": "GitHub Project board fields are planning signals. The current automation produces report-only Status plans and Initiative consistency findings; fast PR review and mergeability state is derived from native GitHub PR state.",
   "canonical_sources": {
     "prose": [
+      "../foundations/fnd-003-governance.md#3-github-projects-the-work-pipeline",
       "../foundations/fnd-003-governance.md#31-the-pipeline-stages",
       "labels.md#ownership-boundaries",
       "pr-workflow.md#project-board-contract"
@@ -12,6 +13,7 @@
     "automation": {
       "dry_run_workflow": ".github/workflows/project-dashboard-plan.yml",
       "dry_run_script": "scripts/github/project_dashboard_plan.py",
+      "initiative_validator": "scripts/github/project_initiative_validate.py",
       "live_project_writes": "disabled_until_project_scoped_credential_and_field_mapping_are_approved"
     }
   },

--- a/scripts/github/project_dashboard_plan_test.py
+++ b/scripts/github/project_dashboard_plan_test.py
@@ -9,6 +9,7 @@ import unittest
 from pathlib import Path
 
 import project_dashboard_plan as planner
+import project_initiative_validate as initiative_validator
 
 
 def issue(state: str = "open", labels: list[str] | None = None, **extra: object) -> dict[str, object]:
@@ -105,6 +106,126 @@ class ProjectDashboardPlanTest(unittest.TestCase):
         ]
         with self.assertRaisesRegex(ValueError, "open catchall"):
             planner.validate_contract(bad_contract)
+
+
+def initiative_snapshot() -> dict[str, object]:
+    initiative = "Runtime Safety (#101)"
+    return {
+        "tracker": {
+            "number": 101,
+            "state": "open",
+            "listed_item_numbers": [102, 103],
+        },
+        "initiative": initiative,
+        "retired_milestone": "Runtime Safety",
+        "items": [
+            {
+                "number": 101,
+                "type": "Issue",
+                "state": "open",
+                "initiative": initiative,
+                "milestone": None,
+            },
+            {
+                "number": 102,
+                "type": "Issue",
+                "state": "open",
+                "initiative": initiative,
+                "milestone": None,
+                "parent_issue_number": 101,
+            },
+            {
+                "number": 103,
+                "type": "PullRequest",
+                "state": "open",
+                "initiative": initiative,
+                "milestone": None,
+                "linked_issue_numbers": [101],
+            },
+            {
+                "number": 104,
+                "type": "PullRequest",
+                "state": "closed",
+                "initiative": initiative,
+                "milestone": "v0.9.0",
+                "related_item_numbers": [102],
+                "release_evidence": "Release tracker explicitly schedules this pull request.",
+            },
+        ],
+    }
+
+
+class ProjectInitiativeValidateTest(unittest.TestCase):
+    def codes(self, snapshot: dict[str, object]) -> list[str]:
+        return [
+            finding.code
+            for finding in initiative_validator.validate_initiative_snapshot(snapshot)
+        ]
+
+    def test_valid_initiative_snapshot_has_no_findings(self) -> None:
+        self.assertEqual(self.codes(initiative_snapshot()), [])
+
+    def test_missing_initiative_variants_are_detected(self) -> None:
+        snapshot = initiative_snapshot()
+        for item in snapshot["items"]:
+            if item["number"] in {101, 102, 103}:
+                item["initiative"] = None
+        self.assertEqual(
+            self.codes(snapshot),
+            [
+                "tracker-missing-initiative",
+                "sub-issue-missing-initiative",
+                "direct-pr-missing-initiative",
+            ],
+        )
+
+    def test_unsupported_initiative_membership_is_detected(self) -> None:
+        snapshot = initiative_snapshot()
+        snapshot["items"].append(
+            {
+                "number": 110,
+                "type": "Issue",
+                "state": "open",
+                "initiative": snapshot["initiative"],
+                "milestone": None,
+            }
+        )
+        self.assertEqual(self.codes(snapshot), ["unsupported-initiative-membership"])
+
+    def test_retired_capability_milestone_is_detected(self) -> None:
+        snapshot = initiative_snapshot()
+        snapshot["items"][1]["milestone"] = snapshot["retired_milestone"]
+        self.assertEqual(
+            self.codes(snapshot),
+            [
+                "retired-milestone-still-assigned",
+                "initiative-with-capability-milestone",
+            ],
+        )
+
+    def test_numbered_release_requires_evidence(self) -> None:
+        snapshot = initiative_snapshot()
+        snapshot["items"][3]["release_evidence"] = None
+        self.assertEqual(self.codes(snapshot), ["release-milestone-without-evidence"])
+
+    def test_closed_tracker_with_open_sub_issue_is_detected(self) -> None:
+        snapshot = initiative_snapshot()
+        snapshot["tracker"]["state"] = "closed"
+        self.assertEqual(self.codes(snapshot), ["closed-tracker-with-open-sub-issue"])
+
+    def test_missing_retired_milestone_name_does_not_flag_unscheduled_items(self) -> None:
+        snapshot = initiative_snapshot()
+        snapshot["retired_milestone"] = None
+        self.assertEqual(self.codes(snapshot), [])
+
+    def test_missing_and_duplicate_tracker_items_are_detected(self) -> None:
+        snapshot = initiative_snapshot()
+        snapshot["tracker"]["listed_item_numbers"].append(111)
+        snapshot["items"].append(dict(snapshot["items"][2]))
+        self.assertEqual(
+            self.codes(snapshot),
+            ["duplicate-project-item", "tracker-item-missing-from-project"],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/github/project_initiative_validate.py
+++ b/scripts/github/project_initiative_validate.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Report-only validation for Project Initiative, hierarchy, and milestone state.
+
+The input is an on-demand snapshot of canonical GitHub state. Its top-level
+keys are ``tracker`` (``number``, ``state``, ``listed_item_numbers``),
+``initiative``, optional ``retired_milestone``, and ``items``. Each item records
+``number``, ``type``, ``state``, Initiative and milestone values, optional parent
+and relationship number lists, and optional ``release_evidence``. Relationship
+lists use ``related_item_numbers``, ``linked_issue_numbers``, and
+``closing_issue_numbers``.
+
+This command does not call GitHub, write Project fields, edit issues, or change
+milestones.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+NUMBERED_RELEASE = re.compile(r"^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    number: int | None
+    message: str
+
+
+def integer(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer")
+    return value
+
+
+def integer_list(value: Any, field_name: str) -> list[int]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    return [integer(item, field_name) for item in value]
+
+
+def text(value: Any, field_name: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        raise ValueError(f"{field_name} must be a string")
+    return value
+
+
+def optional_text(value: Any, field_name: str) -> str | None:
+    if value is None or value == "":
+        return None
+    return text(value, field_name)
+
+
+def item_number(item: dict[str, Any]) -> int:
+    return integer(item.get("number"), "items[].number")
+
+
+def item_relations(item: dict[str, Any]) -> set[int]:
+    relations: set[int] = set()
+    for field_name in (
+        "related_item_numbers",
+        "linked_issue_numbers",
+        "closing_issue_numbers",
+    ):
+        relations.update(integer_list(item.get(field_name), f"items[].{field_name}"))
+    return relations
+
+
+def is_numbered_release(milestone: str | None) -> bool:
+    return bool(milestone and NUMBERED_RELEASE.fullmatch(milestone))
+
+
+def load_snapshot(path: Path) -> dict[str, Any]:
+    snapshot = json.loads(path.read_text())
+    if not isinstance(snapshot, dict):
+        raise ValueError("snapshot must be a JSON object")
+    validate_snapshot_shape(snapshot)
+    return snapshot
+
+
+def validate_snapshot_shape(snapshot: dict[str, Any]) -> None:
+    tracker = snapshot.get("tracker")
+    if not isinstance(tracker, dict):
+        raise ValueError("tracker must be an object")
+    integer(tracker.get("number"), "tracker.number")
+    text(tracker.get("state"), "tracker.state")
+    integer_list(tracker.get("listed_item_numbers"), "tracker.listed_item_numbers")
+    text(snapshot.get("initiative"), "initiative")
+    optional_text(snapshot.get("retired_milestone"), "retired_milestone")
+
+    items = snapshot.get("items")
+    if not isinstance(items, list):
+        raise ValueError("items must be a list")
+    for item in items:
+        if not isinstance(item, dict):
+            raise ValueError("items entries must be objects")
+        item_number(item)
+        item_type = text(item.get("type"), "items[].type")
+        if item_type not in {"Issue", "PullRequest"}:
+            raise ValueError(f"items[].type has unsupported value {item_type!r}")
+        text(item.get("state"), "items[].state")
+        optional_text(item.get("initiative"), "items[].initiative")
+        optional_text(item.get("milestone"), "items[].milestone")
+        optional_text(item.get("release_evidence"), "items[].release_evidence")
+        if item.get("parent_issue_number") is not None:
+            integer(item.get("parent_issue_number"), "items[].parent_issue_number")
+        item_relations(item)
+
+
+def supported_numbers(snapshot: dict[str, Any]) -> set[int]:
+    tracker = snapshot["tracker"]
+    tracker_number = tracker["number"]
+    supported = {tracker_number}
+    supported.update(tracker.get("listed_item_numbers", []))
+
+    items = snapshot["items"]
+    supported.update(
+        item_number(item)
+        for item in items
+        if item.get("parent_issue_number") == tracker_number
+    )
+
+    changed = True
+    while changed:
+        changed = False
+        for item in items:
+            number = item_number(item)
+            if number in supported or not item_relations(item) & supported:
+                continue
+            supported.add(number)
+            changed = True
+    return supported
+
+
+def validate_initiative_snapshot(snapshot: dict[str, Any]) -> list[Finding]:
+    validate_snapshot_shape(snapshot)
+    tracker = snapshot["tracker"]
+    tracker_number = tracker["number"]
+    expected_initiative = snapshot["initiative"]
+    retired_milestone = snapshot.get("retired_milestone")
+    items = snapshot["items"]
+    findings: list[Finding] = []
+
+    by_number: dict[int, list[dict[str, Any]]] = {}
+    for item in items:
+        by_number.setdefault(item_number(item), []).append(item)
+
+    for number, duplicates in sorted(by_number.items()):
+        if len(duplicates) > 1:
+            findings.append(
+                Finding(
+                    "duplicate-project-item",
+                    number,
+                    f"#{number} appears {len(duplicates)} times in the Project snapshot.",
+                )
+            )
+
+    for number in sorted(set(tracker.get("listed_item_numbers", [])) - set(by_number)):
+        findings.append(
+            Finding(
+                "tracker-item-missing-from-project",
+                number,
+                f"Tracker #{tracker_number} lists #{number}, but it is absent "
+                "from the Project snapshot.",
+            )
+        )
+
+    supported = supported_numbers(snapshot)
+    for item in items:
+        number = item_number(item)
+        item_type = item["type"]
+        initiative = item.get("initiative") or None
+        milestone = item.get("milestone") or None
+        parent = item.get("parent_issue_number")
+        direct_tracker_link = tracker_number in item_relations(item)
+
+        if number in supported and initiative != expected_initiative:
+            if number == tracker_number:
+                code = "tracker-missing-initiative"
+                reason = "initiative tracker"
+            elif item_type == "Issue" and parent == tracker_number:
+                code = "sub-issue-missing-initiative"
+                reason = f"sub-issue of #{tracker_number}"
+            elif item_type == "PullRequest" and direct_tracker_link:
+                code = "direct-pr-missing-initiative"
+                reason = f"pull request directly linked to #{tracker_number}"
+            else:
+                code = "supported-item-missing-initiative"
+                reason = f"tracker-supported {item_type.lower()}"
+            findings.append(
+                Finding(
+                    code,
+                    number,
+                    f"#{number} is a {reason} but does not have Initiative "
+                    f"{expected_initiative!r}.",
+                )
+            )
+
+        if initiative == expected_initiative and number not in supported:
+            findings.append(
+                Finding(
+                    "unsupported-initiative-membership",
+                    number,
+                    f"#{number} has Initiative {expected_initiative!r} without "
+                    f"a supported relationship to #{tracker_number}.",
+                )
+            )
+
+        if (
+            initiative == expected_initiative
+            and retired_milestone
+            and milestone == retired_milestone
+        ):
+            findings.append(
+                Finding(
+                    "retired-milestone-still-assigned",
+                    number,
+                    f"#{number} still uses retired milestone {retired_milestone!r}.",
+                )
+            )
+
+        if initiative == expected_initiative and milestone and not is_numbered_release(milestone):
+            findings.append(
+                Finding(
+                    "initiative-with-capability-milestone",
+                    number,
+                    f"#{number} combines an Initiative with non-release milestone {milestone!r}.",
+                )
+            )
+
+        if (
+            initiative == expected_initiative
+            and is_numbered_release(milestone)
+            and not item.get("release_evidence")
+        ):
+            findings.append(
+                Finding(
+                    "release-milestone-without-evidence",
+                    number,
+                    f"#{number} is assigned to {milestone!r} without recorded release evidence.",
+                )
+            )
+
+    if str(tracker["state"]).lower() == "closed":
+        for item in items:
+            if (
+                item.get("type") == "Issue"
+                and item.get("parent_issue_number") == tracker_number
+                and str(item.get("state", "")).lower() == "open"
+            ):
+                number = item_number(item)
+                findings.append(
+                    Finding(
+                        "closed-tracker-with-open-sub-issue",
+                        number,
+                        f"Tracker #{tracker_number} is closed while sub-issue "
+                        f"#{number} remains open.",
+                    )
+                )
+
+    return findings
+
+
+def as_json(snapshot: dict[str, Any], findings: list[Finding]) -> str:
+    payload = {
+        "report_only": True,
+        "tracker": snapshot["tracker"]["number"],
+        "initiative": snapshot["initiative"],
+        "item_count": len(snapshot["items"]),
+        "finding_count": len(findings),
+        "findings": [
+            {"code": finding.code, "number": finding.number, "message": finding.message}
+            for finding in findings
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def as_markdown(snapshot: dict[str, Any], findings: list[Finding]) -> str:
+    lines = [
+        "## Project Initiative Validation",
+        "",
+        f"- Tracker: #{snapshot['tracker']['number']}",
+        f"- Initiative: `{snapshot['initiative']}`",
+        f"- Project items inspected: {len(snapshot['items'])}",
+        f"- Findings: {len(findings)}",
+        "- Action: report-only; no Project fields, issues, pull requests, or "
+        "milestones were changed.",
+    ]
+    if findings:
+        lines.extend(["", "### Findings", ""])
+        lines.extend(
+            f"- `{finding.code}`: {finding.message}" for finding in findings
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", required=True, type=Path)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        snapshot = load_snapshot(args.snapshot)
+        findings = validate_initiative_snapshot(snapshot)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Failed to validate Project Initiative snapshot: {exc}", file=sys.stderr)
+        return 2
+
+    output = (
+        as_json(snapshot, findings)
+        if args.format == "json"
+        else as_markdown(snapshot, findings)
+    )
+    if args.output:
+        args.output.write_text(output)
+        print("Wrote Project Initiative validation report.")
+    else:
+        print(output, end="")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Defines GitHub Projects as long-lived product-area workspaces and Initiatives as bounded outcomes owned by tracker issues.
  - Keeps `Status` authoritative for delivery workflow and reserves native milestones for numbered releases or explicit unscheduled state.
  - Adds a report-only Initiative consistency validator covering hierarchy, relationship, milestone, and release-evidence drift.
- **Scope boundary:** This PR does not perform live Project writes, automate issue events, change labels, or alter native issue/PR state. The separately completed Project 10 pilot migration is the validation case for this policy.
- **Blast radius:** Maintainer governance documentation, the Project board planning contract, and the existing Python planner test entrypoint.
- **Linked issue(s):** Related #6808. Related #8288. Related #8986.
- **Labels:** Expected path labels are `docs` and `scripts`; risk/size/type remain maintainer intake decisions.

### Relationship to #8986

#8986 is still open with changes requested and proposes non-release named milestones as delivery containers. This separate follow-up adopts the Project/Initiative model tested by the #8288 migration instead: a product-area Project persists, Initiatives group bounded outcomes, and native milestones represent releases only. The two policies should not merge unchanged together; #8986 needs to be updated or closed through normal maintainer review. No text or implementation from #8986 is carried into this branch.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is governance documentation plus a report-only validator with focused unit coverage.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` covers the Markdown policy changes; the existing Project planner test entrypoint covers the new validator tests.
- **Known CI coverage gap, if any:** Project view creation is UI-only and is not exercised by repository CI.
- **Commands run and tail output:**

  ```text
  $ python3 scripts/github/project_dashboard_plan_test.py
  Ran 20 tests in 0.004s
  OK

  $ scripts/ci/docs_quality_gate.sh
  Summary: 0 error(s)

  $ scripts/ci/docs_links_gate.sh
  Collected 0 added link(s) from 2 docs file(s).
  No added links detected in changed docs lines.

  $ cargo mdbook check
  All .po files OK.

  $ scripts/check-pr-title.sh 'docs(governance): define Project initiative planning model'
  [no output; exit 0]

  $ git diff --check
  [no output; exit 0]
  ```

- **Beyond CI, what did you manually verify?** Ran the new validator against the live post-migration Project 10 snapshot: 56 items inspected, zero findings. Confirmed 51 Initiative members, 13 native sub-issues, 54 unscheduled items, two preserved `v0.8.1` assignments, and an empty closed retired milestone.
- **If any command was intentionally skipped, why:** Rust workspace tests and clippy were skipped because no Rust production code changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk governance and report-only tooling change. Roll back with `git revert c981ff97a2`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A. This PR explains its policy conflict with #8986 but does not carry its text or implementation.
