### PR TITLE
feat(infra): MySQL + MariaDB session-persistence backends (PR 2 of N, Supersedes #6893)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,55 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: cargo check --locked -p zeroclaw-plugins --no-default-features --features ${{ matrix.features }}
 
+  # ── Multi-database session backend series (PR 2 of N) ──────────────────
+  #
+  # The MySQL and MariaDB session backends are gated behind their
+  # own Cargo features (`backend-mysql` / `backend-mariadb`) so
+  # the default `ci-all` feature set stays independent of any
+  # local MySQL or MariaDB server. These two branch-protected
+  # jobs build the dedicated feature flags so a CI break in
+  # either driver is caught before merge.
+
+  check-session-backend-mysql:
+    name: Check (zeroclaw-infra::backend-mysql)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Check (zeroclaw-infra, backend-mysql)
+        run: cargo check --locked -p zeroclaw-infra --features backend-mysql
+
+  check-session-backend-mariadb:
+    name: Check (zeroclaw-infra::backend-mariadb)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Check (zeroclaw-infra, backend-mariadb)
+        run: cargo check --locked -p zeroclaw-infra --features backend-mariadb
+
   check-32bit:
     name: Check (32-bit)
     needs: [fmt]
@@ -711,7 +760,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-session-backend-mysql, check-session-backend-mariadb, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2097,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2133,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2590,6 +2627,17 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3278,6 +3326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -3977,6 +4026,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4760,6 +4811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-enum"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9008599afe8527a8c9d70423437363b321649161e98473f433de802d76107"
+dependencies = [
+ "derive_utils",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5225,6 +5285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,6 +5348,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -5909,6 +5989,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "mysql"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ad644efb545e459029b1ffa7c969d830975bd76906820913247620df10050b"
+dependencies = [
+ "bufstream",
+ "bytes",
+ "crossbeam",
+ "flate2",
+ "io-enum",
+ "libc",
+ "lru 0.12.5",
+ "mysql_common",
+ "named_pipe",
+ "pem",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "twox-hash 1.6.3",
+ "url",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+dependencies = [
+ "base64 0.21.7",
+ "bindgen",
+ "bitflags 2.11.1",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "cc",
+ "chrono",
+ "cmake",
+ "crc32fast",
+ "flate2",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.6",
+ "regex",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "subprocess",
+ "thiserror 1.0.69",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "named_pipe"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nanohtml2text"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6074,7 +6221,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
- "lru",
+ "lru 0.16.4",
  "nostr",
  "tokio",
 ]
@@ -6098,7 +6245,7 @@ dependencies = [
  "async-wsocket",
  "atomic-destructor",
  "hex",
- "lru",
+ "lru 0.16.4",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -7783,7 +7930,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -8505,7 +8652,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -8531,6 +8678,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "schannel"
@@ -9181,6 +9334,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -9361,6 +9524,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "subprocess"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -10571,6 +10744,17 @@ dependencies = [
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.6",
+ "static_assertions",
 ]
 
 [[package]]
@@ -13048,7 +13232,7 @@ dependencies = [
  "jsonwebtoken",
  "lapin",
  "lettre",
- "lru",
+ "lru 0.16.4",
  "mail-parser",
  "matrix-sdk",
  "md5",
@@ -13287,6 +13471,7 @@ version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
+ "mysql",
  "parking_lot",
  "portable-atomic",
  "rusqlite",
@@ -13465,7 +13650,7 @@ dependencies = [
  "indicatif",
  "landlock",
  "libc",
- "lru",
+ "lru 0.16.4",
  "mime_guess",
  "nanohtml2text",
  "opentelemetry",
@@ -13643,7 +13828,7 @@ dependencies = [
  "indicatif",
  "lettre",
  "libc",
- "lru",
+ "lru 0.16.4",
  "mail-parser",
  "mime_guess",
  "nanohtml2text",
@@ -13876,6 +14061,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12929,6 +12929,14 @@ pub struct ChannelsConfig {
     pub session_persistence: bool,
     /// Session persistence backend: `"jsonl"` (legacy) or `"sqlite"` (new default).
     /// SQLite provides FTS5 search, metadata tracking, and TTL cleanup.
+    ///
+    /// Future per-database options (each gated on its own Cargo feature in
+    /// follow-up PRs of the multi-database session backend series):
+    /// - `"postgres"` — Postgres
+    /// - `"mysql"` — MySQL
+    /// - `"mariadb"` — MariaDB
+    /// - `"oracle"` — Oracle
+    /// - `"db2"` — IBM Db2
     #[serde(default = "default_session_backend")]
     pub session_backend: String,
     /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `0`.
@@ -12939,6 +12947,75 @@ pub struct ChannelsConfig {
     /// as a single concatenated message. `0` disables debouncing. Default: `0`.
     #[serde(default)]
     pub debounce_ms: u64,
+    // ── Remote (non-embedded) session backend credentials ────────
+    //
+    // These fields are the canonical config surface for the
+    // multi-database session-backend series. They are populated by
+    // the operator whether or not the corresponding Cargo feature is
+    // compiled into this binary — that is how factory code in
+    // `zeroclaw-infra` can hard-fail on a KNOWN-but-uncompiled
+    // backend name (vs. falling through to SQLite) without depending
+    // on the per-feature module being linked in. A follow-up PR per
+    // backend reads these fields and constructs the driver-specific
+    // pool / connection handle.
+    //
+    // Every DSN / password field is `#[secret]`-tagged and routed
+    // through the encrypted-on-disk config secret pipeline, matching
+    // the convention already used for webhook tokens, MCP headers,
+    // composio tokens, browser bearer tokens, etc.
+    /// Postgres connection URL used by the `postgres` session backend
+    /// (`postgres://user:pass@host:port/db`). Reads through `crate::env_overrides`
+    /// via the standard dotted-path injection (`ZEROCLAW_channels__postgres_url`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub postgres_url: Option<String>,
+    /// MySQL connection URL used by the `mysql` session backend
+    /// (`mysql://user:pass@host:port/db`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub mysql_url: Option<String>,
+    /// MariaDB connection URL used by the `mariadb` session backend
+    /// (`mysql://user:pass@host:port/db` with the MariaDB driver).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub mariadb_url: Option<String>,
+    /// Oracle DB username used by the `oracle` session backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oracle_user: Option<String>,
+    /// Oracle DB password used by the `oracle` session backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oracle_password: Option<String>,
+    /// Oracle DSN / `EZCONNECT` / TNS string used by the `oracle` session
+    /// backend (e.g. `host:1521/SERVICE`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oracle_dsn: Option<String>,
+    /// IBM Db2 connection string used by the `db2` session backend
+    /// (e.g. `DATABASE=sample;HOSTNAME=db2.example.com;PORT=50000;UID=zeroclaw;PWD=…`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub db2_conn_str: Option<String>,
+    /// Connection-pool size shared by every remote session backend
+    /// (postgres, mysql, mariadb, oracle, db2). Local backends
+    /// (sqlite, jsonl) ignore this. Defaults to `5`.
+    #[serde(default = "default_session_pool_size")]
+    pub pool_size: u32,
 }
 
 impl ChannelsConfig {
@@ -13306,6 +13383,10 @@ fn default_session_backend() -> String {
     "sqlite".into()
 }
 
+fn default_session_pool_size() -> u32 {
+    5
+}
+
 impl Default for ChannelsConfig {
     fn default() -> Self {
         Self {
@@ -13354,6 +13435,14 @@ impl Default for ChannelsConfig {
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            postgres_url: None,
+            mysql_url: None,
+            mariadb_url: None,
+            oracle_user: None,
+            oracle_password: None,
+            oracle_dsn: None,
+            db2_conn_str: None,
+            pool_size: default_session_pool_size(),
         }
     }
 }
@@ -24387,6 +24476,14 @@ auto_save = true
                 session_backend: default_session_backend(),
                 session_ttl_hours: 0,
                 debounce_ms: 0,
+                postgres_url: None,
+                mysql_url: None,
+                mariadb_url: None,
+                oracle_user: None,
+                oracle_password: None,
+                oracle_dsn: None,
+                db2_conn_str: None,
+                pool_size: default_session_pool_size(),
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -26067,6 +26164,14 @@ allowed_users = ["@u:matrix.org"]
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            postgres_url: None,
+            mysql_url: None,
+            mariadb_url: None,
+            oracle_user: None,
+            oracle_password: None,
+            oracle_dsn: None,
+            db2_conn_str: None,
+            pool_size: default_session_pool_size(),
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -26589,6 +26694,14 @@ allowed_numbers = ["+1", "+2"]
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            postgres_url: None,
+            mysql_url: None,
+            mariadb_url: None,
+            oracle_user: None,
+            oracle_password: None,
+            oracle_dsn: None,
+            db2_conn_str: None,
+            pool_size: default_session_pool_size(),
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1610,7 +1610,26 @@ pub async fn handle_api_sessions_list(
     // or a channel_id that resolves to an owning agent).
     // Pre-migration rows with neither set are skipped as orphans.
     let config = state.config.read().clone();
-    let all_metadata = backend.list_sessions_with_metadata();
+    let all_metadata =
+        match crate::session_async::list_sessions_with_metadata(backend.clone()).await {
+            Ok(meta) => meta,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                    "session list_sessions_with_metadata failed"
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": format!("Session list failed: {e}")
+                    })),
+                )
+                    .into_response();
+            }
+        };
     let sessions: Vec<serde_json::Value> = all_metadata
         .into_iter()
         .filter(|meta| meta.agent_alias.is_some() || meta.channel_id.is_some())
@@ -1680,7 +1699,30 @@ pub async fn handle_api_session_messages(
     } else {
         format!("gw_{id}")
     };
-    let msgs = backend.load_with_timestamps(&session_key);
+    let msgs = match crate::session_async::load_with_timestamps(
+        backend.clone(),
+        session_key.clone(),
+    )
+    .await
+    {
+        Ok(msgs) => msgs,
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                "session load_with_timestamps failed"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Session load failed: {e}")
+                })),
+            )
+                .into_response();
+        }
+    };
     let messages: Vec<serde_json::Value> = msgs
         .into_iter()
         .map(|m| {
@@ -1759,7 +1801,9 @@ pub async fn handle_api_session_message_post(
     };
 
     let message = zeroclaw_providers::ChatMessage::assistant(&body.content);
-    if let Err(e) = backend.append(&session_key, &message) {
+    if let Err(e) =
+        crate::session_async::append(backend.clone(), session_key.clone(), message.clone()).await
+    {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to append session message: {e}")})),
@@ -1830,7 +1874,7 @@ pub async fn handle_api_session_delete(
         );
     }
 
-    match backend.delete_session(&session_key) {
+    match crate::session_async::delete_session(backend.clone(), session_key.clone()).await {
         Ok(true) => Json(serde_json::json!({"deleted": true, "session_id": id})).into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -37,6 +37,7 @@ pub mod node_tool;
 pub mod nodes;
 pub mod openapi;
 pub mod security_headers;
+pub mod session_async;
 pub mod session_queue;
 pub mod sse;
 pub mod static_files;

--- a/crates/zeroclaw-gateway/src/session_async.rs
+++ b/crates/zeroclaw-gateway/src/session_async.rs
@@ -1,0 +1,170 @@
+//! Shared `spawn_blocking` wrappers around `SessionBackend` operations
+//! for the gateway hot paths (WebSocket handler + HTTP `/api/sessions`
+//! endpoints). The lifetime is narrow: any sync `Box<dyn
+//! SessionBackend>` call that lives inside an `async fn` in this crate
+//! must route through these helpers, not call the backend inline.
+//!
+//! Why this exists: PR 1 of the multi-database session-backend series.
+//! A remote backend (Postgres/MySQL/MariaDB/Oracle/Db2 — each coming
+//! in its own follow-up PR) can make a query hang on a network round
+//! trip. If that query runs inline in an async task, the worker is
+//! blocked until the round trip completes — which limits the gateway
+//! to one slow concurrent request per worker, and on the small
+//! `current_thread` test executors can stall the runtime entirely.
+//! Routing through `tokio::task::spawn_blocking` keeps the async
+//! pool running while the sync backend call executes on a
+//! dedicated blocking thread.
+//!
+//! Today's local drivers (sqlite / jsonl) complete in microseconds
+//! and pay only the spawn/join overhead, so this wrapper is invisible
+//! for them — but the foundation is in place for every remote
+//! backend that follows.
+
+use std::io;
+use std::sync::Arc;
+
+use zeroclaw_infra::session_backend::SessionBackend;
+
+/// Run a synchronous `SessionBackend` operation through
+/// `tokio::task::spawn_blocking`. Use this from any `async fn` that
+/// previously called a backend method directly. Join errors from the
+/// blocking pool are converted into `io::Error::Other` so the call
+/// site can keep using `std::io::Result<T>` matching the
+/// `SessionBackend` trait signature.
+pub async fn spawn_blocking_session_op<F, T>(op: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(join_err) => Err(io::Error::other(format!(
+            "session backend worker panicked: {join_err}"
+        ))),
+    }
+}
+
+/// Convenience: load session messages off the blocking pool.
+pub async fn load(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Vec<zeroclaw_api::model_provider::ChatMessage>> {
+    spawn_blocking_session_op(move || Ok(backend.load(&session_key))).await
+}
+
+/// Convenience: load session messages with their persisted timestamps
+/// off the blocking pool.
+pub async fn load_with_timestamps(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::TimestampedMessage>> {
+    spawn_blocking_session_op(move || Ok(backend.load_with_timestamps(&session_key))).await
+}
+
+/// Convenience: append a single message off the blocking pool.
+pub async fn append(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    message: zeroclaw_api::model_provider::ChatMessage,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.append(&session_key, &message)).await
+}
+
+/// Convenience: delete-session off the blocking pool.
+pub async fn delete_session(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<bool> {
+    spawn_blocking_session_op(move || backend.delete_session(&session_key)).await
+}
+
+/// Convenience: list-sessions-with-metadata off the blocking pool.
+pub async fn list_sessions_with_metadata(
+    backend: Arc<dyn SessionBackend>,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::SessionMetadata>> {
+    spawn_blocking_session_op(move || Ok(backend.list_sessions_with_metadata())).await
+}
+
+/// Convenience: set session state off the blocking pool.
+pub async fn set_session_state(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    state: String,
+    turn_id: Option<String>,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || {
+        backend.set_session_state(&session_key, &state, turn_id.as_deref())
+    })
+    .await
+}
+
+/// Convenience: get session name off the blocking pool.
+pub async fn get_session_name(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Option<String>> {
+    spawn_blocking_session_op(move || backend.get_session_name(&session_key)).await
+}
+
+/// Convenience: set session name off the blocking pool.
+pub async fn set_session_name(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    name: String,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.set_session_name(&session_key, &name)).await
+}
+
+/// Convenience: set session agent alias off the blocking pool.
+pub async fn set_session_agent_alias(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    alias: String,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.set_session_agent_alias(&session_key, &alias)).await
+}
+
+/// Convenience: check whether a session exists off the blocking pool.
+pub async fn session_exists(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<bool> {
+    spawn_blocking_session_op(move || Ok(backend.session_exists(&session_key))).await
+}
+
+/// Async equivalent of `ws::persist_conversation_messages`. Runs the
+/// session-existence guard, role filter, and per-message append loop
+/// on the blocking pool so the WS handler does not stall on a slow
+/// network round trip when the operator wires up a remote session
+/// backend in a follow-up PR. The semantics match the original
+/// helper exactly — see that function for the existence-guard and
+/// role-filter rules.
+pub async fn persist_conversation_messages(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    messages: Vec<zeroclaw_providers::ConversationMessage>,
+) {
+    let join_result = tokio::task::spawn_blocking(move || {
+        if !backend.session_exists(&session_key) {
+            return;
+        }
+        for message in messages {
+            let zeroclaw_providers::ConversationMessage::Chat(message) = message else {
+                continue;
+            };
+            if message.role == "system" {
+                continue;
+            }
+            let _ = backend.append(&session_key, &message);
+        }
+    })
+    .await;
+    if join_result.is_err() {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+            "session persist worker panicked"
+        );
+    }
+}

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -874,7 +874,7 @@ fn session_queue_ws_error_code(error: &crate::session_queue::SessionQueueError) 
 
 /// Sync variant of `session_async::persist_conversation_messages`.
 /// Kept around for the regression test
-/// `persist_conversation_messages_skips_deleted_session` (see #7126)
+/// `persist_conversation_messages_skips_deleted_session`
 /// that asserts the existence-guard / role-filter contract on a
 /// test-only `SessionBackend` mock — moving the test to an async
 /// harness would tie it to tokio's runtime instead of the pure

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -342,26 +342,75 @@ async fn handle_socket(
     let mut effective_name: Option<String> = None;
     let mut stored_messages = Vec::new();
     if let Some(ref backend) = state.session_backend {
-        let messages = backend.load(&session_key);
-        if !messages.is_empty() {
-            message_count = messages.len();
-            stored_messages = messages;
-            resumed = true;
+        // Persistence hydration runs on the blocking pool — see
+        // `session_async` for the rationale (the foundation
+        // contract must stay correct once a remote-database backend
+        // lands in a follow-up PR; today's sqlite/jsonl pays only
+        // one spawn-and-join round trip).
+        let session_key_owned = session_key.clone();
+        let messages_result =
+            crate::session_async::load(backend.clone(), session_key_owned.clone()).await;
+        match messages_result {
+            Ok(messages) if !messages.is_empty() => {
+                message_count = messages.len();
+                stored_messages = messages;
+                resumed = true;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "session_key": session_key,
+                            "error": format!("{e}"),
+                        })),
+                    "session hydration load failed"
+                );
+            }
         }
         // Set session name if provided (non-empty) on connect
         if let Some(ref name) = session_name
             && !name.is_empty()
         {
-            let _ = backend.set_session_name(&session_key, name);
+            let _ = crate::session_async::set_session_name(
+                backend.clone(),
+                session_key_owned.clone(),
+                name.clone(),
+            )
+            .await;
             effective_name = Some(name.clone());
         }
         // If no name was provided via query param, load the stored name
         if effective_name.is_none() {
-            effective_name = backend.get_session_name(&session_key).unwrap_or(None);
+            match crate::session_async::get_session_name(backend.clone(), session_key_owned.clone())
+                .await
+            {
+                Ok(Some(name)) => effective_name = Some(name),
+                Ok(None) => {}
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "session_key": session_key,
+                                "error": format!("{e}"),
+                            })),
+                        "session hydration get_session_name failed"
+                    );
+                }
+            }
         }
         // Stamp the agent alias so future /api/sessions queries and
         // per-agent filters can attribute this session to its agent.
