### PR TITLE
fix(zerocode): pass selected socket to spawned daemon

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -433,8 +433,8 @@ pub async fn run(
         if matches!(rpc.connection_state(), ConnectionState::Disconnected { .. }) {
             if owns_ephemeral && !ephemeral_respawn_done {
                 ephemeral_respawn_done = true;
-                if let crate::ConnectTarget::LocalSocket(_) = target {
-                    let _ = crate::spawn_ephemeral_daemon(config_dir);
+                if let crate::ConnectTarget::LocalSocket(socket) = target {
+                    let _ = crate::spawn_ephemeral_daemon(config_dir, socket);
                 }
             }
 

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -321,7 +321,7 @@ async fn run() -> anyhow::Result<()> {
                 Err(e) if is_daemon_version_mismatch(&e) => return Err(e),
                 Err(_) => {
                     let config_dir = client::resolve_config_dir(cli.config_dir.as_deref())?;
-                    spawn_ephemeral_daemon(&config_dir)?;
+                    spawn_ephemeral_daemon(&config_dir, socket)?;
                     owns_ephemeral = true;
                     await_daemon_ready(socket).await?
                 }
@@ -406,17 +406,17 @@ async fn run_until_exit(
     }
 }
 
-pub(crate) fn spawn_ephemeral_daemon(config_dir: &std::path::Path) -> anyhow::Result<()> {
+pub(crate) fn spawn_ephemeral_daemon(
+    config_dir: &std::path::Path,
+    socket: &std::path::Path,
+) -> anyhow::Result<()> {
     let exe = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.join("zeroclaw")))
         .unwrap_or_else(|| PathBuf::from("zeroclaw"));
 
     let mut cmd = std::process::Command::new(&exe);
-    cmd.arg("daemon")
-        .arg("--ephemeral")
-        .arg("--config-dir")
-        .arg(config_dir);
+    configure_ephemeral_daemon_command(&mut cmd, config_dir, socket);
 
     // Lower the daemon's log level to DEBUG when spawned ephemerally by
     // zerocode so that the Logs pane can show debug events without any
@@ -438,6 +438,20 @@ pub(crate) fn spawn_ephemeral_daemon(config_dir: &std::path::Path) -> anyhow::Re
         .map_err(|e| anyhow::Error::msg(format!("failed to spawn daemon: {e}")))?;
 
     Ok(())
+}
+
+fn configure_ephemeral_daemon_command(
+    cmd: &mut std::process::Command,
+    config_dir: &std::path::Path,
+    socket: &std::path::Path,
+) {
+    cmd.arg("daemon")
+        .arg("--ephemeral")
+        .arg("--config-dir")
+        .arg(config_dir)
+        // The TUI waits on this exact endpoint, so the child must bind it
+        // instead of independently deriving a potentially different path.
+        .env("ZEROCLAW_SOCKET", socket);
 }
 
 async fn await_daemon_ready(socket: &std::path::Path) -> anyhow::Result<client::RpcClient> {
@@ -467,6 +481,35 @@ fn is_daemon_version_mismatch(err: &anyhow::Error) -> bool {
 mod connection_tests {
     use super::*;
     use crate::config::WssSection;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn ephemeral_daemon_command_sets_selected_socket() {
+        let mut cmd = std::process::Command::new("zeroclaw");
+        configure_ephemeral_daemon_command(
+            &mut cmd,
+            std::path::Path::new("/tmp/zeroclaw-config"),
+            std::path::Path::new("/tmp/zeroclaw.sock"),
+        );
+
+        assert_eq!(
+            cmd.get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            [
+                "daemon",
+                "--ephemeral",
+                "--config-dir",
+                "/tmp/zeroclaw-config",
+            ]
+        );
+        assert_eq!(
+            cmd.get_envs()
+                .find(|(name, _)| *name == OsStr::new("ZEROCLAW_SOCKET"))
+                .and_then(|(_, value)| value),
+            Some(OsStr::new("/tmp/zeroclaw.sock"))
+        );
+    }
 
     #[test]
     fn flag_connect_overrides_config_uri() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Pass the local IPC endpoint selected by `zerocode` to an ephemeral daemon child through the existing `ZEROCLAW_SOCKET` override.
  - Use the same selected endpoint for both initial daemon startup and the one permitted reconnect respawn, so the child binds the socket or Windows named pipe that the TUI is already waiting on.
  - Keep `zerocode` RPC-only: this fix does not add a dependency on daemon, runtime, config, or infrastructure crates.
  - Add command-construction coverage proving the child receives the selected endpoint without lossy path conversion.
- **Scope boundary:** This PR only changes `zerocode`'s initial and reconnect ephemeral-daemon spawn commands. It does not change default endpoint derivation, runtime-directory precedence, attached-daemon behavior, the JSON-RPC protocol, remote WSS connections, or daemon configuration.
- **Blast radius:** Local `zerocode` startup when no daemon is reachable, plus the existing one-time respawn path for a daemon that this TUI process owns. Remote connections and independently managed daemons are unchanged.
- **Linked issue(s):** Closes #9117
- **Labels:** `bug`, `priority:p1`, `risk:medium`, `zerocode`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes. The requested Windows 11 Pro (24H2) smoke is complete: with `ZEROCLAW_SOCKET` unset, `zerocode` reached the TUI, and terminating the owned daemon triggered a successful one-time respawn and reconnect.
- **Interface(s) exercised:** `surface=tui`
- **Setup / preconditions:** Windows environment with `zerocode` and `zeroclaw` built from this branch. Leave `ZEROCLAW_SOCKET` unset for the main smoke path.
- **Steps to run:**
  1. Ensure `ZEROCLAW_SOCKET` is unset.
  2. Start `zerocode` without `--connect` while no daemon is listening on its selected local endpoint.
  3. Let `zerocode` spawn the ephemeral daemon.
  4. Confirm the TUI reaches the dashboard, config, or chat surface instead of timing out while waiting for the named pipe.
  5. Optional reconnect check: stop the owned ephemeral daemon after startup and confirm the one-time respawn reconnects on the same endpoint.
- **Expected on this branch (after):** The spawned daemon receives the exact endpoint selected by `zerocode` through `ZEROCLAW_SOCKET`, binds that endpoint, and the TUI connects successfully.
- **Prior behavior on `master` (before):** `zerocode` and its child daemon could independently derive different Windows named-pipe paths, causing startup to time out unless the operator set `ZEROCLAW_SOCKET` manually.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh GitHub CI runs the repository formatting, RPC-boundary, Windows MSVC check, lint, and test jobs on this head. The focused local evidence below covers the changed child-command construction and confirms `zerocode` retains its no-backend-dependency boundary.
- **Known CI coverage gap, if any:** None for the reported failure. The command boundary is unit-covered, fresh CI includes the Windows MSVC check, and independent Windows 11 startup and reconnect smoke both passed. Targeted Windows Clippy was skipped by the workflow's change detector.
- **Commands run and tail output:**

```sh
cargo fmt -p zerocode -- --check
# passed

cargo test -p zerocode ephemeral_daemon_command_sets_selected_socket
# lib harness: 0 matching tests
# binary harness: 1 passed, 0 failed, 551 filtered out

bash scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
# zerocode gate passed: no zeroclaw-* dependencies

bash scripts/ci/comment_hygiene_gate.sh
# passed

git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** I inspected both production spawn call sites and confirmed they pass the same borrowed `Path` selected by `ConnectTarget::LocalSocket`. `Command::env` changes only the child process environment. @klonuo independently verified native Windows 11 startup and the one-time reconnect path.
- **If any command was intentionally skipped, why:** Workspace-wide local clippy and nextest were not run because the replacement diff is limited to `zerocode` command construction, fresh repository CI covers the wider matrix, and the reported Windows paths are covered by independent Windows 11 smoke evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Run `git revert <merge-commit>`.
- **Feature flags or config toggles:** Existing operator-set `ZEROCLAW_SOCKET` values still select the endpoint and are forwarded unchanged to an ephemeral child.
- **Observable failure symptoms:** `zerocode` times out waiting for its spawned daemon, reconnect fails after the owned daemon exits, or Windows users again need to set `ZEROCLAW_SOCKET` manually for local startup.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why (inspiration-only, no direct code/design carry-over): No superseded PR scope is incorporated.
