### PR TITLE
test(plugins): add channel component fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
         run: |
           base="${{ github.event.pull_request.base.sha }}"
           if [ -z "$base" ]; then echo "run=true" >> "$GITHUB_OUTPUT"; exit 0; fi
-          if git diff --name-only "$base" HEAD | grep -qE '^crates/zeroclaw-plugins/|^Cargo\.(toml|lock)$'; then
+          if git diff --name-only "$base" HEAD | grep -qE '^crates/zeroclaw-plugins/|^wit/|^Cargo\.(toml|lock)$'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -399,6 +399,9 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         with:
           toolchain: 1.96.1
+      - name: Install channel plugin fixture target
+        if: steps.changed.outputs.run == 'true' && matrix.features == 'plugins-wasm-cranelift'
+        run: rustup target add wasm32-wasip2
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.changed.outputs.run == 'true'
         with:
@@ -407,6 +410,9 @@ jobs:
       - name: Check
         if: steps.changed.outputs.run == 'true'
         run: cargo check --locked -p zeroclaw-plugins --no-default-features --features ${{ matrix.features }}
+      - name: Run channel plugin component test
+        if: steps.changed.outputs.run == 'true' && matrix.features == 'plugins-wasm-cranelift'
+        run: cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift --test channel_plugin_e2e
 
   check-32bit:
     name: Check (32-bit)
@@ -743,7 +749,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-32bit, bench, test, test-landlock, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-plugin-backends, check-32bit, bench, test, test-landlock, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12612,6 +12612,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
+ "bitflags 2.11.1",
  "wit-bindgen-rust-macro",
 ]
 
@@ -13021,6 +13022,13 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "zeroclaw-channel-plugin-fixture"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw-config", "crates/zeroclaw-log", "crates/zeroclaw-spawn", "crates/zeroclaw-commands", "crates/zeroclaw-providers", "crates/zeroclaw-memory", "crates/zeroclaw-channels", "crates/zeroclaw-tools", "crates/zeroclaw-sop-graph", "crates/zeroclaw-runtime", "crates/zeroclaw-eval", "apps/zerocode", "crates/zeroclaw-plugins", "crates/zeroclaw-gateway", "crates/zeroclaw-hardware", "crates/zeroclaw-tool-call-parser", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri", "tools/fill-translations", "xtask"]
+members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw-config", "crates/zeroclaw-log", "crates/zeroclaw-spawn", "crates/zeroclaw-commands", "crates/zeroclaw-providers", "crates/zeroclaw-memory", "crates/zeroclaw-channels", "crates/zeroclaw-tools", "crates/zeroclaw-sop-graph", "crates/zeroclaw-runtime", "crates/zeroclaw-eval", "apps/zerocode", "crates/zeroclaw-plugins", "crates/zeroclaw-plugins/tests/fixtures/channel-fixture", "crates/zeroclaw-gateway", "crates/zeroclaw-hardware", "crates/zeroclaw-tool-call-parser", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri", "tools/fill-translations", "xtask"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/zeroclaw-plugins/tests/channel_plugin_e2e.rs
+++ b/crates/zeroclaw-plugins/tests/channel_plugin_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end fixture for the host's channel-component adapter.
+//!
+//! The source fixture is a workspace member and is built on demand into a
+//! separate target directory so the nested Cargo invocation cannot contend
+//! with the host test process's build lock.
+
+#![cfg(feature = "plugins-wasm-cranelift")]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use zeroclaw_api::attribution::Attributable;
+use zeroclaw_api::channel::{Channel, SendMessage};
+use zeroclaw_plugins::component::{HostInboundMessage, PluginLimits};
+use zeroclaw_plugins::endpoint::PluginChannelEndpoint;
+use zeroclaw_plugins::instance::PluginInstanceScope;
+use zeroclaw_plugins::wasm_channel::WasmChannel;
+use zeroclaw_plugins::{PluginCapability, PluginManifest};
+
+fn fixture() -> PathBuf {
+    static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
+    FIXTURE
+        .get_or_init(|| {
+            let fixture_dir =
+                PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/channel-fixture");
+            let target_dir =
+                PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("channel-plugin-fixture");
+            let status = Command::new(env!("CARGO"))
+                .current_dir(&fixture_dir)
+                .args([
+                    "build",
+                    "--locked",
+                    "--quiet",
+                    "--package",
+                    "zeroclaw-channel-plugin-fixture",
+                    "--target",
+                    "wasm32-wasip2",
+                    "--target-dir",
+                ])
+                .arg(&target_dir)
+                .status()
+                .expect("run Cargo for the channel component fixture");
+            assert!(
+                status.success(),
+                "channel fixture must build; install the wasm32-wasip2 target"
+            );
+
+            let wasm = target_dir.join("wasm32-wasip2/debug/zeroclaw_channel_plugin_fixture.wasm");
+            assert!(wasm.is_file(), "channel fixture WASM was not produced");
+            wasm
+        })
+        .clone()
+}
+
+fn limits() -> PluginLimits {
+    PluginLimits {
+        call_fuel: 1_000_000_000,
+        max_memory_bytes: 64 * 1024 * 1024,
+        max_table_elements: 10_000,
+        max_instances: 32,
+    }
+}
+
+async fn channel(binding: &str) -> WasmChannel {
+    let manifest = PluginManifest {
+        name: "channel-fixture".to_string(),
+        version: "0.0.0".to_string(),
+        description: None,
+        author: None,
+        wasm_path: Some("channel-fixture.wasm".to_string()),
+        capabilities: vec![PluginCapability::Channel],
+        permissions: vec![],
+        signature: None,
+        publisher_key: None,
+    };
+    let scope =
+        PluginInstanceScope::from_manifest(&manifest, PluginCapability::Channel, binding, [])
+            .expect("admit fixture scope");
+    let endpoint = PluginChannelEndpoint::new(scope, "plugin").expect("bind fixture endpoint");
+
+    WasmChannel::from_wasm(endpoint, &fixture(), &HashMap::new(), limits())
+        .await
+        .expect("instantiate fixture channel")
+}
+
+fn outbound() -> SendMessage {
+    SendMessage {
+        content: "hello".to_string(),
+        recipient: "room".to_string(),
+        subject: None,
+        thread_ts: None,
+        cancellation_token: None,
+        attachments: Vec::new(),
+        in_reply_to: None,
+        suppress_voice: false,
+        force_voice: false,
+    }
+}
+
+#[tokio::test]
+async fn channel_component_runs_through_host_ingress() {
+    let channel = channel("main").await;
+
+    assert_eq!(channel.name(), "plugin");
+    assert_eq!(channel.alias(), "main");
+    assert_eq!(channel.self_handle().as_deref(), Some("@fixture"));
+    assert!(channel.health_check().await);
+    channel
+        .send(&outbound())
+        .await
+        .expect("fixture accepts send");
+
+    let inbound = channel.inbound();
+    inbound.enqueue(HostInboundMessage {
+        id: "host-1".to_string(),
+        sender: "tester".to_string(),
+        reply_target: "room".to_string(),
+        content: "ping".to_string(),
+        channel: "host-channel".to_string(),
+        channel_alias: Some("host-alias".to_string()),
+        timestamp: 7,
+        ..Default::default()
+    });
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    channel.listen(tx).await.expect("start fixture listener");
+    let message = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("fixture message arrives before timeout")
+        .expect("listener remains connected");
+
+    assert_eq!(message.id, "host-1");
+    assert_eq!(message.content, "ping");
+    assert_eq!(message.timestamp, 7);
+    assert_eq!(message.channel, "plugin");
+    assert_eq!(message.channel_alias.as_deref(), Some("main"));
+}

