### PR TITLE
fix(log): drop issue ref from writer test comment to satisfy hygiene gate

### DIFF
--- a/crates/zeroclaw-log/src/writer.rs
+++ b/crates/zeroclaw-log/src/writer.rs
@@ -1114,7 +1114,7 @@ mod tests {
         let mut ev = LogEvent::new(Severity::Info, "test", EventCategory::Agent);
         ev.message = Some(msg.to_string());
         record_event(ev);
-        // #8439 moved the JSONL fsync off the async hot path, so `record_event`
+        // An earlier change moved the JSONL fsync off the async hot path, so `record_event`
         // returns before the line is on disk. Tests that assert on the log file
         // immediately after emitting must flush first (the explicit idiom used
         // throughout this module); folding it into `emit` keeps every


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** A comment in the `emit` test helper in `crates/zeroclaw-log/src/writer.rs` began with a bare `#8439` issue reference. The comment-hygiene gate (`scripts/ci/comment_hygiene_gate.py`, `ISSUE_REF = #[0-9]{3,}`) rejects issue/PR refs in comments, so `master` is currently failing **Lint** → the **CI Required Gate**, which blocks merge for every open PR gated on CI. This rewords the comment to describe the behavior without the issue number.
- **Blast radius:** One comment line. No code, control-flow, or test behavior change.
- **Introduced by:** #8870 (2026-07-20).

## Testing (required)

### How I tested

- Ran the gate locally against the full tree:

```sh
$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **CI checks relied on and why:** The `Lint` job runs the comment-hygiene gate that this change fixes; a green `Lint` here confirms the violation is cleared.
- **Beyond CI:** Confirmed the reworded comment contains no `#NNNN` token and no banned tracking/see-issue phrasing, and that `writer.rs` compiles unchanged (comment-only edit).

## Security & Privacy Impact (required)

None — comment-only change.