### PR TITLE
fix(doctor): persist model catalog to cache on models refresh

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -11689,6 +11689,44 @@ mod tests {
     }
 
     #[test]
+    fn refresh_then_model_preview_joins_the_real_writer_and_reader() {
+        // Joins the two production halves of the refresh-to-preview contract
+        // directly, rather than exercising each in isolation: the actual
+        // `zeroclaw-runtime::doctor::persist_model_cache` writer (what
+        // `zeroclaw models refresh` calls), then this crate's actual
+        // `load_cached_model_preview` reader (what `/model` calls) — for a
+        // dotted provider ref and a custom, non-default agent workspace.
+        let data_root = TempDir::new().unwrap();
+        let custom_agent_workspace = TempDir::new().unwrap();
+
+        let config = Config {
+            config_path: data_root.path().join("config.toml"),
+            data_dir: data_root.path().to_path_buf(),
+            ..Config::default()
+        };
+
+        zeroclaw_runtime::doctor::persist_model_cache(
+            &config,
+            "custom.local",
+            &["model-a".to_string(), "model-b".to_string()],
+        )
+        .unwrap();
+
+        let found = load_cached_model_preview(
+            data_root.path(),
+            custom_agent_workspace.path(),
+            "custom.local",
+        );
+
+        assert_eq!(
+            found,
+            vec!["model-a".to_string(), "model-b".to_string()],
+            "a refresh written by the real writer must be visible through the real reader \
+             for a non-default agent's custom workspace"
+        );
+    }
+
+    #[test]
     fn no_real_time_channels_message_points_at_quickstart_not_onboard() {
         // The "no channels configured" message must point operators at the
         // current command (zeroclaw quickstart), not the deleted `zeroclaw onboard`.

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2216,7 +2216,7 @@ fn is_context_window_overflow_error(err: &anyhow::Error) -> bool {
 }
 
 fn load_cached_model_preview(
-    install_root_dir: &Path,
+    data_dir: &Path,
     agent_workspace_dir: &Path,
     provider_name: &str,
 ) -> Vec<String> {
@@ -2229,7 +2229,7 @@ fn load_cached_model_preview(
 
     // Check the shared cache location first (written by `zeroclaw models refresh`),
     // then fall back to the agent workspace for backward compatibility.
-    let shared_path = install_root_dir.join("state").join(MODEL_CACHE_FILE);
+    let shared_path = data_dir.join("state").join(MODEL_CACHE_FILE);
     let agent_path = agent_workspace_dir.join("state").join(MODEL_CACHE_FILE);
 
     for cache_path in [&shared_path, &agent_path] {
@@ -2388,7 +2388,7 @@ async fn create_resilient_model_provider_nonblocking(
 
 fn build_models_help_response(
     current: &ChannelRouteSelection,
-    install_root_dir: &Path,
+    data_dir: &Path,
     agent_workspace_dir: &Path,
     model_routes: &[zeroclaw_config::schema::ModelRouteConfig],
 ) -> String {
@@ -2421,11 +2421,8 @@ fn build_models_help_response(
         }
     }
 
-    let cached_models = load_cached_model_preview(
-        install_root_dir,
-        agent_workspace_dir,
-        &current.model_provider,
-    );
+    let cached_models =
+        load_cached_model_preview(data_dir, agent_workspace_dir, &current.model_provider);
     if cached_models.is_empty() {
         response.push('\n');
         response.push_str(&channel_runtime_cli_string_with_args(
@@ -2523,7 +2520,7 @@ fn build_config_text_response(
 /// Build a Slack Block Kit JSON payload for the `/config` interactive UI.
 fn build_config_block_kit(
     current: &ChannelRouteSelection,
-    install_root_dir: &Path,
+    data_dir: &Path,
     agent_workspace_dir: &Path,
     model_routes: &[zeroclaw_config::schema::ModelRouteConfig],
 ) -> String {
@@ -2553,11 +2550,7 @@ fn build_config_block_kit(
         })
         .collect();
 
-    let cached = load_cached_model_preview(
-        install_root_dir,
-        agent_workspace_dir,
-        &current.model_provider,
-    );
+    let cached = load_cached_model_preview(data_dir, agent_workspace_dir, &current.model_provider);
     for model_id in cached {
         if !model_options.iter().any(|o| {
             o.get("value")
@@ -2798,7 +2791,7 @@ async fn handle_runtime_command_if_needed(
         ChannelRuntimeCommand::ShowModel => {
             let mut resp = build_models_help_response(
                 &current,
-                ctx.prompt_config.install_root_dir().as_path(),
+                ctx.prompt_config.data_dir.as_path(),
                 ctx.workspace_dir.as_path(),
                 &ctx.model_routes,
             );
@@ -2908,7 +2901,7 @@ async fn handle_runtime_command_if_needed(
             if msg.channel == "slack" {
                 let blocks_json = build_config_block_kit(
                     &current,
-                    ctx.prompt_config.install_root_dir().as_path(),
+                    ctx.prompt_config.data_dir.as_path(),
                     ctx.workspace_dir.as_path(),
                     &ctx.model_routes,
                 );
@@ -11655,6 +11648,45 @@ mod tests {
     const ASSEMBLY_HANG_GUARD: std::time::Duration = std::time::Duration::from_secs(30);
     use zeroclaw_runtime::agent::loop_::apply_policy_tool_filter;
     use zeroclaw_runtime::agent::loop_::build_tool_instructions;
+
+    #[test]
+    fn load_cached_model_preview_reads_from_data_dir_not_install_root() {
+        // `config_path` and `data_dir` deliberately live under unrelated
+        // temp roots, so `config_path.parent()` (the old install-root-derived
+        // path) cannot accidentally coincide with `data_dir`. This proves the
+        // reader follows the canonical data directory, matching the writer
+        // in `zeroclaw-runtime::doctor::persist_model_cache`.
+        let config_root = TempDir::new().unwrap();
+        let data_root = TempDir::new().unwrap();
+        let agent_workspace = TempDir::new().unwrap();
+
+        let state_dir = data_root.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let cache = zeroclaw_config::schema::ModelCacheState {
+            entries: vec![zeroclaw_config::schema::ModelCacheEntry {
+                model_provider: "ollama.default".to_string(),
+                models: vec!["llama3".to_string()],
+            }],
+        };
+        std::fs::write(
+            state_dir.join(MODEL_CACHE_FILE),
+            serde_json::to_string_pretty(&cache).unwrap(),
+        )
+        .unwrap();
+
+        let found =
+            load_cached_model_preview(data_root.path(), agent_workspace.path(), "ollama.default");
+        assert_eq!(found, vec!["llama3".to_string()]);
+
+        // The stale install-root-derived path (config_path's parent) must
+        // NOT be where the cache is found, since it differs from `data_dir`.
+        let not_found =
+            load_cached_model_preview(config_root.path(), agent_workspace.path(), "ollama.default");
+        assert!(
+            not_found.is_empty(),
+            "cache must not be visible under config_path's parent when it differs from data_dir"
+        );
+    }
 
     #[test]
     fn no_real_time_channels_message_points_at_quickstart_not_onboard() {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2229,19 +2229,14 @@ fn load_cached_model_preview(
 
     // Check the shared cache location first (written by `zeroclaw models refresh`),
     // then fall back to the agent workspace for backward compatibility.
-    let shared_path = install_root_dir
-        .join("state")
-        .join(MODEL_CACHE_FILE);
-    let agent_path = agent_workspace_dir
-        .join("state")
-        .join(MODEL_CACHE_FILE);
+    let shared_path = install_root_dir.join("state").join(MODEL_CACHE_FILE);
+    let agent_path = agent_workspace_dir.join("state").join(MODEL_CACHE_FILE);
 
     for cache_path in [&shared_path, &agent_path] {
         let Ok(raw) = std::fs::read_to_string(cache_path) else {
             continue;
         };
-        let Ok(state) =
-            serde_json::from_str::<zeroclaw_config::schema::ModelCacheState>(&raw)
+        let Ok(state) = serde_json::from_str::<zeroclaw_config::schema::ModelCacheState>(&raw)
         else {
             continue;
         };
@@ -2426,8 +2421,11 @@ fn build_models_help_response(
         }
     }
 
-    let cached_models =
-        load_cached_model_preview(install_root_dir, agent_workspace_dir, &current.model_provider);
+    let cached_models = load_cached_model_preview(
+        install_root_dir,
+        agent_workspace_dir,
+        &current.model_provider,
+    );
     if cached_models.is_empty() {
         response.push('\n');
         response.push_str(&channel_runtime_cli_string_with_args(
@@ -2555,8 +2553,11 @@ fn build_config_block_kit(
         })
         .collect();
 
-    let cached =
-        load_cached_model_preview(install_root_dir, agent_workspace_dir, &current.model_provider);
+    let cached = load_cached_model_preview(
+        install_root_dir,
+        agent_workspace_dir,
+        &current.model_provider,
+    );
     for model_id in cached {
         if !model_options.iter().any(|o| {
             o.get("value")

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -98,7 +98,7 @@ use anyhow::{Context, Result};
 use parking_lot::RwLock;
 use portable_atomic::{AtomicU64, Ordering};
 use pulldown_cmark::{Event, Options as MarkdownOptions, Parser as MarkdownParser, Tag};
-use serde::Deserialize;
+
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::ops::Range;
@@ -326,16 +326,8 @@ enum ChannelRuntimeCommand {
     InvalidThinking(String),
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
-struct ModelCacheState {
-    entries: Vec<ModelCacheEntry>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-struct ModelCacheEntry {
-    model_provider: String,
-    models: Vec<String>,
-}
+// ModelCacheState / ModelCacheEntry are defined in zeroclaw-config::schema
+// as the single source of truth for the on-disk cache contract.
 
 #[derive(Debug, Clone)]
 struct ChannelRuntimeDefaults {
@@ -2223,27 +2215,49 @@ fn is_context_window_overflow_error(err: &anyhow::Error) -> bool {
     .any(|hint| lower.contains(hint))
 }
 
-fn load_cached_model_preview(workspace_dir: &Path, provider_name: &str) -> Vec<String> {
-    let cache_path = workspace_dir.join("state").join(MODEL_CACHE_FILE);
-    let Ok(raw) = std::fs::read_to_string(cache_path) else {
-        return Vec::new();
-    };
-    let Ok(state) = serde_json::from_str::<ModelCacheState>(&raw) else {
-        return Vec::new();
+fn load_cached_model_preview(
+    install_root_dir: &Path,
+    agent_workspace_dir: &Path,
+    provider_name: &str,
+) -> Vec<String> {
+    // Canonicalize undotted names so lookup matches the cache key.
+    let canonical = if provider_name.contains('.') {
+        provider_name.to_string()
+    } else {
+        format!("{provider_name}.default")
     };
 
-    state
-        .entries
-        .into_iter()
-        .find(|entry| entry.model_provider == provider_name)
-        .map(|entry| {
-            entry
+    // Check the shared cache location first (written by `zeroclaw models refresh`),
+    // then fall back to the agent workspace for backward compatibility.
+    let shared_path = install_root_dir
+        .join("state")
+        .join(MODEL_CACHE_FILE);
+    let agent_path = agent_workspace_dir
+        .join("state")
+        .join(MODEL_CACHE_FILE);
+
+    for cache_path in [&shared_path, &agent_path] {
+        let Ok(raw) = std::fs::read_to_string(cache_path) else {
+            continue;
+        };
+        let Ok(state) =
+            serde_json::from_str::<zeroclaw_config::schema::ModelCacheState>(&raw)
+        else {
+            continue;
+        };
+        if let Some(entry) = state
+            .entries
+            .into_iter()
+            .find(|e| e.model_provider == canonical)
+        {
+            return entry
                 .models
                 .into_iter()
                 .take(MODEL_CACHE_PREVIEW_LIMIT)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
+                .collect();
+        }
+    }
+    Vec::new()
 }
 
 /// Build a cache key that includes the runtime-defaults generation, the
@@ -2379,7 +2393,8 @@ async fn create_resilient_model_provider_nonblocking(
 
 fn build_models_help_response(
     current: &ChannelRouteSelection,
-    workspace_dir: &Path,
+    install_root_dir: &Path,
+    agent_workspace_dir: &Path,
     model_routes: &[zeroclaw_config::schema::ModelRouteConfig],
 ) -> String {
     let mut response = String::new();
@@ -2411,7 +2426,8 @@ fn build_models_help_response(
         }
     }
 
-    let cached_models = load_cached_model_preview(workspace_dir, &current.model_provider);
+    let cached_models =
+        load_cached_model_preview(install_root_dir, agent_workspace_dir, &current.model_provider);
     if cached_models.is_empty() {
         response.push('\n');
         response.push_str(&channel_runtime_cli_string_with_args(
@@ -2509,7 +2525,8 @@ fn build_config_text_response(
 /// Build a Slack Block Kit JSON payload for the `/config` interactive UI.
 fn build_config_block_kit(
     current: &ChannelRouteSelection,
-    workspace_dir: &Path,
+    install_root_dir: &Path,
+    agent_workspace_dir: &Path,
     model_routes: &[zeroclaw_config::schema::ModelRouteConfig],
 ) -> String {
     let provider_options: Vec<serde_json::Value> = zeroclaw_providers::list_model_providers()
@@ -2538,7 +2555,8 @@ fn build_config_block_kit(
         })
         .collect();
 
-    let cached = load_cached_model_preview(workspace_dir, &current.model_provider);
+    let cached =
+        load_cached_model_preview(install_root_dir, agent_workspace_dir, &current.model_provider);
     for model_id in cached {
         if !model_options.iter().any(|o| {
             o.get("value")
@@ -2779,6 +2797,7 @@ async fn handle_runtime_command_if_needed(
         ChannelRuntimeCommand::ShowModel => {
             let mut resp = build_models_help_response(
                 &current,
+                ctx.prompt_config.install_root_dir().as_path(),
                 ctx.workspace_dir.as_path(),
                 &ctx.model_routes,
             );
@@ -2888,6 +2907,7 @@ async fn handle_runtime_command_if_needed(
             if msg.channel == "slack" {
                 let blocks_json = build_config_block_kit(
                     &current,
+                    ctx.prompt_config.install_root_dir().as_path(),
                     ctx.workspace_dir.as_path(),
                     &ctx.model_routes,
                 );

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -11694,8 +11694,9 @@ mod tests {
         // directly, rather than exercising each in isolation: the actual
         // `zeroclaw-runtime::doctor::persist_model_cache` writer (what
         // `zeroclaw models refresh` calls), then this crate's actual
-        // `load_cached_model_preview` reader (what `/model` calls) — for a
-        // dotted provider ref and a custom, non-default agent workspace.
+        // `load_cached_model_preview` reader (what `/model` calls) — for an
+        // undotted provider ref (canonicalized to `openrouter.default` on both
+        // sides) and a custom, non-default agent workspace.
         let data_root = TempDir::new().unwrap();
         let custom_agent_workspace = TempDir::new().unwrap();
 
@@ -11707,7 +11708,7 @@ mod tests {
 
         zeroclaw_runtime::doctor::persist_model_cache(
             &config,
-            "custom.local",
+            "openrouter",
             &["model-a".to_string(), "model-b".to_string()],
         )
         .unwrap();
@@ -11715,7 +11716,7 @@ mod tests {
         let found = load_cached_model_preview(
             data_root.path(),
             custom_agent_workspace.path(),
-            "custom.local",
+            "openrouter",
         );
 
         assert_eq!(

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12258,6 +12258,22 @@ pub struct ModelRouteConfig {
     pub api_key: Option<String>,
 }
 
+// ── Model cache (shared between CLI refresh and channel reader) ──
+
+/// Canonical on-disk model cache schema. Written by `zeroclaw models refresh`
+/// and read by the channel `/model` command. Both sides MUST use this type
+/// to prevent schema drift (single-source-of-truth rule).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ModelCacheState {
+    pub entries: Vec<ModelCacheEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ModelCacheEntry {
+    pub model_provider: String,
+    pub models: Vec<String>,
+}
+
 // ── Embedding routing ───────────────────────────────────────────
 
 /// Route an embedding hint to a specific model_provider + model.

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -1071,7 +1071,6 @@ cli-doctor-ctxwin-dry-run = Dry run complete — no changes written. Run without
 cli-doctor-ctxwin-none = No updates needed.
 cli-doctor-ctxwin-write-failed = {$provider_ref}: failed to write context_window: {$error}
 cli-doctor-cache-write-failed = Failed to persist model cache: {$error}
-cli-doctor-cache-dir-failed = Failed to create state dir for model cache: {$error}
 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = SECURITY-CRITICAL config section `{$path}` is invalid and was reset to its default so the daemon can boot; the running posture may be WEAKER than intended. Run `zeroclaw config migrate` to see the parse error, then repair the file.

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -1070,6 +1070,8 @@ cli-doctor-ctxwin-saved = Saved {$updated} updates to config.toml
 cli-doctor-ctxwin-dry-run = Dry run complete — no changes written. Run without --dry-run to apply.
 cli-doctor-ctxwin-none = No updates needed.
 cli-doctor-ctxwin-write-failed = {$provider_ref}: failed to write context_window: {$error}
+cli-doctor-cache-write-failed = Failed to persist model cache: {$error}
+cli-doctor-cache-dir-failed = Failed to create state dir for model cache: {$error}
 
 # ── Degraded config sections (doctor diagnose, #8835) ──
 cli-doctor-degraded-security = SECURITY-CRITICAL config section `{$path}` is invalid and was reset to its default so the daemon can boot; the running posture may be WEAKER than intended. Run `zeroclaw config migrate` to see the parse error, then repair the file.

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use std::io::Write;
 use std::path::Path;
@@ -9,6 +9,16 @@ const SCHEDULER_STALE_SECONDS: i64 = 120;
 const CHANNEL_STALE_SECONDS: i64 = 300;
 const COMMAND_VERSION_PREVIEW_CHARS: usize = 60;
 const MODEL_CACHE_FILE: &str = "models_cache.json";
+
+/// Canonicalize a provider reference: undotted names like `openrouter` become
+/// `openrouter.default` so the cache key matches the channel reader's lookup.
+fn canonicalize_provider_ref(provider_name: &str) -> String {
+    if provider_name.contains('.') {
+        provider_name.to_string()
+    } else {
+        format!("{provider_name}.default")
+    }
+}
 
 // ── Diagnostic item ──────────────────────────────────────────────
 
@@ -368,50 +378,47 @@ fn create_doctor_model_provider(
     }
 }
 
-/// Persist the fetched model catalog to `<workspace_dir>/state/models_cache.json`
-/// so that `/model` can display available models without a live probe.
-fn persist_model_cache(workspace_dir: &Path, provider_name: &str, models: &[String]) {
-    let state_dir = workspace_dir.join("state");
-    if let Err(e) = std::fs::create_dir_all(&state_dir) {
-        eprintln!("  ⚠️  Failed to create state dir for model cache: {e}");
-        return;
-    }
+/// Persist the fetched model catalog to the shared cache location so that
+/// `/model` can display available models without a live probe.
+///
+/// The cache is written to `<install_root_dir>/state/models_cache.json` — a
+/// shared location outside any agent workspace. Both the CLI writer and the
+/// channel reader resolve this same path via [`Config::install_root_dir`].
+fn persist_model_cache(
+    config: &Config,
+    provider_name: &str,
+    models: &[String],
+) -> anyhow::Result<()> {
+    let cache_dir = config.install_root_dir().join("state");
+    std::fs::create_dir_all(&cache_dir).context("Failed to create state dir for model cache")?;
 
-    let cache_path = state_dir.join(MODEL_CACHE_FILE);
+    let cache_path = cache_dir.join(MODEL_CACHE_FILE);
 
     // Load existing cache or start fresh.
-    #[derive(Default, serde::Deserialize, serde::Serialize)]
-    struct Cache {
-        entries: Vec<CacheEntry>,
-    }
-    #[derive(Default, serde::Deserialize, serde::Serialize)]
-    struct CacheEntry {
-        model_provider: String,
-        models: Vec<String>,
-    }
-
-    let mut cache: Cache = std::fs::read_to_string(&cache_path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .unwrap_or_default();
+    let mut cache: zeroclaw_config::schema::ModelCacheState =
+        std::fs::read_to_string(&cache_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default();
 
     // Replace or insert the entry for this provider.
-    cache.entries.retain(|e| e.model_provider != provider_name);
-    cache.entries.push(CacheEntry {
-        model_provider: provider_name.to_string(),
+    let canonical = canonicalize_provider_ref(provider_name);
+    cache.entries.retain(|e| e.model_provider != canonical);
+    cache.entries.push(zeroclaw_config::schema::ModelCacheEntry {
+        model_provider: canonical,
         models: models.to_vec(),
     });
 
-    match serde_json::to_string_pretty(&cache) {
-        Ok(json) => {
-            if let Err(e) = std::fs::write(&cache_path, json) {
-                eprintln!("  ⚠️  Failed to write model cache: {e}");
-            }
-        }
-        Err(e) => {
-            eprintln!("  ⚠️  Failed to serialize model cache: {e}");
-        }
-    }
+    let json = serde_json::to_string_pretty(&cache)
+        .context("Failed to serialize model cache")?;
+
+    // Atomic write: write to a temp file then rename to avoid truncated JSON
+    // on process interruption.
+    let tmp_path = cache_path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &json).context("Failed to write model cache temp file")?;
+    std::fs::rename(&tmp_path, &cache_path).context("Failed to rename model cache temp file")?;
+
+    Ok(())
 }
 
 pub async fn run_models(
@@ -448,8 +455,22 @@ pub async fn run_models(
                 ok_count += 1;
                 println!("    ✅ {} models", models.len());
                 // Persist the catalog so `/model` can display it without a live probe.
-                let workspace_dir = config.agent_workspace_dir("default");
-                persist_model_cache(&workspace_dir, provider_name, &models);
+                if let Err(e) = persist_model_cache(config, provider_name, &models) {
+                    error_count += 1;
+                    println!(
+                        "    ⚠️  {}",
+                        crate::i18n::get_required_cli_string_with_args(
+                            "cli-doctor-cache-write-failed",
+                            &[("error", &e.to_string())],
+                        )
+                    );
+                    matrix_rows.push((
+                        provider_name.clone(),
+                        ModelProbeOutcome::Error,
+                        None,
+                        truncate_for_display(&e.to_string(), 120),
+                    ));
+                }
                 if show_model_names && !models.is_empty() {
                     for m in &models {
                         println!("      • {}", m);

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -8,6 +8,7 @@ const DAEMON_STALE_SECONDS: i64 = 30;
 const SCHEDULER_STALE_SECONDS: i64 = 120;
 const CHANNEL_STALE_SECONDS: i64 = 300;
 const COMMAND_VERSION_PREVIEW_CHARS: usize = 60;
+const MODEL_CACHE_FILE: &str = "models_cache.json";
 
 // ── Diagnostic item ──────────────────────────────────────────────
 
@@ -367,6 +368,52 @@ fn create_doctor_model_provider(
     }
 }
 
+/// Persist the fetched model catalog to `<workspace_dir>/state/models_cache.json`
+/// so that `/model` can display available models without a live probe.
+fn persist_model_cache(workspace_dir: &Path, provider_name: &str, models: &[String]) {
+    let state_dir = workspace_dir.join("state");
+    if let Err(e) = std::fs::create_dir_all(&state_dir) {
+        eprintln!("  ⚠️  Failed to create state dir for model cache: {e}");
+        return;
+    }
+
+    let cache_path = state_dir.join(MODEL_CACHE_FILE);
+
+    // Load existing cache or start fresh.
+    #[derive(Default, serde::Deserialize, serde::Serialize)]
+    struct Cache {
+        entries: Vec<CacheEntry>,
+    }
+    #[derive(Default, serde::Deserialize, serde::Serialize)]
+    struct CacheEntry {
+        model_provider: String,
+        models: Vec<String>,
+    }
+
+    let mut cache: Cache = std::fs::read_to_string(&cache_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default();
+
+    // Replace or insert the entry for this provider.
+    cache.entries.retain(|e| e.model_provider != provider_name);
+    cache.entries.push(CacheEntry {
+        model_provider: provider_name.to_string(),
+        models: models.to_vec(),
+    });
+
+    match serde_json::to_string_pretty(&cache) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&cache_path, json) {
+                eprintln!("  ⚠️  Failed to write model cache: {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("  ⚠️  Failed to serialize model cache: {e}");
+        }
+    }
+}
+
 pub async fn run_models(
     config: &Config,
     provider_override: Option<&str>,
@@ -400,6 +447,9 @@ pub async fn run_models(
             Ok(models) => {
                 ok_count += 1;
                 println!("    ✅ {} models", models.len());
+                // Persist the catalog so `/model` can display it without a live probe.
+                let workspace_dir = config.agent_workspace_dir("default");
+                persist_model_cache(&workspace_dir, provider_name, &models);
                 if show_model_names && !models.is_empty() {
                     for m in &models {
                         println!("      • {}", m);

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -395,22 +395,22 @@ fn persist_model_cache(
     let cache_path = cache_dir.join(MODEL_CACHE_FILE);
 
     // Load existing cache or start fresh.
-    let mut cache: zeroclaw_config::schema::ModelCacheState =
-        std::fs::read_to_string(&cache_path)
-            .ok()
-            .and_then(|raw| serde_json::from_str(&raw).ok())
-            .unwrap_or_default();
+    let mut cache: zeroclaw_config::schema::ModelCacheState = std::fs::read_to_string(&cache_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default();
 
     // Replace or insert the entry for this provider.
     let canonical = canonicalize_provider_ref(provider_name);
     cache.entries.retain(|e| e.model_provider != canonical);
-    cache.entries.push(zeroclaw_config::schema::ModelCacheEntry {
-        model_provider: canonical,
-        models: models.to_vec(),
-    });
+    cache
+        .entries
+        .push(zeroclaw_config::schema::ModelCacheEntry {
+            model_provider: canonical,
+            models: models.to_vec(),
+        });
 
-    let json = serde_json::to_string_pretty(&cache)
-        .context("Failed to serialize model cache")?;
+    let json = serde_json::to_string_pretty(&cache).context("Failed to serialize model cache")?;
 
     // Atomic write: write to a temp file then rename to avoid truncated JSON
     // on process interruption.

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -385,7 +385,7 @@ fn create_doctor_model_provider(
 /// canonical instance-wide runtime-state directory (databases, daemon
 /// state), honoring `ZEROCLAW_DATA_DIR` overrides. Both the CLI writer and
 /// the channel reader resolve this same path via [`Config::data_dir`].
-fn persist_model_cache(
+pub fn persist_model_cache(
     config: &Config,
     provider_name: &str,
     models: &[String],
@@ -431,11 +431,22 @@ fn persist_model_cache(
 
     let json = serde_json::to_string_pretty(&cache).context("Failed to serialize model cache")?;
 
-    // Atomic write: write to a temp file then rename to avoid truncated JSON
-    // on process interruption.
-    let tmp_path = cache_path.with_extension("json.tmp");
-    std::fs::write(&tmp_path, &json).context("Failed to write model cache temp file")?;
-    std::fs::rename(&tmp_path, &cache_path).context("Failed to rename model cache temp file")?;
+    // Atomic write: publish through a unique, exclusively-created temp file in
+    // the same directory, then rename into place. A fixed temp-file name would
+    // let two concurrent refreshes collide on the same inode, or let a
+    // pre-existing symlink at that predictable path get followed and
+    // truncated; `tempfile` picks a fresh random name each call and removes
+    // the file automatically if we return before `persist`.
+    let mut tmp = tempfile::Builder::new()
+        .prefix(MODEL_CACHE_FILE)
+        .suffix(".tmp")
+        .tempfile_in(&cache_dir)
+        .context("Failed to create model cache temp file")?;
+    tmp.write_all(json.as_bytes())
+        .context("Failed to write model cache temp file")?;
+    tmp.persist(&cache_path)
+        .map_err(|e| e.error)
+        .context("Failed to rename model cache temp file")?;
 
     Ok(())
 }
@@ -2088,6 +2099,34 @@ mod tests {
             cache_path.is_dir(),
             "unreadable existing cache path must be left untouched, not replaced"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn persist_model_cache_does_not_follow_a_preexisting_tmp_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        // Plant a symlink at the *old* fixed temp-file name, pointing outside
+        // the cache directory. The old `cache_path.with_extension("json.tmp")`
+        // scheme would write through this predictable path and truncate the
+        // decoy; the new unique/exclusive tempfile-based path must never pick
+        // this name at all.
+        let decoy = tmp.path().join("decoy.json");
+        std::fs::write(&decoy, "untouched").unwrap();
+        std::os::unix::fs::symlink(&decoy, state_dir.join("models_cache.json.tmp")).unwrap();
+
+        persist_model_cache(&config, "openrouter", &["a".to_string()]).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&decoy).unwrap(),
+            "untouched",
+            "persistence must not write through a pre-existing symlink at a predictable temp path"
+        );
+        let raw = std::fs::read_to_string(state_dir.join(MODEL_CACHE_FILE)).unwrap();
+        assert!(raw.contains("openrouter"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -394,11 +394,29 @@ fn persist_model_cache(
 
     let cache_path = cache_dir.join(MODEL_CACHE_FILE);
 
-    // Load existing cache or start fresh.
-    let mut cache: zeroclaw_config::schema::ModelCacheState = std::fs::read_to_string(&cache_path)
-        .ok()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .unwrap_or_default();
+    // Load existing cache, starting fresh only when the file is genuinely
+    // absent. A malformed or unreadable existing file is left untouched and
+    // reported rather than silently replaced with a single-provider cache.
+    let mut cache: zeroclaw_config::schema::ModelCacheState =
+        match std::fs::read_to_string(&cache_path) {
+            Ok(raw) => serde_json::from_str(&raw).with_context(|| {
+                format!(
+                    "Existing model cache at {} is malformed; refusing to overwrite",
+                    cache_path.display()
+                )
+            })?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                zeroclaw_config::schema::ModelCacheState::default()
+            }
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!(
+                        "Failed to read existing model cache at {}",
+                        cache_path.display()
+                    )
+                });
+            }
+        };
 
     // Replace or insert the entry for this provider.
     let canonical = canonicalize_provider_ref(provider_name);
@@ -452,36 +470,43 @@ pub async fn run_models(
 
         match outcome {
             Ok(models) => {
-                ok_count += 1;
-                println!("    ✅ {} models", models.len());
                 // Persist the catalog so `/model` can display it without a live probe.
-                if let Err(e) = persist_model_cache(config, provider_name, &models) {
-                    error_count += 1;
-                    println!(
-                        "    ⚠️  {}",
-                        crate::i18n::get_required_cli_string_with_args(
-                            "cli-doctor-cache-write-failed",
-                            &[("error", &e.to_string())],
-                        )
-                    );
-                    matrix_rows.push((
-                        provider_name.clone(),
-                        ModelProbeOutcome::Error,
-                        None,
-                        truncate_for_display(&e.to_string(), 120),
-                    ));
-                }
-                if show_model_names && !models.is_empty() {
-                    for m in &models {
-                        println!("      • {}", m);
+                // Count and report the provider as successful only after the cache
+                // update actually succeeds — a fetched-but-uncached catalog is a
+                // failed refresh, not a partial success.
+                match persist_model_cache(config, provider_name, &models) {
+                    Ok(()) => {
+                        ok_count += 1;
+                        println!("    ✅ {} models", models.len());
+                        if show_model_names && !models.is_empty() {
+                            for m in &models {
+                                println!("      • {}", m);
+                            }
+                        }
+                        matrix_rows.push((
+                            provider_name.clone(),
+                            ModelProbeOutcome::Ok,
+                            Some(models.len()),
+                            "catalog fetched".to_string(),
+                        ));
+                    }
+                    Err(e) => {
+                        error_count += 1;
+                        println!(
+                            "    ⚠️  {}",
+                            crate::i18n::get_required_cli_string_with_args(
+                                "cli-doctor-cache-write-failed",
+                                &[("error", &e.to_string())],
+                            )
+                        );
+                        matrix_rows.push((
+                            provider_name.clone(),
+                            ModelProbeOutcome::Error,
+                            None,
+                            truncate_for_display(&e.to_string(), 120),
+                        ));
                     }
                 }
-                matrix_rows.push((
-                    provider_name.clone(),
-                    ModelProbeOutcome::Ok,
-                    Some(models.len()),
-                    "catalog fetched".to_string(),
-                ));
             }
             Err(error) => {
                 let error_text = format_error_chain(&error);
@@ -1972,6 +1997,130 @@ mod tests {
         assert!(
             full.iter().any(|item| item.category == "providers.models"),
             "shared structured runner should include the same model probe rows as the CLI"
+        );
+    }
+
+    fn config_with_install_root(tmp: &TempDir) -> Config {
+        Config {
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn canonicalize_provider_ref_defaults_undotted_names() {
+        assert_eq!(
+            canonicalize_provider_ref("openrouter"),
+            "openrouter.default"
+        );
+        assert_eq!(
+            canonicalize_provider_ref("openrouter.work"),
+            "openrouter.work"
+        );
+    }
+
+    #[test]
+    fn persist_model_cache_merges_multiple_providers_and_replaces_on_refresh() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+
+        persist_model_cache(&config, "openrouter", &["a".to_string(), "b".to_string()]).unwrap();
+        persist_model_cache(&config, "ollama", &["c".to_string()]).unwrap();
+        // Refreshing openrouter replaces its entry rather than duplicating it.
+        persist_model_cache(&config, "openrouter", &["a2".to_string()]).unwrap();
+
+        let raw = std::fs::read_to_string(tmp.path().join("state/models_cache.json")).unwrap();
+        let cache: zeroclaw_config::schema::ModelCacheState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(cache.entries.len(), 2);
+        let openrouter = cache
+            .entries
+            .iter()
+            .find(|e| e.model_provider == "openrouter.default")
+            .unwrap();
+        assert_eq!(openrouter.models, vec!["a2".to_string()]);
+        let ollama = cache
+            .entries
+            .iter()
+            .find(|e| e.model_provider == "ollama.default")
+            .unwrap();
+        assert_eq!(ollama.models, vec!["c".to_string()]);
+    }
+
+    #[test]
+    fn persist_model_cache_preserves_malformed_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        let cache_path = state_dir.join(MODEL_CACHE_FILE);
+        std::fs::write(&cache_path, "not valid json").unwrap();
+
+        let result = persist_model_cache(&config, "openrouter", &["a".to_string()]);
+
+        assert!(
+            result.is_err(),
+            "malformed existing cache must fail the write, not silently replace it"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&cache_path).unwrap(),
+            "not valid json",
+            "existing malformed cache must be left untouched"
+        );
+    }
+
+    #[test]
+    fn persist_model_cache_preserves_unreadable_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        // A directory where the cache file is expected produces a read
+        // error that is not `NotFound` — distinct from the missing-file case.
+        let cache_path = state_dir.join(MODEL_CACHE_FILE);
+        std::fs::create_dir_all(&cache_path).unwrap();
+
+        let result = persist_model_cache(&config, "openrouter", &["a".to_string()]);
+
+        assert!(result.is_err());
+        assert!(
+            cache_path.is_dir(),
+            "unreadable existing cache path must be left untouched, not replaced"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_models_targeted_refresh_fails_when_cache_write_fails() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/tags"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "models": [{"name": "llama3"}]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = config_with_install_root(&tmp);
+        config
+            .providers
+            .models
+            .ensure("ollama", "default")
+            .expect("known model_provider type")
+            .uri = Some(server.uri());
+
+        // Make the cache destination unwritable: `state` exists as a plain
+        // file, so `create_dir_all` inside `persist_model_cache` fails even
+        // though the provider fetch itself succeeds.
+        std::fs::write(tmp.path().join("state"), "not a directory").unwrap();
+
+        let result = run_models(&config, Some("ollama.default"), false, false).await;
+
+        assert!(
+            result.is_err(),
+            "a targeted refresh must fail the command when the fetched catalog cannot be persisted, \
+             even though the network fetch itself succeeded"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -381,15 +381,16 @@ fn create_doctor_model_provider(
 /// Persist the fetched model catalog to the shared cache location so that
 /// `/model` can display available models without a live probe.
 ///
-/// The cache is written to `<install_root_dir>/state/models_cache.json` — a
-/// shared location outside any agent workspace. Both the CLI writer and the
-/// channel reader resolve this same path via [`Config::install_root_dir`].
+/// The cache is written to `<data_dir>/state/models_cache.json` — the
+/// canonical instance-wide runtime-state directory (databases, daemon
+/// state), honoring `ZEROCLAW_DATA_DIR` overrides. Both the CLI writer and
+/// the channel reader resolve this same path via [`Config::data_dir`].
 fn persist_model_cache(
     config: &Config,
     provider_name: &str,
     models: &[String],
 ) -> anyhow::Result<()> {
-    let cache_dir = config.install_root_dir().join("state");
+    let cache_dir = config.data_dir.join("state");
     std::fs::create_dir_all(&cache_dir).context("Failed to create state dir for model cache")?;
 
     let cache_path = cache_dir.join(MODEL_CACHE_FILE);
@@ -2003,6 +2004,7 @@ mod tests {
     fn config_with_install_root(tmp: &TempDir) -> Config {
         Config {
             config_path: tmp.path().join("config.toml"),
+            data_dir: tmp.path().to_path_buf(),
             ..Config::default()
         }
     }


### PR DESCRIPTION
## Summary

- **What changed and why:** `models_cache.json` was read by the orchestrator (`/model` command) but never written anywhere. Running `zeroclaw models refresh` — the command the error hint recommends — fetched the catalog and printed it but did not persist it, leaving operators in a dead loop. This fix writes the fetched catalog to the shared, canonical `<data_dir>/state/models_cache.json` after each successful provider probe in `run_models`, and the orchestrator's reader checks that same location (falling back to the legacy per-agent-workspace path) so both sides agree on where the cache lives. The path is rooted at `Config::data_dir` (honors `ZEROCLAW_DATA_DIR`) rather than `install_root_dir()` (derived from `config_path`'s parent), so an installation that separates its config and data directories still gets one shared cache both sides can find.
- **Scope boundary:** Cross-crate, four files: the writer (`zeroclaw-runtime::doctor`), the reader (`zeroclaw-channels::orchestrator`), the shared cache schema (`zeroclaw-config::schema` — `ModelCacheState`/`ModelCacheEntry` now live here as the single on-disk contract both sides import), and a new Fluent warning string for cache-write failures. Does not change log persistence, retention/rotation, or the `config list --filter` interface. Does not add cross-process locking around the read-modify-write cache update — see the concurrent-refresh note below.
- **Blast radius:** Operators using `/model` after `models refresh` will now see cached model IDs instead of the "no cached model list found" message. Undotted provider refs (e.g. `openrouter`) are canonicalized to `<type>.default` so the cache key matches the reader's lookup. No behavioral change for daemon/agent runtime.
- **Known follow-up (not in this PR):** The shared cache's read-modify-write transaction (read → merge → publish) is not locked across processes; two concurrent `models refresh` runs can both read the same old snapshot and one can lose the other's provider entry on publish. The publish step itself is now collision-safe (see below) — this remaining note is about the read-modify-write window, not the write itself. `models refresh` is an interactive, operator-driven command normally run one at a time, so this is a real but narrow edge case rather than a steady-state hazard. Left out of this PR's scope (cross-process file locking is a separate, reviewable change); tracked in #9590.
- **Publish is now collision-safe:** the previous atomic write used a fixed `models_cache.json.tmp` name — two concurrent refreshes could open the same inode, and a pre-existing symlink at that predictable path would get followed and truncated. Publish now goes through `tempfile`'s exclusively-created, randomly-named temp file (already a dependency) in the same directory, then `persist()`s (renames) it into place; the temp file is removed automatically if the write is never persisted. New regression `persist_model_cache_does_not_follow_a_preexisting_tmp_symlink` plants a symlink at the old fixed name and proves it's left untouched.
- **Linked issue(s):** Closes #9046
- **Labels:** `bug`, `channel`, `config`, `doctor`, `runtime`, `channel:core`, `risk:high`, `size:M`, `principal contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` — `zeroclaw models refresh --model-provider <type>.<alias>`
- **Setup / preconditions:** A configured model provider with valid credentials
- **Steps to run:**
  1. Run `zeroclaw models refresh --model-provider <type>.<alias>` on master — observe no file is written
  2. Run the same command on this branch — observe `<data_dir>/state/models_cache.json` is created (default `~/.zeroclaw/data/state/models_cache.json`; `<data_dir>` follows `ZEROCLAW_DATA_DIR` if set)
  3. In a channel, run `/model` — observe cached model IDs are displayed instead of the "no cached model list found" hint
  4. Make `<data_dir>/state` unwritable and re-run a targeted refresh — observe the command now fails instead of reporting success (previously it printed both success and a cache-write warning for the same probe)
  5. Replace `models_cache.json` with malformed JSON and refresh a different provider — observe the malformed file is left untouched and the refresh fails, instead of the whole cache (all other providers) being silently replaced
- **Expected on this branch (after):** `models_cache.json` exists with the probed catalog; `/model` shows cached models; a failed cache write fails the targeted-refresh command; a malformed or unreadable existing cache is preserved, not overwritten
- **Prior behavior on `master` (before):** `models_cache.json` never created; `/model` always shows "no cached model list found"

### How I tested

```sh
cargo build -p zeroclaw-runtime -p zeroclaw-channels
cargo clippy -p zeroclaw-runtime -p zeroclaw-channels --all-targets -- -D warnings
cargo fmt --all -- --check
cargo test -p zeroclaw-runtime doctor::
cargo test -p zeroclaw-channels refresh_then_model_preview_joins_the_real_writer_and_reader
```

- **CI checks relied on and why they cover this change:** `cargo build`, `cargo clippy`, `cargo fmt`, `cargo test` (doctor suite — 4/4 `persist_model_cache*` pass; new joined `zeroclaw-channels` regression below)
- **Known CI coverage gap, if any:** None — both previously noted gaps are gone on current `master`: `zeroclaw-channels --all-targets` clippy with `-D warnings` is clean (the `login_probe.rs`/`login_relink.rs` `unused-imports` warnings were fixed upstream), and the two `zeroclaw-channels` test-isolation flakes no longer reproduce (`cargo test -p zeroclaw-channels --lib` passes 1308+ tests, zero failures).
- **Commands run and tail output:** `test orchestrator::tests::refresh_then_model_preview_joins_the_real_writer_and_reader ... ok`
- **Beyond CI, what did you manually verify?** Added direct unit coverage for `persist_model_cache` (multi-provider merge and replace-on-refresh, malformed/unreadable-existing-file preservation, symlink-at-predictable-temp-path rejection). The remaining gap from the prior review round — that the writer and reader were only proven independently — is now closed by `refresh_then_model_preview_joins_the_real_writer_and_reader` in `zeroclaw-channels`: it calls the actual production `zeroclaw_runtime::doctor::persist_model_cache` (now `pub`, what `run_models` calls) with an *undotted* provider ref (`openrouter`) and a data root separate from a custom, non-default agent workspace, then calls this crate's actual `load_cached_model_preview` and asserts the refreshed models are visible — one test exercising both real production functions and both sides' undotted→`.default` canonicalization across the crate boundary, not two independent helper tests.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes, narrowly** — introduces a derived cache write at `<data_dir>/state/models_cache.json`; it remains confined to the canonical data directory
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes** — the cache file is a new artifact; the reader falls back to the legacy per-agent-workspace path when the shared file isn't present
- Config / env / CLI surface changed? **No** — `models refresh` now writes a file it previously didn't, but the CLI interface is unchanged
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit on `master` (its sha isn't known until merge, so `git revert <sha>` against a placeholder isn't accurate). Reverting removes the writer call in `run_models`, the `data_dir`-rooted path resolution in the orchestrator reader, and the shared `ModelCacheState`/`ModelCacheEntry` types — `/model` goes back to always reporting "no cached model list found" and `models refresh` stops writing `models_cache.json`. No migration or data cleanup needed: `models_cache.json` is a derived cache, safe to leave on disk or delete after rollback.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `zeroclaw models refresh` reporting success but `/model` still shows "no cached model list found" (cache write silently failing or path mismatch between writer/reader); `models refresh` for one provider unexpectedly wiping other providers' cached entries (would indicate the malformed-cache-preservation or multi-provider-merge logic regressed); grep application logs for `cli-doctor-cache-write-failed`.






