### PR TITLE
feat(channel/mattermost): add WebSocket listener mode

### DIFF
--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -1151,8 +1151,6 @@ impl MattermostChannel {
     }
 }
 
-// listen_polling and listen_websocket helpers moved out of the Channel
-// trait impl so they can be tested and reviewed in isolation.
 impl MattermostChannel {
     #[allow(clippy::too_many_arguments)]
     async fn process_inbound_post(
@@ -3325,6 +3323,84 @@ mod tests {
         )
         .await
         .expect_err("a silent server must fail the handshake deadline");
+
+        assert!(error.to_string().contains("handshake timed out"));
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_ws_handshake_times_out_without_hello() {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let (mut write, mut read) = client.split();
+
+        let server_task = zeroclaw_spawn::spawn!(async move {
+            server
+                .next()
+                .await
+                .expect("auth frame should arrive")
+                .unwrap();
+            server
+                .send(WsMessage::Text(
+                    json!({"status": "OK", "seq_reply": 5}).to_string().into(),
+                ))
+                .await
+                .expect("server should send auth response");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+
+        let error = MattermostChannel::authenticate_websocket(
+            &mut write,
+            &mut read,
+            "test-token",
+            5,
+            Duration::from_millis(10),
+        )
+        .await
+        .expect_err("auth without hello must fail the handshake deadline");
+
+        assert!(error.to_string().contains("handshake timed out"));
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_ws_handshake_times_out_without_auth_response() {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let (mut write, mut read) = client.split();
+
+        let server_task = zeroclaw_spawn::spawn!(async move {
+            server
+                .next()
+                .await
+                .expect("auth frame should arrive")
+                .unwrap();
+            server
+                .send(WsMessage::Text(
+                    json!({"event": "hello", "data": {"server_version": "10.8.0"}})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .expect("server should send hello");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+
+        let error = MattermostChannel::authenticate_websocket(
+            &mut write,
+            &mut read,
+            "test-token",
+            6,
+            Duration::from_millis(10),
+        )
+        .await
+        .expect_err("hello without auth response must fail the handshake deadline");
 
         assert!(error.to_string().contains("handshake timed out"));
         server_task.abort();

--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -1,11 +1,16 @@
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt, stream::SplitSink, stream::SplitStream};
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::OnceCell;
+use tokio::{io::AsyncRead, io::AsyncWrite};
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+pub(crate) use zeroclaw_config::schema::MattermostListenMode;
 
 const MAX_MATTERMOST_AUDIO_BYTES: u64 = 25 * 1024 * 1024;
 /// Cadence at which auto-discovery re-runs to pick up newly-created DMs
@@ -14,6 +19,16 @@ const DISCOVERY_REFRESH: Duration = Duration::from_secs(60);
 /// Poll interval per discovery iteration. Matches the previous single-channel
 /// cadence so operators see no change in latency.
 const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Application-level ping interval for the Mattermost WebSocket protocol.
+const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
+/// Deadline for authentication and the server's `hello` event.
+const WS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Read timeout for the active WebSocket session. If no frame arrives
+/// within this window the peer is considered unresponsive and the
+/// listener exits into the reconnect path. Set to 3× ping interval so
+/// the server can miss two pings before we declare it dead.
+const WS_READ_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// One channel the bot will poll. `is_direct` flags DM (`type=D`) and group DM
 /// (`type=G`) channels so the receive path can bypass `mention_only` for them.
@@ -104,6 +119,8 @@ pub struct MattermostChannel {
     proxy_url: Option<String>,
     transcription: Option<zeroclaw_config::schema::TranscriptionConfig>,
     transcription_manager: Option<Arc<super::transcription::TranscriptionManager>>,
+    /// How this channel receives inbound messages. Defaults to `Polling`.
+    listen_mode: MattermostListenMode,
 }
 
 impl MattermostChannel {
@@ -138,6 +155,7 @@ impl MattermostChannel {
             proxy_url: None,
             transcription: None,
             transcription_manager: None,
+            listen_mode: MattermostListenMode::default(),
         }
     }
 
@@ -359,6 +377,12 @@ impl MattermostChannel {
         self
     }
 
+    /// Set the listen mode. Defaults to `Polling` when not called.
+    pub fn with_listen_mode(mut self, listen_mode: MattermostListenMode) -> Self {
+        self.listen_mode = listen_mode;
+        self
+    }
+
     fn http_client(&self) -> reqwest::Client {
         zeroclaw_config::schema::build_channel_proxy_client_with_timeouts(
             "channel.mattermost",
@@ -366,6 +390,106 @@ impl MattermostChannel {
             30,
             10,
         )
+    }
+
+    /// Derive the WebSocket URL from the REST base URL.
+    fn ws_url(&self) -> String {
+        self.base_url
+            .replacen("https://", "wss://", 1)
+            .replacen("http://", "ws://", 1)
+            + "/api/v4/websocket"
+    }
+
+    fn ws_auth_response(event: &serde_json::Value, auth_seq: i64) -> Option<bool> {
+        (event.get("seq_reply").and_then(|v| v.as_i64()) == Some(auth_seq))
+            .then(|| event.get("status").and_then(|v| v.as_str()) == Some("OK"))
+    }
+
+    fn ws_post_from_event(event: &serde_json::Value) -> Option<serde_json::Value> {
+        let post = event.get("data")?.get("post")?.as_str()?;
+        serde_json::from_str(post).ok()
+    }
+
+    async fn authenticate_websocket<S>(
+        write: &mut SplitSink<WebSocketStream<S>, WsMessage>,
+        read: &mut SplitStream<WebSocketStream<S>>,
+        token: &str,
+        auth_seq: i64,
+        timeout: Duration,
+    ) -> Result<String>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let auth = serde_json::json!({
+            "seq": auth_seq,
+            "action": "authentication_challenge",
+            "data": { "token": token }
+        });
+        write
+            .send(WsMessage::Text(auth.to_string().into()))
+            .await
+            .context("Mattermost WebSocket authentication send failed")?;
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut authenticated = false;
+        let mut server_version = None;
+
+        loop {
+            if authenticated && server_version.is_some() {
+                return Ok(server_version.unwrap_or_else(|| "unknown".to_string()));
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep_until(deadline) => {
+                    bail!("Mattermost WebSocket authentication handshake timed out");
+                }
+                frame = read.next() => {
+                    let text = match frame {
+                        Some(Ok(WsMessage::Text(text))) => text,
+                        Some(Ok(WsMessage::Ping(payload))) => {
+                            write
+                                .send(WsMessage::Pong(payload))
+                                .await
+                                .context("Mattermost WebSocket handshake pong failed")?;
+                            continue;
+                        }
+                        Some(Ok(WsMessage::Close(frame))) => {
+                            let reason = frame
+                                .as_ref()
+                                .map(|frame| frame.reason.as_ref())
+                                .unwrap_or("");
+                            bail!("Mattermost WebSocket closed during authentication: {reason}");
+                        }
+                        Some(Err(error)) => {
+                            return Err(error).context("Mattermost WebSocket handshake read failed");
+                        }
+                        None => bail!("Mattermost WebSocket ended during authentication"),
+                        Some(Ok(_)) => continue,
+                    };
+
+                    let event: serde_json::Value = serde_json::from_str(text.as_ref())
+                        .context("Mattermost WebSocket handshake returned invalid JSON")?;
+
+                    if let Some(ok) = Self::ws_auth_response(&event, auth_seq) {
+                        if !ok {
+                            bail!("Mattermost WebSocket authentication was rejected");
+                        }
+                        authenticated = true;
+                    }
+
+                    if event.get("event").and_then(|value| value.as_str()) == Some("hello") {
+                        server_version = Some(
+                            event
+                                .get("data")
+                                .and_then(|data| data.get("server_version"))
+                                .and_then(|value| value.as_str())
+                                .unwrap_or("unknown")
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// Check if a user ID is in the allowlist.
@@ -632,97 +756,9 @@ impl Channel for MattermostChannel {
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
-        // Resolve auth up front so misconfiguration fails fast at listen-time.
-        let initial_token = self.token().await?.to_string();
-        let (bot_user_id, bot_username) = self.get_bot_identity().await;
-
-        let auto_discover = self.scoped_channel_ids().is_none();
-        let mut target_channels = self.list_target_channels().await?;
-        let mut last_discovery = Instant::now();
-        let mut last_create_at_by_channel: HashMap<String, i64> = HashMap::new();
-
-        ::zeroclaw_log::record!(
-            INFO,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
-                ::serde_json::json!({
-                    "alias": self.alias,
-                    "channel_count": target_channels.len(),
-                    "auto_discover": auto_discover,
-                    "team_ids": self.team_ids,
-                    "discover_dms": self.discover_dms,
-                })
-            ),
-            "Mattermost channel listening"
-        );
-
-        loop {
-            tokio::time::sleep(POLL_INTERVAL).await;
-
-            if auto_discover && last_discovery.elapsed() >= DISCOVERY_REFRESH {
-                match self.list_target_channels().await {
-                    Ok(refreshed) => {
-                        if refreshed != target_channels {
-                            ::zeroclaw_log::record!(
-                                INFO,
-                                ::zeroclaw_log::Event::new(
-                                    module_path!(),
-                                    ::zeroclaw_log::Action::Note,
-                                )
-                                .with_attrs(::serde_json::json!({
-                                    "alias": self.alias,
-                                    "before": target_channels.len(),
-                                    "after": refreshed.len(),
-                                })),
-                                "Mattermost auto-discovery refreshed channel list"
-                            );
-                            target_channels = refreshed;
-                        }
-                    }
-                    Err(e) => {
-                        ::zeroclaw_log::record!(
-                            WARN,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note,
-                            )
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({
-                                "alias": self.alias,
-                                "error": format!("{}", e),
-                            })),
-                            "Mattermost auto-discovery refresh failed; keeping previous channel list"
-                        );
-                    }
-                }
-                last_discovery = Instant::now();
-            }
-
-            if target_channels.is_empty() {
-                continue;
-            }
-
-            #[allow(clippy::cast_possible_truncation)]
-            let bootstrap_ms = (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis()) as i64;
-
-            for target in target_channels.clone() {
-                if self
-                    .poll_channel(
-                        &target,
-                        &initial_token,
-                        &bot_user_id,
-                        &bot_username,
-                        bootstrap_ms,
-                        &mut last_create_at_by_channel,
-                        &tx,
-                    )
-                    .await
-                {
-                    return Ok(());
-                }
-            }
+        match self.listen_mode {
+            MattermostListenMode::Polling => self.listen_polling(tx).await,
+            MattermostListenMode::Websocket => self.listen_websocket(tx).await,
         }
     }
 
@@ -800,6 +836,363 @@ impl Channel for MattermostChannel {
 }
 
 impl MattermostChannel {
+    async fn listen_polling(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Resolve auth up front so misconfiguration fails fast at listen-time.
+        let initial_token = self.token().await?.to_string();
+        let (bot_user_id, bot_username) = self.get_bot_identity().await;
+
+        let auto_discover = self.scoped_channel_ids().is_none();
+        let mut target_channels = self.list_target_channels().await?;
+        let mut last_discovery = Instant::now();
+        let mut last_create_at_by_channel: HashMap<String, i64> = HashMap::new();
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "alias": self.alias,
+                    "channel_count": target_channels.len(),
+                    "auto_discover": auto_discover,
+                    "team_ids": self.team_ids,
+                    "discover_dms": self.discover_dms,
+                })
+            ),
+            "Mattermost channel listening (polling)"
+        );
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+
+            if auto_discover && last_discovery.elapsed() >= DISCOVERY_REFRESH {
+                match self.list_target_channels().await {
+                    Ok(refreshed) => {
+                        if refreshed != target_channels {
+                            ::zeroclaw_log::record!(
+                                INFO,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note,
+                                )
+                                .with_attrs(::serde_json::json!({
+                                    "alias": self.alias,
+                                    "before": target_channels.len(),
+                                    "after": refreshed.len(),
+                                })),
+                                "Mattermost auto-discovery refreshed channel list"
+                            );
+                            target_channels = refreshed;
+                        }
+                    }
+                    Err(e) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note,
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "alias": self.alias,
+                                "error": format!("{}", e),
+                            })),
+                            "Mattermost auto-discovery refresh failed; keeping previous channel list"
+                        );
+                    }
+                }
+                last_discovery = Instant::now();
+            }
+
+            if target_channels.is_empty() {
+                continue;
+            }
+
+            #[allow(clippy::cast_possible_truncation)]
+            let bootstrap_ms = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()) as i64;
+
+            for target in target_channels.clone() {
+                if self
+                    .poll_channel(
+                        &target,
+                        &initial_token,
+                        &bot_user_id,
+                        &bot_username,
+                        bootstrap_ms,
+                        &mut last_create_at_by_channel,
+                        &tx,
+                    )
+                    .await
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    async fn listen_websocket(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        let token = self.token().await?.to_string();
+        let (bot_user_id, bot_username) = self.get_bot_identity().await;
+        let auto_discover = self.scoped_channel_ids().is_none();
+        let target_channels = self.list_target_channels().await?;
+        let mut channel_direct_map: HashMap<String, bool> = target_channels
+            .into_iter()
+            .map(|target| (target.id, target.is_direct))
+            .collect();
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "alias": self.alias,
+                    "channel_count": channel_direct_map.len(),
+                    "auto_discover": auto_discover,
+                    "mode": "websocket",
+                })
+            ),
+            "Mattermost WebSocket listening"
+        );
+
+        let ws_url = self.ws_url();
+        let (ws_stream, _) = zeroclaw_config::schema::ws_connect_with_proxy(
+            &ws_url,
+            "channel.mattermost",
+            self.proxy_url.as_deref(),
+        )
+        .await
+        .with_context(|| format!("Mattermost WebSocket connect failed: {ws_url}"))?;
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "alias": self.alias,
+                    "ws_url": &ws_url,
+                })
+            ),
+            "Mattermost WebSocket connected"
+        );
+
+        let (mut write, mut read) = ws_stream.split();
+        let auth_seq = 1;
+        let server_version = Self::authenticate_websocket(
+            &mut write,
+            &mut read,
+            &token,
+            auth_seq,
+            WS_HANDSHAKE_TIMEOUT,
+        )
+        .await?;
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "alias": self.alias,
+                    "server_version": server_version,
+                })
+            ),
+            "Mattermost WebSocket authenticated"
+        );
+
+        let mut seq = auth_seq.wrapping_add(1);
+        let mut ping_interval = tokio::time::interval(WS_PING_INTERVAL);
+        ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        ping_interval.reset();
+
+        let mut discovery_interval = tokio::time::interval(DISCOVERY_REFRESH);
+        discovery_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        discovery_interval.reset();
+
+        let mut last_frame = tokio::time::Instant::now();
+
+        loop {
+            let read_deadline = last_frame + WS_READ_TIMEOUT;
+            tokio::select! {
+                _ = discovery_interval.tick(), if auto_discover => {
+                    match self.list_target_channels().await {
+                        Ok(refreshed) => {
+                            let refreshed_map: HashMap<String, bool> = refreshed
+                                .into_iter()
+                                .map(|target| (target.id, target.is_direct))
+                                .collect();
+                            if refreshed_map != channel_direct_map {
+                                ::zeroclaw_log::record!(
+                                    INFO,
+                                    ::zeroclaw_log::Event::new(
+                                        module_path!(),
+                                        ::zeroclaw_log::Action::Note,
+                                    )
+                                    .with_attrs(::serde_json::json!({
+                                        "alias": self.alias,
+                                        "before": channel_direct_map.len(),
+                                        "after": refreshed_map.len(),
+                                    })),
+                                    "Mattermost WS in-session auto-discovery refreshed"
+                                );
+                                channel_direct_map = refreshed_map;
+                            }
+                        }
+                        Err(error) => {
+                            ::zeroclaw_log::record!(
+                                WARN,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note,
+                                )
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(::serde_json::json!({
+                                    "alias": self.alias,
+                                    "error": error.to_string(),
+                                })),
+                                "Mattermost WS in-session discovery refresh failed"
+                            );
+                        }
+                    }
+                }
+                _ = ping_interval.tick() => {
+                    let ping = serde_json::json!({"seq": seq, "action": "ping"});
+                    write
+                        .send(WsMessage::Text(ping.to_string().into()))
+                        .await
+                        .context("Mattermost WebSocket ping send failed")?;
+                    seq = seq.wrapping_add(1);
+                }
+                frame = read.next() => {
+                    let frame = match frame {
+                        Some(Ok(frame)) => {
+                            last_frame = tokio::time::Instant::now();
+                            frame
+                        }
+                        Some(Err(error)) => {
+                            return Err(error).context("Mattermost WebSocket read failed");
+                        }
+                        None => bail!("Mattermost WebSocket stream ended"),
+                    };
+
+                    let text = match frame {
+                        WsMessage::Text(text) => text,
+                        WsMessage::Ping(payload) => {
+                            write
+                                .send(WsMessage::Pong(payload))
+                                .await
+                                .context("Mattermost WebSocket pong send failed")?;
+                            continue;
+                        }
+                        WsMessage::Close(frame) => {
+                            let reason = frame
+                                .as_ref()
+                                .map(|frame| frame.reason.as_ref())
+                                .unwrap_or("");
+                            bail!("Mattermost WebSocket closed: {reason}");
+                        }
+                        _ => continue,
+                    };
+
+                    let event: serde_json::Value = match serde_json::from_str(text.as_ref()) {
+                        Ok(event) => event,
+                        Err(error) => {
+                            ::zeroclaw_log::record!(
+                                WARN,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note,
+                                )
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(::serde_json::json!({
+                                    "alias": self.alias,
+                                    "error": error.to_string(),
+                                })),
+                                "Mattermost WS event parse failed"
+                            );
+                            continue;
+                        }
+                    };
+
+                    if event.get("event").and_then(|value| value.as_str()) != Some("posted") {
+                        continue;
+                    }
+
+                    let Some(post) = Self::ws_post_from_event(&event) else {
+                        continue;
+                    };
+                    let channel_id = post
+                        .get("channel_id")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("");
+                    let Some(&is_direct) = channel_direct_map.get(channel_id) else {
+                        continue;
+                    };
+
+                    if self
+                        .process_inbound_post(
+                            &post,
+                            &bot_user_id,
+                            &bot_username,
+                            0,
+                            channel_id,
+                            is_direct,
+                            &tx,
+                        )
+                        .await
+                    {
+                        return Ok(());
+                    }
+                }
+                _ = tokio::time::sleep_until(read_deadline) => {
+                    bail!(
+                        "Mattermost WebSocket idle for {} seconds",
+                        WS_READ_TIMEOUT.as_secs()
+                    );
+                }
+            }
+        }
+    }
+}
+
+// listen_polling and listen_websocket helpers moved out of the Channel
+// trait impl so they can be tested and reviewed in isolation.
+impl MattermostChannel {
+    #[allow(clippy::too_many_arguments)]
+    async fn process_inbound_post(
+        &self,
+        post: &serde_json::Value,
+        bot_user_id: &str,
+        bot_username: &str,
+        last_create_at: i64,
+        channel_id: &str,
+        is_direct: bool,
+        tx: &tokio::sync::mpsc::Sender<ChannelMessage>,
+    ) -> bool {
+        let effective_text = if post
+            .get("message")
+            .and_then(|message| message.as_str())
+            .unwrap_or("")
+            .trim()
+            .is_empty()
+            && post_has_audio_attachment(post)
+        {
+            self.try_transcribe_audio_attachment(post).await
+        } else {
+            None
+        };
+
+        let Some(message) = self.parse_mattermost_post(
+            post,
+            bot_user_id,
+            bot_username,
+            last_create_at,
+            channel_id,
+            effective_text.as_deref(),
+            is_direct,
+        ) else {
+            return false;
+        };
+
+        tx.send(message).await.is_err()
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn poll_channel(
         &self,
@@ -875,28 +1268,17 @@ impl MattermostChannel {
                 .unwrap_or(new_cursor);
             new_cursor = new_cursor.max(create_at);
 
-            let effective_text = if post
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or("")
-                .trim()
-                .is_empty()
-                && post_has_audio_attachment(post)
-            {
-                self.try_transcribe_audio_attachment(post).await
-            } else {
-                None
-            };
-
-            if let Some(channel_msg) = self.parse_mattermost_post(
-                post,
-                bot_user_id,
-                bot_username,
-                cursor_before_batch,
-                &target.id,
-                effective_text.as_deref(),
-                target.is_direct,
-            ) && tx.send(channel_msg).await.is_err()
+            if self
+                .process_inbound_post(
+                    post,
+                    bot_user_id,
+                    bot_username,
+                    cursor_before_batch,
+                    &target.id,
+                    target.is_direct,
+                    tx,
+                )
+                .await
             {
                 return true;
             }
@@ -2608,6 +2990,373 @@ mod tests {
             assert_eq!(by_id.get("explicit_dm"), Some(&true));
             assert_eq!(by_id.get("explicit_pub"), Some(&false));
             assert_eq!(targets.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_ws_url_conversion() {
+        let ch = MattermostChannel::new(
+            "https://mm.example.com".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(Vec::new),
+            false,
+            false,
+        );
+        assert_eq!(ch.ws_url(), "wss://mm.example.com/api/v4/websocket");
+
+        let ch2 = MattermostChannel::new(
+            "http://localhost:8065".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(Vec::new),
+            false,
+            false,
+        );
+        assert_eq!(ch2.ws_url(), "ws://localhost:8065/api/v4/websocket");
+
+        // server URL with path prefix should preserve it
+        let ch3 = MattermostChannel::new(
+            "https://mm.example.com/subpath".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(Vec::new),
+            false,
+            false,
+        );
+        assert_eq!(
+            ch3.ws_url(),
+            "wss://mm.example.com/subpath/api/v4/websocket"
+        );
+    }
+
+    #[test]
+    fn test_listen_mode_default_is_polling() {
+        assert_eq!(
+            MattermostListenMode::default(),
+            MattermostListenMode::Polling
+        );
+    }
+
+    #[test]
+    fn test_listen_mode_serde() {
+        // serialize
+        assert_eq!(
+            serde_json::to_string(&MattermostListenMode::Polling).unwrap(),
+            "\"polling\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MattermostListenMode::Websocket).unwrap(),
+            "\"websocket\""
+        );
+
+        // deserialize
+        let polling: MattermostListenMode = serde_json::from_str("\"polling\"").unwrap();
+        assert_eq!(polling, MattermostListenMode::Polling);
+
+        let websocket: MattermostListenMode = serde_json::from_str("\"websocket\"").unwrap();
+        assert_eq!(websocket, MattermostListenMode::Websocket);
+
+        // deserialize unknown variant -> error
+        assert!(serde_json::from_str::<MattermostListenMode>("\"unknown\"").is_err());
+    }
+
+    #[test]
+    fn test_ws_event_posted_parsing() {
+        let post = json!({
+            "id": "post123",
+            "user_id": "user456",
+            "message": "hello world",
+            "create_at": 1717000000000i64,
+            "root_id": "",
+            "channel_id": "chan789",
+            "type": ""
+        });
+
+        let ch = MattermostChannel::new(
+            "https://mm.example.com".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(|| vec!["user456".into()]),
+            false,
+            false,
+        );
+
+        let msg = ch
+            .parse_mattermost_post(&post, "bot_user", "bot_username", 0, "chan789", None, false)
+            .expect("should parse posted event post");
+
+        assert_eq!(msg.id, "mattermost_post123");
+        assert_eq!(msg.sender, "user456");
+        assert_eq!(msg.content, "hello world");
+    }
+
+    #[test]
+    fn test_ws_posted_envelope_post_is_json_string() {
+        // Mattermost sends data.post as a JSON-encoded string, not a nested
+        // object. This test exercises the extraction path the WebSocket listener
+        // uses: Value::String → as_str() → from_str. The old to_string() path
+        // would re-serialize as a quoted literal and silently drop the event.
+        let post_obj = json!({
+            "id": "post789",
+            "user_id": "user999",
+            "message": "ws message",
+            "create_at": 1717000000000i64,
+            "root_id": "",
+            "channel_id": "chan111",
+            "type": ""
+        });
+        let post_str = serde_json::to_string(&post_obj).unwrap();
+
+        let envelope = json!({
+            "event": "posted",
+            "data": {
+                "post": post_str
+            }
+        });
+
+        let post = MattermostChannel::ws_post_from_event(&envelope)
+            .expect("should parse the inner JSON string");
+
+        let ch = MattermostChannel::new(
+            "https://mm.example.com".into(),
+            Some("token".into()),
+            None,
+            None,
+            vec![],
+            "test",
+            Arc::new(|| vec!["user999".into()]),
+            false,
+            false,
+        );
+
+        let msg = ch
+            .parse_mattermost_post(&post, "bot_user", "bot_username", 0, "chan111", None, false)
+            .expect("should parse posted event post from envelope");
+
+        assert_eq!(msg.id, "mattermost_post789");
+        assert_eq!(msg.sender, "user999");
+        assert_eq!(msg.content, "ws message");
+    }
+
+    #[test]
+    fn test_ws_ping_message_format() {
+        // Verify the application-level ping frame the heartbeat pinger sends.
+        let seq = 1i64;
+        let ping = serde_json::json!({"seq": seq, "action": "ping"});
+        assert_eq!(ping["seq"], serde_json::json!(1i64));
+        assert_eq!(ping["action"], serde_json::json!("ping"));
+
+        // Round-trip: the message is a Text frame whose content is the JSON
+        // string. The Mattermost server expects this exact shape.
+        let text = ping.to_string();
+        let roundtripped: serde_json::Value =
+            serde_json::from_str(&text).expect("ping json must round-trip");
+        assert_eq!(roundtripped["action"], serde_json::json!("ping"));
+        assert!(roundtripped["seq"].is_i64());
+    }
+
+    #[test]
+    fn test_ws_auth_challenge_format() {
+        // Verify the authentication_challenge frame sent immediately after connect.
+        let token = "test_bot_token";
+        let seq = 1i64;
+        let auth = serde_json::json!({
+            "seq": seq,
+            "action": "authentication_challenge",
+            "data": { "token": token }
+        });
+        assert_eq!(auth["seq"], serde_json::json!(1i64));
+        assert_eq!(
+            auth["action"],
+            serde_json::json!("authentication_challenge")
+        );
+        assert_eq!(auth["data"]["token"], serde_json::json!("test_bot_token"));
+
+        let text = auth.to_string();
+        let roundtripped: serde_json::Value =
+            serde_json::from_str(&text).expect("auth json must round-trip");
+        assert_eq!(
+            roundtripped["data"]["token"],
+            serde_json::json!("test_bot_token")
+        );
+    }
+
+    #[test]
+    fn test_ws_auth_response_matches_challenge_sequence() {
+        let success = json!({"status": "OK", "seq_reply": 7});
+        let failure = json!({"status": "FAIL", "seq_reply": 7});
+        let unrelated = json!({"status": "OK", "seq_reply": 8});
+
+        assert_eq!(MattermostChannel::ws_auth_response(&success, 7), Some(true));
+        assert_eq!(
+            MattermostChannel::ws_auth_response(&failure, 7),
+            Some(false)
+        );
+        assert_eq!(MattermostChannel::ws_auth_response(&unrelated, 7), None);
+    }
+
+    #[tokio::test]
+    async fn test_ws_handshake_sends_auth_before_waiting_for_hello() {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let (mut write, mut read) = client.split();
+
+        let server_task = zeroclaw_spawn::spawn!(async move {
+            let first = server
+                .next()
+                .await
+                .expect("client should send auth first")
+                .expect("auth frame should be readable");
+            let WsMessage::Text(text) = first else {
+                panic!("first client frame should be text auth");
+            };
+            let auth: serde_json::Value =
+                serde_json::from_str(text.as_ref()).expect("auth should be JSON");
+            assert_eq!(auth["action"], "authentication_challenge");
+            assert_eq!(auth["data"]["token"], "test-token");
+
+            server
+                .send(WsMessage::Text(
+                    json!({"status": "OK", "seq_reply": 7}).to_string().into(),
+                ))
+                .await
+                .expect("server should send auth response");
+            server
+                .send(WsMessage::Text(
+                    json!({"event": "hello", "data": {"server_version": "10.8.0"}})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .expect("server should send hello");
+        });
+
+        let version = MattermostChannel::authenticate_websocket(
+            &mut write,
+            &mut read,
+            "test-token",
+            7,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("auth response followed by hello should complete the handshake");
+
+        assert_eq!(version, "10.8.0");
+        server_task.await.expect("fake server should finish");
+    }
+
+    #[tokio::test]
+    async fn test_ws_handshake_rejects_failed_auth() {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let (mut write, mut read) = client.split();
+
+        let server_task = zeroclaw_spawn::spawn!(async move {
+            server
+                .next()
+                .await
+                .expect("auth frame should arrive")
+                .unwrap();
+            server
+                .send(WsMessage::Text(
+                    json!({"status": "FAIL", "seq_reply": 3}).to_string().into(),
+                ))
+                .await
+                .expect("server should send rejection");
+        });
+
+        let error = MattermostChannel::authenticate_websocket(
+            &mut write,
+            &mut read,
+            "bad-token",
+            3,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect_err("failed auth must end the listener attempt");
+
+        assert!(error.to_string().contains("authentication was rejected"));
+        server_task.await.expect("fake server should finish");
+    }
+
+    #[tokio::test]
+    async fn test_ws_handshake_times_out_after_auth_send() {
+        use tokio_tungstenite::tungstenite::protocol::Role;
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let (mut write, mut read) = client.split();
+
+        let server_task = zeroclaw_spawn::spawn!(async move {
+            server
+                .next()
+                .await
+                .expect("auth frame should arrive")
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+
+        let error = MattermostChannel::authenticate_websocket(
+            &mut write,
+            &mut read,
+            "test-token",
+            4,
+            Duration::from_millis(10),
+        )
+        .await
+        .expect_err("a silent server must fail the handshake deadline");
+
+        assert!(error.to_string().contains("handshake timed out"));
+        server_task.abort();
+    }
+
+    #[test]
+    fn test_ws_timeout_constants() {
+        // WS_READ_TIMEOUT must be strictly greater than WS_PING_INTERVAL
+        // so a single missed ping does not trigger a false positive.
+        assert!(
+            WS_READ_TIMEOUT > WS_PING_INTERVAL,
+            "WS_READ_TIMEOUT ({:?}) must exceed WS_PING_INTERVAL ({:?})",
+            WS_READ_TIMEOUT,
+            WS_PING_INTERVAL
+        );
+        // WS_READ_TIMEOUT should be at least 3× ping interval so the
+        // server can miss two pings before the listener reconnects.
+        assert!(
+            WS_READ_TIMEOUT >= WS_PING_INTERVAL.mul_f64(3.0),
+            "WS_READ_TIMEOUT ({:?}) must be ≥ 3× WS_PING_INTERVAL ({:?})",
+            WS_READ_TIMEOUT,
+            WS_PING_INTERVAL
+        );
+        assert!(WS_HANDSHAKE_TIMEOUT <= WS_READ_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn test_ws_read_timeout_detects_silent_peer() {
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(10);
+        tokio::select! {
+            () = std::future::pending::<()>() => panic!("silent peer unexpectedly produced a frame"),
+            () = tokio::time::sleep_until(deadline) => {}
         }
     }
 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6973,7 +6973,8 @@ fn build_channel_by_id(
                     mm.mention_only.unwrap_or(false),
                 )
                 .with_team_ids(mm.team_ids.clone())
-                .with_discover_dms(mm.discover_dms.unwrap_or(true)),
+                .with_discover_dms(mm.discover_dms.unwrap_or(true))
+                .with_listen_mode(mm.listen_mode),
             ))
         }
         #[cfg(not(feature = "channel-mattermost"))]
@@ -8164,7 +8165,8 @@ fn collect_configured_channels(
                     .with_team_ids(mm.team_ids.clone())
                     .with_discover_dms(mm.discover_dms.unwrap_or(true))
                     .with_proxy_url(mm.proxy_url.clone())
-                    .with_transcription(config.transcription.clone()),
+                    .with_transcription(config.transcription.clone())
+                    .with_listen_mode(mm.listen_mode),
                 ),
                 mm,
             ),
@@ -22377,6 +22379,7 @@ This is an example JSON object for profile settings."#;
                 mention_only: Some(false),
                 interrupt_on_new_message: false,
                 proxy_url: None,
+                listen_mode: zeroclaw_config::schema::MattermostListenMode::default(),
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
@@ -22425,6 +22428,7 @@ This is an example JSON object for profile settings."#;
                 mention_only: Some(false),
                 interrupt_on_new_message: false,
                 proxy_url: None,
+                listen_mode: zeroclaw_config::schema::MattermostListenMode::default(),
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -13623,6 +13623,21 @@ fn resolve_slack_token(configured: Option<&str>, kind: &str) -> Option<String> {
     None
 }
 
+/// How the Mattermost channel receives inbound messages.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, zeroclaw_macros::ConfigEnum,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum MattermostListenMode {
+    /// Poll REST API every 3 seconds. The default — all existing configs
+    /// continue to work without changes.
+    #[default]
+    Polling,
+    /// Connect to `/api/v4/websocket` for near-real-time event delivery.
+    Websocket,
+}
+
 /// Mattermost bot channel configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -13704,6 +13719,13 @@ pub struct MattermostConfig {
     #[tab(Advanced)]
     #[serde(default)]
     pub proxy_url: Option<String>,
+
+    /// Listen mode: `"polling"` (REST API every 3s, default) or `"websocket"`
+    /// (persistent WebSocket connection to `/api/v4/websocket` for near-real-time
+    /// event delivery). WebSocket mode reduces server load and delivers events
+    /// faster but requires a WebSocket-capable Mattermost server (v4.0+).
+    #[serde(default)]
+    pub listen_mode: MattermostListenMode,
 
     /// Tools excluded from this channel's tool spec. When set, these tools
     /// are not exposed to the model when responding via this channel.

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1633,6 +1633,7 @@ fn has_supervised_channels(config: &Config) -> bool {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+    use zeroclaw_config::schema::MattermostListenMode;
 
     fn test_config(tmp: &TempDir) -> Config {
         let config = Config {
@@ -2033,6 +2034,7 @@ mod tests {
                 mention_only: Some(false),
                 interrupt_on_new_message: false,
                 proxy_url: None,
+                listen_mode: MattermostListenMode::default(),
                 excluded_tools: vec![],
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,

--- a/docs/book/src/channels/mattermost.md
+++ b/docs/book/src/channels/mattermost.md
@@ -1,6 +1,6 @@
 # Mattermost
 
-REST v4 polling client. Self-hosted, on-prem, or sovereign-cloud Mattermost servers all work the same way: the bot polls the channels it can read every 3 seconds for new posts, and reply posts go out via `POST /api/v4/posts`.
+REST v4 polling and WebSocket client. By default the bot polls channels every 3 seconds for new posts; set `listen_mode = "websocket"` for near-real-time event delivery over a persistent WebSocket connection. Reply posts always go out via `POST /api/v4/posts` regardless of listen mode.
 
 ## Who can talk to the agent
 
@@ -39,6 +39,25 @@ There are two scoping modes.
 2. **Explicit** (when `channel_ids` is a non-empty list of IDs other than `*`). On startup the bot calls `GET /api/v4/channels/{id}` for each entry to learn its `type` (so it knows which are DMs for the `mention_only` bypass), then polls exactly those channels forever. No periodic re-discovery.
 
 In both modes each channel has its own `since` cursor: the bot tracks the highest `create_at` it has processed per channel and passes that as `since=<ms>` on the next `GET /api/v4/channels/{id}/posts` call. Cursors do not leak across channels, so a slow-moving channel doesn't suppress posts on a busy one.
+
+## WebSocket mode
+
+Set `listen_mode = "websocket"` to switch from REST polling to a persistent WebSocket connection (`wss://<server>/api/v4/websocket`). The WebSocket mode:
+
+- Delivers new posts in near-real-time (no 3-second poll delay).
+- Reduces HTTP load on the Mattermost server (one connection vs. N polls/3s).
+- Returns failed sessions to the shared channel supervisor, which reconnects with bounded exponential backoff using the configured `reliability.channel_initial_backoff_secs` and `reliability.channel_max_backoff_secs` values.
+- Requires Mattermost v4.0+ (the `/api/v4/websocket` endpoint).
+
+Channel discovery, `mention_only`, `thread_replies`, audio transcription, and peer-group authorization work identically in both modes.
+
+**Trade-offs:**
+
+- WebSocket mode must maintain a persistent TCP+TLS connection.
+- During a reconnect window, messages posted to a channel may be missed because this listener does not yet request Mattermost connection resume/replay. Polling catches up via `since=` cursors.
+- Polling mode is more resilient to transient network interruptions at the cost of constant HTTP traffic.
+
+To roll back, set `listen_mode = "polling"` (or remove the field; polling is the default).
 
 ## Direct messages
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add an opt-in `listen_mode = "websocket"` setting for near-real-time Mattermost inbound delivery while preserving REST polling as the default.
  - Authenticate immediately after the WebSocket connection opens, then require both the matching authentication response and Mattermost `hello` event before processing posts.
  - Route WebSocket `posted` events through the existing Mattermost transcription, parsing, authorization, mention, threading, and delivery path.
  - Return failed WebSocket sessions to the shared channel supervisor so existing retry, health, and cancellation behavior remains the single lifecycle owner.
- **Scope boundary:** This changes Mattermost inbound delivery only. Outbound replies still use REST. Only `posted` events are handled, and this implementation does not request Mattermost resume/replay after a disconnect.
- **Blast radius:** Mattermost channel behavior, one additive config enum/field, two channel construction sites, one runtime test fixture, and Mattermost documentation. Other channels and existing Mattermost polling configs are unchanged.
- **Linked issue(s):** Closes #7082. Related #6074. Supersedes #7098.
- **Labels:** `enhancement`, `risk:high`, `size:L`, `channel`, `channel:core`, `channel:mattermost`, `config`, `daemon`, `runtime`, `docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes. A live Mattermost check would close the remaining environment-specific gap.
- **Interface(s) exercised:** channel: Mattermost
- **Setup / preconditions:** A Mattermost v4.0+ server, a configured ZeroClaw Mattermost channel using either `bot_token` or `login_id` plus `password`, and a channel the bot can read.
- **Steps to run:**
  1. On this branch, set `channels.mattermost.<alias>.listen_mode = "websocket"` and start ZeroClaw.
  2. Post an allowed message in a configured channel or direct message.
  3. Interrupt the connection, restore it, and post another message after reconnection.
- **Expected on this branch (after):** Logs report that the Mattermost WebSocket connected and authenticated; allowed posts reach the normal channel pipeline without the polling delay; a failed session returns to the shared supervisor and reconnects with its configured backoff.
- **Prior behavior on `master` (before):** `listen_mode` is unavailable and Mattermost receives inbound posts only through the three-second REST polling loop.

### How I tested

- **CI checks relied on and why they cover this change:** Required GitHub CI passes on head `65262de0ebd2059504352f74f9a8a6c74b8193aa`, including Lint, Test, all-features, Linux build, Windows/macOS checks, security, and the required gate. Local checks cover formatting, the feature-gated Mattermost module, WebSocket protocol helpers, and runtime channel supervision wiring.
- **Known CI coverage gap, if any:** No live Mattermost server was available, so TLS/proxy negotiation, server-driven ping/pong, and disconnect/reconnect behavior against a real deployment remain unverified. The documented lack of resume/replay means posts during a reconnect window may be missed.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

cargo test -p zeroclaw-channels --features channel-mattermost mattermost::tests:: -- --nocapture
# 73 passed on the initial implementation head; 0 failed

cargo test -p zeroclaw-channels --features channel-mattermost mattermost::tests::test_ws_handshake_ -- --nocapture
# 5 passed on the current head; 0 failed

cargo test -p zeroclaw-runtime detects_mattermost_as_supervised_channel -- --nocapture
# 1 passed; 0 failed

cargo clippy -p zeroclaw-channels --features channel-mattermost --all-targets --no-deps -- -D warnings
# reached the changed crate; blocked only by unchanged baseline warnings
# outside this diff
```

- **Beyond CI, what did you manually verify?** In-memory duplex WebSocket tests verify that the authentication challenge is the first client frame and cover successful authentication, rejection, silence, auth success without `hello`, and `hello` without a matching auth response. Unit tests also cover URL derivation, config serialization/defaults, posted-event extraction, ping format, and timeout relationships. I did not run a live Mattermost smoke test.
- **If any command was intentionally skipped, why:** No additional broad local workspace test was run; current-head required CI covers the workspace while the focused local checks exercise the changed Mattermost protocol path.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes.** Operators can opt into a persistent inbound WebSocket connection. Polling remains the default, and the connection is limited to the configured Mattermost server.
- New external network calls? **Yes.** WebSocket mode connects to the configured server's `/api/v4/websocket` endpoint through the existing proxy-aware connector.
- Secrets / tokens / credentials handling changed? **Yes.** The existing Mattermost session or bot token is sent once in the protocol's authentication challenge after connection establishment. The token is not logged or persisted, and it is not exposed to message processing.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **Yes.** Mattermost posts can now arrive over WebSocket, but they pass through the same channel membership, peer-group authorization, mention filtering, parsing, and delivery path as polled posts.
- If any `Yes`, describe the risk and mitigation: The new transport adds a persistent network path and carries the existing credential and untrusted post payloads. It is opt-in, uses the existing proxy/TLS URL mapping and authorization pipeline, applies bounded handshake/read deadlines, and delegates failures to the shared supervisor.

## Compatibility (required)

- Backward compatible? **Yes.** `listen_mode` defaults to `"polling"`, so existing configurations keep their current behavior.
- Config / env / CLI surface changed? **Yes.** Mattermost channel config gains the optional `listen_mode` field with `"polling"` and `"websocket"` values.
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is `No` or either surface/floor question is `Yes`: Existing users need no changes. To opt in, set `channels.mattermost.<alias>.listen_mode = "websocket"` and restart ZeroClaw.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Set `channels.mattermost.<alias>.listen_mode = "polling"` or remove the field, then restart ZeroClaw. Reverting the feature commit is the code-level fallback.
- **Feature flags or config toggles:** The additive `listen_mode` field is the runtime toggle; polling is the default.
- **Observable failure symptoms:** Repeated `Mattermost WebSocket connect failed`, authentication/handshake errors, `Mattermost WebSocket read failed`, idle-timeout errors, or shared channel-supervisor restarts. During those windows, new posts may not be delivered until the connection is restored.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #7098 by @xianshishan
- Scope materially carried forward: The additive listen-mode config, Mattermost WebSocket transport, posted-event extraction, discovery refresh, heartbeat/timeout behavior, docs, and focused tests. This version changes the handshake to authenticate immediately and uses the existing shared channel supervisor for retry ownership.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? **Yes.**
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
