### PR TITLE
fix(plugins): host-stamp channel plugin routes

### DIFF
--- a/crates/zeroclaw-plugins/src/endpoint.rs
+++ b/crates/zeroclaw-plugins/src/endpoint.rs
@@ -1,0 +1,134 @@
+//! Host-owned logical endpoints for plugin traffic.
+//!
+//! A channel plugin may describe the platform payload it received, but only the
+//! host selects the ZeroClaw route that owns that payload. The endpoint keeps
+//! the channel type alongside the admitted instance scope while deriving the
+//! alias from that scope, so routing identity cannot drift across two fields.
+
+use std::sync::Arc;
+
+use crate::PluginCapability;
+use crate::error::PluginError;
+use crate::instance::{PluginInstanceId, PluginInstanceScope};
+
+/// The host-issued route for one admitted channel-plugin binding.
+///
+/// `channel_type` is the canonical channel family used by the orchestrator.
+/// The route alias is always [`PluginInstanceId::binding`]; it is deliberately
+/// not stored again here. Clones share the immutable route and instance scope.
+#[derive(Clone, Debug)]
+pub struct PluginChannelEndpoint {
+    scope: PluginInstanceScope,
+    channel_type: Arc<str>,
+}
+
+impl PluginChannelEndpoint {
+    /// Bind an admitted channel scope to a canonical host routing type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `scope` is not a channel capability or when
+    /// `channel_type` is not a canonical snake_case channel key.
+    pub fn new(
+        scope: PluginInstanceScope,
+        channel_type: impl Into<String>,
+    ) -> Result<Self, PluginError> {
+        scope.require_capability(PluginCapability::Channel)?;
+
+        let channel_type = channel_type.into();
+        validate_channel_type(&channel_type)?;
+
+        Ok(Self {
+            scope,
+            channel_type: Arc::from(channel_type),
+        })
+    }
+
+    /// Canonical channel family selected by the host.
+    #[must_use]
+    pub fn channel_type(&self) -> &str {
+        &self.channel_type
+    }
+
+    /// Canonical configured alias, sourced from the admitted instance binding.
+    #[must_use]
+    pub fn alias(&self) -> &str {
+        self.scope.id().binding()
+    }
+
+    /// Host-owned instance identity behind this endpoint.
+    #[must_use]
+    pub fn instance_id(&self) -> &PluginInstanceId {
+        self.scope.id()
+    }
+
+    #[cfg(feature = "plugins-wasmtime")]
+    pub(crate) fn scope(&self) -> &PluginInstanceScope {
+        &self.scope
+    }
+}
+
+pub(crate) fn validate_channel_type(channel_type: &str) -> Result<(), PluginError> {
+    let bytes = channel_type.as_bytes();
+    let valid = (1..=128).contains(&bytes.len())
+        && bytes.first().is_some_and(u8::is_ascii_lowercase)
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'_');
+
+    if !valid {
+        return Err(PluginError::InvalidEndpoint(format!(
+            "channel type must be a 1-128 character lowercase snake_case key that starts with a letter (got {channel_type:?})"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_uses_the_scope_binding_as_its_only_alias() {
+        let scope = crate::instance::test_scope(PluginCapability::Channel, "operations", []);
+        let endpoint = PluginChannelEndpoint::new(scope.clone(), "nextcloud_talk")
+            .expect("valid channel endpoint");
+        let clone = endpoint.clone();
+
+        assert_eq!(endpoint.channel_type(), "nextcloud_talk");
+        assert_eq!(endpoint.alias(), "operations");
+        assert!(std::ptr::eq(endpoint.instance_id(), scope.id()));
+        assert!(std::ptr::eq(endpoint.channel_type(), clone.channel_type()));
+    }
+
+    #[test]
+    fn endpoint_rejects_ambiguous_channel_types() {
+        for channel_type in [
+            "",
+            "Telegram",
+            "plugin.echo",
+            "bad/type",
+            "bad:type",
+            "bad type",
+            "bad\nkey",
+            "-bad",
+            "nextcloud-talk",
+            "1channel",
+        ] {
+            let scope = crate::instance::test_scope(PluginCapability::Channel, "main", []);
+            assert!(PluginChannelEndpoint::new(scope, channel_type).is_err());
+        }
+
+        for channel_type in ["telegram", "gmail_push", "nextcloud_talk"] {
+            let scope = crate::instance::test_scope(PluginCapability::Channel, "main", []);
+            assert!(PluginChannelEndpoint::new(scope, channel_type).is_ok());
+        }
+    }
+
+    #[test]
+    fn endpoint_rejects_a_non_channel_scope() {
+        let scope = crate::instance::test_scope(PluginCapability::Tool, "main", []);
+        assert!(PluginChannelEndpoint::new(scope, "telegram").is_err());
+    }
+}

--- a/crates/zeroclaw-plugins/src/error.rs
+++ b/crates/zeroclaw-plugins/src/error.rs
@@ -13,6 +13,9 @@ pub enum PluginError {
     #[error("invalid plugin instance identity: {0}")]
     InvalidInstanceId(String),
 
+    #[error("invalid plugin endpoint: {0}")]
+    InvalidEndpoint(String),
+
     #[error("failed to load WASM module: {0}")]
     LoadFailed(String),
 

--- a/crates/zeroclaw-plugins/src/instance.rs
+++ b/crates/zeroclaw-plugins/src/instance.rs
@@ -182,7 +182,6 @@ impl PluginInstanceScope {
     ///
     /// Returns [`PluginError::InvalidInstanceId`] when the instance capability
     /// does not equal `expected`.
-    #[cfg(any(feature = "plugins-wasmtime", test))]
     pub(crate) fn require_capability(&self, expected: PluginCapability) -> Result<(), PluginError> {
         if self.id().capability() != expected {
             return Err(PluginError::InvalidInstanceId(format!(

--- a/crates/zeroclaw-plugins/src/lib.rs
+++ b/crates/zeroclaw-plugins/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod component;
 #[cfg(feature = "plugins-wasmtime")]
 mod component_logging;
+pub mod endpoint;
 pub mod error;
 pub mod host;
 pub mod instance;

--- a/crates/zeroclaw-plugins/src/wasm_channel.rs
+++ b/crates/zeroclaw-plugins/src/wasm_channel.rs
@@ -1,7 +1,6 @@
 //! Channel adapter: `WasmChannel` implements `zeroclaw_api::channel::Channel`
 //! backed by the `channel-plugin` component world.
 
-use crate::PluginCapability;
 use crate::PluginPermission;
 use crate::component::InboundQueue;
 use crate::component::bindings::channel::ChannelPlugin;
@@ -11,7 +10,8 @@ use crate::component::bindings::channel::exports::zeroclaw::plugin::channel::{
     MediaAttachment as WitMediaAttachment, SendMessage as WitSendMessage,
 };
 use crate::component::{PluginState, PluginStoreSpec, call_plugin, engine, load_component, wt};
-use crate::instance::{PluginGrantSet, PluginInstanceScope};
+use crate::endpoint::PluginChannelEndpoint;
+use crate::instance::PluginGrantSet;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -30,7 +30,7 @@ use zeroclaw_api::media::MediaAttachment;
 
 /// A channel backed by a WIT component-model plugin.
 pub struct WasmChannel {
-    scope: PluginInstanceScope,
+    endpoint: PluginChannelEndpoint,
     capabilities: ChannelCapabilities,
     state: Arc<Mutex<(Store<PluginState>, ChannelPlugin)>>,
     inbound: InboundQueue,
@@ -56,7 +56,7 @@ impl Attributable for WasmChannel {
         Role::Channel(ChannelKind::Plugin)
     }
     fn alias(&self) -> &str {
-        self.scope.id().binding()
+        self.endpoint.alias()
     }
 }
 
@@ -93,16 +93,15 @@ fn build_linker(http: bool) -> Result<Linker<PluginState>> {
 
 impl WasmChannel {
     pub async fn from_wasm(
-        scope: PluginInstanceScope,
+        endpoint: PluginChannelEndpoint,
         wasm_path: &Path,
         config: &HashMap<String, String>,
         limits: crate::component::PluginLimits,
     ) -> Result<Self> {
-        scope.require_capability(PluginCapability::Channel)?;
         let component = load_component(wasm_path)?;
         let inbound = InboundQueue::default();
         let mut store = crate::component::new_store(
-            PluginStoreSpec::new(scope.clone(), limits)
+            PluginStoreSpec::new(endpoint.scope().clone(), limits)
                 .with_granted_http()
                 .with_inbound(inbound.clone()),
         );
@@ -120,7 +119,7 @@ impl WasmChannel {
         // section is withheld unless the admitted scope grants `ConfigRead`, matching
         // the tool-plugin `__config` rule, so a plugin without the permission is
         // configured with an empty object rather than another channel's secrets.
-        let config_json = resolve_configure_json(config, scope.grants());
+        let config_json = resolve_configure_json(config, endpoint.scope().grants());
         wt(
             channel.call_configure(&mut store, &config_json).await,
             "channel.configure trapped",
@@ -160,7 +159,7 @@ impl WasmChannel {
             };
 
         Ok(Self {
-            scope,
+            endpoint,
             capabilities,
             state: Arc::new(Mutex::new((store, bindings))),
             inbound,
@@ -206,14 +205,16 @@ fn to_wit_send(msg: &SendMessage) -> WitSendMessage {
     }
 }
 
-fn from_wit_inbound(msg: WitInboundMessage, channel_name: &str) -> ChannelMessage {
+fn from_wit_inbound(msg: WitInboundMessage, endpoint: &PluginChannelEndpoint) -> ChannelMessage {
     ChannelMessage {
         id: msg.id,
         sender: msg.sender,
         reply_target: msg.reply_target,
         content: msg.content,
-        channel: channel_name.to_string(),
-        channel_alias: msg.channel_alias,
+        // Routing identity is issued by the host. Guest-supplied channel and
+        // alias fields cannot select a different owner or session namespace.
+        channel: endpoint.channel_type().to_string(),
+        channel_alias: Some(endpoint.alias().to_string()),
         timestamp: msg.timestamp,
         thread_ts: msg.thread_ts,
         interruption_scope_id: msg.interruption_scope_id,
@@ -245,7 +246,7 @@ fn from_wit_approval_response(r: WitApprovalResponse) -> ChannelApprovalResponse
 #[async_trait]
 impl Channel for WasmChannel {
     fn name(&self) -> &str {
-        self.scope.id().binding()
+        self.endpoint.channel_type()
     }
 
     async fn send(&self, message: &SendMessage) -> Result<()> {
@@ -266,7 +267,7 @@ impl Channel for WasmChannel {
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
-        let channel_name = self.scope.id().binding().to_string();
+        let endpoint = self.endpoint.clone();
         let state = Arc::clone(&self.state);
         let poll_healthy = Arc::clone(&self.poll_healthy);
         zeroclaw_spawn::spawn!(async move {
@@ -287,11 +288,7 @@ impl Channel for WasmChannel {
                     Ok(Some(wit_msg)) => {
                         mark_poll_healthy(&poll_healthy, true);
                         backoff = INITIAL_BACKOFF;
-                        if tx
-                            .send(from_wit_inbound(wit_msg, &channel_name))
-                            .await
-                            .is_err()
-                        {
+                        if tx.send(from_wit_inbound(wit_msg, &endpoint)).await.is_err() {
                             break;
                         }
                     }
@@ -310,7 +307,8 @@ impl Channel for WasmChannel {
                             )
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({
-                                "channel_alias": channel_name,
+                                "channel": endpoint.channel_type(),
+                                "channel_alias": endpoint.alias(),
                                 "error": format!("{e:#}"),
                             })),
                             "channel plugin poll-message trapped; backing off"
@@ -751,6 +749,7 @@ impl Channel for WasmChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PluginCapability;
 
     #[test]
     fn media_round_trip() {
@@ -814,19 +813,40 @@ mod tests {
         assert_eq!(v["identity"], "on-call", "granted section round-trips");
     }
 
-    #[tokio::test]
-    async fn from_wasm_rejects_a_scope_for_another_capability() {
-        let scope = crate::instance::test_scope(PluginCapability::Tool, "main", []);
-        let result = WasmChannel::from_wasm(
-            scope,
-            Path::new("/path/that/must/not/be-read.wasm"),
-            &HashMap::new(),
-            crate::component::test_limits(0),
-        )
-        .await;
+    #[test]
+    fn host_endpoint_overrides_guest_routing_identity() {
+        for (channel_type, alias, guest_alias) in [
+            ("plugin", "acme.chat", Some("guest-selected-alias")),
+            ("telegram", "work", None),
+            ("gmail_push", "main", Some("")),
+        ] {
+            let scope = crate::instance::test_scope(PluginCapability::Channel, alias, []);
+            let endpoint = PluginChannelEndpoint::new(scope, channel_type).unwrap();
+            let message = from_wit_inbound(
+                WitInboundMessage {
+                    id: "evt-1".to_string(),
+                    sender: "sender".to_string(),
+                    reply_target: "room".to_string(),
+                    content: "hello".to_string(),
+                    channel: "guest-selected-type".to_string(),
+                    channel_alias: guest_alias.map(str::to_string),
+                    timestamp: 42,
+                    thread_ts: None,
+                    interruption_scope_id: None,
+                    attachments: Vec::new(),
+                    subject: None,
+                },
+                &endpoint,
+            );
 
-        let error = result.err().expect("capability mismatch must fail");
-        assert!(format!("{error:#}").contains("capability"));
+            assert_eq!(message.channel, channel_type);
+            assert_eq!(message.channel_alias.as_deref(), Some(alias));
+            assert_ne!(message.channel, endpoint.instance_id().package());
+            assert_eq!(message.content, "hello");
+            assert!(message.internal_sop_event.is_none());
+            assert!(!message.passive_context);
+            assert!(!message.explicitly_addressed);
+        }
     }
 
     #[test]

--- a/docs/book/src/plugins/writing-a-channel-plugin.md
+++ b/docs/book/src/plugins/writing-a-channel-plugin.md
@@ -114,14 +114,16 @@ auto-deny. Fail closed.
 
 ## Inbound message shape
 
-Translate platform events into `inbound-message` records faithfully; the
-runtime's session and threading logic keys off these fields
+Translate platform events into `inbound-message` records faithfully. The
+runtime's threading logic keys off the platform payload fields, while routing
+identity comes only from the host-issued endpoint
 (`channel.wit`, `from_wit_inbound` in `wasm_channel.rs`):
 
 - `id`, `sender`, `content`: the basics. `reply-target` is where a response
   should go (channel ID, chat ID, email address).
-- `channel` is the platform type identifier; `channel-alias` distinguishes
-  multiple bot instances of the same platform and feeds distinct session IDs.
+- `channel` and `channel-alias` are legacy hints retained in the v0 record. The
+  host ignores both for routing and stamps the admitted channel type and
+  configured binding, so a plugin cannot select another owner or session.
 - `thread-ts` carries the platform's thread identifier for threaded replies;
   `subject` exists for email threading.
 - `interruption-scope-id` groups messages for interruption/cancellation.

--- a/wit/v0/channel.wit
+++ b/wit/v0/channel.wit
@@ -30,10 +30,11 @@ interface channel {
         sender: string,
         reply-target: string,
         content: string,
-        /// Platform type identifier (e.g. `"telegram"`, `"discord"`).
+        /// Legacy platform hint. The host ignores this for routing and stamps
+        /// the channel type from the admitted logical endpoint.
         channel: string,
-        /// ZeroClaw channel alias, when the platform supports multiple bot
-        /// instances. Used to compute distinct session IDs per bot.
+        /// Legacy alias hint. The host ignores this for routing and stamps the
+        /// alias from the admitted instance binding.
         channel-alias: option<string>,
         /// Unix timestamp in milliseconds.
         timestamp: u64,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds `PluginChannelEndpoint`, a host-owned logical endpoint derived from an admitted channel scope.
  - Separates the channel type used for routing from the binding alias used for instance identity.
  - Overwrites guest-supplied channel and alias fields when converting inbound messages, preventing route spoofing across plugin instances.
  - Makes channel attribution and `Channel::name()` derive from the admitted endpoint rather than guest data.
- **Scope boundary:** This PR does not register HTTP webhook routes, accept arbitrary guest paths, add new listeners, or change plugin configuration/secrets.
- **Blast radius:** WASM channel routing identity, inbound message attribution, and channel-plugin construction.
- **Linked issue(s):** Depended on #9122, which is now merged. Related #8852. Related #8862.
- **Labels:** `risk:high`, `size:S`. Rebased onto `master` after #9122 landed, so the diff is now the isolated delta: 7 files, +201/-41.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; automated tests directly exercise spoofed guest routing metadata and endpoint admission.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI now runs against the rebased head, which is this layer only. `check-plugin-backends` covers the wasmtime/cranelift/pulley feature matrix where `wasm_channel.rs` compiles; the default-feature jobs cover `endpoint.rs` and its admission tests.
- **Known CI coverage gap, if any:** No gateway webhook is exercised because registration is explicitly outside this slice.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
passed

$ cargo clippy -p zeroclaw-plugins --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 55.30s

$ cargo check --locked -p zeroclaw-plugins --no-default-features --features plugins-wasm-cranelift
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 59s

$ cargo test -p zeroclaw-plugins --features plugins-wasm-cranelift
running 90 tests
test result: ok. 90 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/reference_plugin.rs
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/reference_plugin_e2e.rs
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- **Beyond CI, what did you manually verify?** Confirmed `PluginChannelEndpoint` owns both logical channel type and admitted alias, and that host conversion stamps both values after the guest returns an inbound payload.
- **If any command was intentionally skipped, why:** External webhook smoke is deferred to the host-ingress PR that consumes this endpoint.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `Yes`
- If any `Yes`, describe the risk and mitigation: Guest-originated routing metadata crosses the channel boundary. The host now replaces it with the admitted endpoint identity before the message reaches shared routing or model-visible channel context.

## Compatibility (required)

- Backward compatible? `Yes` for the experimental guest WIT ABI; internal channel construction now requires a typed endpoint.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-squash-sha>`
- **Feature flags or config toggles:** Existing `plugins-wasm*` feature gates; no new toggle.
- **Observable failure symptoms:** Plugin channel registration errors naming an endpoint/capability mismatch, wrong channel alias attribution, or inbound messages routed under an unexpected logical channel type.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another contribution.
