### PR TITLE
fix(ci): make comment hygiene gate language-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         run: cargo test --test architecture tests_that_persist_config_isolate_the_path
       - name: Fluent coverage guard (no bare user-facing strings)
         run: cargo test --test architecture user_facing_strings_route_through_fluent
-      - name: Comment hygiene gate (no issue refs / gravitas / truncation artifacts)
+      - name: Comment hygiene gate (no issue refs / review notes / truncation artifacts)
         run: |
           bash scripts/ci/comment_hygiene_gate.test.sh
           bash scripts/ci/comment_hygiene_gate.sh

--- a/scripts/ci/comment_hygiene_gate.py
+++ b/scripts/ci/comment_hygiene_gate.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+
+"""Extract source comments and enforce the repository comment-hygiene policy."""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional, Pattern
+
+
+FINDINGS_EXIT = 1
+FATAL_EXIT = 2
+
+
+@dataclass
+class Comment:
+    path: str
+    line: int
+    source: str
+    text: str
+    family: str
+    block_id: Optional[int] = None
+    continues: bool = False
+
+
+def add(
+    out: list[Comment],
+    path: str,
+    lines: list[str],
+    line: int,
+    text: str,
+    family: str,
+    block_id: Optional[int] = None,
+) -> None:
+    out.append(Comment(path, line, lines[line - 1].rstrip("\n"), text, family, block_id))
+
+
+def rust_comments(path: str, lines: list[str]) -> list[Comment]:
+    out: list[Comment] = []
+    block_depth = 0
+    block_id = 0
+    active_block: Optional[int] = None
+    raw_end: Optional[str] = None
+    in_string = False
+
+    for lineno, line in enumerate(lines, 1):
+        i = 0
+        while i < len(line):
+            if block_depth:
+                start = i
+                while i < len(line):
+                    if line.startswith("/*", i):
+                        block_depth += 1
+                        i += 2
+                    elif line.startswith("*/", i):
+                        block_depth -= 1
+                        i += 2
+                        if block_depth == 0:
+                            break
+                    else:
+                        i += 1
+                add(out, path, lines, lineno, line[start:i], "rust_block", active_block)
+                if block_depth == 0:
+                    active_block = None
+                continue
+
+            if raw_end is not None:
+                end = line.find(raw_end, i)
+                if end < 0:
+                    break
+                i = end + len(raw_end)
+                raw_end = None
+                continue
+
+            if in_string:
+                while i < len(line):
+                    if line[i] == "\\":
+                        i += 2
+                    elif line[i] == '"':
+                        i += 1
+                        in_string = False
+                        break
+                    else:
+                        i += 1
+                continue
+
+            raw = re.match(r'(?:br|rb|r)(?P<hashes>#{0,255})"', line[i:])
+            if raw:
+                raw_end = '"' + raw.group("hashes")
+                i += raw.end()
+                continue
+
+            if line.startswith('b"', i):
+                in_string = True
+                i += 2
+                continue
+            if line[i] == '"':
+                in_string = True
+                i += 1
+                continue
+            if line[i] == "'":
+                end = i + 1
+                escaped = False
+                while end < len(line) and end - i <= 12:
+                    if line[end] == "'" and not escaped:
+                        i = end + 1
+                        break
+                    escaped = line[end] == "\\" and not escaped
+                    if line[end] != "\\":
+                        escaped = False
+                    end += 1
+                else:
+                    i += 1
+                continue
+            if line.startswith("//", i):
+                add(out, path, lines, lineno, line[i:].rstrip("\n"), "rust_line")
+                break
+            if line.startswith("/*", i):
+                block_id += 1
+                active_block = block_id
+                block_depth = 1
+                start = i
+                i += 2
+                while i < len(line):
+                    if line.startswith("/*", i):
+                        block_depth += 1
+                        i += 2
+                    elif line.startswith("*/", i):
+                        block_depth -= 1
+                        i += 2
+                        if block_depth == 0:
+                            break
+                    else:
+                        i += 1
+                add(out, path, lines, lineno, line[start:i], "rust_block", active_block)
+                if block_depth == 0:
+                    active_block = None
+                continue
+            i += 1
+    return out
+
+
+def python_comments(path: str, raw: str, lines: list[str]) -> list[Comment]:
+    out: list[Comment] = []
+    for token in tokenize.generate_tokens(io.StringIO(raw).readline):
+        if token.type == tokenize.COMMENT:
+            add(out, path, lines, token.start[0], token.string, "hash_line")
+    return out
+
+
+def consume_toml_multiline(line: str, start: int, literal: bool) -> tuple[int, bool]:
+    i = start
+    while i < len(line):
+        if not literal and line[i] == "\\":
+            i += 2
+            continue
+        if line.startswith("'''" if literal else '\"\"\"', i):
+            quote = "'" if literal else '"'
+            run = 0
+            while i + run < len(line) and line[i + run] == quote:
+                run += 1
+            if run >= 3:
+                return i + run, True
+        i += 1
+    return i, False
+
+
+def toml_comments(path: str, lines: list[str]) -> list[Comment]:
+    out: list[Comment] = []
+    multiline: Optional[str] = None
+    for lineno, line in enumerate(lines, 1):
+        i = 0
+        while i < len(line):
+            if multiline is not None:
+                i, closed = consume_toml_multiline(line, i, multiline == "literal")
+                if not closed:
+                    break
+                multiline = None
+                continue
+            if line.startswith('\"\"\"', i):
+                i, closed = consume_toml_multiline(line, i + 3, False)
+                if not closed:
+                    multiline = "basic"
+                    break
+                continue
+            if line.startswith("'''", i):
+                i, closed = consume_toml_multiline(line, i + 3, True)
+                if not closed:
+                    multiline = "literal"
+                    break
+                continue
+            if line[i] == '"':
+                i += 1
+                while i < len(line):
+                    if line[i] == "\\":
+                        i += 2
+                    elif line[i] == '"':
+                        i += 1
+                        break
+                    else:
+                        i += 1
+                continue
+            if line[i] == "'":
+                end = line.find("'", i + 1)
+                i = len(line) if end < 0 else end + 1
+                continue
+            if line[i] == "#":
+                add(out, path, lines, lineno, line[i:].rstrip("\n"), "hash_line")
+                break
+            i += 1
+    return out
+
+
+@dataclass
+class Heredoc:
+    delimiter: str
+    strip_tabs: bool
+
+
+def parse_shell_heredoc(line: str, start: int) -> Optional[tuple[Heredoc, int]]:
+    if not line.startswith("<<", start) or line.startswith("<<<", start):
+        return None
+    if start > 0 and line[start - 1] == "<":
+        return None
+
+    i = start + 2
+    strip_tabs = i < len(line) and line[i] == "-"
+    if strip_tabs:
+        i += 1
+    while i < len(line) and line[i] in " \t":
+        i += 1
+
+    delimiter: list[str] = []
+    quote: Optional[str] = None
+    while i < len(line):
+        ch = line[i]
+        if quote == "single":
+            if ch == "'":
+                quote = None
+            else:
+                delimiter.append(ch)
+            i += 1
+            continue
+        if quote == "double":
+            if ch == '"':
+                quote = None
+                i += 1
+            elif ch == "\\" and i + 1 < len(line):
+                nxt = line[i + 1]
+                if nxt in '$`"\\\n':
+                    if nxt != "\n":
+                        delimiter.append(nxt)
+                else:
+                    delimiter.extend(("\\", nxt))
+                i += 2
+            else:
+                delimiter.append(ch)
+                i += 1
+            continue
+        if ch in " \t\r\n;|&()<>#":
+            break
+        if ch == "'":
+            quote = "single"
+            i += 1
+            continue
+        if ch == '"':
+            quote = "double"
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < len(line):
+            delimiter.append(line[i + 1])
+            i += 2
+            continue
+        delimiter.append(ch)
+        i += 1
+
+    if quote is not None or not delimiter:
+        return None
+    return Heredoc("".join(delimiter), strip_tabs), i
+
+
+def shell_comments(path: str, lines: list[str]) -> list[Comment]:
+    out: list[Comment] = []
+    heredocs: list[Heredoc] = []
+    quote: Optional[str] = None
+    substitutions: list[tuple[Optional[str], int]] = []
+    arithmetic_depth = 0
+
+    for lineno, line in enumerate(lines, 1):
+        if heredocs:
+            current = heredocs[0]
+            candidate = line.rstrip("\n")
+            if current.strip_tabs:
+                candidate = candidate.lstrip("\t")
+            if candidate == current.delimiter:
+                heredocs.pop(0)
+            continue
+
+        i = 0
+        while i < len(line):
+            ch = line[i]
+            if arithmetic_depth:
+                if ch == "(":
+                    arithmetic_depth += 1
+                elif ch == ")":
+                    arithmetic_depth -= 1
+                i += 1
+                continue
+            if quote == "single":
+                if ch == "'":
+                    quote = None
+                i += 1
+                continue
+            if quote == "double":
+                if ch == "\\":
+                    i += 2
+                    continue
+                if line.startswith("$((", i):
+                    arithmetic_depth = 2
+                    i += 3
+                    continue
+                if line.startswith("$(", i):
+                    substitutions.append((quote, 1))
+                    quote = None
+                    i += 2
+                    continue
+                if ch == '"':
+                    quote = None
+                i += 1
+                continue
+
+            if ch == "'":
+                quote = "single"
+                i += 1
+                continue
+            if ch == '"':
+                quote = "double"
+                i += 1
+                continue
+            if line.startswith("((", i):
+                arithmetic_depth = 2
+                i += 2
+                continue
+            if line.startswith("$((", i):
+                arithmetic_depth = 2
+                i += 3
+                continue
+            if line.startswith("$(", i):
+                substitutions.append((None, 1))
+                i += 2
+                continue
+            if substitutions and ch == "(":
+                prior, depth = substitutions[-1]
+                substitutions[-1] = (prior, depth + 1)
+                i += 1
+                continue
+            if substitutions and ch == ")":
+                prior, depth = substitutions[-1]
+                depth -= 1
+                if depth == 0:
+                    substitutions.pop()
+                    quote = prior
+                else:
+                    substitutions[-1] = (prior, depth)
+                i += 1
+                continue
+            if line.startswith("<<", i):
+                parsed = parse_shell_heredoc(line, i)
+                if parsed:
+                    heredoc, i = parsed
+                    heredocs.append(heredoc)
+                    continue
+            if ch == "#" and (
+                i == 0 or line[i - 1].isspace() or line[i - 1] in ";|&()"
+            ):
+                if not (lineno == 1 and i == 0 and line.startswith("#!")):
+                    add(out, path, lines, lineno, line[i:].rstrip("\n"), "hash_line")
+                break
+            i += 1
+    return out
+
+
+def nix_comments(path: str, lines: list[str]) -> list[Comment]:
+    out: list[Comment] = []
+    mode = "normal"
+    block_id = 0
+    active_block: Optional[int] = None
+    interpolation: list[tuple[str, int]] = []
+
+    for lineno, line in enumerate(lines, 1):
+        i = 0
+        while i < len(line):
+            if mode == "block":
+                end = line.find("*/", i)
+                if end < 0:
+                    add(out, path, lines, lineno, line[i:].rstrip("\n"), "nix_block", active_block)
+                    break
+                add(out, path, lines, lineno, line[i : end + 2], "nix_block", active_block)
+                i = end + 2
+                mode = "normal"
+                active_block = None
+                continue
+
+            if mode == "multi":
+                if line.startswith("''${", i):
+                    i += 4
+                    continue
+                if line.startswith("'''", i) or line.startswith("''\\", i):
+                    i += 3
+                    continue
+                if line.startswith("${", i):
+                    interpolation.append((mode, 1))
+                    mode = "normal"
+                    i += 2
+                    continue
+                if line.startswith("''", i):
+                    mode = "normal"
+                    i += 2
+                    continue
+                i += 1
+                continue
+
+            if mode == "double":
+                if line[i] == "\\":
+                    i += 2
+                    continue
+                if line.startswith("${", i):
+                    interpolation.append((mode, 1))
+                    mode = "normal"
+                    i += 2
+                    continue
+                if line[i] == '"':
+                    mode = "normal"
+                i += 1
+                continue
+
+            if interpolation and line[i] == "{":
+                return_mode, depth = interpolation[-1]
+                interpolation[-1] = (return_mode, depth + 1)
+                i += 1
+                continue
+            if interpolation and line[i] == "}":
+                return_mode, depth = interpolation[-1]
+                depth -= 1
+                if depth == 0:
+                    interpolation.pop()
+                    mode = return_mode
+                else:
+                    interpolation[-1] = (return_mode, depth)
+                i += 1
+                continue
+            if line.startswith("''", i):
+                mode = "multi"
+                i += 2
+                continue
+            if line[i] == '"':
+                mode = "double"
+                i += 1
+                continue
+            if line.startswith("/*", i):
+                block_id += 1
+                active_block = block_id
+                mode = "block"
+                start = i
+                end = line.find("*/", i + 2)
+                if end < 0:
+                    add(out, path, lines, lineno, line[start:].rstrip("\n"), "nix_block", active_block)
+                    break
+                add(out, path, lines, lineno, line[start : end + 2], "nix_block", active_block)
+                i = end + 2
+                mode = "normal"
+                active_block = None
+                continue
+            if line[i] == "#":
+                add(out, path, lines, lineno, line[i:].rstrip("\n"), "hash_line")
+                break
+            i += 1
+    return out
+
+
+def extract(path: str) -> list[Comment]:
+    with open(path, encoding="utf-8", errors="replace") as source:
+        raw = source.read()
+    lines = raw.splitlines(keepends=True)
+    if not lines:
+        return []
+    ext = Path(path).suffix
+    if ext == ".rs":
+        return rust_comments(path, lines)
+    if ext == ".py":
+        return python_comments(path, raw, lines)
+    if ext == ".toml":
+        return toml_comments(path, lines)
+    if ext == ".sh":
+        return shell_comments(path, lines)
+    if ext == ".nix":
+        return nix_comments(path, lines)
+    return []
+
+
+def mark_continuations(comments: list[Comment]) -> None:
+    by_path_line: dict[tuple[str, int], list[Comment]] = {}
+    for comment in comments:
+        by_path_line.setdefault((comment.path, comment.line), []).append(comment)
+    for comment in comments:
+        for nxt in by_path_line.get((comment.path, comment.line + 1), []):
+            same_block = comment.block_id is not None and (
+                comment.family == nxt.family and comment.block_id == nxt.block_id
+            )
+            same_line_family = comment.block_id is None and comment.family == nxt.family
+            if same_block or same_line_family:
+                comment.continues = True
+                break
+
+
+URL = re.compile(r"https?://\S+")
+COLOR_ASSIGNMENT = re.compile(
+    r"\b(color|background|foreground|fill|stroke)\s*[:=]\s*$", re.I
+)
+ISSUE_REF = re.compile(r"#(?P<number>[0-9]{3,})(?![A-Za-z0-9])")
+
+
+def contains_issue_ref(text: str) -> bool:
+    clean = URL.sub("", text)
+    for match in ISSUE_REF.finditer(clean):
+        digits = match.group("number")
+        context = clean[max(0, match.start() - 40) : match.start()]
+        if len(digits) in {3, 4, 6, 8} and COLOR_ASSIGNMENT.search(context):
+            continue
+        return True
+    return False
+
+
+@dataclass
+class Detector:
+    label: str
+    matcher: Callable[[str], bool]
+    dangling: bool = False
+
+
+def regex_match(pattern: Pattern[str]) -> Callable[[str], bool]:
+    return lambda text: pattern.search(text) is not None
+
+
+DETECTORS = [
+    Detector("issue/PR refs (#NNNN) in comments", contains_issue_ref),
+    Detector(
+        "tracking/see-issue phrasing in comments",
+        regex_match(re.compile(r"tracking #|see #|see issue|see PR |fixes #|closes #|resolves #", re.I)),
+    ),
+    Detector(
+        "review-process leakage in comments",
+        regex_match(
+            re.compile(
+                r"NEW in this PR|previous revision of this PR|that started this PR|audit blocker|review pass|Round [0-9]+:",
+                re.I,
+            )
+        ),
+    ),
+    Detector(
+        "dated notes in comments",
+        regex_match(re.compile(r"as of 20[0-9]{2}-[0-9]{2}|last verified:", re.I)),
+    ),
+    Detector(
+        "RFC/section refs stripped mid-token (RFC-glued artifacts)",
+        regex_match(re.compile(r"RFC(§|\s*\)|#?\s*$)")),
+    ),
+    Detector(
+        "glued-word artifacts (line-join residue from comment deletion)",
+        regex_match(re.compile(r"[a-z](?<!over)(?<!under)(?<!re)(without|exposes|therefore|because)\b")),
+    ),
+    Detector(
+        "dangling open-paren fragments in comments",
+        regex_match(re.compile(r"\((see|issue|ref|tracking|regression)\s*$", re.I)),
+        True,
+    ),
+    Detector(
+        "dangling trailing-reference words in comments",
+        regex_match(re.compile(r"(—|-|,)\s*(see|ref)\s*$", re.I)),
+        True,
+    ),
+    Detector(
+        "bare See/Ref/Tracking stub comments",
+        regex_match(re.compile(r"^(//+!?|#+)\s*(See|Ref|Tracking)\s*[.,;:]?\s*$")),
+    ),
+    Detector(
+        "double-space lowercase stub comments (likely mid-sentence truncation)",
+        regex_match(re.compile(r"^//[/!]?  (?!(?:since|itself)\b)[a-z]")),
+    ),
+]
+
+
+def read_paths(path: str) -> list[str]:
+    raw = Path(path).read_bytes()
+    return [entry.decode("utf-8", errors="surrogateescape") for entry in raw.split(b"\0") if entry]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("FATAL: expected a NUL-delimited input file list", file=sys.stderr)
+        return FATAL_EXIT
+
+    comments: list[Comment] = []
+    for path in read_paths(sys.argv[1]):
+        comments.extend(extract(path))
+    mark_continuations(comments)
+
+    failed = False
+    for detector in DETECTORS:
+        hits: list[str] = []
+        for comment in comments:
+            if detector.matcher(comment.text) and not (
+                detector.dangling and comment.continues
+            ):
+                if detector.dangling:
+                    hits.append(
+                        f"{comment.path}:{comment.line}: dangling fragment "
+                        "(next line is not a comment continuation)"
+                    )
+                else:
+                    hits.append(f"{comment.path}:{comment.line}:{comment.source}")
+        if hits:
+            failed = True
+            print(f"FAIL: {detector.label}")
+            print("\n".join(hits[:50]))
+            print()
+
+    if failed:
+        print("Comment hygiene gate failed. Fix the comment or, if a fixture")
+        print("legitimately needs the pattern, add the path to SKIP_PATHS in")
+        print("scripts/ci/comment_hygiene_gate.sh (reviewed via this script's diff).")
+        return FINDINGS_EXIT
+
+    print("Comment hygiene gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"FATAL: comment parser failed: {exc}", file=sys.stderr)
+        raise SystemExit(FATAL_EXIT)

--- a/scripts/ci/comment_hygiene_gate.sh
+++ b/scripts/ci/comment_hygiene_gate.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Comment hygiene gate: rejects issue/PR refs, review-process leakage,
-# gravitas phrases, dated notes, and sweep-truncation artifacts in
-# source comments. String literals are out of scope by design.
-# Optional args: paths to scan (defaults to the whole tree).
+# Comment hygiene gate for Rust, TOML, shell, Python, and Nix sources.
+# Rejects issue/PR refs, review-process leakage, dated notes, and mechanical
+# sweep artifacts in comments. It does not judge architectural vocabulary.
+# Optional args: paths to scan (defaults to the supported files in the repo).
 
 set -euo pipefail
 
@@ -15,181 +15,43 @@ if ! command -v rg >/dev/null 2>&1; then
     exit 2
 fi
 
-SCAN_ROOTS=("${@:-.}")
+scan_roots=("${@:-.}")
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Paths exempt from the gate. Keep this list short; additions are
-# reviewed via the diff on this script.
-SKIP_PATHS=(
+# Paths exempt from the gate. Keep this list short; additions are reviewed via
+# the diff on this script.
+skip_paths=(
     "scripts/check-pr-title.test.sh"
+    "scripts/ci/comment_hygiene_gate.py"
     "scripts/ci/comment_hygiene_gate.sh"
     "scripts/ci/comment_hygiene_gate.test.sh"
     ".cargo/audit.toml"
     "deny.toml"
 )
 
-GLOBS=(--hidden -g '*.rs' -g '*.toml' -g '*.sh' -g '*.py' -g '*.nix'
+globs=(--hidden -g '*.rs' -g '*.toml' -g '*.sh' -g '*.py' -g '*.nix'
     -g '!.git/' -g '!target/' -g '!web/' -g '!docs/book/' -g '!.claude/')
-for p in "${SKIP_PATHS[@]}"; do
-    GLOBS+=(-g "!${p}")
+for path in "${skip_paths[@]}"; do
+    globs+=(-g "!${path}")
 done
 
-fail=0
+file_list="$(mktemp)"
+trap 'rm -f "$file_list"' EXIT
 
-report() {
-    local label="$1"
-    local hits="$2"
-    if [ -n "$hits" ]; then
-        echo "FAIL: ${label}"
-        echo "$hits" | head -50
-        echo
-        fail=1
-    fi
-}
-
-# Re-match rg hits against only the comment portion of each line, with
-# string literals and URLs removed first. Args: <regex> <flags: i|-> <mode:
-# match|dangling>. Input: rg -n --no-heading output. Output: file:line:content
-# for true comment hits. "dangling" additionally requires that the next
-# source line is NOT a comment continuation.
-filter_comments() {
-    python3 -c "$PYFILTER" "$1" "$2" "$3"
-}
-
-read -r -d '' PYFILTER <<'PY' || true
-import re
-import sys
-
-pattern = re.compile(sys.argv[1], re.I if sys.argv[2] == "i" else 0)
-mode = sys.argv[3]
-dq = re.compile(r'"(?:[^"\\]|\\.)*"')
-sq = re.compile(r"'(?:[^'\\]|\\.)*'")
-url = re.compile(r'https?://\S+')
-HASH_EXTS = {"sh", "py", "nix", "toml"}
-
-def comment_of(path, lineno, content):
-    ext = path.rsplit(".", 1)[-1]
-    text = dq.sub('""', content)
-    if ext == "rs":
-        idx = text.find("//")
-        block = text.find("/*")
-        if block >= 0 and (idx < 0 or block < idx):
-            end = text.find("*/", block + 2)
-            return text[block : end + 2] if end >= 0 else text[block:]
-        return text[idx:] if idx >= 0 else None
-    if ext in HASH_EXTS:
-        text = sq.sub("''", text)
-        idx = text.find("#")
-        if idx < 0:
-            return None
-        if lineno == "1" and text.startswith("#!"):
-            return None
-        return text[idx:]
-    return None
-
-def next_is_comment(path, lineno):
-    try:
-        with open(path, encoding="utf-8", errors="replace") as f:
-            lines = f.readlines()
-    except OSError:
-        return False
-    i = int(lineno)
-    if i >= len(lines):
-        return False
-    nxt = lines[i].lstrip()
-    return nxt.startswith(("//", "#"))
-
-for raw in sys.stdin:
-    raw = raw.rstrip("\n")
-    parts = raw.split(":", 2)
-    if len(parts) != 3:
-        continue
-    path, lineno, content = parts
-    comment = comment_of(path, lineno, content)
-    if comment is None:
-        continue
-    if not pattern.search(url.sub("", comment)):
-        continue
-    if mode == "dangling":
-        if next_is_comment(path, lineno):
-            continue
-        print(f"{path}:{lineno}: dangling fragment (next line is not a comment continuation)")
-    else:
-        print(f"{path}:{lineno}:{content}")
-PY
-
-scan() {
-    local label="$1" rg_pattern="$2" py_pattern="$3" flags="$4" mode="${5:-match}"
-    local rg_flags=(-nH --no-heading)
-    if [ "$flags" = "i" ]; then
-        rg_flags+=(-i)
-    fi
-    local raw rg_status=0
-    raw="$(rg "${rg_flags[@]}" "${GLOBS[@]}" "$rg_pattern" "${SCAN_ROOTS[@]}")" || rg_status=$?
-    if [ "$rg_status" != "0" ] && [ "$rg_status" != "1" ]; then
-        echo "FATAL: ripgrep failed (exit ${rg_status}) scanning ${label}" >&2
-        exit 2
-    fi
-    local hits filter_status=0
-    hits="$(printf '%s' "$raw" | filter_comments "$py_pattern" "$flags" "$mode")" || filter_status=$?
-    if [ "$filter_status" != "0" ]; then
-        echo "FATAL: comment filter failed scanning ${label} (exit ${filter_status})" >&2
-        exit 2
-    fi
-    report "$label" "$hits"
-}
-
-echo "==> comment hygiene: issue/PR refs in comments"
-scan "issue/PR refs (#NNNN) in comments" \
-    '#[0-9]{3,}' '#[0-9]{3,}(?![0-9a-fA-F])(?<![0-9a-fA-F]{7})' - match
-
-echo "==> comment hygiene: tracking/see-issue phrasing"
-scan "tracking/see-issue phrasing in comments" \
-    '(tracking #|see #|see issue|see PR |fixes #|closes #|resolves #)' \
-    '(tracking #|see #|see issue|see PR |fixes #|closes #|resolves #)' i match
-
-echo "==> comment hygiene: gravitas phrases"
-scan "gravitas phrases in comments" \
-    '(sole source of truth|sibling PR|blast radius:|threat model:|rollback plan|canonical contract)' \
-    '(sole source of truth|sibling PR|blast radius:|threat model:|rollback plan|canonical contract)' i match
-
-echo "==> comment hygiene: review-process leakage"
-scan "review-process leakage in comments" \
-    '(NEW in this PR|previous revision of this PR|that started this PR|audit blocker|review pass|Round [0-9]+:)' \
-    '(NEW in this PR|previous revision of this PR|that started this PR|audit blocker|review pass|Round [0-9]+:)' - match
-
-echo "==> comment hygiene: dated notes"
-scan "dated notes in comments" \
-    '(as of 20[0-9]{2}-[0-9]{2}|last verified:)' \
-    '(as of 20[0-9]{2}-[0-9]{2}|last verified:)' i match
-
-echo "==> comment hygiene: ref-strip artifacts"
-scan "RFC/section refs stripped mid-token (RFC-glued artifacts)" \
-    'RFC(§|\s*\)|#?\s*$)' 'RFC(§|\s*\)|#?\s*$)' - match
-
-scan "glued-word artifacts (line-join residue from comment deletion)" \
-    '[a-z](without|exposes|therefore|because)\b' \
-    '[a-z](?<!over)(?<!under)(?<!re)(without|exposes|therefore|because)\b' - match
-
-echo "==> comment hygiene: truncation artifacts"
-scan "dangling open-paren fragments in comments" \
-    '\((see|issue|ref|tracking|regression)\s*$' \
-    '\((see|issue|ref|tracking|regression)\s*$' i dangling
-
-scan "dangling trailing-reference words in comments" \
-    '(—|-|,)\s*(see|ref)\s*$' '(—|-|,)\s*(see|ref)\s*$' i dangling
-
-scan "bare See/Ref/Tracking stub comments" \
-    '(//|#)\s*(See|Ref|Tracking)\s*[.,;:]?\s*$' \
-    '^(//+!?|#+)\s*(See|Ref|Tracking)\s*[.,;:]?\s*$' - match
-
-scan "double-space lowercase stub comments (likely mid-sentence truncation)" \
-    '^\s*//[/!]?  [a-z]' '^//[/!]?  (?!(?:since|itself)\b)[a-z]' - match
-
-if [ "$fail" -ne 0 ]; then
-    echo "Comment hygiene gate failed. Fix the comment or, if a fixture"
-    echo "legitimately needs the pattern, add the path to SKIP_PATHS in"
-    echo "scripts/ci/comment_hygiene_gate.sh (reviewed via this script's diff)."
-    exit 1
+if ! rg --files -0 "${globs[@]}" -- "${scan_roots[@]}" >"$file_list"; then
+    echo "FATAL: ripgrep failed while enumerating comment-hygiene inputs." >&2
+    exit 2
 fi
 
-echo "Comment hygiene gate passed."
+set +e
+python3 "${script_dir}/comment_hygiene_gate.py" "$file_list"
+status=$?
+set -e
+
+case "$status" in
+    0|1) exit "$status" ;;
+    *)
+        echo "FATAL: comment filter failed (exit ${status})." >&2
+        exit 2
+        ;;
+esac

--- a/scripts/ci/comment_hygiene_gate.test.sh
+++ b/scripts/ci/comment_hygiene_gate.test.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 gate="${script_dir}/comment_hygiene_gate.sh"
+scanner="${script_dir}/comment_hygiene_gate.py"
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
@@ -241,6 +242,26 @@ else
     echo "$scanner_out"
     fail_count=$((fail_count + 1))
 fi
+
+printf 'missing.rs\0' > scanner-inputs
+set +e
+parser_out="$(python3 "$scanner" scanner-inputs 2>&1)"
+parser_status=$?
+set -e
+if [ "$parser_status" -eq 0 ]; then
+    echo "PARSER FAILURE NOT PROPAGATED (scanner returned success on a missing source)"
+    fail_count=$((fail_count + 1))
+elif [ "$parser_status" -ne 2 ]; then
+    echo "PARSER FAILURE USED WRONG STATUS (wanted 2, got ${parser_status})"
+    fail_count=$((fail_count + 1))
+elif grep -qF 'FATAL' <<<"$parser_out"; then
+    pass_count=$((pass_count + 1))
+else
+    echo "PARSER FAILED WITHOUT FATAL DIAGNOSTIC"
+    echo "$parser_out"
+    fail_count=$((fail_count + 1))
+fi
+rm -f scanner-inputs
 
 echo
 echo "${pass_count} passed, ${fail_count} failed"

--- a/scripts/ci/comment_hygiene_gate.test.sh
+++ b/scripts/ci/comment_hygiene_gate.test.sh
@@ -18,9 +18,16 @@ fail_count=0
 
 expect_fail() {
     local name="$1" file="$2" label="$3"
-    local out
-    if out="$(bash "$gate" "$file" 2>&1)"; then
+    local out status
+    set +e
+    out="$(bash "$gate" "$file" 2>&1)"
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ]; then
         echo "NOT CAUGHT: ${name}"
+        fail_count=$((fail_count + 1))
+    elif [ "$status" -ne 1 ]; then
+        echo "WRONG STATUS: ${name} (wanted 1, got ${status})"
         fail_count=$((fail_count + 1))
     elif ! grep -qF "$label" <<<"$out"; then
         echo "WRONG DETECTOR: ${name} (wanted '${label}')"
@@ -59,11 +66,14 @@ expect_fail "shell comment tracking phrase" a.sh "tracking/see-issue"
 printf 'x = 1  # closes #4321\n' > a.py
 expect_fail "python trailing comment" a.py "tracking/see-issue"
 
-printf '// this module is the sole source of truth for widgets\n' > a.rs
-expect_fail "gravitas phrase" a.rs "gravitas"
-
 printf '// NEW in this PR (req.123):\n' > a.rs
 expect_fail "review-process leakage" a.rs "review-process"
+
+printf '// New in this PR: mixed-case process note\n' > a.rs
+expect_fail "mixed-case review-process leakage" a.rs "review-process"
+
+printf '// round 2: follow-up process note\n' > a.rs
+expect_fail "lowercase review round leakage" a.rs "review-process"
 
 printf '// as of 2026-05 this is fine\n' > a.rs
 expect_fail "dated note" a.rs "dated notes"
@@ -89,8 +99,47 @@ expect_fail "double-space lowercase stub" a.rs "double-space"
 printf '/* tracking #8519 in a block comment */\n' > a.rs
 expect_fail "rust block comment issue ref" a.rs "issue/PR refs"
 
+printf '/*\n * tracking #8519 in a multiline block comment\n */\n' > a.rs
+expect_fail "rust multiline block comment issue ref" a.rs "issue/PR refs"
+
 printf 'let s = "ok"; // workaround, see #4321 for context\n' > a.rs
 expect_fail "issue ref in comment beside a string literal" a.rs "tracking/see-issue"
+
+printf "printf '%s\\n' '<<EOF'\n# tracking #8519 must still be scanned\n" > a.sh
+expect_fail "quoted heredoc marker does not suppress later comments" a.sh "issue/PR refs"
+
+printf 'cat <<<"payload"\n# tracking #8519 after a here-string\n' > a.sh
+expect_fail "here-string does not start a heredoc" a.sh "issue/PR refs"
+
+printf 'value=$((1 << BITS))\n# tracking #8519 after an arithmetic shift\n' > a.sh
+expect_fail "arithmetic shift does not start a heredoc" a.sh "issue/PR refs"
+
+printf '((value = 1 << BITS))\n# tracking #8519 after an arithmetic command\n' > a.sh
+expect_fail "arithmetic command shift does not start a heredoc" a.sh "issue/PR refs"
+
+printf 'cat <<END-JSON\n# tracking #8519 is heredoc content\nEND-JSON\n# tracking #8519 after the heredoc\n' > a.sh
+expect_fail "hyphenated heredoc delimiter terminates exactly" a.sh "issue/PR refs"
+
+printf "cat <<-EOF\n\tpayload\n\tEOF\n# tracking #8519 after a tab-stripping heredoc\n" > a.sh
+expect_fail "tab-stripping heredoc terminates correctly" a.sh "issue/PR refs"
+
+printf 'let text = "first line\nsecond line"; // tracking #8519 after the close\n' > a.rs
+expect_fail "rust comment after multiline string close" a.rs "issue/PR refs"
+
+printf "value = ''\n  payload\n''; # tracking #8519 inside Nix interpolation\nin value\n" > a.nix
+expect_fail "nix interpolation comment is scanned" a.nix "issue/PR refs"
+
+printf "value = ''\n  \${let\n    # tracking #8519 is a real interpolation comment\n    x = 1;\n  in x}\n'';\n" > a.nix
+expect_fail "actual nix interpolation comment is scanned" a.nix "issue/PR refs"
+
+printf 'note = """value"""" # tracking #8519 after a four-quote close\n' > a.toml
+expect_fail "toml comment after multiline closing quote run" a.toml "issue/PR refs"
+
+printf '// regression #123456 remains relevant\n' > a.rs
+expect_fail "six-digit issue ref" a.rs "issue/PR refs"
+
+printf '// color parser regression #1234 remains relevant\n' > a.rs
+expect_fail "color-related prose does not hide an issue ref" a.rs "issue/PR refs"
 
 # ── legal shapes must pass ──────────────────────────────────────────────
 
@@ -100,8 +149,59 @@ expect_pass "issue ref inside rust string literal" b.rs
 printf '// boundary check\nlet m = format!("see #{n}");\n' > b.rs
 expect_pass "string literal beside an unrelated comment" b.rs
 
+printf '"""\n# tracking #8519 is example text, not a comment\n"""\n' > b.py
+expect_pass "python triple-quoted issue-like text" b.py
+
+printf 'note = """\n# tracking #8519 is multiline TOML text\n"""\n' > b.toml
+expect_pass "toml multiline-string issue-like text" b.toml
+
+printf "text = ''\n  # tracking #8519 is a Nix multiline string\n'';\n" > b.nix
+expect_pass "nix multiline-string issue-like text" b.nix
+
+printf "cat <<'EOF'\n# tracking #8519 is heredoc content\nEOF\n" > b.sh
+expect_pass "shell heredoc issue-like text" b.sh
+
+printf "cat <<EOF\n\tEOF\n# tracking #8519 remains heredoc content\nEOF\n" > b.sh
+expect_pass "ordinary heredoc does not strip terminator tabs" b.sh
+
+printf 'cat <<123\n# tracking #8519 is heredoc content\n123\n' > b.sh
+expect_pass "numeric heredoc delimiter" b.sh
+
+printf 'cat <<END/JSON\n# tracking #8519 is heredoc content\nEND/JSON\n' > b.sh
+expect_pass "punctuated heredoc delimiter" b.sh
+
+printf "cat <<E'OF'\n# tracking #8519 is heredoc content\nEOF\n" > b.sh
+expect_pass "compositionally quoted heredoc delimiter" b.sh
+
+printf 'cat <<E\\OF\n# tracking #8519 is heredoc content\nEOF\n' > b.sh
+expect_pass "escaped heredoc delimiter" b.sh
+
+printf 'cat <<"E\\OF"\n# tracking #8519 is heredoc content\nE\\OF\n' > b.sh
+expect_pass "double-quoted heredoc preserves ordinary backslash" b.sh
+
+printf "text='first line\n# tracking #8519 is multiline shell text\nlast line'\n" > b.sh
+expect_pass "shell multiline single-quoted text" b.sh
+
+printf 'text="first line\n# tracking #8519 is multiline shell text\nlast line"\n' > b.sh
+expect_pass "shell multiline double-quoted text" b.sh
+
+printf 'let text = "first line\n// tracking #8519 is multiline Rust text\nlast line";\n' > b.rs
+expect_pass "rust multiline string issue-like text" b.rs
+
+printf "text = ''\n  literal ''\${name}\n  # tracking #8519 is still Nix string text\n'';\n" > b.nix
+expect_pass "nix escaped interpolation stays in indented string" b.nix
+
+printf 'note = """\ntext \\""" is still multiline text\n# tracking #8519 is TOML string text\n"""\n' > b.toml
+expect_pass "toml escaped triple quote stays in multiline string" b.toml
+
 printf 'color = "#141413"  # hex color comment\n' > b.toml
 expect_pass "hex color in string with trailing comment" b.toml
+
+printf '# background: #141413\n' > b.toml
+expect_pass "numeric hex color in comment" b.toml
+
+printf '# color: #123\n# background: #1234\n# color: #123abc\n' > b.toml
+expect_pass "short numeric and alphanumeric color tokens in comment" b.toml
 
 printf '#!/usr/bin/env bash\necho ok\n' > b.sh
 expect_pass "shebang only" b.sh
@@ -118,8 +218,21 @@ expect_pass "intentional double-space continuation under paren" b.rs
 printf '/* legitimate block comment describing the shape */\n' > b.rs
 expect_pass "clean rust block comment" b.rs
 
-if scanner_out="$(bash "$gate" '/nonexistent/dir/xyz' 2>&1)"; then
+printf '// This module is the sole source of truth for widget ownership.\n// Threat model: untrusted peers cannot mutate it.\n// Rollback plan: restore the previous generated catalog.\n// This is the canonical contract for dispatch ordering.\n' > b.rs
+expect_pass "stable contract vocabulary" b.rs
+
+printf '// deleted the old path (see\n#[cfg(test)]\nfn f() {}\n' > a.rs
+expect_fail "rust attribute is not a comment continuation" a.rs "dangling open-paren"
+
+set +e
+scanner_out="$(bash "$gate" '/nonexistent/dir/xyz' 2>&1)"
+scanner_status=$?
+set -e
+if [ "$scanner_status" -eq 0 ]; then
     echo "SCANNER FAILURE NOT PROPAGATED (gate returned success on a bad path)"
+    fail_count=$((fail_count + 1))
+elif [ "$scanner_status" -ne 2 ]; then
+    echo "SCANNER FAILURE USED WRONG STATUS (wanted 2, got ${scanner_status})"
     fail_count=$((fail_count + 1))
 elif grep -qF 'FATAL' <<<"$scanner_out"; then
     pass_count=$((pass_count + 1))

--- a/scripts/release/bump-version.sh
+++ b/scripts/release/bump-version.sh
@@ -142,9 +142,8 @@ done
 
 # ── Docs book examples + matching i18n catalogs ────────────────────
 # Two surgical patterns, both anchored enough to skip release-runbook
-# history lines like "Last verified: May 2026 (v0.7.4 cycle)" or
-# "scheduled for deletion in v0.7.4 (#5915)" which intentionally pin
-# to the version they were written for:
+# release-runbook history lines that intentionally pin an original verification
+# month or scheduled-removal release instead of tracking the current version:
 #   - container image tags    `zeroclawlabs/zeroclaw:vX.Y.Z`
 #   - /health response example `"version":"X.Y.Z"` (compact or spaced JSON)
 #   - RPC initialize example   `"serverVersion":"X.Y.Z"` (compact or spaced JSON)


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace line-based comment heuristics with a standalone, language-aware Python scanner for Rust, TOML, shell, Python, and Nix; preserve fail-closed distinction between policy findings and scanner failures; expand fixtures for multiline strings, block comments, shell heredocs/arithmetic, Nix interpolation, TOML delimiters, numeric references, and source-read failure propagation; reword a self-triggering dated-note and issue-reference example in `bump-version.sh`.
- **Scope boundary:** No product runtime behavior or source formatting changes. This PR keeps rejecting actionable comment hygiene failures but intentionally removes the broad gravitas-phrase detector so stable architectural vocabulary is not rejected.
- **Blast radius:** The Comment hygiene gate CI step and contributors editing supported source files; input-enumeration and source-read failures fail closed with status 2.
- **Linked issue(s):** Related PR #8901
- **Labels:** `ci`, `scripts`, `type:ci`, `risk:high`, `size:L`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the fixture suite exercises both rejection and false-positive boundaries directly.

### How I tested

- **CI checks relied on and why they cover this change:** The Comment hygiene gate CI step runs both the fixture suite and the whole-tree scanner on the published head.
- **Known CI coverage gap, if any:** None; required CI passed on the corrective head, including Test and CI Required Gate.
- **Commands run and tail output:**
  - `bash scripts/ci/comment_hygiene_gate.test.sh` -> `58 passed, 0 failed`.
  - `bash scripts/ci/comment_hygiene_gate.sh` -> `Comment hygiene gate passed.`
  - `git diff --check` -> passed.
- **Beyond CI, what did you manually verify?** Independently reviewed fail-closed exits, shell/Nix/TOML/Rust lexical boundaries, numeric color handling, and the stale CI step label.
- **If any command was intentionally skipped, why:** No Cargo validation applies; this branch changes shell/Python CI tooling and comments only.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes for product/runtime surfaces**; contributor-facing CI behavior intentionally changes by using language-aware comment extraction and no longer rejecting stable architectural vocabulary.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**; no Rust toolchain setting changes, and the scanner uses only the Python standard library.
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Comment hygiene CI reports false positives, misses planted fixture violations, or exits fatally while enumerating/parsing supported files.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
