### PR TITLE
docs(hardware): fix broken nusb crate repository link

### DIFF
--- a/docs/book/src/hardware/hardware-peripherals-design.md
+++ b/docs/book/src/hardware/hardware-peripherals-design.md
@@ -265,7 +265,7 @@ tracking phase status here (which drifts as work lands), the layers are:
 - [STM32 Nucleo-F401RE](https://www.st.com/en/evaluation-tools/nucleo-f401re.html)
 - [tonic](https://github.com/hyperium/tonic): gRPC for Rust
 - [probe-rs](https://probe.rs/): ARM debug probe, flash, memory access
-- [nusb](https://github.com/nic-hartley/nusb): USB device enumeration (VID/PID)
+- [nusb](https://github.com/kevinmehall/nusb): USB device enumeration (VID/PID)
 
 ## 14. Raw Prompt Summary
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The hardware peripherals design doc linked the `nusb` crate to `https://github.com/nic-hartley/nusb`, which returns 404 — the repository does not exist. Updated to the canonical repository `https://github.com/kevinmehall/nusb`, verified via the crates.io registry entry for `nusb`.
- **Scope boundary:** Single external link in `docs/book/src/hardware/hardware-peripherals-design.md`; no other content changed.
- **Blast radius:** Readers of the hardware design doc following the nusb reference link.
- **Linked issue(s):** None
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — docs-only single-link fix; verification is a HTTP 200 check on the new URL.
- **Prior behavior on `master` (before):** `https://github.com/nic-hartley/nusb` → 404 Not Found.
- **Expected on this branch (after):** `https://github.com/kevinmehall/nusb` → 200 OK (kevinmehall/nusb repo).

### How I tested

- **CI checks relied on and why they cover this change:** Required docs checks validate Markdown structure and changed local-link targets. External reachability was verified manually with `curl` because HTTP validation in `docs_links_gate.sh` is optional and offline.
- **Known CI coverage gap, if any:** External URL availability can change after the recorded manual check.
- **Commands run and tail output:**
  ```sh
  curl -s -o /dev/null -w "%{http_code}" https://github.com/nic-hartley/nusb
  # 404
  curl -s -o /dev/null -w "%{http_code}" https://github.com/kevinmehall/nusb
  # 200
  ```
- **Beyond CI, what did you manually verify?** Confirmed via crates.io API that the `nusb` crate's `repository` field is `https://github.com/kevinmehall/nusb`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert <sha>`.

