### PR TITLE
fix(sop): bypass switch evaluation on a false top-level when guard

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -363,10 +363,6 @@ mod tests {
         assert_eq!(resolve_next(&ctx), NextStep::Step(3));
     }
 
-    // Regression: a true top-level `when` plus a non-empty switch with no
-    // matching port must complete, even when an explicit `routing.next` is
-    // also declared. Pre-#8771 and the pre-PR master both return Complete
-    // here; the original patch incorrectly fell through to `next`.
     #[test]
     fn true_guard_unmatched_switch_with_explicit_next_completes() {
         let switch_rules = vec![SwitchRule {
@@ -392,10 +388,6 @@ mod tests {
         assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 
-    // Regression: same as above but no explicit `next`; the linear
-    // successor (step 2) exists and would be the natural fallthrough if
-    // the unmatched switch fell through. The unmatched switch must still
-    // complete the run.
     #[test]
     fn true_guard_unmatched_switch_with_linear_successor_completes() {
         let switch_rules = vec![SwitchRule {
@@ -420,9 +412,6 @@ mod tests {
         assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 
-    // Regression: same branch as above but with an absent top-level
-    // `when` (None). Absent is the same as true for the routing decision;
-    // it must also complete on an unmatched switch.
     #[test]
     fn absent_guard_unmatched_switch_with_linear_successor_completes() {
         let switch_rules = vec![SwitchRule {
@@ -444,8 +433,6 @@ mod tests {
         assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 
-    // Regression: same branch with absent guard and explicit `next` —
-    // still must complete, not fall through to `next`.
     #[test]
     fn absent_guard_unmatched_switch_with_explicit_next_completes() {
         let switch_rules = vec![SwitchRule {
@@ -467,18 +454,11 @@ mod tests {
         assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 
-    // Regression: false top-level `when` + `terminal: true` + an
-    // available linear successor — terminal must win. Lifts the
-    // precedence note out of prose and pins it as executable behavior.
     #[test]
     fn false_guard_terminal_with_available_successor_completes() {
         let mut step1 = step(1);
         step1.routing.when = Some("$.steps.1.enabled == true".to_string());
         step1.routing.terminal = true;
-        // Also wire a non-empty switch with a catch-all so the test would
-        // catch a regression that lets the switch evaluate when guard is
-        // false. With terminal=true and a false guard, the answer must be
-        // Complete regardless.
         step1.routing.switch = vec![SwitchRule {
             name: "catch_all".to_string(),
             when: None,

--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -23,6 +23,13 @@ pub struct RouteCtx<'a> {
 }
 
 /// Pick the next step, preserving linear behavior when no routing is declared.
+///
+/// Resolution precedence (highest to lowest):
+/// 1. Top-level `when` guard — if false, bypasses ALL routing and routes linearly (only linear successor/terminal considered)
+/// 2. Switch evaluation — top-to-bottom matching on port `when` guards when `when` is true/None
+/// 3. Explicit `next` target (from switch evaluation or declared on step)
+/// 4. Linear successor (current_step + 1) when neither switch nor explicit_next provides a target
+/// 5. Terminal completion when no successor exists
 pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
     if ctx.last_status == SopStepStatus::Failed {
         return NextStep::Fail("step failed".into());
@@ -43,8 +50,35 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
         Some(when) => evaluate_condition(when, Some(&payload)),
     };
 
-    // ── Switch: evaluate ports top to bottom; first passing rule routes. A
-    // rule with no `when` is the catch-all. No rule matches → Complete.
+    // When top-level `when` guard is false, bypass ALL routing decisions (switch, explicit_next)
+    // and route directly to linear successor or terminal completion
+    // This is the fix for issue #9120 - restores pre-PR #8771 behavior for false guards
+    if !when_allows_jump {
+        if current.routing.terminal {
+            return NextStep::Complete;
+        }
+        let next_step = ctx.run.current_step.saturating_add(1);
+        let Some(step) = ctx.sop.steps.iter().find(|step| step.number == next_step) else {
+            return if next_step > ctx.run.total_steps {
+                NextStep::Complete
+            } else {
+                NextStep::Fail(format!("step {next_step} does not exist"))
+            };
+        };
+
+        if !guard::within_visit_bound(ctx.run, next_step, ctx.max_step_visits) {
+            return NextStep::Fail(format!("step {next_step} visit limit reached"));
+        }
+
+        if eligible(step, ctx.run_data) {
+            return NextStep::Step(next_step);
+        } else {
+            return NextStep::Wait(next_step);
+        }
+    }
+
+    // When guard is true or None: proceed with normal routing decisions
+    // Switch evaluation runs first (PR #8771 made it unconditional)
     if !current.routing.switch.is_empty() {
         let payload = ctx.run_data.to_payload().to_string();
         for rule in &current.routing.switch {
@@ -70,28 +104,43 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
                 NextStep::Wait(target)
             };
         }
+        // No switch rules matched, fall through to declared next/linear
+    }
+
+    // Check for explicit next target (from routing configuration)
+    if let Some(next_target) = current.routing.next {
+        if next_target == ctx.run.current_step {
+            // Self-loop, but still need to handle terminal case
+        }
+        let Some(step) = ctx.sop.steps.iter().find(|s| s.number == next_target) else {
+            return NextStep::Fail(format!("step {next_target} does not exist"));
+        };
+
+        if !guard::within_visit_bound(ctx.run, next_target, ctx.max_step_visits) {
+            return NextStep::Fail(format!("step {next_target} visit limit reached"));
+        }
+
+        if eligible(step, ctx.run_data) {
+            return NextStep::Step(next_target);
+        } else {
+            return NextStep::Wait(next_target);
+        }
+    }
+
+    // No explicit next, no switch matched: use linear successor
+    if current.routing.terminal {
         return NextStep::Complete;
     }
 
-    let explicit_next = current.routing.next;
-    // A failed `when` disables the explicit jump: the step routes as if
-    // `next` were absent, so `terminal` still completes the run.
-    let effective_next = if when_allows_jump {
-        explicit_next
-    } else {
-        None
-    };
-    if effective_next.is_none() && current.routing.terminal {
-        return NextStep::Complete;
-    }
-    let next_step = effective_next.unwrap_or_else(|| ctx.run.current_step.saturating_add(1));
+    let next_step = ctx.run.current_step.saturating_add(1);
     let Some(step) = ctx.sop.steps.iter().find(|step| step.number == next_step) else {
-        return if effective_next.is_none() && next_step > ctx.run.total_steps {
+        return if next_step > ctx.run.total_steps {
             NextStep::Complete
         } else {
             NextStep::Fail(format!("step {next_step} does not exist"))
         };
     };
+
     if !guard::within_visit_bound(ctx.run, next_step, ctx.max_step_visits) {
         return NextStep::Fail(format!("step {next_step} visit limit reached"));
     }
@@ -114,8 +163,9 @@ pub fn eligible(step: &SopStep, run_data: &RunData) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sop::types::{
-        SopEvent, SopExecutionMode, SopPriority, SopRunStatus, SopTriggerSource,
+    use crate::sop::{
+        SwitchRule,
+        types::{SopEvent, SopExecutionMode, SopPriority, SopRunStatus, SopTriggerSource},
     };
 
     fn step(number: u32) -> SopStep {
@@ -244,22 +294,90 @@ mod tests {
     }
 
     #[test]
-    fn when_false_advances_to_following_step() {
+    fn when_false_advances_to_linear_successor() {
         let sop = sop_with_steps(vec![step(1), loop_step(2), step(3)]);
         let run = run_at(2, 3);
         let run_data = run_data_with_remaining(2, 0);
         let ctx = route_ctx(&sop, &run, &run_data);
 
+        // When `when` is false, it should bypass all routing and go to linear successor (step 3)
+        // The loop_step has `next = Some(2)` but false `when` ignores it
         assert_eq!(resolve_next(&ctx), NextStep::Step(3));
     }
 
     #[test]
-    fn when_false_tail_loop_completes() {
+    fn when_false_at_end_completes() {
         let sop = sop_with_steps(vec![step(1), loop_step(2)]);
         let run = run_at(2, 2);
         let run_data = run_data_with_remaining(2, 0);
         let ctx = route_ctx(&sop, &run, &run_data);
 
+        // When `when` is false at the last step with terminal=false, it should complete
+        // because linear successor (3) > total_steps (2)
         assert_eq!(resolve_next(&ctx), NextStep::Complete);
+    }
+
+    // Regression test for issue #9120: false top-level `when` should bypass switch to linear
+    #[test]
+    fn when_false_bypasses_switch_to_linear_successor() {
+        let switch_rules = vec![
+            SwitchRule {
+                name: "target2".to_string(),
+                when: Some("$.steps.1.enabled == true".to_string()),
+                goto: Some(2),
+            },
+            SwitchRule {
+                name: "target3".to_string(),
+                when: None, // catch-all goes to step 3
+                goto: Some(3),
+            },
+        ];
+
+        // Step 1 has a false `when` condition and a switch with two ports
+        // It should bypass the switch evaluation entirely and go to linear successor (step 2 = 1+1)
+        let mut step1 = step(1);
+        step1.routing.when = Some("$.steps.1.enabled == false".to_string());
+        step1.routing.switch = switch_rules;
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3)]);
+        let run = run_at(1, 3);
+        let run_data = RunData::default(); // No outputs, making when condition false
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        // Should go to linear successor (step 2 = 1+1), NOT switch target
+        assert_eq!(resolve_next(&ctx), NextStep::Step(2));
+    }
+
+    // Inverse test: true top-level `when` with switch should evaluate based on when + switch
+    #[test]
+    fn when_true_evaluates_switch_correctly() {
+        // Use distinct steps: switch targets are 3 and 4, linear successor is 2
+        // This ensures the test catches bugs where wrong path is taken
+        let switch_rules = vec![
+            SwitchRule {
+                name: "target3".to_string(),
+                when: Some("$.steps.1.enabled == true".to_string()),
+                goto: Some(3),
+            },
+            SwitchRule {
+                name: "target4".to_string(),
+                when: None, // catch-all goes to step 4
+                goto: Some(4),
+            },
+        ];
+
+        // Step 1 has a true `when` condition and a switch with two ports
+        let mut step1 = step(1);
+        let mut run_data = RunData::default();
+        run_data.insert_output_str(1, r#"{"enabled": true}"#);
+        step1.routing.when = Some("$.steps.1.enabled == true".to_string());
+        step1.routing.switch = switch_rules;
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3), step(4)]);
+        let run = run_at(1, 4);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        // Should use the FIRST matching switch port (target3 = step 3), NOT linear successor (2)
+        assert_eq!(resolve_next(&ctx), NextStep::Step(3));
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -52,7 +52,8 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
 
     // When top-level `when` guard is false, bypass ALL routing decisions (switch, explicit_next)
     // and route directly to linear successor or terminal completion
-    // This is the fix for issue #9120 - restores pre-PR #8771 behavior for false guards
+    // Restores the linear-successor behavior for a false guard that predates
+    // unconditional switch evaluation.
     if !when_allows_jump {
         if current.routing.terminal {
             return NextStep::Complete;
@@ -78,7 +79,7 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
     }
 
     // When guard is true or None: proceed with normal routing decisions
-    // Switch evaluation runs first (PR #8771 made it unconditional)
+    // Switch evaluation runs first when the guard allows it.
     if !current.routing.switch.is_empty() {
         let payload = ctx.run_data.to_payload().to_string();
         for rule in &current.routing.switch {
@@ -317,7 +318,7 @@ mod tests {
         assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 
-    // Regression test for issue #9120: false top-level `when` should bypass switch to linear
+    // Regression test: false top-level `when` should bypass switch to linear.
     #[test]
     fn when_false_bypasses_switch_to_linear_successor() {
         let switch_rules = vec![

--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -103,16 +103,7 @@ fn resolve_target(ctx: &RouteCtx<'_>, target: u32) -> NextStep {
     let Some(step) = ctx.sop.steps.iter().find(|s| s.number == target) else {
         return NextStep::Fail(format!("step {target} does not exist"));
     };
-
-    if !guard::within_visit_bound(ctx.run, target, ctx.max_step_visits) {
-        return NextStep::Fail(format!("step {target} visit limit reached"));
-    }
-
-    if eligible(step, ctx.run_data) {
-        NextStep::Step(target)
-    } else {
-        NextStep::Wait(target)
-    }
+    resolve_step_decision(ctx, target, step)
 }
 
 /// Resolve the linear successor (`current_step + 1`). Completes when the
@@ -127,15 +118,19 @@ fn resolve_linear(ctx: &RouteCtx<'_>) -> NextStep {
             NextStep::Fail(format!("step {next_step} does not exist"))
         };
     };
+    resolve_step_decision(ctx, next_step, step)
+}
 
-    if !guard::within_visit_bound(ctx.run, next_step, ctx.max_step_visits) {
-        return NextStep::Fail(format!("step {next_step} visit limit reached"));
+/// Apply the visit-bound and dependency checks shared by every target
+/// resolution path, once the candidate step has been looked up.
+fn resolve_step_decision(ctx: &RouteCtx<'_>, target: u32, step: &SopStep) -> NextStep {
+    if !guard::within_visit_bound(ctx.run, target, ctx.max_step_visits) {
+        return NextStep::Fail(format!("step {target} visit limit reached"));
     }
-
     if eligible(step, ctx.run_data) {
-        NextStep::Step(next_step)
+        NextStep::Step(target)
     } else {
-        NextStep::Wait(next_step)
+        NextStep::Wait(target)
     }
 }
 

--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -24,12 +24,23 @@ pub struct RouteCtx<'a> {
 
 /// Pick the next step, preserving linear behavior when no routing is declared.
 ///
-/// Resolution precedence (highest to lowest):
-/// 1. Top-level `when` guard — if false, bypasses ALL routing and routes linearly (only linear successor/terminal considered)
-/// 2. Switch evaluation — top-to-bottom matching on port `when` guards when `when` is true/None
-/// 3. Explicit `next` target (from switch evaluation or declared on step)
-/// 4. Linear successor (current_step + 1) when neither switch nor explicit_next provides a target
-/// 5. Terminal completion when no successor exists
+/// Resolution precedence (highest to lowest). The branches are mutually
+/// exclusive — only one of them fires per call — so the linear narrative
+/// reads as a *decision tree*, not a fallback chain:
+///
+/// 1. **False top-level `when` guard** → terminal completes; otherwise the
+///    linear successor is taken. `switch` ports and `routing.next` are
+///    bypassed entirely.
+/// 2. **True or absent top-level `when` guard** with a non-empty `switch` →
+///    the first matching port's `goto` is taken, or the run completes if no
+///    port matches. `routing.next` and the linear successor are NOT
+///    consulted.
+/// 3. **True or absent top-level `when` guard** with no `switch` and a
+///    declared `routing.next` → that explicit successor is taken (visit
+///    limit, dependency, and existence checks still apply).
+/// 4. **True or absent top-level `when` guard** with no `switch` and no
+///    `routing.next` → `terminal: true` completes the run; otherwise the
+///    linear successor (`current_step + 1`) is taken.
 pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
     if ctx.last_status == SopStepStatus::Failed {
         return NextStep::Fail("step failed".into());
@@ -50,38 +61,14 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
         Some(when) => evaluate_condition(when, Some(&payload)),
     };
 
-    // When top-level `when` guard is false, bypass ALL routing decisions (switch, explicit_next)
-    // and route directly to linear successor or terminal completion
-    // Restores the linear-successor behavior for a false guard that predates
-    // unconditional switch evaluation.
     if !when_allows_jump {
         if current.routing.terminal {
             return NextStep::Complete;
         }
-        let next_step = ctx.run.current_step.saturating_add(1);
-        let Some(step) = ctx.sop.steps.iter().find(|step| step.number == next_step) else {
-            return if next_step > ctx.run.total_steps {
-                NextStep::Complete
-            } else {
-                NextStep::Fail(format!("step {next_step} does not exist"))
-            };
-        };
-
-        if !guard::within_visit_bound(ctx.run, next_step, ctx.max_step_visits) {
-            return NextStep::Fail(format!("step {next_step} visit limit reached"));
-        }
-
-        if eligible(step, ctx.run_data) {
-            return NextStep::Step(next_step);
-        } else {
-            return NextStep::Wait(next_step);
-        }
+        return resolve_linear(ctx);
     }
 
-    // When guard is true or None: proceed with normal routing decisions
-    // Switch evaluation runs first when the guard allows it.
     if !current.routing.switch.is_empty() {
-        let payload = ctx.run_data.to_payload().to_string();
         for rule in &current.routing.switch {
             let matched = match rule.when.as_deref() {
                 Some(when) => evaluate_condition(when, Some(&payload)),
@@ -93,48 +80,47 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
             let Some(target) = rule.goto else {
                 return NextStep::Fail(format!("switch port '{}' has no target", rule.name));
             };
-            let Some(step) = ctx.sop.steps.iter().find(|s| s.number == target) else {
-                return NextStep::Fail(format!("step {target} does not exist"));
-            };
-            if !guard::within_visit_bound(ctx.run, target, ctx.max_step_visits) {
-                return NextStep::Fail(format!("step {target} visit limit reached"));
-            }
-            return if eligible(step, ctx.run_data) {
-                NextStep::Step(target)
-            } else {
-                NextStep::Wait(target)
-            };
+            return resolve_target(ctx, target);
         }
-        // No switch rules matched, fall through to declared next/linear
+        return NextStep::Complete;
     }
 
-    // Check for explicit next target (from routing configuration)
     if let Some(next_target) = current.routing.next {
-        if next_target == ctx.run.current_step {
-            // Self-loop, but still need to handle terminal case
-        }
-        let Some(step) = ctx.sop.steps.iter().find(|s| s.number == next_target) else {
-            return NextStep::Fail(format!("step {next_target} does not exist"));
-        };
-
-        if !guard::within_visit_bound(ctx.run, next_target, ctx.max_step_visits) {
-            return NextStep::Fail(format!("step {next_target} visit limit reached"));
-        }
-
-        if eligible(step, ctx.run_data) {
-            return NextStep::Step(next_target);
-        } else {
-            return NextStep::Wait(next_target);
-        }
+        return resolve_target(ctx, next_target);
     }
 
-    // No explicit next, no switch matched: use linear successor
     if current.routing.terminal {
         return NextStep::Complete;
     }
 
+    resolve_linear(ctx)
+}
+
+/// Resolve an explicit successor step number (from a switch port or
+/// `routing.next`) into the final `NextStep`. Looks the step up, enforces
+/// the visit bound, and applies dependency-based eligibility.
+fn resolve_target(ctx: &RouteCtx<'_>, target: u32) -> NextStep {
+    let Some(step) = ctx.sop.steps.iter().find(|s| s.number == target) else {
+        return NextStep::Fail(format!("step {target} does not exist"));
+    };
+
+    if !guard::within_visit_bound(ctx.run, target, ctx.max_step_visits) {
+        return NextStep::Fail(format!("step {target} visit limit reached"));
+    }
+
+    if eligible(step, ctx.run_data) {
+        NextStep::Step(target)
+    } else {
+        NextStep::Wait(target)
+    }
+}
+
+/// Resolve the linear successor (`current_step + 1`). Completes when the
+/// successor is past the end of the SOP; fails when the successor falls in
+/// a gap; otherwise delegates to the shared target resolution.
+fn resolve_linear(ctx: &RouteCtx<'_>) -> NextStep {
     let next_step = ctx.run.current_step.saturating_add(1);
-    let Some(step) = ctx.sop.steps.iter().find(|step| step.number == next_step) else {
+    let Some(step) = ctx.sop.steps.iter().find(|s| s.number == next_step) else {
         return if next_step > ctx.run.total_steps {
             NextStep::Complete
         } else {
@@ -380,5 +366,136 @@ mod tests {
 
         // Should use the FIRST matching switch port (target3 = step 3), NOT linear successor (2)
         assert_eq!(resolve_next(&ctx), NextStep::Step(3));
+    }
+
+    // Regression: a true top-level `when` plus a non-empty switch with no
+    // matching port must complete, even when an explicit `routing.next` is
+    // also declared. Pre-#8771 and the pre-PR master both return Complete
+    // here; the original patch incorrectly fell through to `next`.
+    #[test]
+    fn true_guard_unmatched_switch_with_explicit_next_completes() {
+        let switch_rules = vec![SwitchRule {
+            name: "no_match".to_string(),
+            when: Some("$.steps.1.enabled == false".to_string()),
+            goto: Some(3),
+        }];
+
+        let mut step1 = step(1);
+        step1.routing.when = Some("$.steps.1.enabled == true".to_string());
+        step1.routing.switch = switch_rules;
+        // The explicit `next` would route to step 2 if reached; the
+        // unmatched switch must prevent that and complete instead.
+        step1.routing.next = Some(2);
+
+        let mut run_data = RunData::default();
+        run_data.insert_output_str(1, r#"{"enabled": true}"#);
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3)]);
+        let run = run_at(1, 3);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
+    }
+
+    // Regression: same as above but no explicit `next`; the linear
+    // successor (step 2) exists and would be the natural fallthrough if
+    // the unmatched switch fell through. The unmatched switch must still
+    // complete the run.
+    #[test]
+    fn true_guard_unmatched_switch_with_linear_successor_completes() {
+        let switch_rules = vec![SwitchRule {
+            name: "no_match".to_string(),
+            when: Some("$.steps.1.enabled == false".to_string()),
+            goto: Some(3),
+        }];
+
+        let mut step1 = step(1);
+        step1.routing.when = Some("$.steps.1.enabled == true".to_string());
+        step1.routing.switch = switch_rules;
+        // No `next`, no `terminal` — natural linear fallthrough would
+        // route to step 2. The unmatched switch must complete instead.
+
+        let mut run_data = RunData::default();
+        run_data.insert_output_str(1, r#"{"enabled": true}"#);
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3)]);
+        let run = run_at(1, 3);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
+    }
+
+    // Regression: same branch as above but with an absent top-level
+    // `when` (None). Absent is the same as true for the routing decision;
+    // it must also complete on an unmatched switch.
+    #[test]
+    fn absent_guard_unmatched_switch_with_linear_successor_completes() {
+        let switch_rules = vec![SwitchRule {
+            name: "no_match".to_string(),
+            when: Some("$.steps.1.enabled == false".to_string()),
+            goto: Some(3),
+        }];
+
+        let mut step1 = step(1);
+        // No `when` set on the step — treated as "always allow".
+        step1.routing.switch = switch_rules;
+
+        let run_data = RunData::default();
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3)]);
+        let run = run_at(1, 3);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
+    }
+
+    // Regression: same branch with absent guard and explicit `next` —
+    // still must complete, not fall through to `next`.
+    #[test]
+    fn absent_guard_unmatched_switch_with_explicit_next_completes() {
+        let switch_rules = vec![SwitchRule {
+            name: "no_match".to_string(),
+            when: Some("$.steps.1.enabled == false".to_string()),
+            goto: Some(3),
+        }];
+
+        let mut step1 = step(1);
+        step1.routing.switch = switch_rules;
+        step1.routing.next = Some(2);
+
+        let run_data = RunData::default();
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3)]);
+        let run = run_at(1, 3);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
+    }
+
+    // Regression: false top-level `when` + `terminal: true` + an
+    // available linear successor — terminal must win. Lifts the
+    // precedence note out of prose and pins it as executable behavior.
+    #[test]
+    fn false_guard_terminal_with_available_successor_completes() {
+        let mut step1 = step(1);
+        step1.routing.when = Some("$.steps.1.enabled == true".to_string());
+        step1.routing.terminal = true;
+        // Also wire a non-empty switch with a catch-all so the test would
+        // catch a regression that lets the switch evaluate when guard is
+        // false. With terminal=true and a false guard, the answer must be
+        // Complete regardless.
+        step1.routing.switch = vec![SwitchRule {
+            name: "catch_all".to_string(),
+            when: None,
+            goto: Some(2),
+        }];
+
+        let run_data = RunData::default();
+
+        let sop = sop_with_steps(vec![step1, step(2), step(3)]);
+        let run = run_at(1, 3);
+        let ctx = route_ctx(&sop, &run, &run_data);
+
+        assert_eq!(resolve_next(&ctx), NextStep::Complete);
     }
 }

--- a/crates/zeroclaw-runtime/src/sop/route/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/route/mod.rs
@@ -5,6 +5,12 @@ use super::condition::evaluate_condition;
 use super::rundata::RunData;
 use super::types::{Sop, SopRun, SopStep, SopStepStatus};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetKind {
+    Explicit,
+    Linear,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NextStep {
     Step(u32),
@@ -80,13 +86,13 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
             let Some(target) = rule.goto else {
                 return NextStep::Fail(format!("switch port '{}' has no target", rule.name));
             };
-            return resolve_target(ctx, target);
+            return resolve_target(ctx, target, TargetKind::Explicit);
         }
         return NextStep::Complete;
     }
 
     if let Some(next_target) = current.routing.next {
-        return resolve_target(ctx, next_target);
+        return resolve_target(ctx, next_target, TargetKind::Explicit);
     }
 
     if current.routing.terminal {
@@ -96,29 +102,26 @@ pub fn resolve_next(ctx: &RouteCtx<'_>) -> NextStep {
     resolve_linear(ctx)
 }
 
-/// Resolve an explicit successor step number (from a switch port or
-/// `routing.next`) into the final `NextStep`. Looks the step up, enforces
-/// the visit bound, and applies dependency-based eligibility.
-fn resolve_target(ctx: &RouteCtx<'_>, target: u32) -> NextStep {
+/// Resolve a successor step number into the final `NextStep`. Explicit
+/// targets fail when missing; a linear target past the declared end completes.
+fn resolve_target(ctx: &RouteCtx<'_>, target: u32, kind: TargetKind) -> NextStep {
     let Some(step) = ctx.sop.steps.iter().find(|s| s.number == target) else {
-        return NextStep::Fail(format!("step {target} does not exist"));
+        return match kind {
+            TargetKind::Explicit => NextStep::Fail(format!("step {target} does not exist")),
+            TargetKind::Linear if target > ctx.run.total_steps => NextStep::Complete,
+            TargetKind::Linear => NextStep::Fail(format!("step {target} does not exist")),
+        };
     };
     resolve_step_decision(ctx, target, step)
 }
 
-/// Resolve the linear successor (`current_step + 1`). Completes when the
-/// successor is past the end of the SOP; fails when the successor falls in
-/// a gap; otherwise delegates to the shared target resolution.
+/// Resolve the linear successor (`current_step + 1`).
 fn resolve_linear(ctx: &RouteCtx<'_>) -> NextStep {
-    let next_step = ctx.run.current_step.saturating_add(1);
-    let Some(step) = ctx.sop.steps.iter().find(|s| s.number == next_step) else {
-        return if next_step > ctx.run.total_steps {
-            NextStep::Complete
-        } else {
-            NextStep::Fail(format!("step {next_step} does not exist"))
-        };
-    };
-    resolve_step_decision(ctx, next_step, step)
+    resolve_target(
+        ctx,
+        ctx.run.current_step.saturating_add(1),
+        TargetKind::Linear,
+    )
 }
 
 /// Apply the visit-bound and dependency checks shared by every target
@@ -323,7 +326,7 @@ mod tests {
 
         let sop = sop_with_steps(vec![step1, step(2), step(3)]);
         let run = run_at(1, 3);
-        let run_data = RunData::default(); // No outputs, making when condition false
+        let run_data = RunData::default();
         let ctx = route_ctx(&sop, &run, &run_data);
 
         // Should go to linear successor (step 2 = 1+1), NOT switch target


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Preserve the accepted SOP routing contract when a top-level `when` guard is false: bypass `switch` and `routing.next`, then use terminal completion or the shared linear-successor resolver.
  - Preserve the existing allowed-switch contract: when the top-level guard is true or absent, a non-empty switch takes its first matching rule and completes when no rule matches; it does not fall through to `routing.next` or the linear successor.
  - Reuse the existing target-resolution path for explicit and linear successors, keeping step existence, visit-limit, and dependency checks in shared helpers.
  - Document the branched precedence contract in `resolve_next()` and cover false-guard terminal precedence plus true/absent unmatched-switch completion with focused route regressions.
- **Scope boundary:** Only changes SOP route precedence and its unit tests in `crates/zeroclaw-runtime/src/sop/route/mod.rs`. It does not change switch condition evaluation, SOP parsing/schema shape, approval, capability, or executor behavior.
- **Blast radius:** Affects only steps that combine top-level `when` routing with switch/edge metadata. False guards now consistently bypass switch and explicit-next routing; allowed switches retain completion on exhaustion. The independent `when` and `switch` fields and their parser round-trip representation predate #8771; #8771 made the false-guard behavior observable in a live run, rather than introducing the representable shape. No checked-in SOP definition in this repository exercises these paths.
- **Linked issue(s):** Fixes #9120
- **Labels:** `bug`, `runtime`, `priority:p2`, `risk:medium`, `size:S`, `needs-author-action`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is deterministic routing logic covered by focused unit tests; no additional manual interface path adds signal.

### How I tested

- **CI checks relied on and why they cover this change:** The Rust formatting, Clippy, and test checks cover the changed runtime route module and all new regression cases. The focused runtime test isolates the affected decision tree.
- **Known CI coverage gap, if any:** None for the changed route behavior.
- **Commands run and tail output:**

```text
cargo test -p zeroclaw-runtime sop::route
13 passed; 0 failed
```

The suite includes matching-switch, catch-all, false-guard linear bypass, false-guard terminal completion, and true/absent-guard unmatched-switch cases with both explicit and linear successors.
- **Beyond CI, what did you manually verify?** Compared each branch of `resolve_next()` with the documented contract and confirmed that false guards call the shared linear resolver while allowed switches return `Complete` after rule exhaustion.
- **If any command was intentionally skipped, why:** Full workspace validation is run separately after the narrow patch; no changed-surface check is intentionally omitted.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes — this restores the established completion behavior for an allowed switch with no matching rule and limits the new behavior to the reported false-guard precedence bug.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

This is classified as `risk:medium` because it changes runtime route behavior under `crates/zeroclaw-runtime/src/**`. The change is narrow and reversible, but an incorrect precedence decision could cause an SOP run to execute the wrong next step or complete unexpectedly.

- **Fast rollback command/path:** `git revert <sha>` for the fix commit; no migration or data repair is required.
- **Feature flags or config toggles:** None. The fix introduces no feature flag, environment variable, or config key.
- **Observable failure symptoms:** A regression would appear in SOP run traces as an unexpected `Step(<target>)`, `Wait(<target>)`, or `Complete` after a step with a top-level `when` and switch/edge metadata. Focused route tests fail on the corresponding `NextStep` result; no new metric or external alert is introduced by this patch.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede another PR.

---

