### PR TITLE
fix(channels): bound ffmpeg transcode waits

### DIFF
--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -12,6 +12,9 @@ const DEFAULT_MAX_TEXT_LENGTH: usize = 4096;
 /// Default HTTP request timeout for TTS API calls.
 const TTS_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Maximum time allowed for a local ffmpeg transcode.
+const FFMPEG_TRANSCODE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 // ── TtsProvider trait ────────────────────────────────────────────
 
 /// Trait for pluggable TTS backends.
@@ -590,11 +593,37 @@ impl TtsProvider for PiperTtsProvider {
 
 // ── TtsManager ───────────────────────────────────────────────────
 
-async fn transcode_to_opus(audio: Vec<u8>) -> Result<Vec<u8>> {
-    use std::process::Stdio;
+async fn write_audio_and_wait_with_output(
+    mut child: tokio::process::Child,
+    audio: Vec<u8>,
+    timeout: std::time::Duration,
+) -> Result<std::process::Output> {
     use tokio::io::AsyncWriteExt;
 
-    let mut child = tokio::process::Command::new("ffmpeg")
+    let mut stdin = child.stdin.take().context("ffmpeg stdin was not piped")?;
+
+    tokio::time::timeout(timeout, async move {
+        // Drive stdin and wait concurrently: if the child fills its stdout pipe
+        // before stdin is complete, sequential operation would deadlock.
+        let (write_result, output) = tokio::join!(
+            async move {
+                stdin.write_all(&audio).await?;
+                stdin.shutdown().await
+            },
+            child.wait_with_output()
+        );
+
+        write_result.context("failed to write audio to ffmpeg stdin")?;
+        output.context("ffmpeg process error")
+    })
+    .await
+    .with_context(|| format!("ffmpeg transcode timed out after {timeout:?}"))?
+}
+
+async fn transcode_to_opus(audio: Vec<u8>) -> Result<Vec<u8>> {
+    use std::process::Stdio;
+
+    let child = tokio::process::Command::new("ffmpeg")
         .args([
             "-hide_banner",
             "-loglevel",
@@ -614,26 +643,14 @@ async fn transcode_to_opus(audio: Vec<u8>) -> Result<Vec<u8>> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .context(
             "failed to spawn ffmpeg — ensure ffmpeg with libopus support is installed \
              (e.g. `sudo dnf install ffmpeg` / `sudo apt install ffmpeg`)",
         )?;
 
-    let mut stdin = child.stdin.take().expect("stdin configured above");
-
-    // Drive stdin and wait concurrently: if ffmpeg fills its stdout pipe
-    // before we finish writing stdin, sequential operation would deadlock.
-    let (write_result, output) = tokio::join!(
-        async move {
-            stdin.write_all(&audio).await?;
-            stdin.shutdown().await
-        },
-        child.wait_with_output()
-    );
-
-    write_result.context("failed to write audio to ffmpeg stdin")?;
-    let output = output.context("ffmpeg process error")?;
+    let output = write_audio_and_wait_with_output(child, audio, FFMPEG_TRANSCODE_TIMEOUT).await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -899,6 +916,80 @@ impl ::zeroclaw_api::attribution::Attributable for PiperTtsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn piped_shell_child(script: &str) -> tokio::process::Child {
+        use std::process::Stdio;
+
+        tokio::process::Command::new("sh")
+            .args(["-c", script])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn test child")
+    }
+
+    #[cfg(unix)]
+    async fn process_exists(pid: u32) -> bool {
+        use std::process::Stdio;
+
+        tokio::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .is_ok_and(|status| status.success())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn transcode_process_times_out_stalled_child() {
+        let child = piped_shell_child("exec sleep 60");
+        let pid = child.id().expect("spawned child has a process ID");
+        let started = std::time::Instant::now();
+        let error = write_audio_and_wait_with_output(
+            child,
+            b"audio".to_vec(),
+            std::time::Duration::from_millis(20),
+        )
+        .await
+        .expect_err("stalled child must time out");
+
+        assert!(
+            error.to_string().contains("timed out"),
+            "expected timeout error, got: {error:#}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "stalled child must return promptly"
+        );
+
+        let cleanup_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while process_exists(pid).await && std::time::Instant::now() < cleanup_deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(!process_exists(pid).await, "timed-out child must be killed");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn transcode_process_preserves_healthy_pipe_io() {
+        let input = vec![b'a'; 1024 * 1024];
+        let output = write_audio_and_wait_with_output(
+            piped_shell_child("exec cat"),
+            input.clone(),
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .expect("healthy child completes");
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, input);
+    }
 
     fn config_with_edge_alias() -> Config {
         let mut cfg = Config::default();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Bound channel TTS ffmpeg transcoding to 120 seconds so a wedged subprocess cannot hang an agent turn indefinitely.
  - Kill the ffmpeg child when the timed wait is dropped while preserving concurrent stdin and stdout handling.
  - Add Unix regressions for timeout cleanup and bidirectional pipe traffic larger than the pipe buffer.
- **Scope boundary:** This covers only the `zeroclaw-channels` ffmpeg transcode path. It does not change codecs, TTS provider selection, configuration, or the robot-kit subprocess work in #9087.
- **Blast radius:** TTS responses that require ffmpeg Opus transcoding. Transcodes completing within 120 seconds behave as before; longer or stalled transcodes return a timeout error.
- **Linked issue(s):** Related #8560. This resolves the remaining channel ffmpeg site; the issue should remain open until the separate robot-kit slice in #9087 lands.
- **Labels:** bug, channel, hardware, risk:medium, size:S

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` - the deterministic subprocess tests cover the changed timeout boundary without requiring a deliberately wedged ffmpeg installation.

### How I tested

```sh
$ cargo fmt --all -- --check
(clean, no output)

$ cargo test -p zeroclaw-channels transcode_process_ -- --nocapture
running 2 tests
test tts::tests::transcode_process_preserves_healthy_pipe_io ... ok
test tts::tests::transcode_process_times_out_stalled_child ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1244 filtered out
```

- **CI checks relied on and why they cover this change:** Required GitHub `Lint` and `Test` passed on head `706ec894`. `Lint` ran workspace Clippy with all targets and `ci-all`; `Test` ran workspace nextest excluding `zeroclaw-desktop`.
- **Known CI coverage gap, if any:** The focused regressions use real Unix subprocesses but do not invoke a real ffmpeg binary. They verify the timeout, child cleanup, and concurrent pipe behavior at the helper boundary.
- **Commands run and tail output:** Shown above.
- **Beyond CI, what did you manually verify?** The timeout regression confirms the stalled child process disappears, and the healthy regression round-trips 1 MiB through piped stdin/stdout. No live TTS provider or ffmpeg transcode was exercised.
- **If any command was intentionally skipped, why:** No additional broad local run was performed because required CI ran the equivalent workspace Clippy and nextest commands on the current head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes` - API and configuration compatible; runtime behavior intentionally changes for transcodes exceeding 120 seconds.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merge commit to restore the previous unbounded wait.
- **Feature flags or config toggles:** None. The timeout is a compile-time constant in `crates/zeroclaw-channels/src/tts.rs`.
- **Observable failure symptoms:** A legitimate ffmpeg transcode lasting longer than 120 seconds returns `ffmpeg transcode timed out after 120s`. If the protection regresses, a wedged transcode again leaves the agent turn waiting indefinitely.