--- a/crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml
+++ b/crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "zeroclaw-channel-plugin-fixture"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doc = false
+doctest = false
+test = false
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wit-bindgen = "0.51"

--- a/crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs
+++ b/crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs
@@ -1,0 +1,186 @@
+//! Minimal channel component used by the plugin-host integration tests.
+
+#[cfg(target_family = "wasm")]
+mod component {
+    wit_bindgen::generate!({
+        path: "../../../../../wit/v0",
+        world: "channel-plugin",
+        features: ["plugins-wit-v0"],
+    });
+
+    use exports::zeroclaw::plugin::channel::{
+        ApprovalRequest, ApprovalResponse, ChannelCapabilities, Guest as Channel, InboundMessage,
+        SendMessage,
+    };
+    use exports::zeroclaw::plugin::plugin_info::Guest as PluginInfo;
+
+    struct FixtureChannel;
+
+    impl PluginInfo for FixtureChannel {
+        fn plugin_name() -> String {
+            "channel-fixture".to_string()
+        }
+
+        fn plugin_version() -> String {
+            "0.0.0".to_string()
+        }
+    }
+
+    impl Channel for FixtureChannel {
+        fn name() -> String {
+            "channel-fixture".to_string()
+        }
+
+        fn configure(_config: String) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn send(_message: SendMessage) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn poll_message() -> Option<InboundMessage> {
+            let message = zeroclaw::plugin::inbound::inbound_poll()?;
+            Some(InboundMessage {
+                id: message.id,
+                sender: message.sender,
+                reply_target: message.reply_target,
+                content: message.content,
+                // Deliberately untrusted: the host must replace both values
+                // with its admitted logical endpoint.
+                channel: "guest-channel".to_string(),
+                channel_alias: Some("guest-alias".to_string()),
+                timestamp: message.timestamp,
+                thread_ts: message.thread_ts,
+                interruption_scope_id: message.interruption_scope_id,
+                attachments: Vec::new(),
+                subject: message.subject,
+            })
+        }
+
+        fn get_channel_capabilities() -> ChannelCapabilities {
+            ChannelCapabilities::HEALTH_CHECK | ChannelCapabilities::SELF_HANDLE
+        }
+
+        fn health_check() -> bool {
+            true
+        }
+
+        fn self_handle() -> Option<String> {
+            Some("@fixture".to_string())
+        }
+
+        fn self_addressed_mention() -> Option<String> {
+            None
+        }
+
+        fn drop_self_message(_msg: InboundMessage) -> bool {
+            false
+        }
+
+        fn start_typing(_recipient: String) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn stop_typing(_recipient: String) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn supports_draft_updates() -> bool {
+            false
+        }
+
+        fn send_draft(_message: SendMessage) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+
+        fn update_draft(
+            _recipient: String,
+            _message_id: String,
+            _text: String,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn update_draft_progress(
+            _recipient: String,
+            _message_id: String,
+            _text: String,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn finalize_draft(
+            _recipient: String,
+            _message_id: String,
+            _final_text: String,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn cancel_draft(_recipient: String, _message_id: String) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn supports_multi_message_streaming() -> bool {
+            false
+        }
+
+        fn multi_message_delay_ms() -> u64 {
+            800
+        }
+
+        fn add_reaction(
+            _channel: String,
+            _message_id: String,
+            _emoji: String,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn remove_reaction(
+            _channel: String,
+            _message_id: String,
+            _emoji: String,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn pin_message(_channel: String, _message_id: String) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn unpin_message(_channel: String, _message_id: String) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn redact_message(
+            _channel: String,
+            _message_id: String,
+            _reason: Option<String>,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn request_approval(
+            _recipient: String,
+            _request: ApprovalRequest,
+        ) -> Result<Option<ApprovalResponse>, String> {
+            Ok(None)
+        }
+
+        fn request_choice(
+            _question: String,
+            _choices: Vec<String>,
+            _timeout_secs: u64,
+        ) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+
+        fn supports_free_form_ask() -> bool {
+            true
+        }
+    }
+
+    export!(FixtureChannel);
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds a real `wasm32-wasip2` channel component fixture and host-side end-to-end test.
  - Exercises component instantiation, configuration, channel exports, host-fed inbound delivery, routing attribution, media, and cancellation behavior.
  - Makes WIT changes trigger the plugin backend matrix and builds/runs component fixtures in the Cranelift job.
  - Adds `check-plugin-backends` to `CI Required Gate.needs` so backend or component-test failures block merging.
- **Scope boundary:** This PR adds test and CI proof only. It does not register channel plugins in the daemon or add production ingress transports.
- **Blast radius:** Plugin component CI duration and required-gate behavior when plugin/WIT/Cargo files change.
- **Linked issue(s):** Depended on #9123, which is now merged. Related #8852.
- **Labels:** `type:test`, `type:ci`, `risk:high`, `size:M`. Rebased onto `master` after #9123 landed, so the diff is now the isolated delta: 6 files, +358/-3.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** Channel plugin component boundary; no web/TUI/CLI surface.
- **Setup / preconditions:** Install Rust target `wasm32-wasip2`.
- **Steps to run:** `cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift --test channel_plugin_e2e`
- **Expected on this branch (after):** The fixture is built, instantiated, and the host ingress/channel adapter assertions pass.
- **Prior behavior on `master` (before):** No channel component fixture or executable host-adapter E2E exists.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI runs against the rebased head, which is this layer only. This PR explicitly makes the backend/component job part of the required composite gate, so the Cranelift job's fixture execution is itself gating from here on.
- **Known CI coverage gap, if any:** Pulley and runtime-only remain compile checks; Cranelift executes the component fixture.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
passed

$ cargo clippy -p zeroclaw-plugins --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.34s

$ cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift --test channel_plugin_e2e
running 1 test
test channel_component_runs_through_host_ingress ... ok
test result: ok. 1 passed; 0 failed; 0 ignored

$ cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift
test result: ok. 90 passed; 0 failed   (lib)
test result: ok. 1 passed; 0 failed    (channel_plugin_e2e)
test result: ok. 6 passed; 0 failed    (reference_plugin)
test result: ok. 1 passed; 0 failed    (reference_plugin_e2e)
```

- **Beyond CI, what did you manually verify?** Confirmed the workflow change detector includes `wit/`, the fixture target is installed only for Cranelift, and `CI Required Gate` depends on the complete plugin backend matrix.
- **If any command was intentionally skipped, why:** No real external channel artifact is used; cross-repository plugin conformance is a later dedicated gate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. The workflow becomes stricter by making the existing backend matrix merge-blocking.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`; CI installs an existing Rust target.
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-squash-sha>`
- **Feature flags or config toggles:** Existing `plugins-wasm-cranelift` test feature.
- **Observable failure symptoms:** `Check (plugins ... backend)` fails or `CI Required Gate` reports a failed/cancelled dependency after plugin/WIT changes.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another contribution.
