### PR TITLE
docs(channels): fix MD038 trailing space in code span

### DIFF
--- a/docs/book/src/channels/mattermost.md
+++ b/docs/book/src/channels/mattermost.md
@@ -76,7 +76,7 @@ Two paths:
 
 ## Voice messages
 
-When `[transcription]` is configured and an inbound post has an audio attachment (mime `audio/*` or extension `ogg`/`mp3`/`m4a`/`wav`/`opus`/`flac`) with no text body, the audio is downloaded via `GET /api/v4/files/{file_id}` and routed through the configured transcription provider. The transcript is prefixed `[Voice] ` and becomes the message content. Attachments larger than 25 MB or longer than `transcription.max_duration_secs` are dropped with a WARN.
+When `[transcription]` is configured and an inbound post has an audio attachment (mime `audio/*` or extension `ogg`/`mp3`/`m4a`/`wav`/`opus`/`flac`) with no text body, the audio is downloaded via `GET /api/v4/files/{file_id}` and routed through the configured transcription provider. The transcript is prefixed `[Voice]` and becomes the message content. Attachments larger than 25 MB or longer than `transcription.max_duration_secs` are dropped with a WARN.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The voice message section of `mattermost.md` contained a code span `` `[Voice] ` `` with a trailing space inside the backticks. This triggers markdownlint rule MD038 (no-space-in-code). Removed the trailing space from the code span — the space is implied by the sentence structure and is not needed inside the code formatting.
- **Scope boundary:** Single code span on one line in `docs/book/src/channels/mattermost.md`; no other content changed.
- **Blast radius:** None — the rendered output is visually identical; the fix only satisfies the linter.
- **Linked issue(s):** None
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — docs-only lint fix.
- **Prior behavior on `master` (before):** `markdownlint-cli2` reports `MD038/no-space-in-code` on line 79.
- **Expected on this branch (after):** `markdownlint-cli2` passes with no MD038 on that line.

### How I tested

- **CI checks relied on and why they cover this change:** Markdown lint (`scripts/ci/docs_quality_gate.sh`) runs `markdownlint-cli2` which enforces MD038.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**
  ```sh
  npx markdownlint-cli2 docs/book/src/channels/mattermost.md
  # Before: mattermost.md:79:80 MD038/no-space-in-code Spaces inside code span element
  # After: clean
  ```
- **Beyond CI, what did I manually verify?** Confirmed the rendered text reads correctly: "The transcript is prefixed `[Voice]` and becomes the message content."

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert <sha>`.
