### PR TITLE
fix(plugins): keep channel listener under supervision

### DIFF
--- a/crates/zeroclaw-plugins/Cargo.toml
+++ b/crates/zeroclaw-plugins/Cargo.toml
@@ -17,7 +17,6 @@ plugins-wasm-pulley = ["plugins-wasmtime", "wasmtime/pulley"]
 zeroclaw-log.workspace = true
 zeroclaw-api.workspace = true
 zeroclaw-infra.workspace = true
-zeroclaw-spawn.workspace = true
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.22"
@@ -44,3 +43,4 @@ wasmtime-wasi-http = { version = "45.0.3", default-features = false, features = 
 [dev-dependencies]
 tempfile = "3.26"
 zeroclaw-config = { path = "../zeroclaw-config" }
+zeroclaw-spawn.workspace = true

--- a/crates/zeroclaw-plugins/src/component.rs
+++ b/crates/zeroclaw-plugins/src/component.rs
@@ -310,7 +310,7 @@ fn load_inner(wasm_path: &Path) -> wasmtime::Result<Component> {
     unsafe { Component::deserialize_file(engine(), wasm_path) }
 }
 
-/// Run an async call against a warm `Arc<Mutex<(Store, bindings)>>` plugin,
+/// Run an async call against a warm mutex-protected `(Store, bindings)` pair,
 /// holding the store lock for the duration of the single component call.
 macro_rules! call_plugin {
     ($self:expr, $body:expr) => {{

--- a/crates/zeroclaw-plugins/src/wasm_channel.rs
+++ b/crates/zeroclaw-plugins/src/wasm_channel.rs
@@ -16,7 +16,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -32,12 +31,12 @@ use zeroclaw_api::media::MediaAttachment;
 pub struct WasmChannel {
     endpoint: PluginChannelEndpoint,
     capabilities: ChannelCapabilities,
-    state: Arc<Mutex<(Store<PluginState>, ChannelPlugin)>>,
+    state: Mutex<(Store<PluginState>, ChannelPlugin)>,
     inbound: InboundQueue,
     cached_self_handle: Option<String>,
     cached_self_addressed_mention: Option<String>,
     cached_multi_message_delay_ms: u64,
-    poll_healthy: Arc<AtomicBool>,
+    poll_healthy: AtomicBool,
 }
 
 /// Whether the listen loop's last `poll-message` did not trap. A channel whose
@@ -161,12 +160,12 @@ impl WasmChannel {
         Ok(Self {
             endpoint,
             capabilities,
-            state: Arc::new(Mutex::new((store, bindings))),
+            state: Mutex::new((store, bindings)),
             inbound,
             cached_self_handle,
             cached_self_addressed_mention,
             cached_multi_message_delay_ms,
-            poll_healthy: Arc::new(AtomicBool::new(true)),
+            poll_healthy: AtomicBool::new(true),
         })
     }
 
@@ -267,59 +266,60 @@ impl Channel for WasmChannel {
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
-        let endpoint = self.endpoint.clone();
-        let state = Arc::clone(&self.state);
-        let poll_healthy = Arc::clone(&self.poll_healthy);
-        zeroclaw_spawn::spawn!(async move {
-            const INITIAL_BACKOFF: Duration = Duration::from_millis(50);
-            const MAX_BACKOFF: Duration = Duration::from_millis(500);
-            let mut backoff = INITIAL_BACKOFF;
-            loop {
-                let polled = {
-                    let mut guard = state.lock().await;
-                    let (ref mut store, ref mut bindings) = *guard;
-                    crate::component::refuel(store);
-                    bindings
-                        .zeroclaw_plugin_channel()
-                        .call_poll_message(store)
+        const INITIAL_BACKOFF: Duration = Duration::from_millis(50);
+        const MAX_BACKOFF: Duration = Duration::from_millis(500);
+        let mut backoff = INITIAL_BACKOFF;
+        // Keep the poll loop inside the Channel::listen future. The
+        // orchestrator owns cancellation and restart supervision; detaching a
+        // second task here would make every apparent exit leak another loop.
+        loop {
+            let polled = {
+                let mut guard = self.state.lock().await;
+                let (ref mut store, ref mut bindings) = *guard;
+                crate::component::refuel(store);
+                bindings
+                    .zeroclaw_plugin_channel()
+                    .call_poll_message(store)
+                    .await
+            };
+            match polled {
+                Ok(Some(wit_msg)) => {
+                    mark_poll_healthy(&self.poll_healthy, true);
+                    backoff = INITIAL_BACKOFF;
+                    if tx
+                        .send(from_wit_inbound(wit_msg, &self.endpoint))
                         .await
-                };
-                match polled {
-                    Ok(Some(wit_msg)) => {
-                        mark_poll_healthy(&poll_healthy, true);
-                        backoff = INITIAL_BACKOFF;
-                        if tx.send(from_wit_inbound(wit_msg, &endpoint)).await.is_err() {
-                            break;
-                        }
+                        .is_err()
+                    {
+                        return Ok(());
                     }
-                    Ok(None) => {
-                        mark_poll_healthy(&poll_healthy, true);
-                        tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
-                    }
-                    Err(e) => {
-                        mark_poll_healthy(&poll_healthy, false);
-                        ::zeroclaw_log::record!(
-                            WARN,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Inbound
-                            )
+                    continue;
+                }
+                Ok(None) => {
+                    mark_poll_healthy(&self.poll_healthy, true);
+                }
+                Err(e) => {
+                    mark_poll_healthy(&self.poll_healthy, false);
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Inbound)
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({
-                                "channel": endpoint.channel_type(),
-                                "channel_alias": endpoint.alias(),
+                                "channel": self.endpoint.channel_type(),
+                                "channel_alias": self.endpoint.alias(),
                                 "error": format!("{e:#}"),
                             })),
-                            "channel plugin poll-message trapped; backing off"
-                        );
-                        tokio::time::sleep(backoff).await;
-                        backoff = (backoff * 2).min(MAX_BACKOFF);
-                    }
+                        "channel plugin poll-message trapped; backing off"
+                    );
                 }
             }
-        });
-        Ok(())
+
+            tokio::select! {
+                () = tx.closed() => return Ok(()),
+                () = tokio::time::sleep(backoff) => {}
+            }
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+        }
     }
 
     async fn health_check(&self) -> bool {

--- a/crates/zeroclaw-plugins/tests/channel_plugin_e2e.rs
+++ b/crates/zeroclaw-plugins/tests/channel_plugin_e2e.rs
@@ -126,7 +126,7 @@ async fn channel_component_runs_through_host_ingress() {
     });
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-    channel.listen(tx).await.expect("start fixture listener");
+    let listener = zeroclaw_spawn::spawn!(async move { channel.listen(tx).await });
     let message = tokio::time::timeout(Duration::from_secs(5), rx.recv())
         .await
         .expect("fixture message arrives before timeout")
@@ -137,4 +137,28 @@ async fn channel_component_runs_through_host_ingress() {
     assert_eq!(message.timestamp, 7);
     assert_eq!(message.channel, "plugin");
     assert_eq!(message.channel_alias.as_deref(), Some("main"));
+
+    assert!(
+        !listener.is_finished(),
+        "listen must retain ownership of its polling loop"
+    );
+    listener.abort();
+    let error = listener
+        .await
+        .expect_err("aborting listen must cancel its polling loop");
+    assert!(error.is_cancelled());
+}
+
+#[tokio::test]
+async fn channel_listener_stops_when_receiver_closes() {
+    let channel = channel("closed").await;
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let listener = zeroclaw_spawn::spawn!(async move { channel.listen(tx).await });
+
+    drop(rx);
+    tokio::time::timeout(Duration::from_secs(1), listener)
+        .await
+        .expect("listener observes receiver closure")
+        .expect("listener task joins")
+        .expect("listener exits cleanly");
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Keeps the plugin `poll-message` loop inside `Channel::listen` instead of spawning an unowned background task.
  - Lets the channel orchestrator own cancellation, restart, and listener completion.
  - Exits cleanly when the downstream receiver closes and preserves bounded retry backoff for plugin traps.
  - Tracks poll health without allowing a trapping listener to appear idle and healthy.
- **Scope boundary:** This PR does not alter routing identity, message semantics, plugin config, or daemon channel registration.
- **Blast radius:** Warm WASM channel listener lifecycle, health reporting, and orchestrator restart behavior.
- **Linked issue(s):** Depended on #9124, which is now merged. Related #8852.
- **Labels:** `risk:medium`, `size:S`. Rebased onto `master` after #9124 landed, so the diff is now the isolated delta: 4 files, +77/-53.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** Plugin-backed messaging channel.
- **Setup / preconditions:** Rust `wasm32-wasip2` target; the channel fixture is now on `master` via #9124.
- **Steps to run:** `cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift --test channel_plugin_e2e`
- **Expected on this branch (after):** Closing the receiver completes `listen`; a trapping poll marks the channel unhealthy and retry stays supervised.
- **Prior behavior on `master` (before):** `listen` detached the poller, so orchestrator completion could leave an unowned loop running.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI runs against the rebased head, which is this layer only. `check-plugin-backends` became a required gate job with #9124, so the Cranelift job executes the lifecycle fixture as a merge gate.
- **Known CI coverage gap, if any:** No daemon-level restart smoke; the unit and component tests cover the ownership boundary directly.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
passed

$ cargo clippy -p zeroclaw-plugins --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.75s

$ cargo check --locked -p zeroclaw-plugins --no-default-features --features plugins-wasm-cranelift
Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.50s

$ cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift
test result: ok. 90 passed; 0 failed   (lib)
test result: ok. 2 passed; 0 failed    (channel_plugin_e2e)
test result: ok. 6 passed; 0 failed    (reference_plugin)
test result: ok. 1 passed; 0 failed    (reference_plugin_e2e)
```

- **Beyond CI, what did you manually verify?** Read the complete listener control flow to confirm there is no second spawned task and every return drops the warm call future under orchestrator ownership.
- **If any command was intentionally skipped, why:** A daemon registration path is not present in this slice, so no daemon smoke is claimed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. Lifecycle ownership is tightened by removing an untracked task.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-squash-sha>`
- **Feature flags or config toggles:** Existing `plugins-wasm*` feature gates.
- **Observable failure symptoms:** Listener futures never complete after receiver closure, repeated poll-trap warnings without restart, or plugin channels remaining unhealthy after a successful poll.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another contribution.
