### PR TITLE
fix(zerocode): separate the literal Ctrl label from the key on darwin

### DIFF
--- a/apps/zerocode/src/keymap/chord.rs
+++ b/apps/zerocode/src/keymap/chord.rs
@@ -43,11 +43,17 @@ impl Chord {
                 == normalise_mods(event.code, event.modifiers)
     }
 
-    /// `Ctrl+K` on most platforms; `⌘K` on darwin.
+    /// `Ctrl+K` on most platforms; `⌘K` on darwin. On darwin, a
+    /// host-reserved chord's control label is the literal word `Ctrl`
+    /// (not the `⌘` glyph) and needs a separator to stay readable —
+    /// see `control_display_label`.
     pub fn display(&self) -> String {
         let mut parts: Vec<&str> = Vec::new();
+        let mut literal_word_control = false;
         if self.modifiers.contains(KeyModifiers::CONTROL) {
-            parts.push(control_display_label(&self.code));
+            let label = control_display_label(&self.code);
+            literal_word_control = cfg!(target_os = "macos") && label == "Ctrl";
+            parts.push(label);
         }
         if self.modifiers.contains(KeyModifiers::ALT) {
             parts.push(if cfg!(target_os = "macos") {
@@ -62,7 +68,7 @@ impl Chord {
         let key = render_keycode(&self.code);
         if parts.is_empty() {
             key
-        } else if cfg!(target_os = "macos") {
+        } else if cfg!(target_os = "macos") && !literal_word_control {
             format!("{}{}", parts.join(""), key)
         } else {
             format!("{}+{}", parts.join("+"), key)
@@ -375,6 +381,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn session_chords_stay_terminal_safe_ctrl_on_darwin() {
+        // Host-reserved session chords must retain literal Control
+        // matching (not the host-reserved Command event) and display
+        // with the literal word "Ctrl" plus a separator on darwin.
         for c in ['n', 's'] {
             let chord = Chord::ctrl(c);
             let ctrl = KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL);


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - PR #8705 added `session_chords_stay_terminal_safe_ctrl_on_darwin` to lock in that `Ctrl+n` and `Ctrl+s` keep binding the `Control` event (not the host-reserved `Command` event) on darwin. Its display assertion expected `"Ctrl+n"`, but `Chord::display()` on darwin flush-concatenates every modifier label against the key letter with no separator — the right convention for the single-glyph `"⌘"` case (`"⌘k"`), but wrong for `control_display_label()`'s literal-word `"Ctrl"` case used for host-reserved chords. `"Ctrln"`/`"Ctrls"` is genuinely ambiguous: these chord labels are user-visible key hints and status text, and `"Ctrl+n"`/`"Ctrl+s"` is the documented format.
  - **This is now a production display fix**, not a test-only change (after maintainer review — my first pass wrongly weakened the assertion to match the buggy output instead of fixing the bug). `Chord::display()` now separates with `+` specifically when the control label is the literal word `"Ctrl"` (host-reserved chords: `c`/`n`/`s`/`F1`), and keeps flush concatenation for the `"⌘"` glyph and every other modifier combination — no change to `⌘k`, bare Shift/Alt chords, or non-darwin output.
  - `session_chords_stay_terminal_safe_ctrl_on_darwin` now asserts the correct `"Ctrl+n"`/`"Ctrl+s"` display against the fixed implementation; the matching-contract assertions (`Ctrl` binds `Control`, not the host-reserved `Command` event) are unchanged.
  - Also trimmed the test's comment per current `master`'s comment-hygiene gate (rejects PR references and review-history narration in Rust comments) — it now states the durable invariant only.
- **Scope boundary:** `Chord::display()`'s modifier-label separator logic and the one test's assertion/comment. Does not change `control_display_label()`, `is_host_reserved_chord()`, chord matching/parsing, or any non-darwin behavior.
- **Blast radius:** `apps/zerocode/src/keymap/chord.rs` only. User-visible: on darwin, any UI surface that renders a host-reserved chord's display string (key hints, status text) now shows `"Ctrl+n"`/`"Ctrl+s"`/`"Ctrl+c"` instead of `"Ctrln"`/`"Ctrls"`/`"Ctrlc"`. No change to `⌘`-glyph chords or non-darwin output.
- **Linked issue(s):** None — found incidentally while validating PR #8866.
- **Labels:** `bug`, `zerocode`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — covered by the corrected unit test; no separate manual click-through path for this display string.

### How I tested

This is a `#[cfg(target_os = "macos")]` test — GitHub's required CI matrix for this repo does not run a macOS test job, so verification ran on a real macOS (darwin/arm64) build host.

```sh
cargo +1.96.1 fmt --all -- --check
cargo +1.96.1 clippy -p zerocode --all-targets -- -D warnings
cargo +1.96.1 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo +1.96.1 test -p zerocode --lib keymap::chord::
cargo +1.96.1 test --test architecture tests_that_persist_config_isolate_the_path
cargo +1.96.1 test --test architecture user_facing_strings_route_through_fluent
cargo +1.96.1 check --locked --features ci-all --all-targets
cargo +1.96.1 check --locked --no-default-features
```

- **CI checks relied on and why they cover this change:** `cargo test -p zerocode --lib keymap::chord::` is the direct regression coverage (all 20 chord tests, including the fixed assertion and the unaffected `display_ctrl_on_darwin` `⌘k` case); clippy/fmt/checks cover the rest of the required gate.
- **Known CI coverage gap, if any:** No macOS runner in the required CI matrix — this class of darwin-only display bug is invisible to CI and only surfaces when someone runs the suite locally on a Mac (as this one was).
- **Commands run and tail output:**
  ```
  cargo +1.96.1 fmt --all -- --check
  (clean, no diff)

  cargo +1.96.1 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 28s

  cargo +1.96.1 test -p zerocode --lib keymap::chord::
  running 20 tests
  test keymap::chord::tests::session_chords_stay_terminal_safe_ctrl_on_darwin ... ok
  test keymap::chord::tests::display_ctrl_on_darwin ... ok
  (18 more, all ok)
  test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 141 filtered out

  cargo +1.96.1 check --locked --features ci-all --all-targets
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 19s

  cargo +1.96.1 check --locked --no-default-features
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.49s
  ```
- **Beyond CI, what did you manually verify?** Confirmed `display_ctrl_on_darwin` (`⌘k`) and `display_arrow_keys`/`display_bare_letter_preserves_case` (unaffected code paths) still pass unchanged alongside the fixed host-reserved-chord case, ruling out a regression to the glyph-flush convention this PR intentionally preserves.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — chord matching behavior is unchanged; only the darwin display *string* for host-reserved chords changes (cosmetic).
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <merged-squash-sha>`.

