### PR TITLE
fix(hardware): resynchronize serial response frames

### DIFF
--- a/crates/zeroclaw-hardware/src/peripherals/serial.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/serial.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use portable_atomic::{AtomicU64, Ordering};
 use serde_json::{Value, json};
 use std::sync::Arc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::Mutex;
 use tokio_serial::{SerialPortBuilderExt, SerialStream};
 use zeroclaw_api::attribution::ToolKind;
@@ -19,8 +19,17 @@ use zeroclaw_config::schema::PeripheralBoardConfig;
 tool_attribution!(GpioReadTool, ToolKind::Plugin);
 tool_attribution!(GpioWriteTool, ToolKind::Plugin);
 
+/// Timeout for serial request/response (seconds).
+const SERIAL_TIMEOUT_SECS: u64 = 5;
+
+/// Maximum malformed or non-matching response frames skipped per request.
+const MAX_SKIPPED_RESPONSE_FRAMES: usize = 16;
+
 /// JSON request/response over serial.
-async fn send_request(port: &mut SerialStream, cmd: &str, args: Value) -> anyhow::Result<Value> {
+async fn send_request<S>(port: &mut S, cmd: &str, args: Value) -> anyhow::Result<Value>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     static ID: AtomicU64 = AtomicU64::new(0);
     let id = ID.fetch_add(1, Ordering::Relaxed);
     let id_str = id.to_string();
@@ -35,21 +44,31 @@ async fn send_request(port: &mut SerialStream, cmd: &str, args: Value) -> anyhow
     port.write_all(line.as_bytes()).await?;
     port.flush().await?;
 
-    let mut buf = Vec::new();
-    let mut b = [0u8; 1];
-    while port.read_exact(&mut b).await.is_ok() {
-        if b[0] == b'\n' {
-            break;
+    let mut skipped_frames = 0;
+    loop {
+        let mut buf = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            port.read_exact(&mut byte).await?;
+            if byte[0] == b'\n' {
+                break;
+            }
+            buf.push(byte[0]);
         }
-        buf.push(b[0]);
+
+        if let Ok(resp) = serde_json::from_slice::<Value>(&buf)
+            && resp.get("id").and_then(Value::as_str) == Some(id_str.as_str())
+        {
+            return Ok(resp);
+        }
+
+        if skipped_frames == MAX_SKIPPED_RESPONSE_FRAMES {
+            anyhow::bail!(
+                "Serial response skip limit exceeded (maximum {MAX_SKIPPED_RESPONSE_FRAMES} frames)"
+            );
+        }
+        skipped_frames += 1;
     }
-    let line_str = String::from_utf8_lossy(&buf);
-    let resp: Value = serde_json::from_str(line_str.trim())?;
-    let resp_id = resp["id"].as_str().unwrap_or("");
-    if resp_id != id_str {
-        anyhow::bail!("Response id mismatch: expected {}, got {}", id_str, resp_id);
-    }
-    Ok(resp)
 }
 
 /// Shared serial transport for tools. Pub(crate) for capabilities tool.
@@ -57,15 +76,14 @@ pub struct SerialTransport {
     port: Mutex<SerialStream>,
 }
 
-/// Timeout for serial request/response (seconds).
-const SERIAL_TIMEOUT_SECS: u64 = 5;
-
 impl SerialTransport {
     pub(crate) async fn request(&self, cmd: &str, args: Value) -> anyhow::Result<ToolResult> {
         let mut port = self.port.lock().await;
+        // One timeout covers the request and every skipped frame, so stale or
+        // malformed input cannot restart the deadline.
         let resp = tokio::time::timeout(
             std::time::Duration::from_secs(SERIAL_TIMEOUT_SECS),
-            send_request(&mut port, cmd, args),
+            send_request(&mut *port, cmd, args),
         )
         .await
         .map_err(|_| {
@@ -315,5 +333,173 @@ impl Tool for GpioWriteTool {
         self.transport
             .request("gpio_write", json!({ "pin": pin, "value": value }))
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::DuplexStream;
+    use tokio::time::{Duration, sleep, timeout};
+
+    async fn read_frame(port: &mut DuplexStream) -> Vec<u8> {
+        let mut frame = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            port.read_exact(&mut byte)
+                .await
+                .expect("device should receive a complete frame");
+            if byte[0] == b'\n' {
+                return frame;
+            }
+            frame.push(byte[0]);
+        }
+    }
+
+    async fn read_request_id(port: &mut DuplexStream) -> String {
+        let frame = read_frame(port).await;
+        let request: Value =
+            serde_json::from_slice(&frame).expect("host request should be valid JSON");
+        request
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("host request should contain a string id")
+            .to_owned()
+    }
+
+    async fn write_frame(port: &mut DuplexStream, frame: &[u8]) {
+        port.write_all(frame)
+            .await
+            .expect("device should write response frame");
+        port.write_all(b"\n")
+            .await
+            .expect("device should terminate response frame");
+        port.flush()
+            .await
+            .expect("device should flush response frame");
+    }
+
+    async fn write_json_frame(port: &mut DuplexStream, frame: Value) {
+        let frame = serde_json::to_vec(&frame).expect("response should serialize");
+        write_frame(port, &frame).await;
+    }
+
+    #[tokio::test]
+    async fn wrong_id_then_matching_response_succeeds() {
+        let (mut host, mut device) = tokio::io::duplex(4096);
+
+        let host_request = send_request(&mut host, "ping", json!({}));
+        let device_response = async {
+            let request_id = read_request_id(&mut device).await;
+            write_json_frame(
+                &mut device,
+                json!({"id": "unexpected", "ok": true, "result": "stale"}),
+            )
+            .await;
+            write_json_frame(
+                &mut device,
+                json!({"id": request_id, "ok": true, "result": "current"}),
+            )
+            .await;
+        };
+
+        let (response, ()) = tokio::join!(host_request, device_response);
+        let response = response.expect("matching response should succeed");
+        assert_eq!(response["result"], "current");
+    }
+
+    #[tokio::test]
+    async fn malformed_frame_then_matching_response_succeeds() {
+        let (mut host, mut device) = tokio::io::duplex(4096);
+
+        let host_request = send_request(&mut host, "ping", json!({}));
+        let device_response = async {
+            let request_id = read_request_id(&mut device).await;
+            write_frame(&mut device, b"not-json").await;
+            write_json_frame(
+                &mut device,
+                json!({"id": request_id, "ok": true, "result": "current"}),
+            )
+            .await;
+        };
+
+        let (response, ()) = tokio::join!(host_request, device_response);
+        let response = response.expect("matching response should succeed");
+        assert_eq!(response["result"], "current");
+    }
+
+    #[tokio::test]
+    async fn unsolicited_frame_flood_does_not_extend_deadline_and_stream_recovers() {
+        let (mut host, mut device) = tokio::io::duplex(4096);
+
+        let host_requests = async {
+            let first = timeout(
+                Duration::from_millis(200),
+                send_request(&mut host, "first", json!({})),
+            )
+            .await;
+            assert!(
+                first.is_err(),
+                "unsolicited frames must not extend the original request deadline"
+            );
+
+            let second = timeout(
+                Duration::from_secs(2),
+                send_request(&mut host, "second", json!({})),
+            )
+            .await
+            .expect("subsequent request should finish")
+            .expect("subsequent request should recover on the same stream");
+            assert_eq!(second["result"], "recovered");
+        };
+
+        let device_responses = async {
+            let _first_request_id = read_request_id(&mut device).await;
+            for sequence in 0..5 {
+                write_json_frame(
+                    &mut device,
+                    json!({
+                        "id": format!("unsolicited-{sequence}"),
+                        "ok": true,
+                        "result": "stale"
+                    }),
+                )
+                .await;
+                sleep(Duration::from_millis(60)).await;
+            }
+
+            let second_request_id = read_request_id(&mut device).await;
+            write_json_frame(
+                &mut device,
+                json!({"id": second_request_id, "ok": true, "result": "recovered"}),
+            )
+            .await;
+        };
+
+        tokio::join!(host_requests, device_responses);
+    }
+
+    #[tokio::test]
+    async fn unsolicited_frame_skip_limit_is_bounded() {
+        let (mut host, mut device) = tokio::io::duplex(4096);
+
+        let host_request = send_request(&mut host, "ping", json!({}));
+        let device_response = async {
+            let _request_id = read_request_id(&mut device).await;
+            for sequence in 0..=MAX_SKIPPED_RESPONSE_FRAMES {
+                write_json_frame(
+                    &mut device,
+                    json!({"id": format!("unsolicited-{sequence}"), "ok": true}),
+                )
+                .await;
+            }
+        };
+
+        let (response, ()) = tokio::join!(host_request, device_response);
+        let error = response.expect_err("skip limit should reject an unsolicited-frame flood");
+        assert!(
+            error.to_string().contains("skip limit exceeded"),
+            "unexpected error: {error:#}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Skip malformed and non-matching newline-delimited frames until the response for the active request arrives, preventing stale frames from poisoning later requests.
  - Keep the entire exchange—including every skipped frame—inside the existing fixed five-second request timeout.
  - Bound unsolicited input to 16 skipped frames per request as an additional guard.
  - Add deterministic regression coverage for wrong IDs, malformed frames, bounded unsolicited-frame floods, and recovery on the same stream.
- **Scope boundary:** This does not change the serial wire format, request ID generation, timeout duration, configuration surface, or reconnection policy.
- **Blast radius:** Serial peripheral requests routed through `SerialTransport`, including serial GPIO operations. USB discovery, device registration, and non-serial transports are unaffected.
- **Linked issue(s):** Closes #9078; Related #8447 (follow-up to serial desynchronization identified during review)
- **Labels:** `bug`, `tests`, `rust`, `hardware`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — deterministic duplex-stream tests exercise the internal transport behavior without requiring physical serial hardware.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head required CI is green, including Format, Lint, Test, Security, platform checks, and CI Required Gate. Focused host and Docker checks additionally exercise the affected hardware crate and all requested serial resynchronization scenarios.
- **Known CI coverage gap, if any:** The full Docker workspace run reached 3,095 passing tests but had one failure in the unchanged runtime test `agent::agent::tests::turn_streamed_appends_receipts_block_when_show_in_response`. No hardware tests failed. A single-job release build reached the final fat-LTO link but was SIGKILLed under Docker’s memory limit.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check

cargo clippy -p zeroclaw-hardware \
  --features "hardware dev-sim" \
  --all-targets -- -D warnings

cargo test -p zeroclaw-hardware \
  --features "hardware dev-sim" \
  peripherals::serial::tests

# test result: ok. 4 passed; 0 failed; 0 ignored; 148 filtered out

cargo test -p zeroclaw-hardware \
  --features "hardware dev-sim"

# test result: ok. 151 passed; 0 failed; 1 ignored; 0 filtered out

./dev/ci.sh lint
./dev/ci.sh test-manual
./dev/ci.sh security
git diff --check
```

  - `lint` passed. It reported two existing unused-import warnings in unchanged channel modules.
  - All 23 manual CI checks passed.
  - `cargo deny` passed. `cargo audit` exited successfully with the repository’s existing allowed warnings for `proc-macro-error` and `spin`.
- **Beyond CI, what did you manually verify?** Confirmed that the production timeout still wraps the complete request and response-scanning future, rather than being recreated for each frame. The tests verify a wrong ID followed by the correct response, malformed input followed by the correct response, a flood that cannot extend the original deadline, recovery on the same stream, and enforcement of the skip limit. Physical serial hardware was not exercised.
- **If any command was intentionally skipped, why:** `./dev/ci.sh docker-smoke` was skipped because it repeats the fat-LTO release workload and exports a maximal BuildKit cache after the equivalent single-job release link was already OOM-killed locally. PR CI remains the appropriate release-image coverage.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit-sha>`
- **Feature flags or config toggles:** None; this remains internal to the existing `hardware` feature.
- **Observable failure symptoms:** Serial peripheral operations time out or return `Serial response skip limit exceeded` when a device emits more than 16 malformed or non-matching frames before its valid response.
