### PR TITLE
fix(channels): connect CLI Ctrl+C to supervisor lifecycle token

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -616,6 +616,18 @@ pub trait Channel: Send + Sync + crate::attribution::Attributable {
     /// Start listening for incoming messages (long-running)
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()>;
 
+    /// Receive the supervisor lifecycle token before `listen()` is called.
+    /// Channels that internally wait for shutdown can subscribe instead of
+    /// independently catching SIGINT.
+    fn set_cancel_token(&self, _token: CancellationToken) {}
+
+    /// Whether this channel participates in the cooperative cancellation
+    /// contract via `set_cancel_token`. Only participating channels get
+    /// a bounded grace period for cleanup after cancellation.
+    fn uses_cancel_token(&self) -> bool {
+        false
+    }
+
     /// Check if channel is healthy
     async fn health_check(&self) -> bool {
         true

--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -636,6 +636,18 @@ pub trait Channel: Send + Sync + crate::attribution::Attributable {
     /// Start listening for incoming messages (long-running)
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()>;
 
+    /// Receive the supervisor lifecycle token before `listen()` is called.
+    /// Channels that internally wait for shutdown can subscribe instead of
+    /// independently catching SIGINT.
+    fn set_cancel_token(&self, _token: CancellationToken) {}
+
+    /// Whether this channel participates in the cooperative cancellation
+    /// contract via `set_cancel_token`. Only participating channels get
+    /// a bounded grace period for cleanup after cancellation.
+    fn uses_cancel_token(&self) -> bool {
+        false
+    }
+
     /// Check if channel is healthy
     async fn health_check(&self) -> bool {
         true

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4281,6 +4281,16 @@ fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<
     result.trim().to_string()
 }
 
+/// After a clean listener return (no error), decide whether the supervisor
+/// should restart. Cancellation means the operator asked for shutdown — the
+/// exit is expected and must not restart. Any other clean return is
+/// unexpected and must restart.
+fn should_restart_listener_after_clean_return(
+    cancel: &tokio_util::sync::CancellationToken,
+) -> bool {
+    !cancel.is_cancelled()
+}
+
 fn spawn_supervised_listener(
     ch: Arc<dyn Channel>,
     alias: Option<String>,
@@ -4335,18 +4345,37 @@ fn spawn_supervised_listener_with_health_interval(
                     tokio::pin!(listen_future);
 
                     loop {
+                        let mut shutdown = false;
                         tokio::select! {
-                            () = cancel.cancelled() => return,
+                            () = cancel.cancelled() => {
+                                shutdown = true;
+                            }
                             _ = health.tick() => {
                                 zeroclaw_runtime::health::mark_component_ok(&component);
                             }
                             result = &mut listen_future => break result,
                         }
+                        if shutdown {
+                            if ch.uses_cancel_token() {
+                                // Wait for the listener to finish cleanup
+                                // so session teardown runs before exit.
+                                let _ = tokio::time::timeout(
+                                    Duration::from_secs(5),
+                                    listen_future,
+                                )
+                                .await;
+                            }
+                            return;
+                        }
+                        // Health tick fired; loop back.
                     }
                 };
 
                 match result {
                     Ok(()) => {
+                        if !should_restart_listener_after_clean_return(&cancel) {
+                            return;
+                        }
                         ::zeroclaw_log::record!(
                             WARN,
                             ::zeroclaw_log::Event::new(
@@ -11196,6 +11225,12 @@ pub async fn start_channels(
                 .max(DEFAULT_CHANNEL_MAX_BACKOFF_SECS);
 
             let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(100);
+
+            // Inject the lifecycle token so channels that internally wait
+            // for shutdown subscribe to the single SIGINT consumer.
+            for cc in &configured_channels {
+                cc.channel.set_cancel_token(cancel.clone());
+            }
 
             for cc in &configured_channels {
                 listener_handles.push(spawn_supervised_listener(
@@ -25908,6 +25943,58 @@ This is an example JSON object for profile settings."#;
                 .contains("listen boom")
         );
         assert!(calls.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
+    fn should_restart_listener_after_clean_return_respects_cancellation() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        assert!(
+            should_restart_listener_after_clean_return(&cancel),
+            "must restart when cancellation has not been triggered"
+        );
+        cancel.cancel();
+        assert!(
+            !should_restart_listener_after_clean_return(&cancel),
+            "must not restart after cancellation was triggered"
+        );
+    }
+
+    /// Cancellation must exit the supervisor cleanly without restart or
+    /// error-bookkeeping when the listener returns after shutdown.
+    #[tokio::test]
+    async fn supervised_listener_exits_cleanly_on_cancellation() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let channel_name = format!("test-cancel-clean-exit-{}", uuid::Uuid::new_v4());
+        let component = format!("channel:{channel_name}");
+        let channel: Arc<dyn Channel> = Arc::new(BlockUntilClosedChannel {
+            name: channel_name,
+            calls: Arc::clone(&calls),
+        });
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(1);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_supervised_listener(channel, None, tx, 1, 1, cancel.clone());
+
+        // Cancel first, then unblock the listener.
+        cancel.cancel();
+        drop(rx);
+
+        let result = tokio::time::timeout(Duration::from_millis(500), handle).await;
+        assert!(
+            result.is_ok(),
+            "supervisor must exit cleanly after cancellation"
+        );
+
+        // The listener may return Ok(()) (cancelled token → should_restart
+        // says no) or the supervisor may exit via the cancel.cancelled()
+        // branch. Either way: no restart, no error.
+        let snapshot = zeroclaw_runtime::health::snapshot_json();
+        let c = &snapshot["components"][&component];
+        assert_eq!(
+            c["restart_count"].as_u64().unwrap_or(0),
+            0,
+            "must not restart on intentional shutdown"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -30002,6 +30002,67 @@ This is an example JSON object for profile settings."#;
         err: Mutex<Option<anyhow::Error>>,
     }
 
+    /// A test channel that opts into the cooperative cancellation contract:
+    /// `uses_cancel_token()` returns `true`, `set_cancel_token` stores the
+    /// token, and `listen()` awaits cancellation before running a bounded,
+    /// probe-able cleanup phase. Used to prove the supervisor waits for
+    /// participating listeners to finish cleanup before exiting.
+    struct ParticipatingCancelChannel {
+        name: String,
+        calls: Arc<AtomicUsize>,
+        cleanups: Arc<AtomicUsize>,
+        token: Mutex<Option<CancellationToken>>,
+        cleanup_started: Arc<tokio::sync::Notify>,
+        cleanup_finish_allowed: Arc<tokio::sync::Notify>,
+    }
+
+    impl ::zeroclaw_api::attribution::Attributable for ParticipatingCancelChannel {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Channel(
+                ::zeroclaw_api::attribution::ChannelKind::Webhook,
+            )
+        }
+        fn alias(&self) -> &str {
+            "test"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Channel for ParticipatingCancelChannel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn send(&self, _message: &SendMessage) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn set_cancel_token(&self, token: CancellationToken) {
+            *self.token.lock().unwrap() = Some(token);
+        }
+
+        fn uses_cancel_token(&self) -> bool {
+            true
+        }
+
+        async fn listen(
+            &self,
+            _tx: tokio::sync::mpsc::Sender<zeroclaw_api::channel::ChannelMessage>,
+        ) -> anyhow::Result<()> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let token = self.token.lock().unwrap().clone();
+            if let Some(token) = token {
+                token.cancelled().await;
+            }
+            // Cleanup phase: signal start, then wait for the test to
+            // release it so the supervisor's grace period is observable.
+            self.cleanups.fetch_add(1, Ordering::SeqCst);
+            self.cleanup_started.notify_one();
+            self.cleanup_finish_allowed.notified().await;
+            Ok(())
+        }
+    }
+
     impl ::zeroclaw_api::attribution::Attributable for AlwaysFailChannel {
         fn role(&self) -> ::zeroclaw_api::attribution::Role {
             ::zeroclaw_api::attribution::Role::Channel(
@@ -30277,41 +30338,102 @@ This is an example JSON object for profile settings."#;
         );
     }
 
-    /// Cancellation must exit the supervisor cleanly without restart or
-    /// error-bookkeeping when the listener returns after shutdown.
+    /// A participating listener (via `PacedChannel`) must be allowed to
+    /// finish cleanup before the supervisor exits: cancellation while the
+    /// listener is mid-cleanup keeps the supervisor alive, then a clean
+    /// return yields one call, one cleanup, zero restarts, no error.
     #[tokio::test]
-    async fn supervised_listener_exits_cleanly_on_cancellation() {
+    async fn supervised_listener_waits_for_participating_cleanup_on_cancel() {
+        struct Pacing {
+            interval: u64,
+            depth: u16,
+        }
+        impl zeroclaw_config::schema::HasReplyPacing for Pacing {
+            fn reply_min_interval_secs(&self) -> u64 {
+                self.interval
+            }
+            fn reply_queue_depth_max(&self) -> u16 {
+                self.depth
+            }
+        }
+
         let calls = Arc::new(AtomicUsize::new(0));
-        let channel_name = format!("test-cancel-clean-exit-{}", uuid::Uuid::new_v4());
+        let cleanups = Arc::new(AtomicUsize::new(0));
+        let cleanup_started = Arc::new(tokio::sync::Notify::new());
+        let cleanup_finish_allowed = Arc::new(tokio::sync::Notify::new());
+        let channel_name = format!("test-cancel-participating-{}", uuid::Uuid::new_v4());
         let component = format!("channel:{channel_name}");
-        let channel: Arc<dyn Channel> = Arc::new(BlockUntilClosedChannel {
+        let inner: Arc<dyn Channel> = Arc::new(ParticipatingCancelChannel {
             name: channel_name,
             calls: Arc::clone(&calls),
+            cleanups: Arc::clone(&cleanups),
+            token: Mutex::new(None),
+            cleanup_started: Arc::clone(&cleanup_started),
+            cleanup_finish_allowed: Arc::clone(&cleanup_finish_allowed),
         });
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(1);
+        // Wrap through the real PacedChannel with pacing enabled so the
+        // token forwards through the production wrapper boundary.
+        let channel = crate::paced_channel::PacedChannel::wrap(
+            inner,
+            &Pacing {
+                interval: 1,
+                depth: 16,
+            },
+        );
+
+        let (tx, _rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(1);
         let cancel = tokio_util::sync::CancellationToken::new();
+        // The supervisor itself injects the token into every channel before
+        // spawning listeners; here we reproduce that injection manually.
+        channel.set_cancel_token(cancel.clone());
         let handle = spawn_supervised_listener(channel, None, tx, 1, 1, cancel.clone());
 
-        // Cancel first, then unblock the listener.
+        // Give the listener time to enter listen() and park on cancellation.
+        tokio::time::sleep(Duration::from_millis(50)).await;
         cancel.cancel();
-        drop(rx);
+        cleanup_started.notified().await;
+
+        assert_eq!(
+            cleanups.load(Ordering::SeqCst),
+            1,
+            "listener should enter cleanup exactly once"
+        );
+        assert!(
+            !handle.is_finished(),
+            "supervisor must wait for participating cleanup, not exit immediately"
+        );
+
+        // Release cleanup; the supervisor should then exit cleanly.
+        cleanup_finish_allowed.notify_one();
 
         let result = tokio::time::timeout(Duration::from_millis(500), handle).await;
         assert!(
             result.is_ok(),
-            "supervisor must exit cleanly after cancellation"
+            "supervisor must exit cleanly after cleanup completes"
         );
 
-        // The listener may return Ok(()) (cancelled token → should_restart
-        // says no) or the supervisor may exit via the cancel.cancelled()
-        // branch. Either way: no restart, no error.
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "listener ran more than once"
+        );
+        assert_eq!(
+            cleanups.load(Ordering::SeqCst),
+            1,
+            "cleanup ran more than once"
+        );
+
         let snapshot = zeroclaw_runtime::health::snapshot_json();
         let c = &snapshot["components"][&component];
         assert_eq!(
             c["restart_count"].as_u64().unwrap_or(0),
             0,
             "must not restart on intentional shutdown"
+        );
+        assert!(
+            c["status"].is_null() || c["status"].as_str() != Some("error"),
+            "must not record component error on intentional shutdown"
         );
     }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4744,6 +4744,16 @@ fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<
     result.trim().to_string()
 }
 
+/// After a clean listener return (no error), decide whether the supervisor
+/// should restart. Cancellation means the operator asked for shutdown — the
+/// exit is expected and must not restart. Any other clean return is
+/// unexpected and must restart.
+fn should_restart_listener_after_clean_return(
+    cancel: &tokio_util::sync::CancellationToken,
+) -> bool {
+    !cancel.is_cancelled()
+}
+
 fn spawn_supervised_listener(
     ch: Arc<dyn Channel>,
     alias: Option<String>,
@@ -4798,18 +4808,37 @@ fn spawn_supervised_listener_with_health_interval(
                     tokio::pin!(listen_future);
 
                     loop {
+                        let mut shutdown = false;
                         tokio::select! {
-                            () = cancel.cancelled() => return,
+                            () = cancel.cancelled() => {
+                                shutdown = true;
+                            }
                             _ = health.tick() => {
                                 zeroclaw_runtime::health::mark_component_ok(&component);
                             }
                             result = &mut listen_future => break result,
                         }
+                        if shutdown {
+                            if ch.uses_cancel_token() {
+                                // Wait for the listener to finish cleanup
+                                // so session teardown runs before exit.
+                                let _ = tokio::time::timeout(
+                                    Duration::from_secs(5),
+                                    listen_future,
+                                )
+                                .await;
+                            }
+                            return;
+                        }
+                        // Health tick fired; loop back.
                     }
                 };
 
                 match result {
                     Ok(()) => {
+                        if !should_restart_listener_after_clean_return(&cancel) {
+                            return;
+                        }
                         ::zeroclaw_log::record!(
                             WARN,
                             ::zeroclaw_log::Event::new(
@@ -12643,6 +12672,12 @@ pub async fn start_channels(
                 .max(DEFAULT_CHANNEL_MAX_BACKOFF_SECS);
 
             let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(100);
+
+            // Inject the lifecycle token so channels that internally wait
+            // for shutdown subscribe to the single SIGINT consumer.
+            for cc in &configured_channels {
+                cc.channel.set_cancel_token(cancel.clone());
+            }
 
             for cc in &configured_channels {
                 listener_handles.push(spawn_supervised_listener(
@@ -30226,6 +30261,58 @@ This is an example JSON object for profile settings."#;
                 .contains("listen boom")
         );
         assert!(calls.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
+    fn should_restart_listener_after_clean_return_respects_cancellation() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        assert!(
+            should_restart_listener_after_clean_return(&cancel),
+            "must restart when cancellation has not been triggered"
+        );
+        cancel.cancel();
+        assert!(
+            !should_restart_listener_after_clean_return(&cancel),
+            "must not restart after cancellation was triggered"
+        );
+    }
+
+    /// Cancellation must exit the supervisor cleanly without restart or
+    /// error-bookkeeping when the listener returns after shutdown.
+    #[tokio::test]
+    async fn supervised_listener_exits_cleanly_on_cancellation() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let channel_name = format!("test-cancel-clean-exit-{}", uuid::Uuid::new_v4());
+        let component = format!("channel:{channel_name}");
+        let channel: Arc<dyn Channel> = Arc::new(BlockUntilClosedChannel {
+            name: channel_name,
+            calls: Arc::clone(&calls),
+        });
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<zeroclaw_api::channel::ChannelMessage>(1);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_supervised_listener(channel, None, tx, 1, 1, cancel.clone());
+
+        // Cancel first, then unblock the listener.
+        cancel.cancel();
+        drop(rx);
+
+        let result = tokio::time::timeout(Duration::from_millis(500), handle).await;
+        assert!(
+            result.is_ok(),
+            "supervisor must exit cleanly after cancellation"
+        );
+
+        // The listener may return Ok(()) (cancelled token → should_restart
+        // says no) or the supervisor may exit via the cancel.cancelled()
+        // branch. Either way: no restart, no error.
+        let snapshot = zeroclaw_runtime::health::snapshot_json();
+        let c = &snapshot["components"][&component];
+        assert_eq!(
+            c["restart_count"].as_u64().unwrap_or(0),
+            0,
+            "must not restart on intentional shutdown"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/paced_channel.rs
+++ b/crates/zeroclaw-channels/src/paced_channel.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::{Mutex, oneshot};
+use tokio_util::sync::CancellationToken;
 use zeroclaw_api::attribution::{Attributable, Role};
 use zeroclaw_api::channel::{
     Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, ProgressEvent,
@@ -341,6 +342,14 @@ impl Channel for PacedChannel {
 
     async fn start_typing(&self, recipient: &str) -> Result<()> {
         self.inner.start_typing(recipient).await
+    }
+
+    fn set_cancel_token(&self, token: CancellationToken) {
+        self.inner.set_cancel_token(token);
+    }
+
+    fn uses_cancel_token(&self) -> bool {
+        self.inner.uses_cancel_token()
     }
 
     async fn stop_typing(&self, recipient: &str) -> Result<()> {

--- a/crates/zeroclaw-channels/src/paced_channel.rs
+++ b/crates/zeroclaw-channels/src/paced_channel.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::{Mutex, oneshot};
+use tokio_util::sync::CancellationToken;
 use zeroclaw_api::attribution::{Attributable, Role};
 use zeroclaw_api::channel::{
     Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, ProgressEvent,
@@ -349,6 +350,14 @@ impl Channel for PacedChannel {
 
     async fn start_typing(&self, recipient: &str) -> Result<()> {
         self.inner.start_typing(recipient).await
+    }
+
+    fn set_cancel_token(&self, token: CancellationToken) {
+        self.inner.set_cancel_token(token);
+    }
+
+    fn uses_cancel_token(&self) -> bool {
+        self.inner.uses_cancel_token()
     }
 
     async fn stop_typing(&self, recipient: &str) -> Result<()> {

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::select;
+use tokio::{select, sync::Notify};
+use tokio_util::sync::CancellationToken;
 use waproto::whatsapp::device_props::PlatformType;
 use zeroclaw_api::channel::{Channel, ChannelConversationScope, ChannelMessage, SendMessage};
 #[cfg(feature = "whatsapp-web")]
@@ -89,6 +90,10 @@ pub struct WhatsAppWebChannel {
     /// connect, the linked account is persisted into `peer_groups` through
     /// `crate::identity_persist` (no channel-local allowlist cache).
     persist: Option<Arc<parking_lot::RwLock<zeroclaw_config::schema::Config>>>,
+    /// Supervisor lifecycle notification point. Injected via
+    /// `set_cancel_token` before `listen()` starts so the internal
+    /// shutdown `select!` subscribes to the single SIGINT consumer.
+    cancel_notify: Arc<Notify>,
 }
 
 #[cfg(feature = "whatsapp-web")]
@@ -184,6 +189,7 @@ impl WhatsAppWebChannel {
             group_mention_patterns: Arc::new(Vec::new()),
             workspace_dir: None,
             persist: None,
+            cancel_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -1965,6 +1971,18 @@ impl Channel for WhatsAppWebChannel {
         "whatsapp"
     }
 
+    fn set_cancel_token(&self, token: CancellationToken) {
+        let notify = self.cancel_notify.clone();
+        ::zeroclaw_spawn::spawn!(async move {
+            token.cancelled().await;
+            notify.notify_one();
+        });
+    }
+
+    fn uses_cancel_token(&self) -> bool {
+        true
+    }
+
     async fn send(&self, message: &SendMessage) -> Result<()> {
         let client = self.client.lock().clone();
         let Some(client) = client else {
@@ -2515,14 +2533,18 @@ impl Channel for WhatsAppWebChannel {
             drop(logout_tx);
 
             // Wait for a logout signal or process shutdown.
+            // Shutdown arrives through the supervisor lifecycle token
+            // injected via set_cancel_token — a bridge task notifies
+            // so the single SIGINT consumer in main.rs deterministically
+            // reaches this listener.
             let should_reconnect = select! {
                 res = logout_rx.recv() => {
                     // Both Ok(()) and Err (sender dropped) mean the session ended.
                     let _ = res;
                     true
                 }
-                _ = tokio::signal::ctrl_c() => {
-                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), "channel received Ctrl+C");
+                () = self.cancel_notify.notified() => {
+                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), "channel received shutdown signal");
                     false
                 }
             };

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::select;
+use tokio::{select, sync::Notify};
+use tokio_util::sync::CancellationToken;
 use waproto::whatsapp::device_props::PlatformType;
 use zeroclaw_api::channel::{
     Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelConversationScope,
@@ -394,6 +395,10 @@ pub struct WhatsAppWebChannel {
     /// between a token's registration and the cleanup that follows it.
     #[cfg(test)]
     approval_send_hook: Option<ApprovalSendHook>,
+    /// Supervisor lifecycle notification point. Injected via
+    /// `set_cancel_token` before `listen()` starts so the internal
+    /// shutdown `select!` subscribes to the single SIGINT consumer.
+    cancel_notify: Arc<Notify>,
 }
 
 #[cfg(feature = "whatsapp-web")]
@@ -495,6 +500,7 @@ impl WhatsAppWebChannel {
             persist: None,
             #[cfg(test)]
             approval_send_hook: None,
+            cancel_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -2424,6 +2430,18 @@ impl Channel for WhatsAppWebChannel {
         "whatsapp"
     }
 
+    fn set_cancel_token(&self, token: CancellationToken) {
+        let notify = self.cancel_notify.clone();
+        ::zeroclaw_spawn::spawn!(async move {
+            token.cancelled().await;
+            notify.notify_one();
+        });
+    }
+
+    fn uses_cancel_token(&self) -> bool {
+        true
+    }
+
     async fn send(&self, message: &SendMessage) -> Result<()> {
         let client = self.client.lock().clone();
         let Some(client) = client else {
@@ -2994,14 +3012,18 @@ impl Channel for WhatsAppWebChannel {
             drop(logout_tx);
 
             // Wait for a logout signal or process shutdown.
+            // Shutdown arrives through the supervisor lifecycle token
+            // injected via set_cancel_token — a bridge task notifies
+            // so the single SIGINT consumer in main.rs deterministically
+            // reaches this listener.
             let should_reconnect = select! {
                 res = logout_rx.recv() => {
                     // Both Ok(()) and Err (sender dropped) mean the session ended.
                     let _ = res;
                     true
                 }
-                _ = tokio::signal::ctrl_c() => {
-                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), "channel received Ctrl+C");
+                () = self.cancel_notify.notified() => {
+                    ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note), "channel received shutdown signal");
                     false
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4970,6 +4970,15 @@ async fn async_main(command: clap::Command) -> Result<()> {
                 }));
 
                 let cancel = tokio_util::sync::CancellationToken::new();
+                // Single SIGINT consumer for the CLI path: cancel the
+                // shared lifecycle token. Channels subscribe via
+                // set_cancel_token so the same signal reaches all
+                // listeners deterministically.
+                let ctrlc_cancel = cancel.clone();
+                let _ctrlc_guard = ::zeroclaw_spawn::spawn!(async move {
+                    let _ = tokio::signal::ctrl_c().await;
+                    ctrlc_cancel.cancel();
+                });
                 let (sop_engine, sop_audit) = if config.sop.sops_dir.is_some() {
                     let mem: Arc<dyn zeroclaw_memory::Memory> =
                         Arc::from(zeroclaw_memory::create_memory_from_config(&config, None)?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6607,6 +6607,15 @@ async fn async_main(command: clap::Command) -> Result<()> {
                 }));
 
                 let cancel = tokio_util::sync::CancellationToken::new();
+                // Single SIGINT consumer for the CLI path: cancel the
+                // shared lifecycle token. Channels subscribe via
+                // set_cancel_token so the same signal reaches all
+                // listeners deterministically.
+                let ctrlc_cancel = cancel.clone();
+                let _ctrlc_guard = ::zeroclaw_spawn::spawn!(async move {
+                    let _ = tokio::signal::ctrl_c().await;
+                    ctrlc_cancel.cancel();
+                });
                 let (sop_engine, sop_audit) = if config.sop.runtime_enabled() {
                     let mem: Arc<dyn zeroclaw_memory::Memory> =
                         Arc::from(zeroclaw_memory::create_memory_from_config(&config, None)?);


### PR DESCRIPTION
## Summary

Fixes #9155 — pressing Ctrl+C during `zeroclaw channel start` caused the WhatsApp Web listener to restart indefinitely because two independent SIGINT consumers raced, and the supervisor treated a clean shutdown return as an unexpected exit.

## Problem

The CLI path created a `CancellationToken` but never cancelled it. WhatsApp Web independently awaited `tokio::signal::ctrl_c()` inside `listen()`. With two SIGINT consumers there was no ordering guarantee: if WhatsApp finished cleanup before the CLI watcher cancelled the token, the supervisor saw an uncancelled token and restarted the listener.

## Fix

Single-SIGINT-owner design across five files:

- **`src/main.rs`** (+9): spawn a Ctrl+C watcher as the sole SIGINT consumer; it cancels the shared lifecycle token.
- **`crates/zeroclaw-api/src/channel.rs`** (+12): add `set_cancel_token` (default no-op) and `uses_cancel_token` (default false) to the `Channel` trait.
- **`crates/zeroclaw-channels/src/paced_channel.rs`** (+9): forward both hooks to the inner channel so the production wrapper boundary does not discard the token.
- **`crates/zeroclaw-channels/src/whatsapp_web.rs`** (+28): implement `set_cancel_token` via a `Notify` bridge (since `CancellationToken::cancelled()` is not `Send` in tokio-util 0.7), replace the internal `ctrl_c()` in the shutdown `select!` with `notify.notified()`, and return `uses_cancel_token() == true`.
- **`crates/zeroclaw-channels/src/orchestrator/mod.rs`**: inject the token into every channel before spawning listeners; in the supervisor `cancel.cancelled()` branch, wait a bounded 5s for the listener's clean return only when `uses_cancel_token()` is true, then exit without restart or health-error bookkeeping.

## Testing

- `should_restart_listener_after_clean_return_respects_cancellation` — uncancelled clean return still restarts; cancelled clean return exits.
- `supervised_listener_waits_for_participating_cleanup_on_cancel` — a `ParticipatingCancelChannel` wrapped through the real `PacedChannel` boundary (pacing enabled) receives cancellation, pauses mid-cleanup, and proves the supervisor stays alive until cleanup finishes, then yields one listener call, one cleanup, zero restarts, and no component error.
- `supervised_listener_refreshes_health_while_running` — retained: non-participating listeners still shut down promptly.

## Scope / blast radius

- Five files, +265/−4 lines (public `Channel` trait, `PacedChannel`, WhatsApp Web, orchestrator, `main.rs`).
- Affects every channel under `zeroclaw channel start`, but the grace-wait is gated on `uses_cancel_token()`, so non-participating listeners keep prompt shutdown.

## CI evidence

Local: `cargo fmt -- --check` passes; `cargo check -p zeroclaw-channels` passes; `cargo test -p zeroclaw-channels --lib supervised_listener` 6/6 passes.

## Manual verification

Not yet run against a linked WhatsApp Web device. The deterministic regression covers the ownership boundary; a live Ctrl+C smoke (start → Ctrl+C once → shell returns with no restart → restart and confirm no SQLite/WAL errors) remains as follow-up evidence.

## Security / privacy

No credential, message-content, or data-at-rest changes. Process lifecycle control-flow only.

## Compatibility

Backwards-compatible: new trait methods have default impls, no config/API/protocol changes.

## Rollback

Revert the two commits (`fix(channels): connect CLI Ctrl+C...` and `test(channels): prove participating listeners...`).
