### PR TITLE
docs(agents): correct rename and deletion lifecycle

### DIFF
--- a/docs/book/src/agents/internals.md
+++ b/docs/book/src/agents/internals.md
@@ -33,11 +33,19 @@ Each agent has its own `Arc<dyn Memory>` instance. The factory (`zeroclaw_memory
 
 Cross-backend cross-agent memory is not supported: the schema validator at config load rejects `read_memory_from` entries that point at a sibling on a different backend.
 
+## Rename and delete lifecycle
+
+Use the gateway dashboard's agent controls or the dedicated `zeroclaw agents` CLI for rename and delete. In the standard build with `gateway` and `agent-runtime` enabled, both surfaces run the reference and owned-state cascades; directly removing or re-keying `agents.<alias>` in TOML or through a generic config setter does not. A reduced-feature CLI still updates config references but warns that owned state was not cascaded, so use a build with both features enabled for lifecycle operations.
+
+Both operations make the config change durable before running owned-state side effects. Rename rewrites config references first, then moves the default per-alias workspace and re-points memory, cron, ACP, and session state. Delete first refuses hard references and live ACP sessions, then removes the config entry and soft references before attempting workspace archival, owned-state export and cleanup, and session-attribution clearing.
+
+The post-persist side effects are best-effort and report surfaced failures, but archive-file write failures may appear only in gateway logs. Rename warnings call for retrying the same gateway API rename to converge residue left under the old alias. After deletion, verify the archive contents and logs before relying on the archive for recovery. Automated restore is not supported.
+
+See [Multi-agent setup walkthrough](../contributing/multi-agent-setup.md#rename-an-agent) for the current controls, blockers, archive layout, and operator checks.
+
 ## Not supported today
 
 1. Cross-backend cross-agent memory access (e.g. SQLite agent reading a Postgres agent's rows).
-2. Agent rename (the `agents.id` UUID indirection is the rename-ready foundation, but no CLI/UI surface exists).
-3. Pre-delete archive and restore.
-4. Per-agent secret namespacing: there is a single workspace-wide `SecretStore`.
-5. Lucid wire-format extensions for cross-agent scoping.
-6. A dedicated `zeroclaw agents` management CLI for creating/deleting/listing agents.
+2. Automated restore from an agent deletion archive.
+3. Per-agent secret namespacing: there is a single workspace-wide `SecretStore`.
+4. Lucid wire-format extensions for cross-agent scoping.

--- a/docs/book/src/contributing/multi-agent-setup.md
+++ b/docs/book/src/contributing/multi-agent-setup.md
@@ -54,19 +54,48 @@ Every configured agent lives under an `agents.<alias>` entry with its risk profi
 
 {{#config-where agents}}
 
-## Delete an agent
+> The `zeroclaw agents` lifecycle commands perform the full owned-state cascade only in builds with `gateway` and `agent-runtime` enabled, including the standard distributed binary. A reduced-feature CLI still changes config but prints that owned state was not cascaded. Use the gateway dashboard or a binary with both features enabled for the operations below when owned state exists.
 
-1. Remove the `agents.<alias>` entry (and any nested `workspace` / `memory` tables) through the gateway, zerocode, or `zeroclaw config set`.
-2. Strip the alias from every `[peer_groups.<name>]` block's `agents` list.
-3. Remove the workspace dir: `rm -rf <install>/agents/<alias>/workspace/`.
-4. Optional cleanup of the agent's memory rows (they retain `agent_id = <alias-uuid>` attribution but no live agent maps to that UUID anymore):
+## Rename an agent
 
-```sql
-DELETE FROM memories WHERE agent_id = (SELECT id FROM agents WHERE alias = 'researcher');
-DELETE FROM agents WHERE alias = 'researcher';
+Use the rename control for the agent under **Config > Agents** in the gateway dashboard, or run:
+
+```sh
+zeroclaw agents rename researcher analyst
 ```
 
-The schema validator will refuse to load if a `[peer_groups.<name>]` still lists the deleted alias, so step 2 is required before the daemon will start cleanly.
+Both surfaces rewrite references to the alias, persist the config, move the default per-alias workspace, and re-point owned memory, cron, ACP, and session state. Custom workspace paths do not move because they are not derived from the alias. The reserved `default` alias cannot be renamed from or to.
+
+Read any warnings in the response. The config rename commits before workspace and owned-state migration, so warnings identify a side effect that still needs attention. The same gateway API rename request can be reissued to retry residue left under the old alias.
+
+## Delete an agent
+
+Use the delete control under **Config > Agents**, or preview and apply the CLI operation:
+
+```sh
+zeroclaw agents delete researcher --dry-run
+zeroclaw agents delete researcher --yes
+```
+
+1. Review the impact preview and clear every blocker it reports. Common config blockers are an enabled heartbeat owned by the agent and an enabled channel binding that no other enabled agent owns. The preview also lists soft references that the cascade will remove automatically.
+2. End any live ACP sessions. The dashboard includes them in its preview; the CLI verifies them when `--yes` executes, after the config-only `--dry-run` preview.
+3. Confirm the dashboard deletion or run the CLI command with `--yes`. The operation removes the agent and soft references from config first, then runs the owned-state cascade.
+4. Inspect `<data_dir>/agents/_deleted/<alias>-<timestamp>/` and the gateway logs before relying on the archive or cleanup result.
+
+The owned-state cascade attempts to:
+
+- move the configured workspace into the deletion archive;
+- write exported memory, cron, and ACP data under `cascade/`;
+- purge the agent's memory rows and cron jobs;
+- remove its non-live ACP sessions;
+- clear agent attribution from retained conversation sessions; and
+- write `manifest.json` with counts and surfaced warnings.
+
+These side effects are best-effort. An export or archive-file write can fail while later cleanup continues. Verify the applicable `workspace/`, `cascade/*.json`, and `manifest.json` entries instead of assuming the archive is complete. The CLI prints surfaced cascade warnings. The delete API also returns them, but the dashboard does not currently display them; dashboard operators must check the gateway logs as well.
+
+> Do not replace this flow with direct TOML edits, `zeroclaw config set`, manual workspace deletion, or SQL deletion. Those paths do not run the gateway's reference and owned-state cascade.
+
+There is no automated restore command. Keep the deletion archive until you no longer need it for inspection or manual recovery.
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Corrects the agent internals and multi-agent setup docs to match the shipped rename and deletion cascades. The walkthrough now covers the gateway dashboard and `zeroclaw agents` CLI, hard blockers, config-before-owned-state ordering, archive verification, warning visibility, and the reduced-feature CLI boundary.
- **Scope boundary:** Documentation only. This PR does not change rename/delete behavior, add automated restore, or fix the dashboard's current omission of delete-response warnings.
- **Blast radius:** Agent operator and architecture documentation. Runtime, gateway, CLI, dashboard, config, and stored state are unchanged.
- **Linked issue(s):** Related #6808.
- **Labels:** `docs`, `type:docs`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is a documentation-only correction to already-shipped behavior.

### How I tested

- **CI checks relied on and why they cover this change:** Required Docs Style, Format, Repository Structure, and CI Required Gate passed on the published head.
- **Known CI coverage gap, if any:** No documentation CI gap. The dedicated CLI dispatch and reduced-feature warning paths do not have direct regression tests; this PR does not change those code paths.
- **Commands run and tail output:**

```text
bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
No blocking markdown issues on changed lines.

bash scripts/ci/docs_links_gate.sh
PASS

git diff --check origin/master...HEAD
PASS

scripts/check-pr-title.sh 'docs(agents): correct rename and deletion lifecycle'
PASS
```

- **Beyond CI, what did you manually verify?** Compared every operator claim with the gateway rename/delete handlers, alias-reference planner, owned-state cascade, dashboard controls, and `zeroclaw agents` implementation. Three independent read-only review passes were clean after correcting archive durability, dashboard warning visibility, custom-workspace deletion, CLI availability, and reduced-feature behavior.
- **If any command was intentionally skipped, why:** Cargo and runtime tests were skipped because this PR changes only Markdown documentation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. The docs describe existing destructive lifecycle behavior without changing it.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk documentation rollback: `git revert <sha>`.
