### PR TITLE
fix(sop): construct required admission fields in blankSop

### DIFF
--- a/web/src/pages/Sops.tsx
+++ b/web/src/pages/Sops.tsx
@@ -147,6 +147,8 @@ function blankSop(name: string): Sop {
     steps: [blankStep(1)],
     cooldown_secs: 0,
     max_concurrent: 1,
+    admission_policy: 'parallel',
+    max_pending_approvals: 0,
     deterministic: false,
   };
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The per-SOP admission-policy work added `admission_policy: SopAdmissionPolicy` and `max_pending_approvals: u32` to the `Sop` struct in `crates/zeroclaw-runtime/src/sop/types.rs`. Both are `#[serde(default)]`, but — exactly like the sibling defaulted fields `cooldown_secs` / `max_concurrent` / `deterministic` — they surface as **required** in the generated OpenAPI `Sop` type. The frontend factory `blankSop()` in `web/src/pages/Sops.tsx` was never updated to construct them, so the dashboard typecheck fails.
- **Impact:** `web/src/lib/api-generated.ts` is a gitignored, build-time artifact rendered in-process from `zeroclaw_gateway::openapi::build_spec()`, so the mismatch is invisible in source review and only bites at build time. Result: `cargo web check` / `tsc -b` fails with `TS2739` at `web/src/pages/Sops.tsx:140`, and `install.sh --source --features embedded-web` cannot build `web/dist`, breaking source installs that include the dashboard.
- **The fix:** construct both fields in `blankSop()` with the backend serde defaults (`admission_policy: 'parallel'`, `max_pending_approvals: 0`), consistent with how the other defaulted `Sop` fields are already constructed there.
- **Scope boundary:** Frontend factory only. No Rust changes, no schema changes, no editor UI for the fields, no admission behavior changes.
- **Blast radius:** `web/src/pages/Sops.tsx` `blankSop()` (new-SOP draft defaults). No other consumer constructs a bare `Sop` literal — `tsc` reports only this one site.
- **Linked issue(s):** Related #9027.
- **Labels:** `bug`, `risk:low`, `size:XS`, `web`, `distinguished contributor`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `surface: web`
- **Setup / preconditions:** Node from `.nvmrc`; `cargo run -p xtask --bin web -- install` once for `web/node_modules`.
- **Steps to run:** `cargo run -p xtask --bin web -- check` (renders the gateway OpenAPI spec, regenerates `web/src/lib/api-generated.ts`, then runs `tsc -b`).
- **Expected on this branch (after):** typecheck passes, exit 0.
- **Prior behavior on `master` (before):** `tsc -b` fails with `error TS2739: Type '{ ... }' is missing the following properties from type '...': admission_policy, max_pending_approvals` at `web/src/pages/Sops.tsx:140`.

### How I tested

Ran the full generate-and-typecheck path against the real backend spec on this branch:

```sh
$ cargo run -p xtask --bin web -- check
==> gen-api → web/src/lib/api-generated.ts
🚀 target/openapi.json → src/lib/api-generated.ts [910.9ms]
==> npx tsc -b
# exit 0

$ grep -n "admission_policy\|max_pending_approvals" web/src/lib/api-generated.ts
20031:  admission_policy: components["schemas"]["SopAdmissionPolicy"];
20077:  max_pending_approvals: number;
```

The generated `Sop` type carries both fields as required (no `?`); `tsc -b` exits 0 with the fix and fails without it.

- **CI checks relied on and why they cover this change:** `CI Required Gate` is green for the repository-wide checks, but normal PR CI does not run the dashboard typecheck, so correctness here relies on the focused command above.
- **Known CI coverage gap, if any:** Normal PR CI does not run `cargo web check`; the focused generate-and-typecheck command above covers that gap.
- **Commands run and tail output:** see above.
- **Beyond CI, what did you manually verify?** Confirmed the generated type marks both fields required and that the two literal values are valid (`'parallel'` is a `SopAdmissionPolicy` member; `max_pending_approvals` is `number`). Did not add SOP-editor UI for the fields — out of scope.
- **If any command was intentionally skipped, why:** Rust `fmt`/`clippy`/`test` not run — no Rust files changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low-risk: `git revert <sha>`.
