### PR TITLE
chore(providers): drop issue refs from tool-argument comments

### DIFF
--- a/crates/zeroclaw-providers/src/azure_openai.rs
+++ b/crates/zeroclaw-providers/src/azure_openai.rs
@@ -977,10 +977,9 @@ mod tests {
 
     #[test]
     fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
-        // Regression for #8675: pins that the azure_openai `convert_messages`
-        // call site of `sanitize_tool_arguments` is wired in. The helper
-        // contract itself is covered in
-        // `compatible::tests::sanitize_tool_arguments_*`.
+        // Pins that the azure_openai `convert_messages` call site of
+        // `sanitize_tool_arguments` is wired in. The helper contract itself is
+        // covered in `compatible::tests::sanitize_tool_arguments_*`.
         use zeroclaw_api::model_provider::ChatMessage;
 
         let messages = vec![ChatMessage {

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -99,7 +99,7 @@ pub enum AuthStyle {
 /// `tool_calls[].function.arguments` is not well-formed JSON. Smaller /
 /// reasoning models sometimes emit a malformed arguments string; when that
 /// happens the whole turn fails with HTTP 400 and the user receives the
-/// generic fallback instead of the agent's response. #8675.
+/// generic fallback instead of the agent's response.
 ///
 /// Contract:
 /// - empty / whitespace-only → `"{}"` (every upstream accepts this)
@@ -1370,8 +1370,7 @@ impl StreamToolCallAccumulator {
         let name = self.name?;
         // Route through the shared `sanitize_tool_arguments` helper so the
         // normalization contract (empty/whitespace → "{}", invalid JSON →
-        // WARN + "{}", valid JSON → passthrough) has a single source of
-        // truth. #8675.
+        // WARN + "{}", valid JSON → passthrough) has a single source of truth.
         let normalized_arguments = sanitize_tool_arguments(&name, &self.arguments);
 
         Some(ProviderToolCall {
@@ -3426,7 +3425,7 @@ mod tests {
         assert_eq!(sanitize_tool_arguments("f", r#"{"path":"/tmp"#), "{}");
         // Trailing junk
         assert_eq!(sanitize_tool_arguments("f", r#"{"x":1}garbage"#), "{}");
-        // Truncated (the actual observed failure case from #8675)
+        // Truncated (the observed failure case from the field)
         assert_eq!(sanitize_tool_arguments("f", ""), "{}");
     }
 

--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -866,9 +866,9 @@ mod tests {
 
     #[test]
     fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
-        // Regression for #8675: pins that the copilot `convert_messages` call
-        // site of `sanitize_tool_arguments` is wired in. The helper contract
-        // itself is covered in `compatible::tests::sanitize_tool_arguments_*`.
+        // Pins that the copilot `convert_messages` call site of
+        // `sanitize_tool_arguments` is wired in. The helper contract itself is
+        // covered in `compatible::tests::sanitize_tool_arguments_*`.
         use zeroclaw_api::model_provider::ChatMessage;
 
         let messages = vec![ChatMessage {

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -1851,9 +1851,9 @@ mod tests {
 
     #[test]
     fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
-        // Regression for #8675: pins that the openai `convert_messages` call
-        // site of `sanitize_tool_arguments` is wired in. The helper contract
-        // itself is covered in `compatible::tests::sanitize_tool_arguments_*`.
+        // Pins that the openai `convert_messages` call site of
+        // `sanitize_tool_arguments` is wired in. The helper contract itself is
+        // covered in `compatible::tests::sanitize_tool_arguments_*`.
         use zeroclaw_api::model_provider::ChatMessage;
 
         let messages = vec![ChatMessage::assistant(

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -332,7 +332,7 @@ fn decode_responses_history_items(reasoning_content: &str) -> Option<Vec<Value>>
 /// `sanitize_tool_arguments` helper so the openai_codex call site inherits
 /// the same malformed-JSON → `"{}"` contract as the other four typed
 /// providers. Factored out so the call-site behavior is testable without
-/// running the full input builder. #8675.
+/// running the full input builder.
 pub(crate) fn build_function_call_item(call: ProviderToolCall) -> Value {
     let name = call.name;
     serde_json::json!({
@@ -2526,9 +2526,9 @@ data: [DONE]
 
     #[test]
     fn build_function_call_item_sanitizes_invalid_arguments_to_empty_object() {
-        // Regression for #8675: pins that the openai_codex call site of
-        // `sanitize_tool_arguments` is wired in. The helper contract itself
-        // is covered in `compatible::tests::sanitize_tool_arguments_*`.
+        // Pins that the openai_codex call site of `sanitize_tool_arguments`
+        // is wired in. The helper contract itself is covered in
+        // `compatible::tests::sanitize_tool_arguments_*`.
         let call = ProviderToolCall {
             id: "call_bad".to_string(),
             name: "shell".to_string(),

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -1806,12 +1806,11 @@ mod tests {
 
     #[test]
     fn convert_messages_sanitizes_invalid_tool_arguments_to_empty_object() {
-        // Regression for #8675: a malformed arguments string in the assistant
-        // history must be normalized to "{}" so the outbound chat-completions
-        // request doesn't 400 on strict upstreams. This test pins that the
-        // openrouter call site of `sanitize_tool_arguments` is wired in; the
-        // helper contract itself is covered in
-        // `compatible::tests::sanitize_tool_arguments_*`.
+        // A malformed arguments string in the assistant history must be
+        // normalized to "{}" so the outbound chat-completions request doesn't
+        // 400 on strict upstreams. This test pins that the openrouter call site
+        // of `sanitize_tool_arguments` is wired in; the helper contract itself
+        // is covered in `compatible::tests::sanitize_tool_arguments_*`.
         let messages = vec![ChatMessage {
             role: "assistant".into(),
             content: r#"{"content":"trying","tool_calls":[{"id":"call_bad","name":"shell","arguments":"{\"command\":\"rm -rf"}]}"#


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `scripts/ci/comment_hygiene_gate.sh` rejects issue/PR references in source comments, but nine of them remain in the provider tool-argument sanitization comments. The gate runs repo-wide and unscoped, so it currently fails on `master` itself — `CI Required Gate` and `Lint` are red at `28b5b76f9` — and every open PR inherits the same failure from files outside its own diff.
  - Rewrote the nine affected comments to state the behavior they document without the reference. Each already explained the contract it guards (which call site is pinned, why malformed arguments must normalize to `"{}"`, where the helper contract is covered), so only the trailing provenance is dropped and no explanation is lost.
- **Scope boundary:** Comments only, in `crates/zeroclaw-providers/src/{openai,azure_openai,openai_codex,compatible,copilot,openrouter}.rs`. No code, test, assertion, or behavior change; no change to the gate script or its exemption list; no other lint category touched.
- **Blast radius:** None at runtime. `git diff -U0` contains no changed line that is not a comment (verified below).
- **Linked issue(s):** None. This unblocks the repo-wide gate rather than fixing a reported defect.
- **Labels:** provider, provider:azure-openai, provider:compatible, provider:copilot, provider:openai, provider:openrouter, risk:low, size:XS, type:ci.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — comments-only change with no runtime surface to exercise; the gate result below is the whole signal.

### How I tested

```sh
$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ bash scripts/ci/comment_hygiene_gate.test.sh
58 passed, 0 failed

$ cargo fmt -p zeroclaw-providers -- --check
(clean, no output)

$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
(no warnings)

$ cargo test -p zeroclaw-providers --lib
test result: ok. 1118 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.78s
```

- **CI checks relied on and why they cover this change:** the `Lint` job runs exactly the two gate commands above, which are the checks this PR exists to fix; the required Rust gate rebuilds and retests `zeroclaw-providers` on the pinned toolchain to confirm the edits did not disturb the surrounding code.
- **Known CI coverage gap, if any:** None. The gate is the authority for this change and it runs repo-wide in CI.
- **Commands run and tail output:** as above. The repo-wide gate is the meaningful one — it fails on `master` and passes on this branch.
- **Beyond CI, what did you manually verify?** That the change is genuinely comments-only: `git diff -U0 | grep '^[+-]'` yields no line that is not a `//` or `///` comment. I also read each of the nine sites before editing to confirm the surrounding text still carries the meaning once the reference is gone — in every case the comment already named the call site being pinned and pointed at `compatible::tests::sanitize_tool_arguments_*` for the helper contract, so the reference was pure provenance. **What I did NOT verify:** nothing beyond this; there is no runtime behavior to drive.
- **If any command was intentionally skipped, why:** the full workspace gate was not run locally — this host's toolchain is `rustc 1.95.0` against the pinned `1.96.1`. Required CI supplies it, and the gate commands above are toolchain-independent.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No` — comments are not model-visible at runtime.
- If any `Yes`, describe the risk and mitigation: N/A — all `No`.

## Compatibility (required)

- Backward compatible? `Yes` — comments only.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A.

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the plan. Reverting restores the references and with them the repo-wide gate failure.