### PR TITLE
docs(container): replace broken zeroclaw-templates link with deploy-k8s

### DIFF
--- a/docs/book/src/setup/container.md
+++ b/docs/book/src/setup/container.md
@@ -273,7 +273,7 @@ Configure a tunnel by setting the top-level `[tunnel]` `tunnel_provider` (overri
 
 ## Kubernetes
 
-Helm chart templates are published to the [zeroclaw-templates](https://github.com/zeroclaw-labs/zeroclaw-templates) repo. Typical manifest fragment:
+Sample Kubernetes manifests are provided in the [`deploy-k8s/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/deploy-k8s) directory. Typical manifest fragment:
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The Kubernetes section of `container.md` linked to `https://github.com/zeroclaw-labs/zeroclaw-templates`, which returns 404 — the repository does not exist. The actual sample Kubernetes manifests live in the in-repo [`deploy-k8s/`](https://github.com/zeroclaw-labs/zeroclaw/tree/master/deploy-k8s) directory. Updated the link and reworded "Helm chart templates" → "Sample Kubernetes manifests" to match what `deploy-k8s/` actually contains (plain YAML manifests, not Helm charts).
- **Scope boundary:** Single line in `docs/book/src/setup/container.md`; no other content changed.
- **Blast radius:** Readers following the Kubernetes deployment instructions.
- **Linked issue(s):** None
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — docs-only link fix.
- **Prior behavior on `master` (before):** `https://github.com/zeroclaw-labs/zeroclaw-templates` → 404 Not Found.
- **Expected on this branch (after):** `https://github.com/zeroclaw-labs/zeroclaw/tree/master/deploy-k8s` → 200 OK, shows sample manifests.

### How I tested

- **CI checks relied on and why they cover this change:** Required docs checks validate Markdown structure and changed local-link targets. External reachability was verified manually with `curl` because HTTP validation in `docs_links_gate.sh` is optional and offline.
- **Known CI coverage gap, if any:** External URL availability can change after the recorded manual check.
- **Commands run and tail output:**
  ```sh
  curl -s -o /dev/null -w "%{http_code}" https://github.com/zeroclaw-labs/zeroclaw-templates
  # 404
  curl -s -o /dev/null -w "%{http_code}" https://github.com/zeroclaw-labs/zeroclaw/tree/master/deploy-k8s
  # 200
  ```
- **Beyond CI, what did I manually verify?** Confirmed `deploy-k8s/` contains sample manifests (deployment, configmap, namespace, route, secret, service) and a README with deployment instructions.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert <sha>`.

