### PR TITLE
fix(sop): resolve a relative sops_dir against the workspace, not CWD

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -142,11 +142,16 @@ fn sops_dir(workspace_dir: &Path) -> PathBuf {
 }
 
 /// Resolve the SOPs directory from config, falling back to workspace default.
+///
+/// A relative `config_dir` (the common case in the documented
+/// `<workspace>/sops` layout) resolves against `workspace_dir`; an
+/// absolute or `~`-prefixed value is used as-is (`Path::join` replaces
+/// the base entirely when the joined path is itself absolute).
 pub fn resolve_sops_dir(workspace_dir: &Path, config_dir: Option<&str>) -> PathBuf {
     match config_dir {
         Some(dir) if !dir.is_empty() => {
             let expanded = shellexpand::tilde(dir);
-            PathBuf::from(expanded.as_ref())
+            workspace_dir.join(expanded.as_ref())
         }
         _ => sops_dir(workspace_dir),
     }
@@ -1047,6 +1052,30 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn resolve_sops_dir_joins_relative_config_value_to_workspace() {
+        let workspace = Path::new("/home/user/.zoder/data");
+        let resolved = resolve_sops_dir(workspace, Some("shared/sops"));
+        assert_eq!(resolved, workspace.join("shared/sops"));
+    }
+
+    #[test]
+    fn resolve_sops_dir_keeps_absolute_config_value_as_is() {
+        let workspace = Path::new("/home/user/.zoder/data");
+        let resolved = resolve_sops_dir(workspace, Some("/srv/shared/sops"));
+        assert_eq!(resolved, Path::new("/srv/shared/sops"));
+    }
+
+    #[test]
+    fn resolve_sops_dir_falls_back_to_workspace_sops_when_unset() {
+        let workspace = Path::new("/home/user/.zoder/data");
+        assert_eq!(resolve_sops_dir(workspace, None), workspace.join("sops"));
+        assert_eq!(
+            resolve_sops_dir(workspace, Some("")),
+            workspace.join("sops")
+        );
+    }
 
     fn authoring_sop(steps: Vec<SopStep>) -> Sop {
         Sop {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `resolve_sops_dir()` handled the omitted/empty-config case correctly (`<workspace>/sops`, matching the documented layout in `docs/book/src/sop/syntax.md`), but an explicit *relative* `sop.sops_dir` value fell through to `PathBuf::from(shellexpand::tilde(dir))`, which resolves against whatever directory the process happens to be running in, not the workspace.
  - Changed the relative-path branch to `workspace_dir.join(expanded.as_ref())`. `Path::join` already replaces the base entirely when the joined path is absolute, so this is a strict superset of the old behavior: absolute paths and `~`-prefixed paths (post tilde-expansion) resolve exactly as before; relative paths now resolve against the workspace as the function's own doc comment and the published docs already implied.
  - Added 3 unit tests covering the relative/absolute/unset cases directly against `resolve_sops_dir`.
- **Scope boundary:** Only `resolve_sops_dir()` in `crates/zeroclaw-runtime/src/sop/mod.rs`. Does not touch SOP loading, validation, execution, or the `[sop]` config schema itself.
- **Blast radius:** `zeroclaw sop list/validate/show/approve/deny/pending` and the `sop_*` agent tools, all of which resolve their working directory through this function. No effect on deployments that already use an absolute or `~`-prefixed `sops_dir`, or that omit it (the default `<workspace>/sops` path is unchanged).
- **Linked issue(s):** None filed; found and fixed while smoke-testing a real SOP deployment.
- **Labels:** `bug`, `config`, `runtime`, `tool:sop`, `risk:high`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — pure function fix, fully covered by the added unit tests; no user-visible click-through beyond what the tests already assert.

### How I tested

```sh
cargo fmt --all -- --check
cargo +1.96.1 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo +1.96.1 test --test architecture tests_that_persist_config_isolate_the_path
cargo +1.96.1 test --test architecture user_facing_strings_route_through_fluent
cargo +1.96.1 check --locked --features ci-all --all-targets
cargo +1.96.1 check --locked --no-default-features
cargo +1.96.1 test -p zeroclaw-runtime --lib sop::tests::resolve_sops_dir
```

- **CI checks relied on and why they cover this change:** `Check (all features)` and the clippy/fmt gates cover the changed crate directly; the 3 new `resolve_sops_dir_*` tests are the direct regression coverage for this fix.
- **Known CI coverage gap, if any:** None after the above.
- **Commands run and tail output:**
  ```
  cargo fmt --all -- --check
  (clean, no diff)

  cargo +1.96.1 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 47.08s

  cargo +1.96.1 check --locked --features ci-all --all-targets
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 28s

  cargo +1.96.1 check --locked --no-default-features
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.68s

  cargo +1.96.1 test -p zeroclaw-runtime --lib sop::tests::resolve_sops_dir
  test sop::tests::resolve_sops_dir_falls_back_to_workspace_sops_when_unset ... ok
  test sop::tests::resolve_sops_dir_keeps_absolute_config_value_as_is ... ok
  test sop::tests::resolve_sops_dir_joins_relative_config_value_to_workspace ... ok
  test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 3107 filtered out; finished in 0.00s
  ```
- **Beyond CI, what did you manually verify?** Reproduced the bug against a real deployment: `sops_dir = "shared/sops"` with SOP files under `<workspace>/shared/sops/<name>/` returned "No SOPs found" from `zeroclaw sop list/validate/show` before this fix (the daemon's CWD ≠ workspace, so the relative path missed). After the fix, `list`/`validate`/`show` all correctly resolve and load the deployed SOP. Did not test the `sop_*` agent-tool path directly, only the CLI surface; both route through the same `resolve_sops_dir()`, and that function is exactly what's under test.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert 879f41ca4` is the plan.

