### PR TITLE
feat(release): add broad-channel measurement builds

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -2,6 +2,15 @@ name: Cross-Platform Build
 
 on:
   workflow_dispatch:
+    inputs:
+      distribution:
+        description: Feature distribution to measure
+        required: true
+        type: choice
+        default: dist
+        options:
+          - dist
+          - dist-broad
 
 permissions:
   contents: read
@@ -43,10 +52,10 @@ jobs:
           retention-days: 1
 
   build:
-    name: Build ${{ matrix.target }}
+    name: Build ${{ inputs.distribution }} / ${{ matrix.target }}
     needs: [web]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: ${{ inputs.distribution == 'dist-broad' && 90 || 40 }}
     strategy:
       fail-fast: false
       matrix:
@@ -132,18 +141,26 @@ jobs:
             export CXXFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
             export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C target-feature=-neon"
           fi
-          FEATURES="$(cargo run --quiet -p xtask --bin generate -- features --selection dist --target "${{ matrix.target }}")"
+          FEATURES="$(cargo run --quiet -p xtask --bin generate -- features --selection "${{ inputs.distribution }}" --target "${{ matrix.target }}")"
           echo "Resolved features: $FEATURES"
           cargo build --release --locked --no-default-features --features "${FEATURES}" --target ${{ matrix.target }}
-          if [ "${{ matrix.target }}" != "aarch64-linux-android" ]; then
-            cargo build --release --locked -p zerocode --target ${{ matrix.target }}
-          fi
+          binary="target/${{ matrix.target }}/release/${{ runner.os == 'Windows' && 'zeroclaw.exe' || 'zeroclaw' }}"
+          bytes="$(wc -c < "$binary" | tr -d ' ')"
+          {
+            echo "### ${{ inputs.distribution }} / ${{ matrix.target }}"
+            echo
+            echo "- Binary bytes: $bytes"
+            echo "- Resolved features: \`$FEATURES\`"
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: zeroclaw-manual-${{ matrix.target }}
+          name: zeroclaw-manual-${{ inputs.distribution }}-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ runner.os == 'Windows' && 'zeroclaw.exe' || 'zeroclaw' }}
           if-no-files-found: error
           retention-days: 1
