### PR TITLE
fix(ci): publish Docker variants before scheduled scans

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      release_ref:
+        description: "Immutable release tag to build (vX.Y.Z)"
+        required: true
+        type: string
   workflow_dispatch:
 
 concurrency:
@@ -37,6 +43,8 @@ jobs:
       include: ${{ steps.read.outputs.include }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release_ref || github.ref }}
       - name: Read generated docker-tags.toml into a build matrix
         id: read
         run: |
@@ -61,6 +69,8 @@ jobs:
         include: ${{ fromJSON(needs.matrix.outputs.include) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release_ref || github.ref }}
 
       - name: Log in to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/master-branch-flow.md
+++ b/.github/workflows/master-branch-flow.md
@@ -7,7 +7,7 @@ Use with:
 - [`docs/book/src/maintainers/ci-and-actions.md`](../../docs/book/src/maintainers/ci-and-actions.md)
 - [`docs/book/src/maintainers/release-runbook.md`](../../docs/book/src/maintainers/release-runbook.md)
 
-Last updated: **June 2026** (merge queue disabled on `master`; maintainers
+Last updated: **July 2026** (merge queue disabled on `master`; maintainers
 merge directly. The `merge_group` CI plumbing is retained, so the queue can be
 re-enabled from branch protection with no code change).
 
@@ -28,6 +28,8 @@ Maintainers with merge authority: `JordanTheJet`, `Audacity88`, `WareWolf-MoonWa
 |---|---|---|
 | `ci.yml` | `pull_request` → `master`; `push` → `master`; `merge_group` (dormant) | Lint + test + build on PRs and trusted post-merge cache-warming runs. The `merge_group` trigger stays wired but never fires while the merge queue is disabled. |
 | `release-stable-manual.yml` | `workflow_dispatch`, tag push `v*` | Stable release (manual, version-gated) |
+| `docker-publish.yml` | `workflow_call`, `workflow_dispatch`, tag push `v*` | Build, sign, and scan the generated Docker variant matrix |
+| `trivy-scheduled.yml` | `workflow_dispatch`; weekly schedule | Re-scan published `dist` and `default-features` images for new CVEs |
 | `cross-platform-build-manual.yml` | `workflow_dispatch` | Full platform build matrix (manual smoke check) |
 | `cross-platform-clippy.yml` | `workflow_dispatch`; weekly schedule | Advisory macOS/Windows Clippy coverage, outside the required PR gate |
 | `pr-path-labeler.yml` | `pull_request` lifecycle | Automatic path-based PR labeling |
@@ -42,8 +44,8 @@ Maintainers with merge authority: `JordanTheJet`, `Audacity88`, `WareWolf-MoonWa
 | PR opened or updated against `master` | `ci.yml` (full lint + test + build) |
 | PR added to the merge queue (`merge_group`) | **Inactive**: the merge queue is currently disabled. If re-enabled, `ci.yml` runs the full gate on a temporary `gh-readonly-queue/master/…` branch stacking the base + earlier queue entries + this PR. |
 | Push to `master` | `ci.yml` (post-merge quality signal + trusted Rust cache warming) |
-| Manual dispatch | `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `project-dashboard-plan.yml`, or `release-stable-manual.yml` |
-| Tag push `vX.Y.Z` | `release-stable-manual.yml` (full release pipeline) |
+| Manual dispatch | `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docker-publish.yml`, `trivy-scheduled.yml`, `project-dashboard-plan.yml`, or `release-stable-manual.yml` |
+| Tag push `vX.Y.Z` | `release-stable-manual.yml` (full release pipeline) and `docker-publish.yml` (generated variant matrix) |
 
 There is no automatic release on merge. `ci.yml` does run after trusted
 `master` pushes so post-merge Quality Gate runs can seed Rust caches for later
@@ -88,10 +90,11 @@ for the full procedure. In summary:
 2. Version bump PR is merged.
 3. Maintainer triggers `release-stable-manual.yml` via `workflow_dispatch`
    with the version number, or pushes an annotated tag `vX.Y.Z`.
-4. Workflow builds all targets, creates the GitHub Release, publishes to
-   crates.io, pushes Docker images, and notifies distribution channels.
-5. Maintainer approves the three environment gates
-   (`github-releases`, `crates-io`, `docker`) when prompted.
+4. Workflow builds all targets, creates the GitHub Release, pushes the prebuilt
+   Docker images, calls the generated Docker variant matrix, and notifies
+   distribution channels.
+5. Maintainer approves the two environment gates (`github-releases`, `docker`)
+   when prompted.
 
 ### 3) Full Platform Build (manual)
 
@@ -142,8 +145,8 @@ flowchart TD
   A["workflow_dispatch: version=X.Y.Z\nor tag push vX.Y.Z"] --> V["validate\nsemver · Cargo.toml match · tag uniqueness"]
   V --> BLD["build all targets"]
   BLD --> PUB["publish\nGitHub Release · SHA256SUMS"]
-  PUB --> CR["crates-io"]
-  PUB --> DOC["docker\nGHCR :vX.Y.Z + :latest"]
+  BLD --> DOC["docker\nprebuilt :vX.Y.Z · :latest · :debian"]
+  PUB & DOC --> MATRIX["docker-publish.yml\nminimal · default-features · dist · all-features"]
   PUB --> DIST["scoop · aur · homebrew"]
   PUB --> ANN["discord · tweet"]
 ```

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -946,7 +946,6 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       release_ref: ${{ needs.validate.outputs.tag }}
-    secrets: inherit
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -939,6 +939,20 @@ jobs:
             --ref master \
             -f tag="$TAG"
 
+  docker-matrix:
+    name: Publish Docker Variant Matrix
+    needs: [validate, publish, docker]
+    if: ${{ github.event_name == 'workflow_dispatch' && !cancelled() && needs.publish.result == 'success' && needs.docker.result == 'success' }}
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      release_ref: ${{ needs.validate.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
+
   docker:
     name: Push Docker Image
     needs: [validate, build]

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -52,6 +52,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify published image exists
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ matrix.floating_tag }}
+        run: |
+          set -euo pipefail
+          error_log="$(mktemp)"
+          trap 'rm -f "$error_log"' EXIT
+          if docker manifest inspect "$IMAGE_REF" >/dev/null 2>"$error_log"; then
+            exit 0
+          fi
+          cat "$error_log" >&2
+          if grep -Eiq 'manifest unknown|no such manifest|not found' "$error_log"; then
+            echo "::error title=Published image missing::Expected published image $IMAGE_REF. Check the Docker Publish release job before retrying this scan."
+          else
+            echo "::error title=Image inspection failed::Could not inspect $IMAGE_REF. Check GHCR authentication and availability before retrying this scan."
+          fi
+          exit 1
+
       - name: Scan ${{ matrix.stem }} with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -71,29 +89,8 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  upload-sarif:
-    name: Upload SARIF (${{ matrix.stem }})
-    if: github.repository == 'zeroclaw-labs/zeroclaw'
-    needs: [scan]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - stem: dist
-          - stem: default-features
-
-    steps:
-      - name: Download Trivy SARIF artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: trivy-results-${{ matrix.stem }}
-
       - name: Upload Trivy SARIF to GitHub Security tab
+        if: always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           sarif_file: trivy-results.sarif

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -38,6 +38,10 @@ Runs `cargo deny check advisories` daily at 09:00 UTC against the dependency tre
 
 Runs `npm audit --audit-level=high` daily at 09:23 UTC against `web/package-lock.json`. Opens one deduplicated `security` + `dependencies` issue when high-severity npm advisories affect the committed web lockfile.
 
+### Weekly Trivy Image Scan (`trivy-scheduled.yml`)
+
+Scans the published `dist` and `default-features` GHCR images every Saturday and uploads HIGH/CRITICAL findings to the Security tab as SARIF. The scan is report-first (`exit-code: 0` for findings), but a missing expected image fails the job before Trivy setup with the absent tag and the owning publisher workflow named in the error.
+
 ### PR Path Labeler (`pr-path-labeler.yml`)
 
 Auto-applies path and scope labels based on changed files. It runs on PR open, reopen, and every pushed update to the PR branch. Because `sync-labels: true` is enabled, labels defined in `.github/labeler.yml` are recalculated from the current PR file set.
@@ -63,6 +67,12 @@ Triggered on tag push (and `workflow_dispatch`); builds and publishes versioned 
 ### Docker Image PR Check (`docker-image-pr.yml`)
 
 Runs only when Docker image or release-Docker context files change. It prepares a smoke `docker-ctx` with the same helper used by the stable release workflow, then builds the default prebuilt image and the Debian compatibility prebuilt image from `Dockerfile.ci` without pushing either image. This catches image dependency and `COPY` path breakage before release without giving PR runs registry write permission or running on every PR.
+
+### Docker Publish (`docker-publish.yml`)
+
+Builds, signs, and scans the generated four-variant matrix from `dev/ci/docker-tags.toml`: `minimal`, `default-features`, `dist`, and `all-features`. A human-created `v*` tag starts this workflow directly. A stable release started with `workflow_dispatch` creates its tag with `GITHUB_TOKEN`, which does not emit another tag-push event, so `release-stable-manual.yml` calls Docker Publish synchronously at the immutable release tag after the canonical release and Docker jobs succeed.
+
+This matrix supplements rather than replaces the stable release's prebuilt `latest`, versioned, and `debian` images. The two paths use different build inputs and publish distinct tags.
 
 ### Discord Release (`discord-release.yml`)
 
@@ -92,7 +102,7 @@ Manual and weekly scheduled advisory lint coverage on macOS aarch64 and Windows 
 
 ### Release Stable (`release-stable-manual.yml`)
 
-Manual trigger for the full release pipeline. Builds all targets, creates the GitHub Release, pushes Docker images to GHCR, triggers the website redeploy, and invokes the distribution sub-workflows (Scoop, AUR, Homebrew, Discord, tweet). Two environment gates require maintainer approval mid-run: `github-releases` (the `publish` job) and `docker`.
+Manual trigger for the full release pipeline. Builds all targets, creates the GitHub Release, pushes the prebuilt `latest`, versioned, and `debian` Docker images to GHCR, calls the generated Docker variant matrix at the release tag, triggers the website redeploy, and invokes the distribution sub-workflows (Scoop, AUR, Homebrew, Discord, tweet). Two environment gates require maintainer approval mid-run: `github-releases` (the `publish` job) and `docker`.
 
 See the [Release Runbook](./release-runbook.md) for the full procedure.
 
@@ -151,19 +161,19 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `actions/checkout` (`v6.0.2`) | Most workflows | Repository checkout |
 | `actions/cache` (`v4.2.3`, `v5.0.5`) | `docker-image-pr.yml`, `tweet-release.yml` | Generic dependency and Trivy database caching |
 | `actions/setup-node` (`v6.4.0`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Node toolchain for the web-dashboard build |
-| `actions/upload-artifact` (`v7.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml` | Upload build artifacts and Trivy SARIF handoff artifacts |
+| `actions/upload-artifact` (`v7.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | Upload build artifacts and Trivy SARIF handoff artifacts |
 | `actions/download-artifact` (`v8.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml` | Download build artifacts and Trivy SARIF handoff artifacts |
 | `actions/labeler` (`v6.1.0`) | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
 | `dtolnay/rust-toolchain` (`stable`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml` | Install Rust toolchain |
 | `Swatinem/rust-cache` (`v2.9.1`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching |
-| `docker/setup-buildx-action` (`v4.0.0`) | `release-stable-manual.yml` | Docker Buildx setup |
-| `docker/login-action` (`v4.1.0`) | `release-stable-manual.yml` | GHCR authentication |
-| `docker/build-push-action` (`v7.1.0`) | `release-stable-manual.yml` | Multi-platform image build and push |
+| `docker/setup-buildx-action` (`v3.11.1`, `v4.0.0`) | `release-stable-manual.yml`, `docker-publish.yml` | Docker Buildx setup |
+| `docker/login-action` (`v3.4.0`, `v4.1.0`) | `release-stable-manual.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | GHCR authentication |
+| `docker/build-push-action` (`v6.18.0`, `v7.1.0`) | `release-stable-manual.yml`, `docker-publish.yml` | Multi-platform image build and push |
 | `sigstore/cosign-installer` (`v3.8.1`) | `release-stable-manual.yml`, `docker-publish.yml` | Install cosign for keyless signing of release assets and container images |
 | `anchore/sbom-action` (`v0.17.9`) | `release-stable-manual.yml` | Generate SPDX + CycloneDX SBOMs for each release |
 | `slsa-framework/slsa-github-generator` (`v2.1.0`) | `release-stable-manual.yml` | Reusable workflow that produces SLSA L2 provenance for release artifacts |
-| `aquasecurity/trivy-action` (`v0.36.0`) | `docker-image-pr.yml`, `docker-publish.yml` | Report-only container vulnerability scanning |
-| `github/codeql-action/upload-sarif` (`v3.36.2`) | `docker-publish.yml` | Upload Trivy SARIF reports to the Security tab |
+| `aquasecurity/trivy-action` (`v0.36.0`) | `docker-image-pr.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | Report-only container vulnerability scanning |
+| `github/codeql-action/upload-sarif` (`v3.36.2`) | `docker-publish.yml`, `trivy-scheduled.yml` | Upload Trivy SARIF reports to the Security tab |
 | `github/codeql-action/init` (`v3`) | `ci-code-analysis.yml` | Initialize CodeQL Rust analysis |
 | `github/codeql-action/analyze` (`v3`) | `ci-code-analysis.yml` | Upload CodeQL SARIF to the Security tab |
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -338,15 +338,20 @@ Once `publish` completes, confirm:
 [ ] Release notes are non-empty
 [ ] SHA256SUMS asset is present and non-empty
 [ ] At least one binary archive is downloadable (spot-check linux x86_64)
+[ ] Prebuilt Docker and generated Docker matrix jobs are green
 ```
 
 `CHANGELOG-next.md` is intentionally left on `master` after the release: the
 publish job only reads it as the release body, it does not delete it. The next
 release cycle overwrites it, so no manual cleanup is required.
 
-You do not need to manually verify Docker or the distribution channels
-unless a job in the workflow run shows red. Check the workflow run summary; if
-all jobs are green, you are done.
+For the normal `workflow_dispatch` path, Docker Publish runs synchronously
+inside the stable release workflow. You do not need a separate Docker check if
+all release jobs are green. If a maintainer instead starts the release by
+pushing a `vX.Y.Z` tag, Docker Publish starts as a separate tag-triggered run;
+confirm that sibling run is green before treating container publication as
+complete. Distribution channels need separate attention only when their jobs
+show red.
 
 Consumers who want to verify signatures, SBOMs, or SLSA provenance on the
 published artifacts can follow

--- a/tests/architecture/container_release.rs
+++ b/tests/architecture/container_release.rs
@@ -39,7 +39,6 @@ fn manual_stable_release_calls_container_matrix_at_release_tag() {
         "needs.docker.result == 'success'",
         "uses: ./.github/workflows/docker-publish.yml",
         "release_ref: ${{ needs.validate.outputs.tag }}",
-        "secrets: inherit",
         "contents: read",
         "packages: write",
         "id-token: write",
@@ -50,6 +49,10 @@ fn manual_stable_release_calls_container_matrix_at_release_tag() {
             "Docker matrix call is missing release invariant: {required}"
         );
     }
+    assert!(
+        !matrix_job.contains("secrets: inherit"),
+        "Docker matrix call must not inherit unrelated release secrets"
+    );
 
     let publisher = workflow("docker-publish.yml");
     assert!(

--- a/tests/architecture/container_release.rs
+++ b/tests/architecture/container_release.rs
@@ -1,0 +1,104 @@
+//! Release invariants for published container variants and scheduled scans.
+
+use std::{fs, path::Path};
+
+fn workflow(name: &str) -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(root.join(".github/workflows").join(name))
+        .unwrap_or_else(|error| panic!("failed to read {name}: {error}"))
+}
+
+fn top_level_job<'a>(workflow: &'a str, name: &str) -> &'a str {
+    let marker = format!("\n  {name}:\n");
+    let (_, rest) = workflow
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("workflow must contain the {name} job"));
+    let end = rest
+        .match_indices("\n  ")
+        .find_map(|(offset, _)| {
+            let line = rest[offset + 1..].lines().next()?;
+            (line.starts_with("  ")
+                && !line.starts_with("    ")
+                && !line.trim_start().starts_with('#')
+                && line.trim_end().ends_with(':'))
+            .then_some(offset)
+        })
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+#[test]
+fn manual_stable_release_calls_container_matrix_at_release_tag() {
+    let release = workflow("release-stable-manual.yml");
+    let matrix_job = top_level_job(&release, "docker-matrix");
+
+    for required in [
+        "needs: [validate, publish, docker]",
+        "github.event_name == 'workflow_dispatch'",
+        "needs.publish.result == 'success'",
+        "needs.docker.result == 'success'",
+        "uses: ./.github/workflows/docker-publish.yml",
+        "release_ref: ${{ needs.validate.outputs.tag }}",
+        "secrets: inherit",
+        "contents: read",
+        "packages: write",
+        "id-token: write",
+        "security-events: write",
+    ] {
+        assert!(
+            matrix_job.contains(required),
+            "Docker matrix call is missing release invariant: {required}"
+        );
+    }
+
+    let publisher = workflow("docker-publish.yml");
+    assert!(
+        publisher.contains("push:\n    tags:\n      - \"v*\"")
+            && publisher.contains("workflow_call:")
+            && publisher.contains("release_ref:")
+            && publisher.contains("workflow_dispatch:"),
+        "Docker Publish must keep tag-push, reusable, and manual entry points"
+    );
+    assert_eq!(
+        publisher
+            .matches("ref: ${{ inputs.release_ref || github.ref }}")
+            .count(),
+        2,
+        "matrix resolution and image builds must use the requested immutable ref"
+    );
+}
+
+#[test]
+fn scheduled_trivy_verifies_published_tag_before_scan() {
+    let scheduled = workflow("trivy-scheduled.yml");
+    let preflight = scheduled
+        .find("- name: Verify published image exists")
+        .expect("scheduled Trivy must contain an image-existence preflight");
+    let scan = scheduled
+        .find("- name: Scan ${{ matrix.stem }} with Trivy")
+        .expect("scheduled Trivy scan step must exist");
+
+    assert!(
+        preflight < scan,
+        "scheduled Trivy must verify the published image before scanner setup"
+    );
+    for required in [
+        "IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ matrix.floating_tag }}",
+        "docker manifest inspect \"$IMAGE_REF\"",
+        "manifest unknown|no such manifest|not found",
+        "Expected published image $IMAGE_REF",
+        "Image inspection failed",
+        "Docker Publish release job",
+        "- name: Upload Trivy SARIF to GitHub Security tab",
+        "category: trivy-${{ matrix.stem }}",
+    ] {
+        assert!(
+            scheduled.contains(required),
+            "scheduled Trivy preflight is missing invariant: {required}"
+        );
+    }
+    assert!(
+        !scheduled.contains("\n  upload-sarif:\n"),
+        "each scan matrix leg must upload its own SARIF result independently"
+    );
+}

--- a/tests/architecture/container_release.rs
+++ b/tests/architecture/container_release.rs
@@ -39,10 +39,6 @@ fn manual_stable_release_calls_container_matrix_at_release_tag() {
         "needs.docker.result == 'success'",
         "uses: ./.github/workflows/docker-publish.yml",
         "release_ref: ${{ needs.validate.outputs.tag }}",
-        "contents: read",
-        "packages: write",
-        "id-token: write",
-        "security-events: write",
     ] {
         assert!(
             matrix_job.contains(required),
@@ -52,6 +48,16 @@ fn manual_stable_release_calls_container_matrix_at_release_tag() {
     assert!(
         !matrix_job.contains("secrets: inherit"),
         "Docker matrix call must not inherit unrelated release secrets"
+    );
+    let permissions = matrix_job
+        .split_once("\n    permissions:\n")
+        .expect("Docker matrix call must declare scoped permissions")
+        .1
+        .trim();
+    assert_eq!(
+        permissions,
+        "contents: read\n      packages: write\n      id-token: write\n      security-events: write",
+        "Docker matrix call permissions must remain minimal and complete"
     );
 
     let publisher = workflow("docker-publish.yml");
@@ -74,10 +80,11 @@ fn manual_stable_release_calls_container_matrix_at_release_tag() {
 #[test]
 fn scheduled_trivy_verifies_published_tag_before_scan() {
     let scheduled = workflow("trivy-scheduled.yml");
-    let preflight = scheduled
+    let scan_job = top_level_job(&scheduled, "scan");
+    let preflight = scan_job
         .find("- name: Verify published image exists")
         .expect("scheduled Trivy must contain an image-existence preflight");
-    let scan = scheduled
+    let scan = scan_job
         .find("- name: Scan ${{ matrix.stem }} with Trivy")
         .expect("scheduled Trivy scan step must exist");
 
@@ -92,14 +99,24 @@ fn scheduled_trivy_verifies_published_tag_before_scan() {
         "Expected published image $IMAGE_REF",
         "Image inspection failed",
         "Docker Publish release job",
+        "strategy:\n      fail-fast: false",
+        "- stem: dist\n            floating_tag: dist",
+        "- stem: default-features\n            floating_tag: default-features",
         "- name: Upload Trivy SARIF to GitHub Security tab",
         "category: trivy-${{ matrix.stem }}",
     ] {
         assert!(
-            scheduled.contains(required),
+            scan_job.contains(required),
             "scheduled Trivy preflight is missing invariant: {required}"
         );
     }
+    assert_eq!(
+        scan_job
+            .matches("if: always() && hashFiles('trivy-results.sarif') != ''")
+            .count(),
+        2,
+        "artifact and Security tab SARIF uploads must both be guarded per matrix leg"
+    );
     assert!(
         !scheduled.contains("\n  upload-sarif:\n"),
         "each scan matrix leg must upload its own SARIF result independently"

--- a/tests/test_architecture.rs
+++ b/tests/test_architecture.rs
@@ -14,3 +14,6 @@ mod cli_fluent_coverage;
 
 #[path = "architecture/desktop_release.rs"]
 mod desktop_release;
+
+#[path = "architecture/container_release.rs"]
+mod container_release;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Make the generated Docker variant workflow reusable and call it synchronously from the manual stable-release workflow at the exact validated release tag.
  - Add a classified image-existence preflight to scheduled Trivy scans and upload SARIF independently for each matrix leg, so one missing image does not discard healthy scan output.
  - Add architecture regression coverage and align the maintainer CI/release documentation with the actual release graph.
- **Scope boundary:** This does not change the prebuilt release-image job, image feature composition, Trivy policy, release artifact contents, or application runtime behavior.
- **Blast radius:** Stable release orchestration, generated GHCR variant tags, scheduled container scanning, and their maintainer documentation.
- **Linked issue(s):** No issue. This repairs the repeated failures visible in [Actions run 29638220300](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/29638220300).
- **Labels:** `ci`, `docs`, `tests`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is release-workflow orchestration that cannot be safely exercised end to end from an untrusted PR branch. The focused architecture tests and workflow lint cover the changed contract before a real stable release exercises it.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI is green. `CI Required Gate` covers the repository's required format, lint, test, security, architecture, and documentation checks; the Docker source-build jobs cover all three maintained image/platform paths. Local `actionlint` covers workflow syntax and expression wiring, while the focused architecture test locks the release-call, exact-ref checkout, Trivy preflight, and per-leg SARIF-upload contracts.
- **Known CI coverage gap, if any:** No live stable-release or GHCR publication was triggered from this branch. The first post-merge stable release remains the end-to-end proof of registry publication.
- **Commands run and tail output:**

```sh
actionlint \
  .github/workflows/release-stable-manual.yml \
  .github/workflows/trivy-scheduled.yml \
  .github/workflows/docker-publish.yml
# exit 0 (v1.7.7, with the repository's custom runner labels configured)

CARGO_MANIFEST_DIR="$PWD" rustc --edition 2024 --test \
  tests/architecture/container_release.rs \
  -o /tmp/container-release-architecture-test
/tmp/container-release-architecture-test --nocapture
# test result: ok. 2 passed; 0 failed

rustfmt --edition 2024 --check \
  tests/architecture/container_release.rs tests/test_architecture.rs
# exit 0

scripts/ci/docs_links_gate.sh
# Docs links gate passed (no added links requiring validation)
```

- **Beyond CI, what did you manually verify?** Confirmed the stable-release call waits for the validated publish and prebuilt-image jobs, uses the validated immutable tag, preserves direct tag-push behavior without duplicate matrix publication, and keeps SARIF upload inside each scheduled scan leg. The full-file docs quality gate also exposed one pre-existing `MD028` at `release-runbook.md:403`; the changed Markdown lines have no lint findings.
- **If any command was intentionally skipped, why:** Full workspace tests and Clippy were not run locally because the production diff is GitHub Actions and documentation; fresh required CI completed the repository test and lint lanes, and the focused local architecture test exercises the new Rust regression module. No live release or registry publication was triggered because that would mutate production release state.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`Yes`)
- New external network calls? (`Yes`)
- Secrets / tokens / credentials handling changed? (`Yes`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: The manual stable-release workflow now invokes the existing Docker variant publisher, which builds, signs, scans, and publishes images to GHCR. The reusable job receives only `contents: read`, `packages: write`, `id-token: write`, and `security-events: write`; it does not inherit unrelated repository secrets. Its existing steps use the automatic `GITHUB_TOKEN` under those job-scoped permissions. Architecture coverage locks the permission, secret-isolation, and exact-tag contracts.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR. For an already-created release tag whose variant publication failed, recover the existing publisher directly with `gh workflow run docker-publish.yml --ref <release-tag>` after the workflow fix or revert is on the selected ref.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** The stable-release run fails in `Publish Docker Variant Matrix`; expected GHCR tags such as `dist` or `default-features` are absent; or the scheduled Trivy preflight reports a missing manifest and points to the Docker Publish release job.
