### PR TITLE
fix(ci): prevent shell injection via workflow_dispatch tag input

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -104,17 +104,27 @@ jobs:
 
       - name: Determine version tag
         id: version
+        # Pass workflow context through env, never interpolated into the script
+        # body. `${{ github.event.inputs.tag }}` is an untrusted workflow_dispatch
+        # input; expanding it directly into `run:` would let a crafted value inject
+        # shell before the validation regex below ever runs. As env vars the shell
+        # reads them as data.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+          GIT_REF: ${{ github.ref }}
+          GIT_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$TAG_INPUT"
             # Validate: must be 'master' or a semver tag like v0.7.5 / v0.8.0-beta-1.
             if ! [[ "$TAG" =~ ^(master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?)$ ]]; then
               echo "::error::Invalid tag input '${TAG}'. Must be 'master' or match v<major>.<minor>.<patch>[-<pre>]."
               exit 1
             fi
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            TAG="${{ github.ref_name }}"
+          elif [[ "$GIT_REF" == refs/tags/* ]]; then
+            TAG="$GIT_REF_NAME"
           else
             # Master push: always deploy master. A pointer flip in the same push is
             # already validated above; the master deploy refreshes the pointer file


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `Determine version tag` step in `docs-deploy.yml` expanded `${{ github.event.inputs.tag }}` **directly into the `run:` script**, one line before the regex that validates it. GitHub performs `${{ }}` template interpolation *before* the shell runs, so a crafted `workflow_dispatch` tag input (e.g. `"; curl … | sh; "`) executes before the validation can reject it — a GitHub-Actions script injection (CWE-94) in a job that holds `permissions: contents: write`.
  - Moves the four workflow-context expansions used by that step (`github.event_name`, `github.event.inputs.tag`, `github.ref`, `github.ref_name`) into an `env:` block and references them as shell variables (`"$TAG_INPUT"` etc.). Env values reach the shell as data and can never be parsed as code.
- **Scope boundary:** Only the `Determine version tag` step. The validation regex, the version-floor check, `$GITHUB_OUTPUT` write, and every downstream step are unchanged. No other workflow, script, or product code touched.
- **Blast radius:** `docs-deploy.yml` only. Behavior is identical for all legitimate inputs (`master`, `vX.Y.Z[-pre]`, tag pushes, master pushes); the only change is that a malicious input can no longer inject shell.
- **Linked issue(s):** None. Surfaced by the repo's own Semgrep rule `yaml.github-actions.security.run-shell-injection`.
- **Labels:** `bug`, `ci`, `security`, `risk:high`, `size:XS`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` (optional but quick).
- **Interface(s) exercised:** `cli`/CI — GitHub Actions `workflow_dispatch` on the Deploy-docs workflow.
- **Setup / preconditions:** Ability to run `workflow_dispatch` on this workflow (repo write).
- **Steps to run:** Trigger the workflow with a normal `tag` (`master` or `v0.8.0`) and confirm docs build as before; separately confirm an invalid tag (`nope`) still fails the regex with the same `::error::Invalid tag input` message.
- **Expected on this branch (after):** Valid tags behave identically; invalid tags rejected identically; a shell-metacharacter tag is treated as a plain (invalid) string and rejected, not executed.
- **Prior behavior on `master` (before):** Same visible behavior for valid/invalid tags, but a `${{ }}`-interpolated metacharacter payload would have run before the regex check.

### How I tested

Comment/`env`-plumbing change to a single workflow step; no product code.

- **CI checks relied on and why they cover this change:** `actionlint` and the `Code Analysis` (Semgrep) job parse and lint this workflow.
- **Known CI coverage gap, if any:** GitHub does not run the modified workflow from a fork PR (fork `pull_request` runs the base-repo workflow), so the change takes effect only once on `master`. It is a self-contained `env:`-plumbing edit; behavior for valid inputs is unchanged.
- **Commands run and tail output:**

```sh
$ actionlint .github/workflows/docs-deploy.yml && echo OK
OK
$ git diff --stat upstream/master -- .github/workflows/docs-deploy.yml
 .github/workflows/docs-deploy.yml | 18 ++++++++++++++----
 1 file changed, 14 insertions(+), 4 deletions(-)
```

- **Beyond CI, what did you manually verify?** Read the full step: the four moved expansions are the only `${{ }}` uses in the block, and `TAG` is still regex-validated before any downstream use, so behavior is preserved for all legitimate inputs.
- **If any command was intentionally skipped, why:** Rust build/test gates skipped — no Rust or product code changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- **This PR *reduces* attack surface:** it closes a `workflow_dispatch`-input shell-injection (CWE-94) in a `contents: write` job. Exploitability was low (trigger requires repo write access; the regex bounds valid values), but the untrusted input is no longer interpolated into the script body.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Docs-deploy `Determine version tag` step failing for a previously-valid tag; none expected (behavior unchanged for legitimate inputs).
