### PR TITLE
docs(ops): drop spurious positional arg from channel start example

### DIFF
--- a/docs/book/src/ops/network-deployment.md
+++ b/docs/book/src/ops/network-deployment.md
@@ -188,7 +188,7 @@ Telegram Bot API's `getUpdates` is single-poller per bot token. You cannot run t
 If you see this:
 
 1. `ps aux | grep zeroclaw` and confirm only one daemon is running
-2. Check you don't have `cargo run --bin zeroclaw -- channel start telegram` from a dev session hanging around
+2. Check you don't have `cargo run --bin zeroclaw -- channel start` from a dev session hanging around
 3. If stale, reset Telegram's poll session:
 
    <div class="os-tabs-src">


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `docs/book/src/ops/network-deployment.md` had `channel start telegram` — but `ChannelCommands::Start` (`src/lib.rs:247`) is a unit variant with the doc "Start all configured channels". It takes no positional argument; `telegram` is rejected as an unexpected argument.
- **Scope boundary:** One word in one page. Docs only.
- **Blast radius:** None.
- **Linked issue(s):** Related to doc/code drift audit (#8858)
- **Labels:** `docs`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — one-word docs fix. The clap definition at `src/lib.rs:247` confirms `Start` is a unit variant.

### How I tested

```sh
grep -n "Start," src/lib.rs    # unit variant, no fields
```

- **CI checks relied on and why they cover this change:** Docs style gates in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes (docs only)
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low-risk: `git revert <sha>`.