### PR TITLE
ci(release): raise build matrix timeout to 90 minutes

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -202,7 +202,11 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: [validate, web]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    # 90 min: the x86_64-apple-darwin leg needs ~45-50 min on GitHub's slower
+    # Intel macOS runners (v0.8.3 hit the old 40-min ceiling twice, killing the
+    # cache save each time and compounding the slowdown). Fast legs are
+    # unaffected; this is a ceiling, not an allocation.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

One line (plus comment): `build` matrix `timeout-minutes` 40 → 90 in `release-stable-manual.yml`.

## Why

The v0.8.3 release run (29457035190) was killed at exactly 40:04 and 40:18 on two attempts — both times it was the `x86_64-apple-darwin` leg hitting the job timeout (annotation: *"The job has exceeded the maximum execution time of 40m0s"*), not a human cancellation.

That leg genuinely needs ~45-50 min today:
- GitHub's Intel macOS runners (`macos-15-intel`) are ~35-40% slower than the arm64 runners — the identical `aarch64-apple-darwin` leg finished in 29 min
- ~8 min compiling xtask on a cold cache to resolve the `dist` feature set before the real build starts
- the leg builds two binaries (`zeroclaw` + `zerocode`)

Worse, the timeout is self-perpetuating: attempt 1 had **finished** build/package/upload and was killed during the rust-cache save post-step, so every retry starts cold.

90 is a ceiling, not an allocation — the other 10 legs (10-30 min) are unaffected.

## Verification

Timing evidence from run 29457035190 attempts 1-2 as above. Fresh v0.8.3 dispatch after merge will exercise it.