### PR TITLE
docs(ci): correct stale Rust-CodeQL note in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,8 @@ name: CodeQL
 
 # Static analysis for JavaScript/TypeScript source under web/.
 # Uses the existing .github/codeql/codeql-config.yml (paths-ignore tests/).
-# Rust CodeQL support is currently in beta upstream — add once stable.
+# Rust CodeQL lives in the sibling ci-code-analysis.yml workflow (master push
+# + daily, alongside Semgrep); language coverage is split across the two.
 #
 # Triggers:
 #   push to master     — immediate feedback on merged code


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `codeql.yml`'s header comment claimed *"Rust CodeQL support is currently in beta upstream — add once stable."* That guidance is stale: Rust CodeQL was already added in the sibling `ci-code-analysis.yml` workflow (master push + daily schedule, alongside Semgrep).
  - Rewrites that line to point at where Rust analysis actually runs and to document that language coverage is deliberately split across the two workflows (`codeql.yml` = JS/TS under `web/`; `ci-code-analysis.yml` = Rust), so a reader doesn't conclude Rust source is unanalyzed.
- **Scope boundary:** Comment-only. Does not change any workflow trigger, permission, job, matrix language, CodeQL config, or product code. No change to `ci-code-analysis.yml` or `codeql-config.yml`.
- **Blast radius:** None at runtime — a YAML comment. Affects only how a human reads the file.
- **Linked issue(s):** None.
- **Labels:** `ci`, `domain:ci`, `risk:low`, `risk:manual`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — comment-only change with no runtime surface to exercise.

### How I tested

Comment-only edit to a single line's worth of YAML comment; the diff is one hunk in `.github/workflows/codeql.yml` (+2/-1) and touches no YAML keys, so the workflow parses and behaves identically.

- **CI checks relied on and why they cover this change:** Required CI is green; no behavior-bearing workflow content changed.
- **Known CI coverage gap, if any:** None — there is no behavior to test.
- **Commands run and tail output:**

```sh
$ git diff --stat upstream/master..HEAD
 .github/workflows/codeql.yml | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

- **Beyond CI, what did you manually verify?** Confirmed Rust CodeQL genuinely runs in `ci-code-analysis.yml` (languages: rust; master push + daily schedule), so the new comment is accurate.
- **If any command was intentionally skipped, why:** Rust build/lint/test gates skipped — no Rust or product code changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk, comment-only.

- **Fast rollback command/path:** `git revert <merged-squash-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** None — no runtime behavior changes.

