### PR TITLE
fix(ci): align Code Analysis with workspace MSRV

### DIFF
--- a/.github/workflows/ci-code-analysis.yml
+++ b/.github/workflows/ci-code-analysis.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
       - name: Install system dependencies
         run: sudo apt-get update -qq && sudo apt-get install -y libudev-dev
       - name: Initialize CodeQL


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Updates the Rust toolchain used by the `Code Analysis` workflow from `1.93.0` to `1.96.1`.
  - Aligns the workflow with the workspace `rust-version`, allowing the Rust CodeQL build to start instead of failing Cargo's toolchain compatibility check.
- **Scope boundary:** Does not change the workspace MSRV, CodeQL configuration, workflow triggers, permissions, build command, or product code.
- **Blast radius:** Only Rust CodeQL runs on `master` pushes and the daily schedule use the corrected toolchain. Semgrep and other CI workflows are unchanged.
- **Linked issue(s):** None. Failure reproduced in https://github.com/zeroclaw-labs/zeroclaw/actions/runs/29555329336/job/87806111598.
- **Labels:** `ci`, `type:ci`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a one-line CI toolchain alignment and the workflow run is the useful end-to-end check.

### How I tested

- **CI checks relied on and why they cover this change:** Pull requests run Semgrep while the Rust CodeQL job is intentionally skipped. After merge, the upstream `Code Analysis` workflow will exercise the corrected toolchain on the next `master` push or scheduled run.
- **Known CI coverage gap, if any:** The Rust CodeQL job cannot execute on a pull request by design, so final end-to-end proof arrives on the next `master` push or scheduled run.
- **Commands run and tail output:**

```sh
$ actionlint .github/workflows/ci-code-analysis.yml
# no output; exit 0

$ rg -n 'rust-version|toolchain:' Cargo.toml .github/workflows/ci-code-analysis.yml
.github/workflows/ci-code-analysis.yml:69:          toolchain: 1.96.1
Cargo.toml:10:rust-version = "1.96.1"
Cargo.toml:50:rust-version.workspace = true
```

- **Beyond CI, what did you manually verify?** Confirmed the changed workflow pin exactly matches the canonical workspace MSRV and that the diff changes no other workflow behavior.
- **If any command was intentionally skipped, why:** Cargo validation was skipped because the patch changes only the CI-selected Rust version and does not change Rust source, manifests, or the dependency graph.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**; the workspace already requires Rust `1.96.1`.
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR: revert the resulting commit if rollback is needed.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another contribution.