+      - name: Build ZeroCode companion
+        if: matrix.target != 'aarch64-linux-android'
+        run: cargo build --release --locked -p zerocode --target ${{ matrix.target }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.target != 'aarch64-linux-android'
         with:

--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -127,20 +127,26 @@ jobs:
           fi
           echo "$NDK_PREBUILT/bin" >> "$GITHUB_PATH"
 
+      - name: Configure target environment
+        shell: bash
+        run: |
+          {
+            if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
+              echo "${{ matrix.linker_env }}=${{ matrix.linker }}"
+            fi
+            if [ "${{ matrix.target }}" = "arm-unknown-linux-gnueabihf" ]; then
+              # Force ARMv6 codegen for arm-unknown-linux-gnueabihf (#4556).
+              # Ubuntu's gcc-arm-linux-gnueabihf defaults to ARMv7+NEON,
+              # which segfaults on ARMv6 devices (e.g., Raspberry Pi Zero W).
+              echo "CFLAGS_arm_unknown_linux_gnueabihf=-march=armv6 -mfpu=vfp -mfloat-abi=hard"
+              echo "CXXFLAGS_arm_unknown_linux_gnueabihf=-march=armv6 -mfpu=vfp -mfloat-abi=hard"
+              echo "CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS=-C target-feature=-neon"
+            fi
+          } >> "$GITHUB_ENV"
+
       - name: Build release
         shell: bash
         run: |
-          if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
-            export "${{ matrix.linker_env }}=${{ matrix.linker }}"
-          fi
-          if [ "${{ matrix.target }}" = "arm-unknown-linux-gnueabihf" ]; then
-            # Force ARMv6 codegen for arm-unknown-linux-gnueabihf (#4556).
-            # Ubuntu 22.04's gcc-arm-linux-gnueabihf defaults to ARMv7+NEON,
-            # which segfaults on ARMv6 devices (e.g., Raspberry Pi Zero W).
-            export CFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
-            export CXXFLAGS_arm_unknown_linux_gnueabihf="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
-            export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C target-feature=-neon"
-          fi
           FEATURES="$(cargo run --quiet -p xtask --bin generate -- features --selection "${{ inputs.distribution }}" --target "${{ matrix.target }}")"
           echo "Resolved features: $FEATURES"
           cargo build --release --locked --no-default-features --features "${FEATURES}" --target ${{ matrix.target }}

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -111,18 +111,18 @@ pub fn features(
     target: Option<&str>,
     excluded: &[String],
 ) -> anyhow::Result<()> {
-    let menu = Sel::menu();
-    let selection = menu
-        .iter()
-        .find(|s| s.id() == selection_id)
-        .ok_or_else(|| {
-            anyhow::Error::msg(format!(
-                "unknown selection `{selection_id}` (known: {})",
-                menu.iter().map(|s| s.id()).collect::<Vec<_>>().join(", ")
-            ))
-        })?;
+    let selection = Sel::from_id(selection_id).ok_or_else(|| {
+        anyhow::Error::msg(format!(
+            "unknown selection `{selection_id}` (known: {})",
+            Sel::named()
+                .iter()
+                .map(Sel::id)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    })?;
     let list = spec::exclude_features(
-        spec::resolve_feature_list_for_target(&workspace_root(), selection, target)?,
+        spec::resolve_feature_list_for_target(&workspace_root(), &selection, target)?,
         excluded,
     )?;
     println!("{}", list.join(","));

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -1054,12 +1054,25 @@ mod tests {
         );
         assert!(manual.contains("--selection \"${{ inputs.distribution }}\""));
         assert!(manual.contains("zeroclaw-manual-${{ inputs.distribution }}-${{ matrix.target }}"));
+        assert!(manual.contains("echo \"- Binary bytes: $bytes\""));
+        assert!(manual.contains("echo \"- Resolved features: \\`$FEATURES\\`\""));
+        assert_eq!(
+            manual
+                .matches("if: matrix.target != 'aarch64-linux-android'")
+                .count(),
+            2,
+            "both the ZeroCode build and upload must skip Android"
+        );
         assert!(!manual.contains("excluded_features"));
 
         let target_env = manual.find("- name: Configure target environment").unwrap();
         let release_step = manual.find("- name: Build release").unwrap();
         let companion = manual.find("- name: Build ZeroCode companion").unwrap();
         assert!(target_env < release_step && release_step < companion);
+        assert!(
+            manual[target_env..release_step]
+                .contains("echo \"${{ matrix.linker_env }}=${{ matrix.linker }}\"")
+        );
         assert!(manual[target_env..release_step].contains(">> \"$GITHUB_ENV\""));
         assert!(!manual[release_step..companion].contains("matrix.linker_env"));
 

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -1056,6 +1056,13 @@ mod tests {
         assert!(manual.contains("zeroclaw-manual-${{ inputs.distribution }}-${{ matrix.target }}"));
         assert!(!manual.contains("excluded_features"));
 
+        let target_env = manual.find("- name: Configure target environment").unwrap();
+        let release_step = manual.find("- name: Build release").unwrap();
+        let companion = manual.find("- name: Build ZeroCode companion").unwrap();
+        assert!(target_env < release_step && release_step < companion);
+        assert!(manual[target_env..release_step].contains(">> \"$GITHUB_ENV\""));
+        assert!(!manual[release_step..companion].contains("matrix.linker_env"));
+
         for feature in exclusions.values().flatten() {
             assert!(!release.contains(feature));
             assert!(!manual.contains(feature));

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -467,7 +467,7 @@ fn resolve_feature_list_from_package(
 }
 
 /// Resolve a selection and apply the registry-owned compatibility policy for
-/// one build target. Target policy is defined only for the Dist selection.
+/// one build target. Target policy is defined only for distribution selections.
 pub fn resolve_feature_list_for_target(
     manifest_dir: &Path,
     selection: &Selection,
@@ -484,8 +484,8 @@ pub fn resolve_feature_list_for_target(
     };
     anyhow::ensure!(!target.is_empty(), "target must not be empty");
     anyhow::ensure!(
-        matches!(selection, Selection::Dist),
-        "target-specific exclusions are only defined for the dist selection"
+        matches!(selection, Selection::Dist | Selection::DistBroad),
+        "target-specific exclusions are only defined for distribution selections"
     );
 
     let exclusions = dist_target_exclusions(root)?;
@@ -493,7 +493,7 @@ pub fn resolve_feature_list_for_target(
         for feature in excluded {
             anyhow::ensure!(
                 features.iter().any(|candidate| candidate == feature),
-                "dist_target_exclusions.{configured_target} names `{feature}`, which is not in the dist selection"
+                "dist_target_exclusions.{configured_target} names `{feature}`, which is not in the selected distribution"
             );
         }
     }
@@ -591,6 +591,10 @@ pub enum Selection {
     /// registry-owned distribution additions. The set a single-artifact
     /// package manager ships.
     Dist,
+    /// Measurement-only broad distribution: `Dist` plus the canonical
+    /// `channels-full` aggregate. Not offered by installer menus until a
+    /// stable broad artifact lifecycle exists.
+    DistBroad,
     /// Every selectable feature (all − non_row − pure-alias). The docker
     /// `:all-features` kitchen sink.
     All,
@@ -606,6 +610,7 @@ impl Selection {
             Selection::Full => "default",
             Selection::Minimal => "minimal",
             Selection::Dist => "dist",
+            Selection::DistBroad => "dist-broad",
             Selection::All => "all",
             Selection::Features(_) => "custom",
         }
@@ -618,21 +623,36 @@ impl Selection {
             Selection::Full => "default feature set",
             Selection::Minimal => "core only, no default features",
             Selection::Dist => "lean standard distribution (recommended)",
+            Selection::DistBroad => "broad-channel distribution measurement build",
             Selection::All => "every feature including hardware and browser",
             Selection::Features(_) => "custom feature selection",
         }
     }
 
-    /// The selections a packaged/menu surface offers, in menu order. Single
-    /// source for "which build modes exist"; surfaces walk this, they do not
-    /// enumerate modes themselves.
-    pub fn menu() -> Vec<Selection> {
+    /// Every named selection accepted by the feature resolver.
+    pub fn named() -> Vec<Selection> {
         vec![
             Selection::Minimal,
             Selection::Dist,
+            Selection::DistBroad,
             Selection::Full,
             Selection::All,
         ]
+    }
+
+    /// The selections a packaged/menu surface offers, in menu order.
+    pub fn menu() -> Vec<Selection> {
+        Self::named()
+            .into_iter()
+            .filter(|selection| !matches!(selection, Selection::DistBroad))
+            .collect()
+    }
+
+    /// Resolve a named build selection without coupling it to installer menus.
+    pub fn from_id(id: &str) -> Option<Self> {
+        Self::named()
+            .into_iter()
+            .find(|selection| selection.id() == id)
     }
 
     /// Cargo flag string for this selection (wraps `to_feature_list`).
@@ -650,7 +670,7 @@ impl Selection {
         let mut set = match self {
             Selection::Minimal => Vec::new(),
             Selection::Full => ctx.expand("default"),
-            Selection::Dist => {
+            Selection::Dist | Selection::DistBroad => {
                 let mut s = ctx.expand("default");
                 for feature in ctx.dist_extra {
                     anyhow::ensure!(
@@ -658,6 +678,9 @@ impl Selection {
                         "unknown dist_extra_features entry `{feature}` (not in [features])"
                     );
                     s.push(feature.clone());
+                }
+                if matches!(self, Selection::DistBroad) {
+                    s.extend(ctx.expand("channels-full"));
                 }
                 s
             }
@@ -838,6 +861,52 @@ mod tests {
     }
 
     #[test]
+    fn dist_broad_derives_membership_from_channels_full() {
+        let meta = cargo_metadata::MetadataCommand::new()
+            .manifest_path(root().join("Cargo.toml"))
+            .no_deps()
+            .exec()
+            .unwrap();
+        let pkg = workspace_root_package(&meta).unwrap();
+        let all_features: Vec<String> = pkg.features.keys().cloned().collect();
+        let non_row = non_row_features(&meta, pkg);
+        let dist_extra = dist_extra_features(pkg).unwrap();
+        let container_excluded = container_excluded_features(pkg);
+        let ctx = FeatureCtx {
+            graph: &pkg.features,
+            all: &all_features,
+            non_row: &non_row,
+            dist_extra: &dist_extra,
+            container_excluded: &container_excluded,
+        };
+
+        let mut expected = resolve_feature_list(&root(), &Selection::Dist).unwrap();
+        expected.extend(ctx.expand("channels-full"));
+        expected.sort();
+        expected.dedup();
+
+        let broad = resolve_feature_list(&root(), &Selection::DistBroad).unwrap();
+        assert_eq!(broad, expected);
+        assert!(broad.contains(&"channel-slack".to_string()));
+        assert!(!broad.contains(&"hardware".to_string()));
+    }
+
+    #[test]
+    fn dist_broad_is_named_but_not_offered_in_installer_menus() {
+        assert_eq!(Selection::DistBroad.id(), "dist-broad");
+        assert!(matches!(
+            Selection::from_id("dist-broad"),
+            Some(Selection::DistBroad)
+        ));
+        assert!(Selection::from_id("unknown-selection").is_none());
+        assert!(
+            Selection::menu()
+                .iter()
+                .all(|selection| selection.id() != Selection::DistBroad.id())
+        );
+    }
+
+    #[test]
     fn all_is_superset_of_dist() {
         let dist = resolve(&root(), &Selection::Dist).unwrap();
         let all = resolve(&root(), &Selection::All).unwrap();
@@ -907,16 +976,19 @@ mod tests {
             .unwrap();
         let exclusions = dist_target_exclusions(workspace_root_package(&meta).unwrap()).unwrap();
 
-        for (target, excluded) in &exclusions {
-            let resolved =
-                resolve_feature_list_for_target(&root(), &Selection::Dist, Some(target)).unwrap();
-            assert_eq!(resolved.len(), dist.len() - excluded.len());
-            for feature in &dist {
-                assert_eq!(
-                    resolved.contains(feature),
-                    !excluded.contains(feature),
-                    "unexpected resolution for {target}: {feature}"
-                );
+        for selection in [Selection::Dist, Selection::DistBroad] {
+            let unfiltered = resolve_feature_list(&root(), &selection).unwrap();
+            for (target, excluded) in &exclusions {
+                let resolved =
+                    resolve_feature_list_for_target(&root(), &selection, Some(target)).unwrap();
+                assert_eq!(resolved.len(), unfiltered.len() - excluded.len());
+                for feature in &unfiltered {
+                    assert_eq!(
+                        resolved.contains(feature),
+                        !excluded.contains(feature),
+                        "unexpected resolution for {target}: {feature}"
+                    );
+                }
             }
         }
 
@@ -963,25 +1035,30 @@ mod tests {
             .exec()
             .unwrap();
         let exclusions = dist_target_exclusions(workspace_root_package(&meta).unwrap()).unwrap();
-        for workflow in [
-            ".github/workflows/cross-platform-build-manual.yml",
-            ".github/workflows/release-stable-manual.yml",
-        ] {
-            let contents = std::fs::read_to_string(root().join(workflow)).unwrap();
-            assert!(
-                contents.contains("features --selection dist --target \"${{ matrix.target }}\""),
-                "{workflow} must pass the target triple to the canonical feature resolver"
-            );
-            assert!(
-                !contents.contains("excluded_features"),
-                "{workflow} must not own a parallel target exclusion policy"
-            );
-            for feature in exclusions.values().flatten() {
-                assert!(
-                    !contents.contains(feature),
-                    "{workflow} must not name target-excluded feature {feature}"
-                );
-            }
+        let release =
+            std::fs::read_to_string(root().join(".github/workflows/release-stable-manual.yml"))
+                .unwrap();
+        assert!(release.contains("features --selection dist --target \"${{ matrix.target }}\""));
+        assert!(!release.contains("excluded_features"));
+
+        let manual = std::fs::read_to_string(
+            root().join(".github/workflows/cross-platform-build-manual.yml"),
+        )
+        .unwrap();
+        assert!(manual.contains("distribution:"));
+        assert!(manual.contains("- dist-broad"));
+        assert!(
+            manual.contains(
+                "timeout-minutes: ${{ inputs.distribution == 'dist-broad' && 90 || 40 }}"
+            )
+        );
+        assert!(manual.contains("--selection \"${{ inputs.distribution }}\""));
+        assert!(manual.contains("zeroclaw-manual-${{ inputs.distribution }}-${{ matrix.target }}"));
+        assert!(!manual.contains("excluded_features"));
+
+        for feature in exclusions.values().flatten() {
+            assert!(!release.contains(feature));
+            assert!(!manual.contains(feature));
         }
     }
 

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -1046,14 +1046,17 @@ mod tests {
         )
         .unwrap();
         assert!(manual.contains("distribution:"));
-        assert!(manual.contains("- dist-broad"));
+        assert!(
+            manual.contains(
+                "default: dist\n        options:\n          - dist\n          - dist-broad"
+            )
+        );
         assert!(
             manual.contains(
                 "timeout-minutes: ${{ inputs.distribution == 'dist-broad' && 90 || 40 }}"
             )
         );
         assert!(manual.contains("--selection \"${{ inputs.distribution }}\""));
-        assert!(manual.contains("zeroclaw-manual-${{ inputs.distribution }}-${{ matrix.target }}"));
         assert!(manual.contains("echo \"- Binary bytes: $bytes\""));
         assert!(manual.contains("echo \"- Resolved features: \\`$FEATURES\\`\""));
         assert_eq!(
@@ -1067,8 +1070,15 @@ mod tests {
 
         let target_env = manual.find("- name: Configure target environment").unwrap();
         let release_step = manual.find("- name: Build release").unwrap();
+        let zeroclaw_upload = manual
+            .find("name: zeroclaw-manual-${{ inputs.distribution }}-${{ matrix.target }}")
+            .unwrap();
         let companion = manual.find("- name: Build ZeroCode companion").unwrap();
-        assert!(target_env < release_step && release_step < companion);
+        assert!(
+            target_env < release_step
+                && release_step < zeroclaw_upload
+                && zeroclaw_upload < companion
+        );
         assert!(
             manual[target_env..release_step]
                 .contains("echo \"${{ matrix.linker_env }}=${{ matrix.linker }}\"")


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a named `dist-broad` feature selection for measuring an optional broad-channel prebuilt before adding it to stable releases.
  - Derives `dist-broad` from the existing lean `dist` selection plus the canonical `channels-full` aggregate; no second channel-membership list is introduced.
  - Lets the manual cross-platform workflow build either `dist` or `dist-broad`, names artifacts by selection, and records the resolved features and binary size for each target.
  - Keeps the standard manual-build timeout at 40 minutes, allows 90 minutes for broad builds, and uploads the measured ZeroClaw binary before building the independent ZeroCode companion.
- **Scope boundary:** This PR does not change the stable release workflow, publish a new release asset, expose `dist-broad` in installer menus, change `install.sh` or `zeroclaw update`, alter package-manager or container defaults, or change channel runtime behavior.
- **Blast radius:** The xtask feature resolver and the maintainer-invoked cross-platform build workflow. Stable releases and normal installs continue to use the lean `dist` selection.
- **Linked issue(s):** Related #7952. This is the measurement and target-compatibility slice; it does not close the full artifact-lifecycle issue.
- **Labels:** `enhancement`, `ci`, `risk:high`, `size:S`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** No additional reviewer testing is requested. The fixed-head `dist-broad` matrix completed successfully in [run 29689496541](https://github.com/Audacity88/zeroclaw/actions/runs/29689496541).
- **Setup / preconditions:** The linked matrix ran at head `a6ba91d64194b85bdffb5620670e206007d4ef60`; the current head `a25b6c59a9fa77986c088fe291f62db4cf5ce075` adds regression assertions for the measured workflow fields, lean distribution choices, and upload/companion ordering without changing the workflow.
- **Steps to run:** Inspect each target's job summary for its resolved feature list and binary byte count. The run uploaded `zeroclaw-manual-dist-broad-<target>` for all eight targets and ZeroCode companions for all seven applicable targets; the short-retention artifacts have since expired.
- **Expected on this branch (after):** Each target resolves broad channel membership from the canonical feature registry, reports the measurement, and uploads a selection-qualified ZeroClaw artifact before the ZeroCode companion build.
- **Prior behavior on `master` (before):** The workflow always resolves `dist`, provides no distribution choice, and does not report the resolved feature set or binary byte count in the job summary.

### How I tested

```text
cargo fmt --all -- --check
Result: pass

cargo test -p xtask --lib generate::spec::tests:: -- --nocapture
Result: pass at matrix head a6ba91d641; 18 passed, 0 failed

cargo test -p xtask generate::spec::tests::release_workflows_delegate_target_policy_to_generator -- --exact --nocapture
Result: pass at current head a25b6c59a9; 1 passed, 0 failed

cargo clippy --locked -p xtask --all-targets --no-deps -- -D warnings
Result: pass

cargo run --locked -p xtask --bin generate -- installers --check
Result: pass; install.sh, setup.bat, container, package, Nix, and Docker-tag surfaces are in sync

cargo run --locked -p xtask --bin generate -- features --selection dist-broad --target aarch64-linux-android
Result: pass; Slack is included and target-incompatible WhatsApp Web is excluded by registry-owned target policy

actionlint .github/workflows/cross-platform-build-manual.yml
Result: pass

bash scripts/ci/comment_hygiene_gate.sh
Result: pass

git diff --check
Result: pass
```

- **CI checks relied on and why they cover this change:** [Required PR CI](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/29938360843) passed at the current head, covering formatting, lint, tests, security, and host/platform compile checks. The focused xtask suite covers selection derivation, parser acceptance, unchanged installer-menu membership, target exclusions, and workflow delegation; the current-head focused test additionally locks the reported summary fields, lean distribution default/options, Android companion guards, persisted linker environment, and ZeroClaw-upload-before-companion ordering. Fixed-head manual run 29689496541 passed all eight `dist-broad` ZeroClaw target jobs and all seven applicable ZeroCode companion builds, including the repaired ARMv6 and ARMv7 jobs.
- **Known CI coverage gap, if any:** None for this measurement slice. Publishing stable broad-channel assets and preserving that selection through install, update, package-manager, and container lifecycles remain outside this PR.
- **Commands run and tail output:** Summarized above.
- **Beyond CI, what did you manually verify?** I inspected the root and channel-crate `channels-full` aggregates, confirmed the root leaves preserve the channel-crate membership, verified the Android resolver output directly, and checked the fixed-head matrix result and selection-qualified artifact inventory. I did not publish a release asset.
- **If any command was intentionally skipped, why:** A local cross-platform release build was not run because fixed-head manual run 29689496541 collected the target-specific evidence on the supported runners.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** The workflow remains manual with `contents: read`.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any `Yes`, describe the risk and mitigation: **N/A.**

## Compatibility (required)

- Backward compatible? **Yes.** Existing `dist` resolution and stable artifacts are unchanged.
- Config / env / CLI surface changed? **Yes.** The xtask `generate features` command accepts the additional named selection `dist-broad`, and the manual workflow adds a typed distribution input.
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is `No` or either surface/floor question is `Yes`: Existing commands and defaults require no migration. `dist-broad` is additive and is not exposed in installer menus.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR to remove the `dist-broad` resolver and restore the single-selection manual workflow.
- **Feature flags or config toggles:** None. The workflow input selects the measurement build only when manually dispatched.
- **Observable failure symptoms:** The manual workflow rejects `dist-broad`, resolves a feature set that does not include Slack, fails a target build, omits a selection-qualified artifact, or reports a feature set/size that does not match the uploaded binary.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): **N/A.**
- Scope materially carried forward: **N/A.**
- `Co-authored-by` trailers added in commit messages for incorporated contributors? **No.**
- If `No`, why (inspiration-only, no direct code/design carry-over): This PR does not supersede another PR.