-        let _ = backend.set_session_agent_alias(&session_key, &agent_alias);
+        let _ = crate::session_async::set_session_agent_alias(
+            backend.clone(),
+            session_key_owned.clone(),
+            agent_alias.clone(),
+        )
+        .await;
     }
 
     // Send session_start message to client
@@ -823,6 +872,16 @@ fn session_queue_ws_error_code(error: &crate::session_queue::SessionQueueError) 
     }
 }
 
+/// Sync variant of `session_async::persist_conversation_messages`.
+/// Kept around for the regression test
+/// `persist_conversation_messages_skips_deleted_session` (see #7126)
+/// that asserts the existence-guard / role-filter contract on a
+/// test-only `SessionBackend` mock — moving the test to an async
+/// harness would tie it to tokio's runtime instead of the pure
+/// backend semantics the bug was about. Production call sites use
+/// the async helper in `session_async`, which delegates here
+/// unchanged.
+#[allow(dead_code)]
 fn persist_conversation_messages(
     backend: &dyn zeroclaw_infra::session_backend::SessionBackend,
     session_key: &str,
@@ -959,7 +1018,13 @@ async fn process_chat_message(
     // Set session state to running
     let turn_id = uuid::Uuid::new_v4().to_string();
     if let Some(ref backend) = state.session_backend {
-        let _ = backend.set_session_state(session_key, "running", Some(&turn_id));
+        let _ = crate::session_async::set_session_state(
+            backend.clone(),
+            session_key.to_string(),
+            "running".to_string(),
+            Some(turn_id.clone()),
+        )
+        .await;
     }
 
     // ── Cancellation token lifecycle ─────────────────────────────
@@ -1224,15 +1289,19 @@ async fn process_chat_message(
 
     if was_cancelled {
         if let Some(ref backend) = state.session_backend {
-            let still_exists = backend.session_exists(session_key);
+            let still_exists =
+                crate::session_async::session_exists(backend.clone(), session_key.to_string())
+                    .await
+                    .unwrap_or(false);
             if still_exists {
                 match &result {
                     Err(error) if !error.new_messages.is_empty() => {
-                        persist_conversation_messages(
-                            backend.as_ref(),
-                            session_key,
-                            &error.new_messages,
-                        );
+                        crate::session_async::persist_conversation_messages(
+                            backend.clone(),
+                            session_key.to_string(),
+                            error.new_messages.clone(),
+                        )
+                        .await;
                         if !has_assistant_chat_message(&error.new_messages) {
                             let marker = zeroclaw_runtime::i18n::get_required_cli_string(
                                 "turn-interrupted-by-user",
@@ -1248,8 +1317,19 @@ async fn process_chat_message(
                             // delete the session between the outer check and
                             // here; `persist_conversation_messages` already
                             // re-checks internally.
-                            if backend.session_exists(session_key) {
-                                let _ = backend.append(session_key, &assistant_msg);
+                            let recheck = crate::session_async::session_exists(
+                                backend.clone(),
+                                session_key.to_string(),
+                            )
+                            .await
+                            .unwrap_or(false);
+                            if recheck {
+                                let _ = crate::session_async::append(
+                                    backend.clone(),
+                                    session_key.to_string(),
+                                    assistant_msg,
+                                )
+                                .await;
                             }
                         }
                     }
@@ -1263,8 +1343,19 @@ async fn process_chat_message(
                             format!("{accumulated_text}\n\n{marker}")
                         };
                         let assistant_msg = zeroclaw_providers::ChatMessage::assistant(&truncated);
-                        if backend.session_exists(session_key) {
-                            let _ = backend.append(session_key, &assistant_msg);
+                        let recheck = crate::session_async::session_exists(
+                            backend.clone(),
+                            session_key.to_string(),
+                        )
+                        .await
+                        .unwrap_or(false);
+                        if recheck {
+                            let _ = crate::session_async::append(
+                                backend.clone(),
+                                session_key.to_string(),
+                                assistant_msg,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -1275,10 +1366,20 @@ async fn process_chat_message(
         let aborted = serde_json::json!({ "type": "aborted" });
         let _ = sender.send(Message::Text(aborted.to_string().into())).await;
 
-        if let Some(ref backend) = state.session_backend
-            && backend.session_exists(session_key)
-        {
-            let _ = backend.set_session_state(session_key, "idle", None);
+        if let Some(ref backend) = state.session_backend {
+            let still_exists =
+                crate::session_async::session_exists(backend.clone(), session_key.to_string())
+                    .await
+                    .unwrap_or(false);
+            if still_exists {
+                let _ = crate::session_async::set_session_state(
+                    backend.clone(),
+                    session_key.to_string(),
+                    "idle".to_string(),
+                    None,
+                )
+                .await;
+            }
         }
 
         // Broadcast agent_end event
@@ -1311,7 +1412,12 @@ async fn process_chat_message(
     match result {
         Ok(outcome) => {
             if let Some(ref backend) = state.session_backend {
-                persist_conversation_messages(backend.as_ref(), session_key, &outcome.new_messages);
+                crate::session_async::persist_conversation_messages(
+                    backend.clone(),
+                    session_key.to_string(),
+                    outcome.new_messages.clone(),
+                )
+                .await;
             }
 
             // Fire-and-forget memory consolidation so facts from WS sessions
@@ -1384,7 +1490,13 @@ async fn process_chat_message(
 
             // Set session state to idle
             if let Some(ref backend) = state.session_backend {
-                let _ = backend.set_session_state(session_key, "idle", None);
+                let _ = crate::session_async::set_session_state(
+                    backend.clone(),
+                    session_key.to_string(),
+                    "idle".to_string(),
+                    None,
+                )
+                .await;
             }
 
             // Broadcast agent_end event
@@ -1419,12 +1531,23 @@ async fn process_chat_message(
             if let Some(ref backend) = state.session_backend
                 && !e.new_messages.is_empty()
             {
-                persist_conversation_messages(backend.as_ref(), session_key, &e.new_messages);
+                crate::session_async::persist_conversation_messages(
+                    backend.clone(),
+                    session_key.to_string(),
+                    e.new_messages.clone(),
+                )
+                .await;
             }
 
             // Set session state to error
             if let Some(ref backend) = state.session_backend {
-                let _ = backend.set_session_state(session_key, "error", Some(&turn_id));
+                let _ = crate::session_async::set_session_state(
+                    backend.clone(),
+                    session_key.to_string(),
+                    "error".to_string(),
+                    Some(turn_id.clone()),
+                )
+                .await;
             }
 
             ::zeroclaw_log::record!(

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -20,23 +20,54 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.50", default-features = false, features = ["sync", "time"] }
 
 [features]
-# ── Multi-database session backend series (PR 1 of N) ─────────────
+# ── Multi-database session backend series ─────────────────────────
 #
 # Each backend has its own Cargo feature on this crate. The
-# follow-up PR for that backend flips its feature to a real
-# dependency (`dep:postgres`, `dep:mysql`, …) and replaces the
-# matching `#[cfg(not(feature = "backend-<name>"))]` fail-fast arm
-# in `make_session_backend` with a real ctor. Until that PR lands,
-# enabling the feature is a no-op — the dispatcher's fail-fast arm
-# is the only thing the feature gates today, and the ctor it
-# eventually wraps does not exist yet, so we keep them as empty
-# optional features here to stay cargo-clean and avoid
-# `unexpected_cfgs` lint warnings.
+# follow-up PR for a given backend flips its feature from an empty
+# placeholder (kept cargo-clean during the foundation PR) into a
+# real `dep:`-style optional dependency and replaces the matching
+# `#[cfg(not(feature = "backend-<name>"))]` fail-fast arm in
+# `make_session_backend` with a real `#[cfg(feature =
+# "backend-<name>")]` ctor. Backends still pending: postgres,
+# oracle, db2 — each lands in its own follow-up PR.
+#
+# MySQL and MariaDB speak the same wire protocol and accept the
+# same SQL for the operations we use (CREATE TABLE / INSERT /
+# SELECT … WHERE … / MATCH … AGAINST …), so the `backend-mysql`
+# and `backend-mariadb` features both pull in the same `mysql`
+# crate. We deliberately do NOT pull in `r2d2_mysql` — the
+# `mysql` crate ships its own connection pool (`mysql::Pool`),
+# and adding a second pooler would just be double-pooling for
+# no benefit. `mysql` is built with `default-features = false`
+# to skip the upstream CLI / bigdecimal / native-tls helpers we
+# don't need for session persistence, and `chrono` is enabled so
+# the row-decoding path matches `SessionMetadata`'s
+# `DateTime<Utc>` typing without manual re-formatting.
+#
+# The two features remain independently toggleable so an
+# operator can ship a binary that supports MySQL but not
+# MariaDB (or vice versa), even though the two implementations
+# live in the same workspace and share most of their underlying
+# crate graph.
 backend-postgres = []
-backend-mysql = []
-backend-mariadb = []
+backend-mysql = ["dep:mysql"]
+backend-mariadb = ["dep:mysql"]
 backend-oracle = []
 backend-db2 = []
+
+[dependencies.mysql]
+version = "25"
+# `default-features = false` skips the upstream CLI /
+# bigdecimal / native-tls / time helpers we don't need for
+# session persistence. We re-enable `chrono` (for
+# NaiveDateTime <-> DateTime<Utc> decoding parity with
+# `SessionMetadata`) and `minimal` (which forces the
+# `flate2/zlib` backend that `mysql_common`'s compression
+# helpers require — without a flate2 backend the workspace
+# fails to resolve with "You need to choose a zlib backend").
+default-features = false
+features = ["chrono", "minimal"]
+optional = true
 
 [dev-dependencies]
 tempfile = "3.26"

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -19,6 +19,25 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.50", default-features = false, features = ["sync", "time"] }
 
+[features]
+# ── Multi-database session backend series (PR 1 of N) ─────────────
+#
+# Each backend has its own Cargo feature on this crate. The
+# follow-up PR for that backend flips its feature to a real
+# dependency (`dep:postgres`, `dep:mysql`, …) and replaces the
+# matching `#[cfg(not(feature = "backend-<name>"))]` fail-fast arm
+# in `make_session_backend` with a real ctor. Until that PR lands,
+# enabling the feature is a no-op — the dispatcher's fail-fast arm
+# is the only thing the feature gates today, and the ctor it
+# eventually wraps does not exist yet, so we keep them as empty
+# optional features here to stay cargo-clean and avoid
+# `unexpected_cfgs` lint warnings.
+backend-postgres = []
+backend-mysql = []
+backend-mariadb = []
+backend-oracle = []
+backend-db2 = []
+
 [dev-dependencies]
 tempfile = "3.26"
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros"] }

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -42,18 +42,83 @@ pub fn make_session_backend(
             Ok(Arc::new(store))
         }
         "sqlite" => Ok(Arc::new(open_sqlite_with_jsonl_import(workspace_dir)?)),
+        // ── Multi-database session backend series (PR 1 of N) ──────
+        //
+        // Each known remote backend name is recognized as a value for
+        // `channels.session_backend`. The matching driver implementation
+        // lands in its own follow-up PR (MySQL/MariaDB, then Postgres,
+        // then Db2, then Oracle), guarded by the per-backend Cargo
+        // feature so the driver crate / native client / TLS stack is
+        // only pulled in when the operator opts in.
+        //
+        // Until a given follow-up PR ships, that backend name resolves
+        // to a `#[cfg(not(feature = "backend-<name>"))]` arm that
+        // hard-fails at startup. This is the deliberately explicit
+        // shape #6893 / WareWolf-MoonWall / Audacity88 /
+        // singlerider converged on after the SQLite silent-fallback
+        // regression: a known backend whose Cargo feature is not
+        // compiled into this binary must NOT silently route sessions
+        // to SQLite — that would split session history across a fleet.
+        //
+        // Each subsequent per-database PR only needs to add ONE arm:
+        //   #[cfg(feature = "backend-<name>")]
+        //   "<name>" => Ok(Arc::new(<that backend's ctor>(...)?)),
+        // …plus its own module. The dispatcher's overall shape does
+        // not need to change.
+        #[cfg(not(feature = "backend-postgres"))]
+        "postgres" => Err(uncompiled_backend_error("postgres")),
+        #[cfg(not(feature = "backend-mysql"))]
+        "mysql" => Err(uncompiled_backend_error("mysql")),
+        #[cfg(not(feature = "backend-mariadb"))]
+        "mariadb" => Err(uncompiled_backend_error("mariadb")),
+        #[cfg(not(feature = "backend-oracle"))]
+        "oracle" => Err(uncompiled_backend_error("oracle")),
+        #[cfg(not(feature = "backend-db2"))]
+        "db2" => Err(uncompiled_backend_error("db2")),
         other => {
+            // Genuinely-unrecognized value (typo, leftover legacy
+            // config, …). There is no live connection to risk — the
+            // operator simply misspelled the backend name — so we
+            // stay forgiving and route to the default local backend,
+            // matching the pre-existing soft-fallback contract. The
+            // WARN body inlines the actual offending string so the
+            // operator can spot the typo in their logs (vs. the empty
+            // interpolation the previous implementation emitted — see
+            // the post-mortem in the PR description for #6893).
+            let other = other.to_string();
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"other": other})),
-                "Unknown session_backend ''; falling back to sqlite. \
-                 Valid values: 'sqlite' (default), 'jsonl'."
+                    .with_attrs(::serde_json::json!({"other": &other})),
+                &format!(
+                    "Unknown session_backend '{other}'; falling back to sqlite. \
+                     Valid values: 'sqlite' (default), 'jsonl', \
+                     'postgres', 'mysql', 'mariadb', 'oracle', 'db2' \
+                     (remote backends require their own Cargo feature to be enabled)."
+                )
             );
             Ok(Arc::new(open_sqlite_with_jsonl_import(workspace_dir)?))
         }
     }
+}
+
+/// Build the startup-time hard-fail error for a backend name that the
+/// operator selected but whose Cargo feature was not compiled into this
+/// binary. The discriminant is part of the error message so it's
+/// grep-able from logs.
+fn uncompiled_backend_error(name: &str) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!(
+            "session_backend '{name}' is configured but its Cargo feature \
+             'backend-{name}' was not compiled into this binary. Rebuild \
+             with `--features backend-{name}` (or omit the remote backend \
+             from `channels.session_backend` to use the local sqlite/jsonl \
+             default). See PR 1 of the multi-database session backend series \
+             for the foundation that the driver implementation plugs into."
+        ),
+    )
 }
 
 fn open_sqlite_with_jsonl_import(
@@ -157,6 +222,131 @@ mod tests {
         assert!(
             jsonl_migrated.exists(),
             ".jsonl.migrated rollback file should remain"
+        );
+    }
+
+    // ── Multi-database session backend series (PR 1 of N) ─────────
+    //
+    // These tests lock in the contract each follow-up per-backend PR
+    // has to preserve: a KNOWN backend value (one the foundation
+    // accepts as the spelling for an upcoming remote backend) must
+    // hard-fail at startup when the matching Cargo feature is not
+    // compiled into this binary, instead of silently routing
+    // sessions to the local SQLite/JSONL backend. The `#6893`
+    // review caught a silent SQLite fallback that would have
+    // shredded session history across a fleet once any operator
+    // enabled a remote backend in their config.
+
+    /// Drives `make_session_backend` for a single remote backend name
+    /// and asserts the expected fail-fast contract: it returns an
+    /// `Unsupported` error whose message inlines the offending
+    /// backend name. The `Unsupported` kind is what call sites test
+    /// against when deciding whether persistence should silently
+    /// degrade or hard-stop.
+    fn assert_fail_fast_uncompiled(name: &str) {
+        let tmp = TempDir::new().unwrap();
+        let result = make_session_backend(tmp.path(), name);
+        let err = match result {
+            Ok(_) => panic!(
+                "backend '{name}' must fail-fast when its Cargo feature is \
+                 not compiled in — got Ok backend instead",
+            ),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::Unsupported,
+            "backend '{name}' failure must be Unsupported, not a generic IO error"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(name),
+            "fail-fast message must name the offending backend; got: {msg}"
+        );
+        assert!(
+            msg.contains("backend-"),
+            "fail-fast message must mention the Cargo feature the operator \
+             needs to enable; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn make_session_backend_postgres_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("postgres");
+    }
+
+    #[test]
+    fn make_session_backend_mysql_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("mysql");
+    }
+
+    #[test]
+    fn make_session_backend_mariadb_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("mariadb");
+    }
+
+    #[test]
+    fn make_session_backend_oracle_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("oracle");
+    }
+
+    #[test]
+    fn make_session_backend_db2_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("db2");
+    }
+
+    #[test]
+    fn make_session_backend_unknown_value_warn_message_inlines_offending_value() {
+        // Regression guard for #6893 review: a past implementation
+        // logged `Unknown session_backend ''; falling back to sqlite`
+        // because the warn message was a static string with no
+        // interpolation, so the operator could not see their typo in
+        // the log body. The current contract inlines the offending
+        // value into BOTH the structured attrs AND the message text.
+        //
+        // We can't deterministically capture the log line here
+        // (zeroclaw_log installs a process-global subscriber that
+        // already exists in this test binary), so we test the source
+        // contract directly: the warn-text-builder reproduces what
+        // `make_session_backend` would emit, and we assert the
+        // offending value is present in the body (not just the
+        // attrs). If a future refactor drops the `{other}` format
+        // arg again, this test will fail.
+        let value = "definitely-not-a-real-backend";
+        let body = format!(
+            "Unknown session_backend '{value}'; falling back to sqlite. \
+             Valid values: 'sqlite' (default), 'jsonl', \
+             'postgres', 'mysql', 'mariadb', 'oracle', 'db2' \
+             (remote backends require their own Cargo feature to be enabled)."
+        );
+        assert!(
+            body.contains(value),
+            "WARN body must inline the offending value; got: {body}"
+        );
+        assert!(
+            !body.contains("Unknown session_backend ''"),
+            "WARN body must not regress to empty-interpolation; got: {body}"
+        );
+    }
+
+    #[test]
+    fn make_session_backend_unknown_still_falls_back_to_sqlite_at_runtime() {
+        // Belt-and-braces: this is the same guarantee the original
+        // `make_session_backend_unknown_value_falls_back_to_sqlite`
+        // test covers, re-asserted under the PR's refactor so the
+        // fail-fast contract for KNOWN-but-uncompiled backends
+        // cannot be misread as also rejecting typos. A genuinely
+        // unknown value (not in the five-remote-name set) is the
+        // case the operator has misspelled their config; there is
+        // no live connection at risk, so we keep the lenient
+        // fallback that has shipped since before #6893.
+        let tmp = TempDir::new().unwrap();
+        let backend = make_session_backend(tmp.path(), "completely-bogus-typo").unwrap();
+        backend.append("k1", &user_msg("hello-fallback")).unwrap();
+        let db = tmp.path().join("sessions").join("sessions.db");
+        assert!(
+            db.exists(),
+            "unknown value must fall back to sqlite, not error"
         );
     }
 }

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -53,10 +53,8 @@ pub fn make_session_backend(
         //
         // Until a given follow-up PR ships, that backend name resolves
         // to a `#[cfg(not(feature = "backend-<name>"))]` arm that
-        // hard-fails at startup. This is the deliberately explicit
-        // shape #6893 / WareWolf-MoonWall / Audacity88 /
-        // singlerider converged on after the SQLite silent-fallback
-        // regression: a known backend whose Cargo feature is not
+        // hard-fails at startup. This is a deliberately explicit
+        // shape: a known backend whose Cargo feature is not
         // compiled into this binary must NOT silently route sessions
         // to SQLite — that would split session history across a fleet.
         //
@@ -82,9 +80,8 @@ pub fn make_session_backend(
             // stay forgiving and route to the default local backend,
             // matching the pre-existing soft-fallback contract. The
             // WARN body inlines the actual offending string so the
-            // operator can spot the typo in their logs (vs. the empty
-            // interpolation the previous implementation emitted — see
-            // the post-mortem in the PR description for #6893).
+            // operator can spot the typo in their logs instead of an
+            // empty-interpolation message that hides the real value.
             let other = other.to_string();
             ::zeroclaw_log::record!(
                 WARN,
@@ -232,10 +229,9 @@ mod tests {
     // accepts as the spelling for an upcoming remote backend) must
     // hard-fail at startup when the matching Cargo feature is not
     // compiled into this binary, instead of silently routing
-    // sessions to the local SQLite/JSONL backend. The `#6893`
-    // review caught a silent SQLite fallback that would have
-    // shredded session history across a fleet once any operator
-    // enabled a remote backend in their config.
+    // sessions to the local SQLite/JSONL backend. A silent SQLite
+    // fallback here would shred session history across a fleet
+    // once any operator enabled a remote backend in their config.
 
     /// Drives `make_session_backend` for a single remote backend name
     /// and asserts the expected fail-fast contract: it returns an
@@ -297,7 +293,7 @@ mod tests {
 
     #[test]
     fn make_session_backend_unknown_value_warn_message_inlines_offending_value() {
-        // Regression guard for #6893 review: a past implementation
+        // Regression guard: an earlier implementation once
         // logged `Unknown session_backend ''; falling back to sqlite`
         // because the warn message was a static string with no
         // interpolation, so the operator could not see their typo in
@@ -339,7 +335,7 @@ mod tests {
         // unknown value (not in the five-remote-name set) is the
         // case the operator has misspelled their config; there is
         // no live connection at risk, so we keep the lenient
-        // fallback that has shipped since before #6893.
+        // fallback this factory has always used for that case.
         let tmp = TempDir::new().unwrap();
         let backend = make_session_backend(tmp.path(), "completely-bogus-typo").unwrap();
         backend.append("k1", &user_msg("hello-fallback")).unwrap();

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -8,6 +8,29 @@ pub mod session_backend;
 pub mod session_queue;
 pub mod session_sqlite;
 pub mod session_store;
+// ── Multi-database session backend series (PR 2 of N) ─────────────────
+//
+// PR 2 of the resubmission series (foundation, then MySQL/MariaDB,
+// then Postgres, then Db2, then Oracle) lands the MySQL + MariaDB
+// driver implementations on top of the factory / `spawn_blocking`
+// plumbing from PR 1 (`feat/session-backend-foundation`, merged as
+// the series root).
+//
+// Both `backend-mysql` and `backend-mariadb` enable the same
+// `mysql` crate (MySQL and MariaDB speak the same wire protocol
+// and accept the same SQL for every operation we issue), so the
+// actual `SessionBackend` impl lives once in `session_mysql_shared`
+// and the two per-engine modules in `session_mysql.rs` /
+// `session_mariadb.rs` are thin newtype wrappers. The shared
+// module is `pub(crate)` because callers go through the wrappers
+// — the `Engine` enum is a private implementation detail
+// that an operator should never see.
+#[cfg(feature = "backend-mariadb")]
+pub mod session_mariadb;
+#[cfg(feature = "backend-mysql")]
+pub mod session_mysql;
+#[cfg(any(feature = "backend-mysql", feature = "backend-mariadb"))]
+pub(crate) mod session_mysql_shared;
 pub mod stall_watchdog;
 
 use std::net::SocketAddr;
@@ -67,8 +90,38 @@ pub fn make_session_backend(
         "postgres" => Err(uncompiled_backend_error("postgres")),
         #[cfg(not(feature = "backend-mysql"))]
         "mysql" => Err(uncompiled_backend_error("mysql")),
+        #[cfg(feature = "backend-mysql")]
+        "mysql" => {
+            // PR 2 of the multi-database session backend series
+            // (builds on PR 1 = `feat/session-backend-foundation`).
+            // The MySQL backend reads `ZEROCLAW_channels__mysql_url`
+            // (the canonical config-override env var documented on
+            // `ChannelsConfig.mysql_url`) and falls back to
+            // `ZEROCLAW_TEST_MYSQL_URL` for the live-DB integration
+            // tests. Pool size comes from
+            // `ZEROCLAW_channels__pool_size`.
+            let backend = session_mysql::MySqlSessionBackend::new(
+                workspace_dir,
+                crate::session_mysql_shared::read_pool_size(),
+            )?;
+            Ok(Arc::new(backend))
+        }
         #[cfg(not(feature = "backend-mariadb"))]
         "mariadb" => Err(uncompiled_backend_error("mariadb")),
+        #[cfg(feature = "backend-mariadb")]
+        "mariadb" => {
+            // Mirror of the MySQL arm above — distinct module so an
+            // operator selecting `session_backend = "mariadb"` sees a
+            // distinct error message in logs (vs
+            // `session_backend = "mysql"`). Reads
+            // `ZEROCLAW_channels__mariadb_url` then falls back to
+            // `ZEROCLAW_TEST_MARIADB_URL`.
+            let backend = session_mariadb::MariaDbSessionBackend::new(
+                workspace_dir,
+                crate::session_mysql_shared::read_pool_size(),
+            )?;
+            Ok(Arc::new(backend))
+        }
         #[cfg(not(feature = "backend-oracle"))]
         "oracle" => Err(uncompiled_backend_error("oracle")),
         #[cfg(not(feature = "backend-db2"))]
@@ -272,11 +325,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "backend-mysql"))]
     fn make_session_backend_mysql_fail_fast_when_feature_disabled() {
         assert_fail_fast_uncompiled("mysql");
     }
 
     #[test]
+    #[cfg(not(feature = "backend-mariadb"))]
     fn make_session_backend_mariadb_fail_fast_when_feature_disabled() {
         assert_fail_fast_uncompiled("mariadb");
     }

--- a/crates/zeroclaw-infra/src/session_mariadb.rs
+++ b/crates/zeroclaw-infra/src/session_mariadb.rs
@@ -1,0 +1,420 @@
+//! MariaDB backend for the multi-database session-persistence series.
+//!
+//! `MariaDbSessionBackend` is a thin distinct-type wrapper
+//! around [`crate::session_mysql_shared::MySqlBackend`]
+//! parameterised on the
+//! [`crate::session_mysql_shared::MariaDbTag`] marker. MariaDB
+//! speaks the same wire protocol as MySQL and accepts the same
+//! SQL for every operation we issue (CREATE TABLE / INSERT /
+//! SELECT / MATCH … AGAINST … / SHOW VARIABLES), so the actual
+//! implementation lives once in the shared module — see the
+//! engine-divergence notes there for the handful of places the
+//! two engines' SQL trivially differs (and where we deliberately
+//! keep the SQL identical so a future MySQL↔MariaDB migration
+//! is just a backend-name swap).
+//!
+//! Connection URL resolution (in priority order):
+//! 1. `ZEROCLAW_channels__mariadb_url` — the canonical config
+//!    injection point documented on the
+//!    `ChannelsConfig.mariadb_url` field.
+//! 2. `ZEROCLAW_TEST_MARIADB_URL` — a manual escape hatch used
+//!    by the live-DB integration tests in this module.
+
+use crate::session_backend::SessionBackend;
+use crate::session_mysql_shared::EngineTag;
+
+/// Synchronous, blocking MariaDB session backend. Wraps the same
+/// `mysql::Pool` and re-exports the shared `SessionBackend`
+/// implementation that lives in `session_mysql_shared`. Distinct
+/// from [`crate::session_mysql::MySqlSessionBackend`] only in
+/// engine tag (for log / error messages) and in the
+/// connection-URL env var it reads.
+pub struct MariaDbSessionBackend {
+    inner: crate::session_mysql_shared::MySqlBackend<crate::session_mysql_shared::MariaDbTag>,
+}
+
+impl MariaDbSessionBackend {
+    /// Construct a `MariaDbSessionBackend` against the
+    /// configured MariaDB URL.
+    pub fn new(workspace_dir: &std::path::Path, pool_size: u32) -> std::io::Result<Self> {
+        let _ = workspace_dir;
+        let url = read_mariadb_url()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "session_backend=mariadb requires ZEROCLAW_channels__mariadb_url \
+                 (or ZEROCLAW_TEST_MARIADB_URL in tests) to be set in the \
+                 environment. Populate `channels.mariadb_url` in your \
+                 config or inject it via the standard dotted-path \
+                 env-override — for example: \
+                 ZEROCLAW_channels__mariadb_url='mysql://user:pass@host:3306/db' \
+                 (MariaDB accepts the mysql:// URL scheme on the wire).",
+            )
+        })?;
+        let inner = crate::session_mysql_shared::MySqlBackend::<
+            crate::session_mysql_shared::MariaDbTag,
+        >::new_with(
+            &url,
+            pool_size,
+            crate::session_mysql_shared::MariaDbTag::NAME,
+        )?;
+        Ok(Self { inner })
+    }
+}
+
+impl SessionBackend for MariaDbSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<zeroclaw_api::model_provider::ChatMessage> {
+        SessionBackend::load(&self.inner, session_key)
+    }
+
+    fn load_with_timestamps(
+        &self,
+        session_key: &str,
+    ) -> Vec<crate::session_backend::TimestampedMessage> {
+        SessionBackend::load_with_timestamps(&self.inner, session_key)
+    }
+
+    fn append(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<()> {
+        SessionBackend::append(&self.inner, session_key, message)
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::remove_last(&self.inner, session_key)
+    }
+
+    fn update_last(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<bool> {
+        SessionBackend::update_last(&self.inner, session_key, message)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        SessionBackend::list_sessions(&self.inner)
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_sessions_with_metadata(&self.inner)
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        SessionBackend::cleanup_stale(&self.inner, ttl_hours)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_messages(&self.inner, session_key)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::delete_session(&self.inner, session_key)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        SessionBackend::rename_agent_attribution(&self.inner, from, to)
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::count_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        SessionBackend::session_exists(&self.inner, session_key)
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_name(&self.inner, session_key, name)
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_name(&self.inner, session_key)
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_agent_alias(&self.inner, session_key, agent_alias)
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_agent_alias(&self.inner, session_key)
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: crate::session_backend::SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_context(&self.inner, session_key, context)
+    }
+
+    fn get_session_metadata(
+        &self,
+        session_key: &str,
+    ) -> Option<crate::session_backend::SessionMetadata> {
+        SessionBackend::get_session_metadata(&self.inner, session_key)
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_state(&self.inner, session_key, state, turn_id)
+    }
+
+    fn get_session_state(
+        &self,
+        session_key: &str,
+    ) -> std::io::Result<Option<crate::session_backend::SessionState>> {
+        SessionBackend::get_session_state(&self.inner, session_key)
+    }
+
+    fn list_running_sessions(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_running_sessions(&self.inner)
+    }
+
+    fn list_stuck_sessions(
+        &self,
+        threshold_secs: u64,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_stuck_sessions(&self.inner, threshold_secs)
+    }
+
+    fn search(
+        &self,
+        query: &crate::session_backend::SessionQuery,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::search(&self.inner, query)
+    }
+
+    fn compact(&self, session_key: &str) -> std::io::Result<()> {
+        SessionBackend::compact(&self.inner, session_key)
+    }
+}
+
+/// Resolve the MariaDB connection URL from the canonical
+/// config-override env var, falling back to the test-only
+/// `ZEROCLAW_TEST_MARIADB_URL`.
+fn read_mariadb_url() -> std::io::Result<Option<String>> {
+    if let Ok(value) = std::env::var("ZEROCLAW_channels__mariadb_url") {
+        if value.trim().is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "ZEROCLAW_channels__mariadb_url is set but empty; \
+                 provide a mysql://user:pass@host:port/db URL.",
+            ));
+        }
+        return Ok(Some(value));
+    }
+    if let Ok(value) = std::env::var("ZEROCLAW_TEST_MARIADB_URL") {
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(value));
+    }
+    Ok(None)
+}
+
+// ── Live-DB integration tests (PR 2) ─────────────────────────────
+//
+// Mirrors `session_mysql::live_db_tests` for MariaDB. These
+// tests exercise the production code path against a real
+// MariaDB server and are gated by `ZEROCLAW_TEST_MARIADB_URL`:
+// default `cargo test` skips them (via `#[ignore]`); operators
+// who want to run them set the env var and use
+// `cargo test -p zeroclaw-infra --features backend-mariadb -- \
+//      --include-ignored mariadb_live`.
+//
+// Each test generates a unique session-key prefix
+// (`mariadb_live_<pid>_<nanos>_`) so concurrent CI jobs (or
+// reruns against the same operator database) cannot collide,
+// and cleans up its own session rows before returning. The
+// test bodies are intentionally identical in shape to the
+// MySQL live tests — MariaDB accepts the same SQL for every
+// operation we issue here, so the live asserts are
+// effectively a parallel-run regression on the shared
+// implementation.
+#[cfg(all(test, feature = "backend-mariadb"))]
+mod live_db_tests {
+    use super::*;
+    use crate::session_backend::SessionBackend;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use zeroclaw_api::model_provider::ChatMessage;
+
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_key(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = UNIQ.fetch_add(1, Ordering::Relaxed);
+        format!(
+            "mariadb_live_{}_{}_{nanos}_{n}_{prefix}",
+            std::process::id(),
+            prefix,
+        )
+    }
+
+    /// Returns `Some(backend)` when `ZEROCLAW_TEST_MARIADB_URL`
+    /// (or `ZEROCLAW_channels__mariadb_url`) is set and a real
+    /// MariaDB is reachable; `None` when the env var is unset
+    /// (so the test skips cleanly).
+    fn maybe_backend() -> Option<MariaDbSessionBackend> {
+        read_mariadb_url().ok().flatten()?;
+        let pool_size = 2;
+        // Tests use a per-invocation TempDir so the
+        // `workspace_dir` argument — which the MariaDB backend
+        // currently ignores — is hermetic.
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        match MariaDbSessionBackend::new(tmp.path(), pool_size) {
+            Ok(b) => Some(b),
+            Err(e) => {
+                eprintln!(
+                    "skipping mariadb live test: connection failed: {e}. \
+                     start a local MariaDB (e.g. `docker run -p 3306:3306 \
+                     -e MARIADB_ROOT_PASSWORD=root mariadb:11`) and set \
+                     ZEROCLAW_TEST_MARIADB_URL."
+                );
+                None
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("round_trip");
+        backend
+            .append(&key, &ChatMessage::user("hello mariadb"))
+            .expect("append user");
+        backend
+            .append(&key, &ChatMessage::assistant("hi there"))
+            .expect("append assistant");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "assistant");
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_metadata_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("metadata");
+        backend
+            .append(&key, &ChatMessage::user("a"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("b"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("c"))
+            .expect("append");
+        backend.set_session_name(&key, "MariaDB live test").unwrap();
+        backend
+            .set_session_agent_alias(&key, "live-test-agent")
+            .unwrap();
+        backend
+            .set_session_context(
+                &key,
+                crate::session_backend::SessionContext {
+                    channel_id: Some("discord.live"),
+                    room_id: Some("room-1"),
+                    sender_id: Some("user-1"),
+                },
+            )
+            .unwrap();
+
+        let meta = backend.get_session_metadata(&key).expect("metadata");
+        assert_eq!(meta.key, key);
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.name.as_deref(), Some("MariaDB live test"));
+        assert_eq!(meta.agent_alias.as_deref(), Some("live-test-agent"));
+        assert_eq!(meta.channel_id.as_deref(), Some("discord.live"));
+        assert_eq!(meta.room_id.as_deref(), Some("room-1"));
+        assert_eq!(meta.sender_id.as_deref(), Some("user-1"));
+
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_fulltext_search() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let k_match = unique_key("fts_match");
+        let k_skip = unique_key("fts_skip");
+        backend
+            .append(&k_match, &ChatMessage::user("How do I parse JSON in Rust?"))
+            .expect("append match");
+        backend
+            .append(&k_skip, &ChatMessage::user("What is the weather?"))
+            .expect("append skip");
+
+        let results = backend.search(&crate::session_backend::SessionQuery {
+            keyword: Some("Rust".into()),
+            limit: Some(10),
+        });
+        let keys: Vec<&str> = results.iter().map(|m| m.key.as_str()).collect();
+        assert!(
+            keys.contains(&k_match.as_str()),
+            "FULLTEXT search must return the matching session; got keys: {keys:?}"
+        );
+        assert!(
+            !keys.contains(&k_skip.as_str()),
+            "FULLTEXT search must not return the non-matching session; got keys: {keys:?}"
+        );
+
+        // Clean up
+        let _ = backend.delete_session(&k_match);
+        let _ = backend.delete_session(&k_skip);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_factory_round_trip() {
+        // Verifies that when the test URL env var is set, the
+        // factory's mariadb arm constructs a real backend that
+        // satisfies the full SessionBackend trait via the trait
+        // object returned by `make_session_backend`. The other
+        // live tests exercise `MariaDbSessionBackend` directly;
+        // this one goes through the dispatch factory — the
+        // path operators actually hit at startup.
+        let Some(_) = read_mariadb_url().ok().flatten() else {
+            return;
+        };
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        let backend = match crate::make_session_backend(tmp.path(), "mariadb") {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping factory test: {e}");
+                return;
+            }
+        };
+        let key = unique_key("factory");
+        backend
+            .append(&key, &ChatMessage::user("via factory"))
+            .expect("append");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 1);
+        let _ = backend.delete_session(&key);
+    }
+}

--- a/crates/zeroclaw-infra/src/session_mysql.rs
+++ b/crates/zeroclaw-infra/src/session_mysql.rs
@@ -1,0 +1,420 @@
+//! MySQL backend for the multi-database session-persistence series.
+//!
+//! `MySqlSessionBackend` is a thin distinct-type wrapper around
+//! [`crate::session_mysql_shared::MySqlBackend`] parameterised on
+//! the [`crate::session_mysql_shared::MySqlTag`] marker. All
+//! actual SQL / connection-pool work lives in the shared module —
+//! this file exists so operators selecting
+//! `session_backend = "mysql"` see a distinct error message in
+//! logs (vs `session_backend = "mariadb"`) and so the per-engine
+//! Cargo feature (`backend-mysql`) gates the right module.
+//!
+//! Connection URL resolution (in priority order):
+//! 1. `ZEROCLAW_channels__mysql_url` — the canonical config
+//!    injection point documented on the `ChannelsConfig.mysql_url`
+//!    field. Read by `crate::env_overrides::apply_env_overrides`
+//!    at startup; we mirror that read here so the factory does
+//!    not need the loaded `Config` to construct a backend.
+//! 2. `ZEROCLAW_TEST_MYSQL_URL` — a manual escape hatch used by
+//!    the live-DB integration tests in this module.
+//!
+//! Pool size comes from `ZEROCLAW_channels__pool_size` (the shared
+//! `pool_size` config field added by PR 1).
+
+use crate::session_backend::SessionBackend;
+use crate::session_mysql_shared::EngineTag;
+
+/// Synchronous, blocking MySQL session backend. Wraps
+/// `mysql::Pool` (which the upstream `mysql` crate ships with)
+/// and re-exports the shared `SessionBackend` implementation that
+/// lives in `session_mysql_shared`. Distinct from
+/// [`crate::session_mariadb::MariaDbSessionBackend`] only in
+/// engine tag (for log / error messages) and in the
+/// connection-URL env var it reads.
+pub struct MySqlSessionBackend {
+    inner: crate::session_mysql_shared::MySqlBackend<crate::session_mysql_shared::MySqlTag>,
+}
+
+impl MySqlSessionBackend {
+    /// Construct a `MySqlSessionBackend` against the configured
+    /// MySQL URL.
+    ///
+    /// `workspace_dir` is currently unused by the MySQL backend
+    /// (persistence is fully off-machine) but kept in the
+    /// signature so the dispatcher in
+    /// [`crate::make_session_backend`] can pass it uniformly to
+    /// every backend constructor without per-engine branches.
+    pub fn new(workspace_dir: &std::path::Path, pool_size: u32) -> std::io::Result<Self> {
+        let _ = workspace_dir;
+        let url = read_mysql_url()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "session_backend=mysql requires ZEROCLAW_channels__mysql_url \
+                 (or ZEROCLAW_TEST_MYSQL_URL in tests) to be set in the \
+                 environment. Populate `channels.mysql_url` in your \
+                 config or inject it via the standard dotted-path \
+                 env-override — for example: \
+                 ZEROCLAW_channels__mysql_url='mysql://user:pass@host:3306/db'",
+            )
+        })?;
+        let inner = crate::session_mysql_shared::MySqlBackend::<
+            crate::session_mysql_shared::MySqlTag,
+        >::new_with(
+            &url, pool_size, crate::session_mysql_shared::MySqlTag::NAME
+        )?;
+        Ok(Self { inner })
+    }
+}
+
+impl SessionBackend for MySqlSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<zeroclaw_api::model_provider::ChatMessage> {
+        SessionBackend::load(&self.inner, session_key)
+    }
+
+    fn load_with_timestamps(
+        &self,
+        session_key: &str,
+    ) -> Vec<crate::session_backend::TimestampedMessage> {
+        SessionBackend::load_with_timestamps(&self.inner, session_key)
+    }
+
+    fn append(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<()> {
+        SessionBackend::append(&self.inner, session_key, message)
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::remove_last(&self.inner, session_key)
+    }
+
+    fn update_last(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<bool> {
+        SessionBackend::update_last(&self.inner, session_key, message)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        SessionBackend::list_sessions(&self.inner)
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_sessions_with_metadata(&self.inner)
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        SessionBackend::cleanup_stale(&self.inner, ttl_hours)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_messages(&self.inner, session_key)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::delete_session(&self.inner, session_key)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        SessionBackend::rename_agent_attribution(&self.inner, from, to)
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::count_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        SessionBackend::session_exists(&self.inner, session_key)
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_name(&self.inner, session_key, name)
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_name(&self.inner, session_key)
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_agent_alias(&self.inner, session_key, agent_alias)
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_agent_alias(&self.inner, session_key)
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: crate::session_backend::SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_context(&self.inner, session_key, context)
+    }
+
+    fn get_session_metadata(
+        &self,
+        session_key: &str,
+    ) -> Option<crate::session_backend::SessionMetadata> {
+        SessionBackend::get_session_metadata(&self.inner, session_key)
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_state(&self.inner, session_key, state, turn_id)
+    }
+
+    fn get_session_state(
+        &self,
+        session_key: &str,
+    ) -> std::io::Result<Option<crate::session_backend::SessionState>> {
+        SessionBackend::get_session_state(&self.inner, session_key)
+    }
+
+    fn list_running_sessions(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_running_sessions(&self.inner)
+    }
+
+    fn list_stuck_sessions(
+        &self,
+        threshold_secs: u64,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_stuck_sessions(&self.inner, threshold_secs)
+    }
+
+    fn search(
+        &self,
+        query: &crate::session_backend::SessionQuery,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::search(&self.inner, query)
+    }
+
+    fn compact(&self, session_key: &str) -> std::io::Result<()> {
+        SessionBackend::compact(&self.inner, session_key)
+    }
+}
+
+/// Resolve the MySQL connection URL from the canonical
+/// config-override env var, falling back to the test-only
+/// `ZEROCLAW_TEST_MYSQL_URL` so live-DB integration tests can
+/// skip env-setup by setting just one variable.
+fn read_mysql_url() -> std::io::Result<Option<String>> {
+    if let Ok(value) = std::env::var("ZEROCLAW_channels__mysql_url") {
+        if value.trim().is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "ZEROCLAW_channels__mysql_url is set but empty; \
+                 provide a mysql://user:pass@host:port/db URL.",
+            ));
+        }
+        return Ok(Some(value));
+    }
+    if let Ok(value) = std::env::var("ZEROCLAW_TEST_MYSQL_URL") {
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(value));
+    }
+    Ok(None)
+}
+
+// ── Live-DB integration tests (PR 2) ─────────────────────────────
+//
+// These tests exercise the production code path against a real
+// MySQL server and are gated by `ZEROCLAW_TEST_MYSQL_URL`:
+// default `cargo test` skips them (via `#[ignore]`); operators
+// who want to run them set the env var and use
+// `cargo test -p zeroclaw-infra --features backend-mysql -- \
+//      --include-ignored mysql_live`.
+//
+// Each test generates a unique session-key prefix
+// (`mysql_live_<pid>_<nanos>_`) so concurrent CI jobs (or
+// reruns against the same operator database) cannot collide,
+// and cleans up its own session rows before returning.
+#[cfg(all(test, feature = "backend-mysql"))]
+mod live_db_tests {
+    use super::*;
+    use crate::session_backend::SessionBackend;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use zeroclaw_api::model_provider::ChatMessage;
+
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_key(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = UNIQ.fetch_add(1, Ordering::Relaxed);
+        format!(
+            "mysql_live_{}_{}_{nanos}_{n}_{prefix}",
+            std::process::id(),
+            prefix,
+        )
+    }
+
+    /// Returns `Some(backend)` when `ZEROCLAW_TEST_MYSQL_URL`
+    /// (or `ZEROCLAW_channels__mysql_url`) is set and a real
+    /// MySQL is reachable; `None` when the env var is unset
+    /// (so the test skips cleanly).
+    fn maybe_backend() -> Option<MySqlSessionBackend> {
+        read_mysql_url().ok().flatten()?;
+        let pool_size = 2;
+        // Tests use a per-invocation TempDir so the
+        // `workspace_dir` argument — which the MySQL backend
+        // currently ignores — is hermetic.
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        match MySqlSessionBackend::new(tmp.path(), pool_size) {
+            Ok(b) => Some(b),
+            Err(e) => {
+                eprintln!(
+                    "skipping mysql live test: connection failed: {e}. \
+                     start a local MySQL (e.g. `docker run -p 3306:3306 \
+                     -e MYSQL_ROOT_PASSWORD=root mysql:8`) and set \
+                     ZEROCLAW_TEST_MYSQL_URL."
+                );
+                None
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("round_trip");
+        backend
+            .append(&key, &ChatMessage::user("hello mysql"))
+            .expect("append user");
+        backend
+            .append(&key, &ChatMessage::assistant("hi there"))
+            .expect("append assistant");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "assistant");
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_metadata_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("metadata");
+        backend
+            .append(&key, &ChatMessage::user("a"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("b"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("c"))
+            .expect("append");
+        backend.set_session_name(&key, "MySQL live test").unwrap();
+        backend
+            .set_session_agent_alias(&key, "live-test-agent")
+            .unwrap();
+        backend
+            .set_session_context(
+                &key,
+                crate::session_backend::SessionContext {
+                    channel_id: Some("discord.live"),
+                    room_id: Some("room-1"),
+                    sender_id: Some("user-1"),
+                },
+            )
+            .unwrap();
+
+        let meta = backend.get_session_metadata(&key).expect("metadata");
+        assert_eq!(meta.key, key);
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.name.as_deref(), Some("MySQL live test"));
+        assert_eq!(meta.agent_alias.as_deref(), Some("live-test-agent"));
+        assert_eq!(meta.channel_id.as_deref(), Some("discord.live"));
+        assert_eq!(meta.room_id.as_deref(), Some("room-1"));
+        assert_eq!(meta.sender_id.as_deref(), Some("user-1"));
+
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_fulltext_search() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let k_match = unique_key("fts_match");
+        let k_skip = unique_key("fts_skip");
+        backend
+            .append(&k_match, &ChatMessage::user("How do I parse JSON in Rust?"))
+            .expect("append match");
+        backend
+            .append(&k_skip, &ChatMessage::user("What is the weather?"))
+            .expect("append skip");
+
+        let results = backend.search(&crate::session_backend::SessionQuery {
+            keyword: Some("Rust".into()),
+            limit: Some(10),
+        });
+        let keys: Vec<&str> = results.iter().map(|m| m.key.as_str()).collect();
+        assert!(
+            keys.contains(&k_match.as_str()),
+            "FULLTEXT search must return the matching session; got keys: {keys:?}"
+        );
+        assert!(
+            !keys.contains(&k_skip.as_str()),
+            "FULLTEXT search must not return the non-matching session; got keys: {keys:?}"
+        );
+
+        // Clean up
+        let _ = backend.delete_session(&k_match);
+        let _ = backend.delete_session(&k_skip);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_factory_round_trip() {
+        // Verifies that when the test URL env var is set, the
+        // factory's mysql arm constructs a real backend that
+        // satisfies the full SessionBackend trait via the trait
+        // object returned by `make_session_backend`. The other
+        // live tests exercise `MySqlSessionBackend` directly;
+        // this one goes through the dispatch factory — the
+        // path operators actually hit at startup.
+        let Some(_) = read_mysql_url().ok().flatten() else {
+            return;
+        };
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        let backend = match crate::make_session_backend(tmp.path(), "mysql") {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping factory test: {e}");
+                return;
+            }
+        };
+        let key = unique_key("factory");
+        backend
+            .append(&key, &ChatMessage::user("via factory"))
+            .expect("append");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 1);
+        let _ = backend.delete_session(&key);
+    }
+}

--- a/crates/zeroclaw-infra/src/session_mysql_shared.rs
+++ b/crates/zeroclaw-infra/src/session_mysql_shared.rs
@@ -1,0 +1,921 @@
+//! Shared MySQL / MariaDB session-persistence implementation.
+//!
+//! MySQL and MariaDB speak the same wire protocol and accept the
+//! same SQL for every operation we use (CREATE TABLE / INSERT /
+//! SELECT / MATCH … AGAINST …). The two backends exposed to the
+//! factory (`MySqlSessionBackend`, `MariaDbSessionBackend`) are
+//! thin distinct-type wrappers around this shared `MySqlBackend`
+//! so callers can tell which engine they configured, but the
+//! connection pool, schema DDL, and query / mutation logic are
+//! genuinely identical and live here.
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use mysql::prelude::Queryable;
+use mysql::{Opts, OptsBuilder, Pool, PoolConstraints, PoolOpts, Value};
+use zeroclaw_api::model_provider::ChatMessage;
+
+use crate::session_backend::{
+    SessionBackend, SessionContext, SessionMetadata, SessionQuery, SessionState,
+};
+
+/// Tag marker — distinct zero-sized types so the two
+/// SessionBackend newtypes (`MySqlSessionBackend`,
+/// `MariaDbSessionBackend`) can be distinguished in error / log
+/// messages even though they're both sharing the same underlying
+/// `MySqlBackend<…>` data path.
+pub trait EngineTag {
+    const NAME: &'static str;
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Used only under backend-mysql.
+pub enum MySqlTag {}
+impl EngineTag for MySqlTag {
+    const NAME: &'static str = "mysql";
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Used only under backend-mariadb.
+pub enum MariaDbTag {}
+impl EngineTag for MariaDbTag {
+    const NAME: &'static str = "mariadb";
+}
+
+/// Shared `SessionBackend` implementation for both MySQL and
+/// MariaDB. The `Tag` parameter exists purely for log /
+/// error-message differentiation; all data access goes through
+/// the single `pool` field below.
+pub struct MySqlBackend<Tag: EngineTag> {
+    pool: Pool,
+    engine_name: &'static str,
+    _tag: std::marker::PhantomData<Tag>,
+}
+
+impl<Tag: EngineTag + Send + Sync> MySqlBackend<Tag> {
+    pub fn new_with(url: &str, pool_size: u32, engine_name: &'static str) -> std::io::Result<Self> {
+        let pool_size = usize::try_from(pool_size).unwrap_or(1).max(1);
+        let opts = build_opts(url, pool_size)?;
+        let pool = Pool::new(opts).map_err(|e| map_mysql_err(engine_name, e))?;
+        let backend = Self {
+            pool,
+            engine_name,
+            _tag: std::marker::PhantomData,
+        };
+        backend.ensure_schema()?;
+        Ok(backend)
+    }
+
+    fn engine_name(&self) -> &'static str {
+        self.engine_name
+    }
+
+    /// Run `op` against a pooled connection. The closure is
+    /// expected to return `std::io::Result<T>` so callers can
+    /// use `?` to short-circuit and convert mysql errors via
+    /// `map_mysql_err` inline.
+    fn with_conn<F, T>(&self, op: F) -> std::io::Result<T>
+    where
+        F: FnOnce(&mut mysql::PooledConn) -> std::io::Result<T>,
+    {
+        let mut conn = self
+            .pool
+            .get_conn()
+            .map_err(|e| map_mysql_err(self.engine_name, e))?;
+        op(&mut conn)
+    }
+
+    fn ensure_schema(&self) -> std::io::Result<()> {
+        let en = self.engine_name();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.query_drop(
+                "CREATE TABLE IF NOT EXISTS sessions (
+                    id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                    session_key VARCHAR(512) NOT NULL,
+                    role        VARCHAR(64) NOT NULL,
+                    content     MEDIUMTEXT NOT NULL,
+                    created_at  DATETIME(3) NOT NULL,
+                    KEY idx_sessions_key (session_key),
+                    KEY idx_sessions_key_id (session_key, id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            conn.query_drop(
+                "CREATE TABLE IF NOT EXISTS session_metadata (
+                    session_key    VARCHAR(512) NOT NULL PRIMARY KEY,
+                    created_at     DATETIME(3) NOT NULL,
+                    last_activity  DATETIME(3) NOT NULL,
+                    message_count  BIGINT NOT NULL DEFAULT 0,
+                    name           VARCHAR(255) NULL,
+                    state          VARCHAR(32) NOT NULL DEFAULT 'idle',
+                    turn_id        VARCHAR(255) NULL,
+                    turn_started_at DATETIME(3) NULL,
+                    agent_alias    VARCHAR(255) NULL,
+                    channel_id     VARCHAR(255) NULL,
+                    room_id        VARCHAR(255) NULL,
+                    sender_id      VARCHAR(255) NULL,
+                    KEY idx_session_metadata_agent_alias (agent_alias),
+                    KEY idx_session_metadata_channel_id (channel_id),
+                    KEY idx_session_metadata_room_id (room_id),
+                    KEY idx_session_metadata_sender_id (sender_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            let _ = conn.query_drop(
+                "CREATE FULLTEXT INDEX idx_sessions_content_fulltext ON sessions(content)",
+            );
+            Ok(())
+        })
+    }
+
+    fn now_value() -> Value {
+        let nd = Utc::now().naive_utc();
+        let formatted = nd.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+        Value::Bytes(formatted.into_bytes())
+    }
+
+    fn parse_dt(value: Value) -> Option<DateTime<Utc>> {
+        match value {
+            Value::Date(y, m, d, h, mi, s, us) => {
+                let date = chrono::NaiveDate::from_ymd_opt(y.into(), m.into(), d.into())?;
+                let time = chrono::NaiveTime::from_hms_micro_opt(
+                    u32::from(h),
+                    u32::from(mi),
+                    u32::from(s),
+                    us,
+                )?;
+                Some(chrono::NaiveDateTime::new(date, time).and_utc())
+            }
+            Value::Bytes(bytes) => {
+                let s = std::str::from_utf8(&bytes).ok()?;
+                for fmt in [
+                    "%Y-%m-%d %H:%M:%S%.3f",
+                    "%Y-%m-%d %H:%M:%S",
+                    "%Y-%m-%dT%H:%M:%S%.3f",
+                    "%Y-%m-%dT%H:%M:%S",
+                ] {
+                    if let Ok(nd) = NaiveDateTime::parse_from_str(s, fmt) {
+                        return Some(nd.and_utc());
+                    }
+                }
+                DateTime::parse_from_rfc3339(s)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            }
+            Value::NULL => None,
+            _ => None,
+        }
+    }
+
+    fn row_to_metadata(
+        key: String,
+        created: Value,
+        activity: Value,
+        count: i64,
+        name: Option<String>,
+        agent_alias: Option<String>,
+        channel_id: Option<String>,
+        room_id: Option<String>,
+        sender_id: Option<String>,
+    ) -> SessionMetadata {
+        let created_at = Self::parse_dt(created).unwrap_or_else(Utc::now);
+        let last_activity = Self::parse_dt(activity).unwrap_or_else(Utc::now);
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let message_count = count.max(0) as usize;
+        SessionMetadata {
+            key,
+            name,
+            created_at,
+            last_activity,
+            message_count,
+            agent_alias,
+            channel_id,
+            room_id,
+            sender_id,
+        }
+    }
+
+    fn row_to_state(state: String, turn_id: Option<String>, started: Value) -> SessionState {
+        SessionState {
+            state,
+            turn_id,
+            turn_started_at: Self::parse_dt(started),
+        }
+    }
+}
+
+fn build_opts(url: &str, pool_size: usize) -> std::io::Result<Opts> {
+    let constraints =
+        PoolConstraints::new(pool_size, pool_size).unwrap_or(PoolConstraints::DEFAULT);
+    let pool_opts = PoolOpts::default().with_constraints(constraints);
+    let opts = Opts::from_url(url).map_err(map_url_err)?;
+    let opts: Opts = OptsBuilder::from_opts(opts).pool_opts(pool_opts).into();
+    Ok(opts)
+}
+
+fn map_url_err(e: mysql::UrlError) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!("session URL is not a valid mysql:// URL: {e}"),
+    )
+}
+
+fn map_mysql_err(engine: &'static str, e: mysql::Error) -> std::io::Error {
+    // Map mysql::Error variants to std::io::ErrorKind. The
+    // upstream `mysql::Error` enum is non-exhaustive across
+    // upstream versions (new variants land in patch releases),
+    // so we MUST include a wildcard arm to compile against
+    // versions that introduce new variants. We pick Other for
+    // every known variant that doesn't already have a more
+    // specific category.
+    let kind = match &e {
+        mysql::Error::IoError(_) => std::io::ErrorKind::Other,
+        mysql::Error::CodecError(_) => std::io::ErrorKind::Other,
+        mysql::Error::MySqlError(_) => std::io::ErrorKind::Other,
+        mysql::Error::DriverError(_) => std::io::ErrorKind::Other,
+        mysql::Error::UrlError(_) => std::io::ErrorKind::InvalidInput,
+        mysql::Error::FromValueError(_) => std::io::ErrorKind::InvalidData,
+        mysql::Error::FromRowError(_) => std::io::ErrorKind::InvalidData,
+        #[allow(unreachable_patterns)]
+        _ => std::io::ErrorKind::Other,
+    };
+    std::io::Error::new(kind, format!("session_backend={engine}: {e}"))
+}
+
+impl<Tag: EngineTag + Send + Sync> SessionBackend for MySqlBackend<Tag> {
+    fn load(&self, session_key: &str) -> Vec<ChatMessage> {
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<(String, String)>> {
+            conn.exec(
+                "SELECT role, content FROM sessions WHERE session_key = ? ORDER BY id ASC",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(role, content)| ChatMessage { role, content })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn load_with_timestamps(
+        &self,
+        session_key: &str,
+    ) -> Vec<crate::session_backend::TimestampedMessage> {
+        use crate::session_backend::TimestampedMessage;
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<(String, String, Value)>> {
+            conn.exec(
+                "SELECT role, content, created_at FROM sessions \
+                     WHERE session_key = ? ORDER BY id ASC",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(role, content, created_at)| TimestampedMessage {
+                    message: ChatMessage { role, content },
+                    created_at: MySqlBackend::<Tag>::parse_dt(created_at),
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn append(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let now = MySqlBackend::<Tag>::now_value();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "INSERT INTO sessions (session_key, role, content, created_at) \
+                 VALUES (?, ?, ?, ?)",
+                (session_key, &message.role, &message.content, now.clone()),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            conn.exec_drop(
+                "INSERT INTO session_metadata \
+                    (session_key, created_at, last_activity, message_count) \
+                 VALUES (?, ?, ?, 1) \
+                 ON DUPLICATE KEY UPDATE \
+                    last_activity = VALUES(last_activity), \
+                    message_count = message_count + 1",
+                (session_key, now.clone(), now.clone()),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            Ok(())
+        })
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        let en = self.engine_name();
+        let row_id: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT id FROM sessions WHERE session_key = ? ORDER BY id DESC LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let Some(id) = row_id else {
+            return Ok(false);
+        };
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop("DELETE FROM sessions WHERE id = ?", (id,))
+                .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let now = MySqlBackend::<Tag>::now_value();
+        let _ = self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET message_count = GREATEST(message_count - 1, 0), \
+                                       last_activity = ? \
+                 WHERE session_key = ?",
+                (now, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        Ok(true)
+    }
+
+    fn update_last(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<bool> {
+        let en = self.engine_name();
+        let row_id: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT id FROM sessions WHERE session_key = ? ORDER BY id DESC LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let Some(id) = row_id else {
+            return Ok(false);
+        };
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE sessions SET role = ?, content = ? WHERE id = ?",
+                (&message.role, &message.content, id),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let now = MySqlBackend::<Tag>::now_value();
+        let _ = self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET last_activity = ? WHERE session_key = ?",
+                (now, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        Ok(true)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<String>> {
+            conn.query("SELECT session_key FROM session_metadata ORDER BY last_activity DESC")
+                .map_err(|e| map_mysql_err(en, e))
+        });
+        result.unwrap_or_default()
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.query(
+                "SELECT session_key, created_at, last_activity, message_count, \
+                        name, agent_alias, channel_id, room_id, sender_id \
+                 FROM session_metadata ORDER BY last_activity DESC",
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let cutoff_stmt = format!(
+            "SELECT session_key FROM session_metadata \
+             WHERE last_activity < DATE_SUB(UTC_TIMESTAMP(3), INTERVAL {ttl_hours} HOUR)"
+        );
+        let stale: Vec<String> = self.with_conn(|conn| -> std::io::Result<Vec<String>> {
+            conn.query(cutoff_stmt.as_str())
+                .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let count = stale.len();
+        for key in stale {
+            let _ = self.with_conn(|conn| -> std::io::Result<()> {
+                conn.exec_drop("DELETE FROM sessions WHERE session_key = ?", (key.clone(),))
+                    .map_err(|e| map_mysql_err(en, e))
+            });
+            let _ = self.with_conn(|conn| -> std::io::Result<()> {
+                conn.exec_drop("DELETE FROM session_metadata WHERE session_key = ?", (key,))
+                    .map_err(|e| map_mysql_err(en, e))
+            });
+        }
+        Ok(count)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let affected: u64 = self.with_conn(|conn| -> std::io::Result<u64> {
+            conn.exec_drop("DELETE FROM sessions WHERE session_key = ?", (session_key,))
+                .map_err(|e| map_mysql_err(en, e))?;
+            Ok(conn.affected_rows())
+        })?;
+        let count = affected as usize;
+        if count > 0 {
+            let now = MySqlBackend::<Tag>::now_value();
+            let _ = self.with_conn(|conn| -> std::io::Result<()> {
+                conn.exec_drop(
+                    "UPDATE session_metadata SET message_count = 0, last_activity = ? \
+                     WHERE session_key = ?",
+                    (now, session_key),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            });
+        }
+        Ok(count)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        let en = self.engine_name();
+        let exists: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT 1 FROM session_metadata WHERE session_key = ? LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        if exists.is_none() {
+            return Ok(false);
+        }
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop("DELETE FROM sessions WHERE session_key = ?", (session_key,))
+                .map_err(|e| map_mysql_err(en, e))
+        })?;
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "DELETE FROM session_metadata WHERE session_key = ?",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        Ok(true)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let affected: u64 = self.with_conn(|conn| -> std::io::Result<u64> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET agent_alias = NULL WHERE agent_alias = ?",
+                (agent_alias,),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            Ok(conn.affected_rows())
+        })?;
+        Ok(affected as usize)
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let affected: u64 = self.with_conn(|conn| -> std::io::Result<u64> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET agent_alias = ? WHERE agent_alias = ?",
+                (to, from),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            Ok(conn.affected_rows())
+        })?;
+        Ok(affected as usize)
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let count: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT COUNT(*) FROM session_metadata WHERE agent_alias = ?",
+                (agent_alias,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        Ok(count.unwrap_or(0).max(0) as usize)
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        let en = self.engine_name();
+        let exists_result = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT 1 FROM session_metadata WHERE session_key = ? LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        // exists_result is `io::Result<Option<i64>>`. A DB
+        // error returns Err (which we silently absorb per the
+        // trait contract that `session_exists` cannot fail);
+        // a missing row unwraps to None; a present row unwraps
+        // to Some(1).
+        exists_result.ok().and_then(|inner| inner).is_some()
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let name_val = if name.is_empty() { None } else { Some(name) };
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET name = ? WHERE session_key = ?",
+                (name_val, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let en = self.engine_name();
+        let name: Option<Option<String>> =
+            self.with_conn(|conn| -> std::io::Result<Option<Option<String>>> {
+                conn.exec_first(
+                    "SELECT name FROM session_metadata WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })?;
+        // Flatten the Option<Option<String>>: outer Some means
+        // a row matched, inner Option reflects NULL column.
+        Ok(name.flatten())
+    }
+
+    fn get_session_metadata(&self, session_key: &str) -> Option<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let row: Option<Row> = self
+            .with_conn(|conn| -> std::io::Result<Option<Row>> {
+                conn.exec_first(
+                    "SELECT session_key, created_at, last_activity, message_count, \
+                            name, agent_alias, channel_id, room_id, sender_id \
+                     FROM session_metadata WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })
+            .ok()
+            .flatten();
+        let (key, created, activity, count, name, agent, channel, room, sender) = row?;
+        Some(MySqlBackend::<Tag>::row_to_metadata(
+            key, created, activity, count, name, agent, channel, room, sender,
+        ))
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let now = MySqlBackend::<Tag>::now_value();
+        let started: Option<Value> = if state == "running" {
+            Some(now.clone())
+        } else {
+            None
+        };
+        // turn_id may be Some("") or Some(&str) — store NULL for empty.
+        let turn_id_val: Option<String> = turn_id.filter(|s| !s.is_empty()).map(|s| s.to_string());
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata \
+                 SET state = ?, turn_id = ?, turn_started_at = ? \
+                 WHERE session_key = ?",
+                (state, turn_id_val, started, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+
+    fn get_session_state(&self, session_key: &str) -> std::io::Result<Option<SessionState>> {
+        type Row = (String, Option<String>, Option<Value>);
+        let en = self.engine_name();
+        let row: Option<Row> = self
+            .with_conn(|conn| -> std::io::Result<Option<Row>> {
+                conn.exec_first(
+                    "SELECT state, turn_id, turn_started_at FROM session_metadata \
+                     WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })
+            .ok()
+            .flatten();
+        let (state, turn_id, started) = match row {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        let started = started.unwrap_or(Value::NULL);
+        Ok(Some(MySqlBackend::<Tag>::row_to_state(
+            state, turn_id, started,
+        )))
+    }
+
+    fn list_running_sessions(&self) -> Vec<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.query(
+                "SELECT session_key, created_at, last_activity, message_count, \
+                        name, agent_alias, channel_id, room_id, sender_id \
+                 FROM session_metadata \
+                 WHERE state = 'running' \
+                 ORDER BY turn_started_at DESC",
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn list_stuck_sessions(&self, threshold_secs: u64) -> Vec<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let stmt = format!(
+            "SELECT session_key, created_at, last_activity, message_count, \
+                    name, agent_alias, channel_id, room_id, sender_id \
+             FROM session_metadata \
+             WHERE state = 'running' \
+               AND turn_started_at < DATE_SUB(UTC_TIMESTAMP(3), INTERVAL {threshold_secs} SECOND) \
+             ORDER BY turn_started_at ASC"
+        );
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.query(stmt.as_str()).map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn search(&self, query: &SessionQuery) -> Vec<SessionMetadata> {
+        let Some(keyword) = query.keyword.as_deref() else {
+            return self.list_sessions_with_metadata();
+        };
+        let limit = query.limit.unwrap_or(50) as i64;
+        let en = self.engine_name();
+        let fts_query = build_fts_query(keyword);
+        let stmt = format!(
+            "SELECT DISTINCT session_key \
+             FROM sessions \
+             WHERE MATCH(content) AGAINST (? IN NATURAL LANGUAGE MODE) \
+             LIMIT {limit}"
+        );
+        let keys: Vec<String> = match self.with_conn(|conn| -> std::io::Result<Vec<String>> {
+            conn.exec(stmt.as_str(), (fts_query.as_str(),))
+                .map_err(|e| map_mysql_err(en, e))
+        }) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        if keys.is_empty() {
+            return Vec::new();
+        }
+        let placeholders = keys.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let meta_stmt = format!(
+            "SELECT session_key, created_at, last_activity, message_count, \
+                    name, agent_alias, channel_id, room_id, sender_id \
+             FROM session_metadata WHERE session_key IN ({placeholders})"
+        );
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let params: mysql::Params = mysql::Params::from(keys);
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.exec(meta_stmt.as_str(), params)
+                .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let alias_val = if agent_alias.is_empty() {
+            None
+        } else {
+            Some(agent_alias)
+        };
+        let now = MySqlBackend::<Tag>::now_value();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "INSERT INTO session_metadata \
+                    (session_key, created_at, last_activity, message_count, agent_alias) \
+                 VALUES (?, ?, ?, 0, ?) \
+                 ON DUPLICATE KEY UPDATE agent_alias = VALUES(agent_alias)",
+                (session_key, now.clone(), now.clone(), alias_val),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let en = self.engine_name();
+        let alias: Option<Option<String>> =
+            self.with_conn(|conn| -> std::io::Result<Option<Option<String>>> {
+                conn.exec_first(
+                    "SELECT agent_alias FROM session_metadata WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })?;
+        Ok(alias.flatten())
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let normalize = |v: Option<&str>| -> Option<String> {
+            v.map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        };
+        let channel_id = normalize(context.channel_id);
+        let room_id = normalize(context.room_id);
+        let sender_id = normalize(context.sender_id);
+        let now = MySqlBackend::<Tag>::now_value();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "INSERT INTO session_metadata \
+                    (session_key, created_at, last_activity, message_count, \
+                     channel_id, room_id, sender_id) \
+                 VALUES (?, ?, ?, 0, ?, ?, ?) \
+                 ON DUPLICATE KEY UPDATE \
+                    channel_id = COALESCE(VALUES(channel_id), channel_id), \
+                    room_id    = COALESCE(VALUES(room_id),    room_id), \
+                    sender_id  = COALESCE(VALUES(sender_id),  sender_id)",
+                (
+                    session_key,
+                    now.clone(),
+                    now.clone(),
+                    channel_id,
+                    room_id,
+                    sender_id,
+                ),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+}
+
+/// Build a MATCH … AGAINST clause payload from a free-text
+/// keyword.
+fn build_fts_query(keyword: &str) -> String {
+    keyword
+        .split_whitespace()
+        .filter(|w| !w.is_empty())
+        .map(|w| format!("\"{w}\""))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Resolve the shared `pool_size` config field, mirroring the
+/// foundation PR's `default_session_pool_size` of 5. Operators
+/// who want to override set `ZEROCLAW_channels__pool_size=<int>`.
+/// This is the same dotted-path env override
+/// `crate::env_overrides` injects into `channels.pool_size`;
+/// reading it directly here matches that contract.
+pub(crate) fn read_pool_size() -> u32 {
+    std::env::var("ZEROCLAW_channels__pool_size")
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dt_handles_textual_form() {
+        let v = Value::Bytes(b"2026-07-21 20:00:00.123".to_vec());
+        let dt = MySqlBackend::<MySqlTag>::parse_dt(v).expect("parses textual");
+        assert_eq!(dt.to_rfc3339(), "2026-07-21T20:00:00.123+00:00");
+    }
+
+    #[test]
+    fn parse_dt_handles_binary_form() {
+        let v = Value::Date(2026, 7, 21, 20, 0, 0, 0);
+        let dt = MySqlBackend::<MySqlTag>::parse_dt(v).expect("parses binary");
+        assert_eq!(dt.to_rfc3339(), "2026-07-21T20:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_dt_handles_null() {
+        let dt = MySqlBackend::<MySqlTag>::parse_dt(Value::NULL);
+        assert!(dt.is_none());
+    }
+
+    #[test]
+    fn fts_query_quotes_each_token() {
+        let q = build_fts_query("rust async (best)");
+        assert_eq!(q, "\"rust\" \"async\" \"(best)\"");
+    }
+
+    #[test]
+    fn fts_query_empty_yields_empty_string() {
+        let q = build_fts_query("   \t  \n ");
+        assert_eq!(q, "");
+    }
+}

--- a/crates/zeroclaw-runtime/src/lib.rs
+++ b/crates/zeroclaw-runtime/src/lib.rs
@@ -36,6 +36,7 @@ pub mod routines;
 pub mod rpc;
 pub mod security;
 pub mod service;
+pub mod session_async;
 pub mod skillforge;
 pub mod skills;
 pub mod sop;

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -586,7 +586,10 @@ impl RpcDispatcher {
             return true;
         }
         if let Some(backend) = self.ctx.session_backend.as_ref()
-            && backend.count_agent_attribution(from).unwrap_or(0) > 0
+            && crate::session_async::count_agent_attribution(backend.clone(), from.to_string())
+                .await
+                .unwrap_or(0)
+                > 0
         {
             return true;
         }
@@ -1261,16 +1264,40 @@ impl RpcDispatcher {
             crate::rpc::types::ChatMode::Chat => {
                 if let Some(ref backend) = self.ctx.session_backend {
                     let session_key = format!("rpc_{session_id}");
-                    let _ = backend.set_session_agent_alias(&session_key, &req.agent_alias);
-                    let stored = backend.load(&session_key);
-                    if !stored.is_empty() {
-                        let seed_event = self
-                            .ctx
-                            .sessions
-                            .seed_history_with_event(&session_id, &stored)
-                            .await;
-                        self.forward_seed_event(&session_id, seed_event).await;
-                        message_count = stored.len();
+                    let _ = crate::session_async::set_session_agent_alias(
+                        backend.clone(),
+                        session_key.clone(),
+                        req.agent_alias.clone(),
+                    )
+                    .await;
+                    let stored_result =
+                        crate::session_async::load(backend.clone(), session_key.clone()).await;
+                    match stored_result {
+                        Ok(stored) if !stored.is_empty() => {
+                            let seed_event = self
+                                .ctx
+                                .sessions
+                                .seed_history_with_event(&session_id, &stored)
+                                .await;
+                            self.forward_seed_event(&session_id, seed_event).await;
+                            message_count = stored.len();
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            ::zeroclaw_log::record!(
+                                WARN,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note
+                                )
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(::serde_json::json!({
+                                    "session_id": session_id,
+                                    "error": format!("{e}"),
+                                })),
+                                "RPC chat session load failed"
+                            );
+                        }
                     }
                 }
             }
@@ -1851,15 +1878,30 @@ impl RpcDispatcher {
             crate::rpc::types::ChatMode::Chat => {
                 if let Some(ref backend) = self.ctx.session_backend {
                     let key = format!("rpc_{sid}");
-                    let _ = backend.append(&key, &ChatMessage::user(&prompt));
+                    let _ = crate::session_async::append(
+                        backend.clone(),
+                        key.clone(),
+                        ChatMessage::user(&prompt),
+                    )
+                    .await;
                     match &outcome {
                         Ok(TurnOutcome::Completed { text, .. }) => {
-                            let _ = backend.append(&key, &ChatMessage::assistant(text));
+                            let _ = crate::session_async::append(
+                                backend.clone(),
+                                key.clone(),
+                                ChatMessage::assistant(text),
+                            )
+                            .await;
                         }
                         Ok(TurnOutcome::Cancelled { partial_text, .. })
                             if !partial_text.is_empty() =>
                         {
-                            let _ = backend.append(&key, &ChatMessage::assistant(partial_text));
+                            let _ = crate::session_async::append(
+                                backend.clone(),
+                                key.clone(),
+                                ChatMessage::assistant(partial_text),
+                            )
+                            .await;
                         }
                         _ => {}
                     }
@@ -2152,19 +2194,45 @@ impl RpcDispatcher {
         let config = self.ctx.config.read().clone();
 
         // Use FTS when a query is provided, plain list otherwise.
-        let all = if let Some(ref keyword) = req.query {
-            if keyword.trim().is_empty() {
-                backend.list_sessions_with_metadata()
+        // Both branches run on the blocking pool — the foundation
+        // contract has to stay correct once a remote-database
+        // session backend lands in a follow-up PR; today's
+        // sqlite/jsonl pay only the spawn-and-join round trip.
+        let all: Vec<zeroclaw_infra::session_backend::SessionMetadata> =
+            if let Some(ref keyword) = req.query {
+                if keyword.trim().is_empty() {
+                    crate::session_async::list_sessions_with_metadata(backend.clone())
+                        .await
+                        .map_err(|e| JsonRpcError {
+                            code: INTERNAL_ERROR,
+                            message: format!("session backend error: {e}"),
+                            data: None,
+                        })?
+                } else {
+                    use zeroclaw_infra::session_backend::SessionQuery;
+                    crate::session_async::search(
+                        backend.clone(),
+                        SessionQuery {
+                            keyword: Some(keyword.clone()),
+                            limit: req.limit,
+                        },
+                    )
+                    .await
+                    .map_err(|e| JsonRpcError {
+                        code: INTERNAL_ERROR,
+                        message: format!("session backend error: {e}"),
+                        data: None,
+                    })?
+                }
             } else {
-                use zeroclaw_infra::session_backend::SessionQuery;
-                backend.search(&SessionQuery {
-                    keyword: Some(keyword.clone()),
-                    limit: req.limit,
-                })
-            }
-        } else {
-            backend.list_sessions_with_metadata()
-        };
+                crate::session_async::list_sessions_with_metadata(backend.clone())
+                    .await
+                    .map_err(|e| JsonRpcError {
+                        code: INTERNAL_ERROR,
+                        message: format!("session backend error: {e}"),
+                        data: None,
+                    })?
+            };
 
         let sessions: Vec<SessionEntry> = all
             .into_iter()
@@ -2250,10 +2318,25 @@ impl RpcDispatcher {
         ];
         let mut raw: Vec<zeroclaw_api::model_provider::ChatMessage> = Vec::new();
         for key in &candidates {
-            let loaded = backend.load(key);
-            if !loaded.is_empty() {
-                raw = loaded;
-                break;
+            match crate::session_async::load(backend.clone(), key.clone()).await {
+                Ok(loaded) if !loaded.is_empty() => {
+                    raw = loaded;
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "session_id": req.session_id,
+                                "key": key,
+                                "error": format!("{e}"),
+                            })),
+                        "RPC session load failed"
+                    );
+                }
             }
         }
 
@@ -2327,7 +2410,7 @@ impl RpcDispatcher {
             format!("gw_{}", req.session_id),
         ];
         for key in &candidates {
-            match backend.get_session_state(key) {
+            match crate::session_async::get_session_state(backend.clone(), key.clone()).await {
                 Ok(Some(ss)) => {
                     return to_result(SessionStateResult {
                         session_id: req.session_id,

--- a/crates/zeroclaw-runtime/src/session_async.rs
+++ b/crates/zeroclaw-runtime/src/session_async.rs
@@ -1,0 +1,101 @@
+//! Shared `spawn_blocking` wrappers around `SessionBackend` operations
+//! used by the runtime RPC dispatcher hot paths. This is the runtime
+//! counterpart to `zeroclaw_gateway::session_async` — same contract,
+//! same rationale (a slow remote database backend cannot stall the
+//! async workers), kept as a separate module so each consumer crate
+//! does not have to depend on the gateway.
+
+use std::io;
+use std::sync::Arc;
+
+use zeroclaw_infra::session_backend::SessionBackend;
+
+/// Run a synchronous `SessionBackend` operation through
+/// `tokio::task::spawn_blocking`. Join errors from the blocking
+/// pool are converted into `io::Error::Other`.
+pub async fn spawn_blocking_session_op<F, T>(op: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(join_err) => Err(io::Error::other(format!(
+            "session backend worker panicked: {join_err}"
+        ))),
+    }
+}
+
+/// Convenience: count_agent_attribution off the blocking pool.
+pub async fn count_agent_attribution(
+    backend: Arc<dyn SessionBackend>,
+    agent_alias: String,
+) -> io::Result<usize> {
+    spawn_blocking_session_op(move || backend.count_agent_attribution(&agent_alias)).await
+}
+
+/// Convenience: set_session_agent_alias off the blocking pool.
+pub async fn set_session_agent_alias(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    alias: String,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.set_session_agent_alias(&session_key, &alias)).await
+}
+
+/// Convenience: load off the blocking pool.
+pub async fn load(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Vec<zeroclaw_api::model_provider::ChatMessage>> {
+    spawn_blocking_session_op(move || Ok(backend.load(&session_key))).await
+}
+
+/// Convenience: append off the blocking pool.
+pub async fn append(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    message: zeroclaw_api::model_provider::ChatMessage,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.append(&session_key, &message)).await
+}
+
+/// Convenience: list_sessions_with_metadata off the blocking pool.
+pub async fn list_sessions_with_metadata(
+    backend: Arc<dyn SessionBackend>,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::SessionMetadata>> {
+    spawn_blocking_session_op(move || Ok(backend.list_sessions_with_metadata())).await
+}
+
+/// Convenience: delete_session off the blocking pool.
+pub async fn delete_session(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<bool> {
+    spawn_blocking_session_op(move || backend.delete_session(&session_key)).await
+}
+
+/// Convenience: rename_agent_attribution off the blocking pool.
+pub async fn rename_agent_attribution(
+    backend: Arc<dyn SessionBackend>,
+    from: String,
+    to: String,
+) -> io::Result<usize> {
+    spawn_blocking_session_op(move || backend.rename_agent_attribution(&from, &to)).await
+}
+
+/// Convenience: search off the blocking pool.
+pub async fn search(
+    backend: Arc<dyn SessionBackend>,
+    query: zeroclaw_infra::session_backend::SessionQuery,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::SessionMetadata>> {
+    spawn_blocking_session_op(move || Ok(backend.search(&query))).await
+}
+
+/// Convenience: get_session_state off the blocking pool.
+pub async fn get_session_state(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Option<zeroclaw_infra::session_backend::SessionState>> {
+    spawn_blocking_session_op(move || backend.get_session_state(&session_key)).await
+}

--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -10,6 +10,35 @@ use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::policy::ToolOperation;
 use zeroclaw_infra::session_backend::SessionBackend;
 
+/// Run a synchronous `SessionBackend` operation through
+/// `tokio::task::spawn_blocking` so a slow/wedged remote backend
+/// (Postgres/MySQL/MariaDB/Oracle/Db2 — the upcoming drivers in this
+/// series) cannot stall the async task's executor worker. Today's
+/// local drivers (sqlite/jsonl) complete in microseconds, so this
+/// wraps to a single-shot blocking thread; the foundation cost is
+/// tiny and the contract stays correct for every remote backend that
+/// follows.
+///
+/// The helper is intentionally infallible at the async boundary: any
+/// `std::io::Error` the backend raised inside `op` is bubbled out;
+/// any join error from the blocking pool is converted back to a
+/// `std::io::Error::Other("session backend worker panicked")`. Tools
+/// already translate the `std::io::Result<T>` they receive into a
+/// `ToolResult`, so this matches the call sites without adding a new
+/// error type at this layer.
+async fn spawn_blocking_session_op<F, T>(op: F) -> std::io::Result<T>
+where
+    F: FnOnce() -> std::io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(join_err) => Err(std::io::Error::other(format!(
+            "session backend worker panicked: {join_err}"
+        ))),
+    }
+}
+
 /// Validate that a session ID is non-empty and contains at least one
 /// alphanumeric character (prevents blank keys after sanitization).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,7 +197,9 @@ impl Tool for SessionsListTool {
             .and_then(serde_json::Value::as_u64)
             .map_or(50, |v| v as usize);
 
-        let metadata = self.backend.list_sessions_with_metadata();
+        let backend = self.backend.clone();
+        let metadata =
+            spawn_blocking_session_op(move || Ok(backend.list_sessions_with_metadata())).await?;
 
         if metadata.is_empty() {
             return Ok(ToolResult {
@@ -275,7 +306,11 @@ impl Tool for SessionsHistoryTool {
             .and_then(serde_json::Value::as_u64)
             .map_or(20, |v| v as usize);
 
-        let messages = self.backend.load(session_id);
+        let messages = {
+            let backend = self.backend.clone();
+            let session_id = session_id.to_string();
+            spawn_blocking_session_op(move || Ok(backend.load(&session_id))).await?
+        };
 
         if messages.is_empty() {
             return Ok(ToolResult {
@@ -414,7 +449,12 @@ impl Tool for SessionsSendTool {
 
         let chat_msg = zeroclaw_api::model_provider::ChatMessage::user(message);
 
-        match self.backend.append(&target_session_key, &chat_msg) {
+        let append_result = {
+            let backend = self.backend.clone();
+            let target_session_key = target_session_key.clone();
+            spawn_blocking_session_op(move || backend.append(&target_session_key, &chat_msg)).await
+        };
+        match append_result {
             Ok(()) => {
                 let output = if target_session_key == session_id.trim() {
                     format!("Message sent to session '{target_session_key}'.")
@@ -487,7 +527,13 @@ impl Tool for SessionsCurrentTool {
         };
 
         let mut output = format!("Current session: {key}\n");
-        if let Some(meta) = self.backend.get_session_metadata(&key) {
+        let metadata = {
+            let backend = self.backend.clone();
+            let key_for_blocking = key.clone();
+            spawn_blocking_session_op(move || Ok(backend.get_session_metadata(&key_for_blocking)))
+                .await?
+        };
+        if let Some(meta) = metadata {
             if let Some(name) = meta.name.filter(|name| !name.is_empty()) {
                 let _ = writeln!(output, "Name: {name}");
             }
@@ -605,7 +651,12 @@ impl Tool for SessionResetTool {
                 .unwrap_or_else(|| session_id.trim().to_string()),
         };
 
-        match self.backend.clear_messages(&target_session_key) {
+        let clear_result = {
+            let backend = self.backend.clone();
+            let target = target_session_key.clone();
+            spawn_blocking_session_op(move || backend.clear_messages(&target)).await
+        };
+        match clear_result {
             Ok(0) => Ok(ToolResult {
                 success: true,
                 output: format!("Session '{target_session_key}' is already empty.").into(),
@@ -726,9 +777,19 @@ impl Tool for SessionDeleteTool {
                 .unwrap_or_else(|| session_id.trim().to_string()),
         };
 
-        let existed = !self.backend.load(&target_session_key).is_empty();
+        let existed = {
+            let backend = self.backend.clone();
+            let target = target_session_key.clone();
+            spawn_blocking_session_op(move || Ok(backend.load(&target))).await?
+        };
+        let existed = !existed.is_empty();
 
-        match self.backend.delete_session(&target_session_key) {
+        let delete_result = {
+            let backend = self.backend.clone();
+            let target = target_session_key.clone();
+            spawn_blocking_session_op(move || backend.delete_session(&target)).await
+        };
+        match delete_result {
             Ok(true) => Ok(ToolResult {
                 success: true,
                 output: format!("Session '{target_session_key}' deleted.").into(),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Implements the MySQL and MariaDB session-persistence backends on top of the shared plumbing landed in #9249 (`SessionBackend` trait, `make_session_backend` factory, `spawn_blocking` async boundary, config schema for remote backends).
  - `crates/zeroclaw-infra/src/session_mysql.rs` and `session_mariadb.rs`: full `SessionBackend` implementations (sessions + session_metadata tables, routing columns for `agent_alias`/`channel_id`/`room_id`/`sender_id`, `search()` via `FULLTEXT` index), each behind its own Cargo feature (`backend-mysql`, `backend-mariadb`).
  - `crates/zeroclaw-infra/src/session_mysql_shared.rs`: connection-pool/client plumbing genuinely shared between the two engines (both are MySQL-wire-protocol compatible), while keeping MySQL and MariaDB as distinct `SessionBackend` impls so real dialect divergence isn't papered over.
  - Fills in the two `#[cfg(feature = "backend-mysql"/"backend-mariadb")]` arms in `make_session_backend` (fail-fast stubs since #9249) to construct the real backends.
  - Dedicated required CI check jobs (`.github/workflows/ci.yml`) compiling each feature independently.
- **Scope boundary:** MySQL and MariaDB only. Postgres, Db2, and Oracle are separate follow-up PRs in the same series, per the agreed resubmission plan for #6893.
- **Blast radius:** New opt-in Cargo features only; default build and every existing backend (SQLite/JSONL/the other `#[cfg(not(feature = ...))]` fail-fast arms) are unaffected. Verified via the existing fail-fast regression tests for postgres/oracle/db2/mysql/mariadb, all still passing.
- **Linked issue(s):** Supersedes #6893 (this is a from-scratch reimplementation against the current `SessionBackend` trait, not a port of that branch's forked error model). Depends on #9249 (session-backend foundation, currently open/green, not yet merged) — this branch is stacked on it and will show its commits until #9249 merges.
- **Labels:** `type:feature`, `size:L`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — both engines are live-verified (see evidence below). The gated live-DB tests (`ZEROCLAW_TEST_MYSQL_URL` / `ZEROCLAW_TEST_MARIADB_URL`) were run against real servers and pass; they skip cleanly when the env vars are unset.

### How I tested

```sh
cargo +1.96.1 fmt --all -- --check
cargo +1.96.1 check --locked --features ci-all --all-targets
cargo +1.96.1 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo +1.96.1 check -p zeroclaw-infra --features backend-mysql
cargo +1.96.1 check -p zeroclaw-infra --features backend-mariadb
cargo +1.96.1 test -p zeroclaw-infra fail_fast_when_feature_disabled
cargo nextest run --locked --workspace --exclude zeroclaw-desktop
```

- **CI checks relied on and why they cover this change:** `Check (all features)` compiles this crate under `ci-all`; the two new dedicated `backend-mysql`/`backend-mariadb` feature jobs are the only way either backend's code is exercised at all, since neither feature is in the default set.
- **Known CI coverage gap, if any:** CI itself has no live-database service container, but the gated live-DB tests **were run manually against real servers and pass** — MariaDB 11.8 (4/4) and MySQL 8.4 (4/4), covering round-trip, factory construction, metadata, and FULLTEXT search on each. A follow-up could wire service containers into CI to run them automatically.
- **Commands run and tail output:**
  ```
  cargo +1.96.1 check -p zeroclaw-infra --features backend-mysql
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s

  cargo +1.96.1 check -p zeroclaw-infra --features backend-mariadb
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s

  cargo +1.96.1 test -p zeroclaw-infra fail_fast_when_feature_disabled
  running 5 tests
  test tests::make_session_backend_db2_fail_fast_when_feature_disabled ... ok
  test tests::make_session_backend_oracle_fail_fast_when_feature_disabled ... ok
  test tests::make_session_backend_postgres_fail_fast_when_feature_disabled ... ok
  test tests::make_session_backend_mariadb_fail_fast_when_feature_disabled ... ok
  test tests::make_session_backend_mysql_fail_fast_when_feature_disabled ... ok
  test result: ok. 5 passed; 0 failed

  cargo nextest run --locked --workspace --exclude zeroclaw-desktop
  Summary [82.752s] 12117 tests run: 12117 passed, 11 skipped
  ```
- **Beyond CI, what did you manually verify?** **Live-verified both engines end-to-end against real servers** — MariaDB 11.8 and MySQL 8.4, 4/4 tests each (`mysql/mariadb_live_round_trip`, `_factory_round_trip`, `_metadata_round_trip`, `_fulltext_search`). Also confirmed the pre-existing fail-fast tests for the other three remote backends (postgres/oracle/db2) continue to hard-fail-fast and were not disturbed by filling in the mysql/mariadb arms.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? Yes — outbound TCP to an operator-configured MySQL/MariaDB endpoint, only when the corresponding feature is compiled in and the backend is explicitly selected in config; disabled by default.
- Secrets / tokens / credentials handling changed? No — reuses the connection-string config fields already added in #9249.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No — config fields already landed in #9249
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` this PR's merge commit. New code is entirely behind opt-in Cargo features; reverting cannot affect any existing default-config deployment.
- **Feature flags or config toggles:** `backend-mysql` / `backend-mariadb` Cargo features (compile-time), plus the `session_backend = "mysql"/"mariadb"` config value from #9249 (runtime).
- **Observable failure symptoms:** Session read/write errors surfaced from `MySqlSessionBackend`/`MariaDbSessionBackend` in logs; connection-pool exhaustion or connectivity errors to the configured `mysql_url`/`mariadb_url`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: #6893 by @perlowja
- Scope materially carried forward: the goal of multi-database session-backend support, and the two-table (`sessions` + `session_metadata`) schema shape with routing columns for parity with the SQLite reference implementation.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? No
- If `No`, why: #6893 was solely self-authored; this is a from-scratch reimplementation against the current `SessionBackend` trait (`std::io::Result`-based), not a code port of #6893's forked `SessionResult`/`BackendCapabilities` error model, so there is no other contributor's code being carried over.

