### PR TITLE
fix(demo): bridge OpenRouter credential into typed config

### DIFF
--- a/demo/.env.template
+++ b/demo/.env.template
@@ -6,9 +6,9 @@
 #
 # `demo/.env` is gitignored.
 #
-# The host scripts source this file and `run-agent-host.sh` bridges
-# OPENROUTER_API_KEY and TELEGRAM_BOT_TOKEN into the current schema-mirror env
-# vars at runtime without writing secrets into demo/data/config/config.toml.
+# The host scripts source this file, while Docker Compose reads demo/.env
+# automatically. Both launch paths bridge credentials into current
+# schema-mirror env vars without writing secrets into config.toml.
 
 # Primary model provider for this demo (via OpenRouter).
 export OPENROUTER_API_KEY=""

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
-      MINIMAX_API_KEY: "${MINIMAX_API_KEY:-}"
-      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
+      ZEROCLAW_providers__models__openrouter__agent_demo__api_key: "${OPENROUTER_API_KEY:-}"
       RUST_LOG: "${RUST_LOG:-zeroclaw=info,zeroclaw_hardware=info,esp32_sim=info}"
     volumes:
       # Mount the demo config (constrained hardware-only surface).

--- a/demo/run-sim.sh
+++ b/demo/run-sim.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-# Pass env from .env if present (so MINIMAX_API_KEY etc. reach the container).
+# Load .env if present so Docker Compose can interpolate demo credentials.
 if [[ -f .env ]]; then
   set -a
   # shellcheck disable=SC1091

--- a/demo/zeroclaw.toml.example
+++ b/demo/zeroclaw.toml.example
@@ -24,7 +24,8 @@ default_provider = "openrouter"
 [model_providers.openrouter]
 name = "openrouter"
 base_url = "https://openrouter.ai/api/v1"
-# API key is picked up from OPENROUTER_API_KEY environment variable.
+# The launchers inject OPENROUTER_API_KEY into the openrouter.agent_demo alias
+# synthesized from [agents.demo] below without storing the key in this file.
 temperature = 0.3
 max_tokens = 1024
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Bridge the `OPENROUTER_API_KEY` value from `demo/.env` into the exact schema-mirror variable for the `openrouter.agent_demo` provider alias. Remove the unused MiniMax pass-through and align the demo comments with the credential path that the runtime actually consumes.
- **Scope boundary:** This does not convert the demo config to schema V3, change the dev Docker templates owned by #8953, or change provider error guidance tracked by #9154.
- **Blast radius:** The Docker-packaged ESP32 smart-room demo only. The host launcher already uses the same schema-mirror mapping.
- **Linked issue(s):** Related #8858
- **Labels:** `bug`, `config`, `provider:openrouter`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` through the Docker-packaged demo launcher
- **Setup / preconditions:** Docker Compose and a synthetic or real `OPENROUTER_API_KEY` value
- **Steps to run:** `OPENROUTER_API_KEY=synthetic-demo-key docker compose -f demo/docker-compose.yml config`
- **Expected on this branch (after):** The rendered `zeroclaw` environment contains `ZEROCLAW_providers__models__openrouter__agent_demo__api_key: synthetic-demo-key` and does not contain raw `OPENROUTER_API_KEY` or `MINIMAX_API_KEY` entries.
- **Prior behavior on `master` (before):** The rendered environment contains raw `OPENROUTER_API_KEY` and `MINIMAX_API_KEY` entries but no schema-mirror credential variable, so the migrated demo provider does not receive the key.

### How I tested

- **CI checks relied on and why they cover this change:** Required PR CI passed on head `1d2eeb170`, including Test, Lint, build, all-features, no-default-features, and cross-platform checks. These cover repository compilation and test integrity for this YAML/shell-only patch; they do not exercise Docker Compose interpolation.
- **Known CI coverage gap, if any:** Docker is unavailable on the local machine, so Compose interpolation and an end-to-end container credential smoke were not run.
- **Commands run and tail output:**

```text
$ git diff --check
(exit 0, no output)

$ bash -n demo/run-sim.sh
(exit 0, no output)

$ ruby -ryaml -e 'env = YAML.load_file("demo/docker-compose.yml").dig("services", "zeroclaw", "environment"); expected = ["RUST_LOG", "ZEROCLAW_providers__models__openrouter__agent_demo__api_key"]; abort "unexpected environment keys: #{env.keys}" unless env.keys.sort == expected.sort; abort "wrong credential bridge" unless env[expected.last] == "${OPENROUTER_API_KEY:-}"; puts env'
{"ZEROCLAW_providers__models__openrouter__agent_demo__api_key"=>"${OPENROUTER_API_KEY:-}", "RUST_LOG"=>"${RUST_LOG:-zeroclaw=info,zeroclaw_hardware=info,esp32_sim=info}"}
```

- **Beyond CI, what did you manually verify?** Inspected the V2-to-V3 migration that synthesizes `openrouter.agent_demo`, the environment-override load ordering, and the existing exact-alias runtime regression test. Confirmed that an empty interpolated key is treated as a missing credential rather than a configured key.
- **If any command was intentionally skipped, why:** `docker compose config` and container execution were skipped because Docker is not installed. Cargo validation was skipped because no Rust code changed and the exact migration-plus-override path already has a focused regression test. Consumed-file drift coverage remains out of scope and can be handled as a separate #8858 follow-up.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: The demo now maps its existing `.env` credential into the typed runtime configuration path. The key remains environment-only, is not written to the mounted config, and is not included in the diff or validation output.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: Demo users continue setting `OPENROUTER_API_KEY` in `demo/.env`; Docker Compose now performs the required translation internally. No user migration is required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The Docker demo agent reports a missing OpenRouter credential or fails while initializing its model provider.
