### PR TITLE
docs(agent): fix MD018 heading misparse from PR reference at line start

### DIFF
--- a/docs/book/src/contributing/agent-policy-parity-harness.md
+++ b/docs/book/src/contributing/agent-policy-parity-harness.md
@@ -75,7 +75,7 @@ The per-agent tool registry is the first surface with a single gated constructor
 `ScopedToolRegistry::assemble` (`crates/zeroclaw-runtime/src/tools/scoped.rs`). The
 registry has historically been assembled by hand at six construction sites - the
 reason the built-in filter and MCP scoping had to be patched per-site (#7064,
-#6960, #8120). `assemble` applies, in order: the agent's `config.peripherals`
+\#6960, #8120). `assemble` applies, in order: the agent's `config.peripherals`
 (when connected - see the knob below), the built-in `allowed_tools`/
 `excluded_tools` filter, the ACP memory strip, MCP server scoping per `mcp_bundles`
 plus per-tool gating (eager or deferred; omission is not a grant) with the MCP


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Line 78 of `agent-policy-parity-harness.md` starts with `#6960` — a GitHub PR reference that wrapped from the previous line. Because `#` appears at column 0, markdownlint interprets it as an ATX heading (MD018: no-missing-space-atx). Escaped the leading hash as `\#6960` so it renders identically as `#6960` but is not parsed as a heading.
- **Scope boundary:** Single character (added `\` before `#`) on one line in `docs/book/src/contributing/agent-policy-parity-harness.md`; no other content changed.
- **Blast radius:** None — rendered output is visually identical; the fix only satisfies the linter.
- **Linked issue(s):** None
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — docs-only lint fix.
- **Prior behavior on `master` (before):** `markdownlint-cli2` reports `MD018/no-missing-space-atx` on line 78.
- **Expected on this branch (after):** `markdownlint-cli2` passes with 0 issues.

### How I tested

- **CI checks relied on and why they cover this change:** Markdown lint (`scripts/ci/docs_quality_gate.sh`) runs `markdownlint-cli2` which enforces MD018.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**
  ```sh
  npx markdownlint-cli2 docs/book/src/contributing/agent-policy-parity-harness.md
  # Summary: 0 issues in 0 files
  ```
- **Beyond CI, what did I manually verify?** Confirmed the rendered text reads identically: `#6960, #8120` PR references are preserved.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert <sha>`.
