### PR TITLE
fix(channels): clear branch-isolated clippy warnings

### DIFF
--- a/crates/zeroclaw-channels/src/login_probe.rs
+++ b/crates/zeroclaw-channels/src/login_probe.rs
@@ -86,7 +86,12 @@ pub fn persisted_login(channel: QrPairingChannel, config: &Config, alias: &str) 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use super::{PersistedLogin, persisted_login};
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use crate::listing::QrPairingChannel;
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use zeroclaw_config::schema::Config;
 
     #[test]
     fn channels_without_a_probe_resolve_to_no_qr_pairing_key() {

--- a/crates/zeroclaw-channels/src/login_relink.rs
+++ b/crates/zeroclaw-channels/src/login_relink.rs
@@ -117,7 +117,12 @@ pub fn relink(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use super::{RelinkOutcome, relink};
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use crate::listing::QrPairingChannel;
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use zeroclaw_config::schema::Config;
 
     #[test]
     fn channels_without_a_relink_hook_resolve_to_no_qr_pairing_key() {

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -2305,17 +2305,14 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         let is_group = Self::is_group_message(message);
         if self.mention_only && is_group {
             let bot_username = self.bot_username.lock();
-            if let Some(ref bot_username) = *bot_username {
-                // If the user is replying directly to the bot's message, bypass
-                // the mention check — replies are an unambiguous signal of intent.
-                if !Self::contains_bot_mention(text, bot_username) {
-                    let bot_id = *self.bot_id.lock();
-                    if bot_id.is_none_or(|id| !Self::is_reply_to_bot(message, id)) {
-                        return None;
-                    }
+            let bot_username = bot_username.as_ref()?;
+            // If the user is replying directly to the bot's message, bypass
+            // the mention check — replies are an unambiguous signal of intent.
+            if !Self::contains_bot_mention(text, bot_username) {
+                let bot_id = *self.bot_id.lock();
+                if bot_id.is_none_or(|id| !Self::is_reply_to_bot(message, id)) {
+                    return None;
                 }
-            } else {
-                return None;
             }
         }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Replaces two cfg-sensitive wildcard imports in `zeroclaw-channels` login tests with narrow, feature-gated imports so the `channel-mattermost` lint build no longer sees unused imports.
  - Rewrites the Telegram group mention-only `bot_username` branch with `?`, preserving the existing early-return behavior while satisfying Clippy.
  - Keeps the cleanup scoped to warnings reproduced with `channel-mattermost` enabled.
- **Scope boundary:** This PR does not change Mattermost runtime behavior, Telegram mention matching semantics, QR-login probing, relink behavior, channel configuration, or user-facing output.
- **Blast radius:** Limited to `zeroclaw-channels` test imports under feature-gated login helper tests and the Telegram group mention-only guard. No config, persistence, network, or public API surface changes are intended.
- **Linked issue(s):** Related #6074
- **Labels:** `risk:medium`, `size:XS`, `type:refactor`, `domain:code-quality`, `channel`, `channel:telegram`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a warning cleanup with a behavior-preserving refactor. The useful reviewer check is the focused Clippy command below plus the repository CI checks.

### How I tested

- **CI checks relied on and why they cover this change:** `Lint`, `Check (all features)`, and `CI Required Gate` passed on this head. The focused local Clippy command below covers the original `channel-mattermost` no-deps warning surface.
- **Known CI coverage gap, if any:** The isolated `channel-wechat` feature path was not compiled separately in local validation or the cited CI feature set.
- **Commands run and tail output:**

```sh
cargo clippy -p zeroclaw-channels --all-targets --features channel-mattermost --no-deps -- -D warnings
# PASS: zeroclaw-channels completed cleanly under -D warnings.

git diff --check
# PASS: no whitespace errors.
```

- **Beyond CI, what did you manually verify?** Reviewed the diff to confirm the login helper imports are gated to the WeChat/WhatsApp feature combinations and the Telegram branch still returns `None` when `bot_username` is unavailable.
- **If any command was intentionally skipped, why:** No broader local workspace gate was run because the diff is a small warning cleanup and the focused Clippy command covers the reported failure surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merge commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** The focused `zeroclaw-channels` Clippy command above reports the same warning class again, or feature-gated channel login tests fail to compile because a test import is missing.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
