### PR TITLE
feat(infra): Oracle session-persistence backend (PR 5 of N, Supersedes #6893)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,55 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: cargo check --locked -p zeroclaw-plugins --no-default-features --features ${{ matrix.features }}
 
+  # ── Multi-database session backend series (PR 2 of N) ──────────────────
+  #
+  # The MySQL and MariaDB session backends are gated behind their
+  # own Cargo features (`backend-mysql` / `backend-mariadb`) so
+  # the default `ci-all` feature set stays independent of any
+  # local MySQL or MariaDB server. These two branch-protected
+  # jobs build the dedicated feature flags so a CI break in
+  # either driver is caught before merge.
+
+  check-session-backend-mysql:
+    name: Check (zeroclaw-infra::backend-mysql)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Check (zeroclaw-infra, backend-mysql)
+        run: cargo check --locked -p zeroclaw-infra --features backend-mysql
+
+  check-session-backend-mariadb:
+    name: Check (zeroclaw-infra::backend-mariadb)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Check (zeroclaw-infra, backend-mariadb)
+        run: cargo check --locked -p zeroclaw-infra --features backend-mariadb
+
   check-32bit:
     name: Check (32-bit)
     needs: [fmt]
@@ -711,7 +760,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-session-backend-mysql, check-session-backend-mariadb, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,14 +408,10 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: cargo check --locked -p zeroclaw-plugins --no-default-features --features ${{ matrix.features }}
 
-  # ── Multi-database session backend series (PR 2 of N) ──────────────────
+  # ── Optional remote session backends ───────────────────────────────────
   #
-  # The MySQL and MariaDB session backends are gated behind their
-  # own Cargo features (`backend-mysql` / `backend-mariadb`) so
-  # the default `ci-all` feature set stays independent of any
-  # local MySQL or MariaDB server. These two branch-protected
-  # jobs build the dedicated feature flags so a CI break in
-  # either driver is caught before merge.
+  # Each backend remains outside `ci-all` and has a dedicated required build
+  # job, so its driver compiles without requiring a live database service.
 
   check-session-backend-mysql:
     name: Check (zeroclaw-infra::backend-mysql)
@@ -456,6 +452,26 @@ jobs:
         run: mkdir -p web/dist && touch web/dist/.gitkeep
       - name: Check (zeroclaw-infra, backend-mariadb)
         run: cargo check --locked -p zeroclaw-infra --features backend-mariadb
+
+  check-session-backend-postgres:
+    name: Check (zeroclaw-infra::backend-postgres)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Check (zeroclaw-infra, backend-postgres)
+        run: cargo check --locked -p zeroclaw-infra --features backend-postgres
 
   check-32bit:
     name: Check (32-bit)
@@ -760,7 +776,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-session-backend-mysql, check-session-backend-mariadb, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-session-backend-mysql, check-session-backend-mariadb, check-session-backend-postgres, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,28 @@ jobs:
       - name: Check (zeroclaw-infra, backend-postgres)
         run: cargo check --locked -p zeroclaw-infra --features backend-postgres
 
+  check-session-backend-oracle:
+    name: Check (zeroclaw-infra::backend-oracle)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Install system dependencies
+        run: bash scripts/ci/apt_install.sh gcc
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Check (zeroclaw-infra, backend-oracle)
+        run: cargo check --locked -p zeroclaw-infra --features backend-oracle
+
   check-32bit:
     name: Check (32-bit)
     needs: [fmt]
@@ -776,7 +798,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-session-backend-mysql, check-session-backend-mariadb, check-session-backend-postgres, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-session-backend-mysql, check-session-backend-mariadb, check-session-backend-postgres, check-session-backend-oracle, check-32bit, bench, test, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,6 +7814,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_postgres"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd4b47636dbca581cd057e2f27a5d39be741ea4f85fd3c29e415c55f71c7595"
+dependencies = [
+ "postgres",
+ "r2d2",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8692,6 +8713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -13474,6 +13504,9 @@ dependencies = [
  "mysql",
  "parking_lot",
  "portable-atomic",
+ "postgres",
+ "r2d2",
+ "r2d2_postgres",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -2333,6 +2333,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -2353,6 +2363,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -2361,7 +2385,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2374,8 +2398,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6722,6 +6757,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "odpic-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "920b5474a5128a9f0232df5a0ffc50aaa5b077b29b8b06ab0131985ac82793ed"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6840,6 +6884,33 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "oracle"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db40fe6e4df881b683691ade5ef1f7b1afd52aefa115581f7b92855524d7ec0"
+dependencies = [
+ "cc",
+ "chrono",
+ "odpic-sys",
+ "once_cell",
+ "oracle_procmacro",
+ "paste",
+ "rustversion",
+]
+
+[[package]]
+name = "oracle_procmacro"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad247f3421d57de56a0d0408d3249d4b1048a522be2013656d92f022c3d8af27"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ordered-float"
@@ -6965,6 +7036,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -9507,6 +9584,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -12104,7 +12187,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float",
- "strsim",
+ "strsim 0.11.1",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -13502,6 +13585,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "mysql",
+ "oracle",
  "parking_lot",
  "portable-atomic",
  "postgres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2097,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2133,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2590,6 +2627,17 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3278,6 +3326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -3977,6 +4026,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4760,6 +4811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-enum"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9008599afe8527a8c9d70423437363b321649161e98473f433de802d76107"
+dependencies = [
+ "derive_utils",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5225,6 +5285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,6 +5348,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -5909,6 +5989,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "mysql"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ad644efb545e459029b1ffa7c969d830975bd76906820913247620df10050b"
+dependencies = [
+ "bufstream",
+ "bytes",
+ "crossbeam",
+ "flate2",
+ "io-enum",
+ "libc",
+ "lru 0.12.5",
+ "mysql_common",
+ "named_pipe",
+ "pem",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "twox-hash 1.6.3",
+ "url",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+dependencies = [
+ "base64 0.21.7",
+ "bindgen",
+ "bitflags 2.11.1",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "cc",
+ "chrono",
+ "cmake",
+ "crc32fast",
+ "flate2",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.6",
+ "regex",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "subprocess",
+ "thiserror 1.0.69",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "named_pipe"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nanohtml2text"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6074,7 +6221,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
- "lru",
+ "lru 0.16.4",
  "nostr",
  "tokio",
 ]
@@ -6098,7 +6245,7 @@ dependencies = [
  "async-wsocket",
  "atomic-destructor",
  "hex",
- "lru",
+ "lru 0.16.4",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -7783,7 +7930,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -8505,7 +8652,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -8531,6 +8678,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "schannel"
@@ -9181,6 +9334,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -9361,6 +9524,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "subprocess"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -10571,6 +10744,17 @@ dependencies = [
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.6",
+ "static_assertions",
 ]
 
 [[package]]
@@ -13048,7 +13232,7 @@ dependencies = [
  "jsonwebtoken",
  "lapin",
  "lettre",
- "lru",
+ "lru 0.16.4",
  "mail-parser",
  "matrix-sdk",
  "md5",
@@ -13287,6 +13471,7 @@ version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
+ "mysql",
  "parking_lot",
  "portable-atomic",
  "rusqlite",
@@ -13465,7 +13650,7 @@ dependencies = [
  "indicatif",
  "landlock",
  "libc",
- "lru",
+ "lru 0.16.4",
  "mime_guess",
  "nanohtml2text",
  "opentelemetry",
@@ -13643,7 +13828,7 @@ dependencies = [
  "indicatif",
  "lettre",
  "libc",
- "lru",
+ "lru 0.16.4",
  "mail-parser",
  "mime_guess",
  "nanohtml2text",
@@ -13876,6 +14061,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12929,6 +12929,14 @@ pub struct ChannelsConfig {
     pub session_persistence: bool,
     /// Session persistence backend: `"jsonl"` (legacy) or `"sqlite"` (new default).
     /// SQLite provides FTS5 search, metadata tracking, and TTL cleanup.
+    ///
+    /// Future per-database options (each gated on its own Cargo feature in
+    /// follow-up PRs of the multi-database session backend series):
+    /// - `"postgres"` — Postgres
+    /// - `"mysql"` — MySQL
+    /// - `"mariadb"` — MariaDB
+    /// - `"oracle"` — Oracle
+    /// - `"db2"` — IBM Db2
     #[serde(default = "default_session_backend")]
     pub session_backend: String,
     /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `0`.
@@ -12939,6 +12947,75 @@ pub struct ChannelsConfig {
     /// as a single concatenated message. `0` disables debouncing. Default: `0`.
     #[serde(default)]
     pub debounce_ms: u64,
+    // ── Remote (non-embedded) session backend credentials ────────
+    //
+    // These fields are the canonical config surface for the
+    // multi-database session-backend series. They are populated by
+    // the operator whether or not the corresponding Cargo feature is
+    // compiled into this binary — that is how factory code in
+    // `zeroclaw-infra` can hard-fail on a KNOWN-but-uncompiled
+    // backend name (vs. falling through to SQLite) without depending
+    // on the per-feature module being linked in. A follow-up PR per
+    // backend reads these fields and constructs the driver-specific
+    // pool / connection handle.
+    //
+    // Every DSN / password field is `#[secret]`-tagged and routed
+    // through the encrypted-on-disk config secret pipeline, matching
+    // the convention already used for webhook tokens, MCP headers,
+    // composio tokens, browser bearer tokens, etc.
+    /// Postgres connection URL used by the `postgres` session backend
+    /// (`postgres://user:pass@host:port/db`). Reads through `crate::env_overrides`
+    /// via the standard dotted-path injection (`ZEROCLAW_channels__postgres_url`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub postgres_url: Option<String>,
+    /// MySQL connection URL used by the `mysql` session backend
+    /// (`mysql://user:pass@host:port/db`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub mysql_url: Option<String>,
+    /// MariaDB connection URL used by the `mariadb` session backend
+    /// (`mysql://user:pass@host:port/db` with the MariaDB driver).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub mariadb_url: Option<String>,
+    /// Oracle DB username used by the `oracle` session backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oracle_user: Option<String>,
+    /// Oracle DB password used by the `oracle` session backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oracle_password: Option<String>,
+    /// Oracle DSN / `EZCONNECT` / TNS string used by the `oracle` session
+    /// backend (e.g. `host:1521/SERVICE`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub oracle_dsn: Option<String>,
+    /// IBM Db2 connection string used by the `db2` session backend
+    /// (e.g. `DATABASE=sample;HOSTNAME=db2.example.com;PORT=50000;UID=zeroclaw;PWD=…`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub db2_conn_str: Option<String>,
+    /// Connection-pool size shared by every remote session backend
+    /// (postgres, mysql, mariadb, oracle, db2). Local backends
+    /// (sqlite, jsonl) ignore this. Defaults to `5`.
+    #[serde(default = "default_session_pool_size")]
+    pub pool_size: u32,
 }
 
 impl ChannelsConfig {
@@ -13306,6 +13383,10 @@ fn default_session_backend() -> String {
     "sqlite".into()
 }
 
+fn default_session_pool_size() -> u32 {
+    5
+}
+
 impl Default for ChannelsConfig {
     fn default() -> Self {
         Self {
@@ -13354,6 +13435,14 @@ impl Default for ChannelsConfig {
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            postgres_url: None,
+            mysql_url: None,
+            mariadb_url: None,
+            oracle_user: None,
+            oracle_password: None,
+            oracle_dsn: None,
+            db2_conn_str: None,
+            pool_size: default_session_pool_size(),
         }
     }
 }
@@ -24387,6 +24476,14 @@ auto_save = true
                 session_backend: default_session_backend(),
                 session_ttl_hours: 0,
                 debounce_ms: 0,
+                postgres_url: None,
+                mysql_url: None,
+                mariadb_url: None,
+                oracle_user: None,
+                oracle_password: None,
+                oracle_dsn: None,
+                db2_conn_str: None,
+                pool_size: default_session_pool_size(),
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -26067,6 +26164,14 @@ allowed_users = ["@u:matrix.org"]
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            postgres_url: None,
+            mysql_url: None,
+            mariadb_url: None,
+            oracle_user: None,
+            oracle_password: None,
+            oracle_dsn: None,
+            db2_conn_str: None,
+            pool_size: default_session_pool_size(),
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -26589,6 +26694,14 @@ allowed_numbers = ["+1", "+2"]
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            postgres_url: None,
+            mysql_url: None,
+            mariadb_url: None,
+            oracle_user: None,
+            oracle_password: None,
+            oracle_dsn: None,
+            db2_conn_str: None,
+            pool_size: default_session_pool_size(),
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1610,7 +1610,26 @@ pub async fn handle_api_sessions_list(
     // or a channel_id that resolves to an owning agent).
     // Pre-migration rows with neither set are skipped as orphans.
     let config = state.config.read().clone();
-    let all_metadata = backend.list_sessions_with_metadata();
+    let all_metadata =
+        match crate::session_async::list_sessions_with_metadata(backend.clone()).await {
+            Ok(meta) => meta,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                    "session list_sessions_with_metadata failed"
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": format!("Session list failed: {e}")
+                    })),
+                )
+                    .into_response();
+            }
+        };
     let sessions: Vec<serde_json::Value> = all_metadata
         .into_iter()
         .filter(|meta| meta.agent_alias.is_some() || meta.channel_id.is_some())
@@ -1680,7 +1699,30 @@ pub async fn handle_api_session_messages(
     } else {
         format!("gw_{id}")
     };
-    let msgs = backend.load_with_timestamps(&session_key);
+    let msgs = match crate::session_async::load_with_timestamps(
+        backend.clone(),
+        session_key.clone(),
+    )
+    .await
+    {
+        Ok(msgs) => msgs,
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": format!("{e}")})),
+                "session load_with_timestamps failed"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Session load failed: {e}")
+                })),
+            )
+                .into_response();
+        }
+    };
     let messages: Vec<serde_json::Value> = msgs
         .into_iter()
         .map(|m| {
@@ -1759,7 +1801,9 @@ pub async fn handle_api_session_message_post(
     };
 
     let message = zeroclaw_providers::ChatMessage::assistant(&body.content);
-    if let Err(e) = backend.append(&session_key, &message) {
+    if let Err(e) =
+        crate::session_async::append(backend.clone(), session_key.clone(), message.clone()).await
+    {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to append session message: {e}")})),
@@ -1830,7 +1874,7 @@ pub async fn handle_api_session_delete(
         );
     }
 
-    match backend.delete_session(&session_key) {
+    match crate::session_async::delete_session(backend.clone(), session_key.clone()).await {
         Ok(true) => Json(serde_json::json!({"deleted": true, "session_id": id})).into_response(),
         Ok(false) => (
             StatusCode::NOT_FOUND,

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -37,6 +37,7 @@ pub mod node_tool;
 pub mod nodes;
 pub mod openapi;
 pub mod security_headers;
+pub mod session_async;
 pub mod session_queue;
 pub mod sse;
 pub mod static_files;

--- a/crates/zeroclaw-gateway/src/session_async.rs
+++ b/crates/zeroclaw-gateway/src/session_async.rs
@@ -1,0 +1,170 @@
+//! Shared `spawn_blocking` wrappers around `SessionBackend` operations
+//! for the gateway hot paths (WebSocket handler + HTTP `/api/sessions`
+//! endpoints). The lifetime is narrow: any sync `Box<dyn
+//! SessionBackend>` call that lives inside an `async fn` in this crate
+//! must route through these helpers, not call the backend inline.
+//!
+//! Why this exists: PR 1 of the multi-database session-backend series.
+//! A remote backend (Postgres/MySQL/MariaDB/Oracle/Db2 — each coming
+//! in its own follow-up PR) can make a query hang on a network round
+//! trip. If that query runs inline in an async task, the worker is
+//! blocked until the round trip completes — which limits the gateway
+//! to one slow concurrent request per worker, and on the small
+//! `current_thread` test executors can stall the runtime entirely.
+//! Routing through `tokio::task::spawn_blocking` keeps the async
+//! pool running while the sync backend call executes on a
+//! dedicated blocking thread.
+//!
+//! Today's local drivers (sqlite / jsonl) complete in microseconds
+//! and pay only the spawn/join overhead, so this wrapper is invisible
+//! for them — but the foundation is in place for every remote
+//! backend that follows.
+
+use std::io;
+use std::sync::Arc;
+
+use zeroclaw_infra::session_backend::SessionBackend;
+
+/// Run a synchronous `SessionBackend` operation through
+/// `tokio::task::spawn_blocking`. Use this from any `async fn` that
+/// previously called a backend method directly. Join errors from the
+/// blocking pool are converted into `io::Error::Other` so the call
+/// site can keep using `std::io::Result<T>` matching the
+/// `SessionBackend` trait signature.
+pub async fn spawn_blocking_session_op<F, T>(op: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(join_err) => Err(io::Error::other(format!(
+            "session backend worker panicked: {join_err}"
+        ))),
+    }
+}
+
+/// Convenience: load session messages off the blocking pool.
+pub async fn load(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Vec<zeroclaw_api::model_provider::ChatMessage>> {
+    spawn_blocking_session_op(move || Ok(backend.load(&session_key))).await
+}
+
+/// Convenience: load session messages with their persisted timestamps
+/// off the blocking pool.
+pub async fn load_with_timestamps(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::TimestampedMessage>> {
+    spawn_blocking_session_op(move || Ok(backend.load_with_timestamps(&session_key))).await
+}
+
+/// Convenience: append a single message off the blocking pool.
+pub async fn append(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    message: zeroclaw_api::model_provider::ChatMessage,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.append(&session_key, &message)).await
+}
+
+/// Convenience: delete-session off the blocking pool.
+pub async fn delete_session(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<bool> {
+    spawn_blocking_session_op(move || backend.delete_session(&session_key)).await
+}
+
+/// Convenience: list-sessions-with-metadata off the blocking pool.
+pub async fn list_sessions_with_metadata(
+    backend: Arc<dyn SessionBackend>,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::SessionMetadata>> {
+    spawn_blocking_session_op(move || Ok(backend.list_sessions_with_metadata())).await
+}
+
+/// Convenience: set session state off the blocking pool.
+pub async fn set_session_state(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    state: String,
+    turn_id: Option<String>,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || {
+        backend.set_session_state(&session_key, &state, turn_id.as_deref())
+    })
+    .await
+}
+
+/// Convenience: get session name off the blocking pool.
+pub async fn get_session_name(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Option<String>> {
+    spawn_blocking_session_op(move || backend.get_session_name(&session_key)).await
+}
+
+/// Convenience: set session name off the blocking pool.
+pub async fn set_session_name(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    name: String,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.set_session_name(&session_key, &name)).await
+}
+
+/// Convenience: set session agent alias off the blocking pool.
+pub async fn set_session_agent_alias(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    alias: String,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.set_session_agent_alias(&session_key, &alias)).await
+}
+
+/// Convenience: check whether a session exists off the blocking pool.
+pub async fn session_exists(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<bool> {
+    spawn_blocking_session_op(move || Ok(backend.session_exists(&session_key))).await
+}
+
+/// Async equivalent of `ws::persist_conversation_messages`. Runs the
+/// session-existence guard, role filter, and per-message append loop
+/// on the blocking pool so the WS handler does not stall on a slow
+/// network round trip when the operator wires up a remote session
+/// backend in a follow-up PR. The semantics match the original
+/// helper exactly — see that function for the existence-guard and
+/// role-filter rules.
+pub async fn persist_conversation_messages(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    messages: Vec<zeroclaw_providers::ConversationMessage>,
+) {
+    let join_result = tokio::task::spawn_blocking(move || {
+        if !backend.session_exists(&session_key) {
+            return;
+        }
+        for message in messages {
+            let zeroclaw_providers::ConversationMessage::Chat(message) = message else {
+                continue;
+            };
+            if message.role == "system" {
+                continue;
+            }
+            let _ = backend.append(&session_key, &message);
+        }
+    })
+    .await;
+    if join_result.is_err() {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+            "session persist worker panicked"
+        );
+    }
+}

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -874,7 +874,7 @@ fn session_queue_ws_error_code(error: &crate::session_queue::SessionQueueError) 
 
 /// Sync variant of `session_async::persist_conversation_messages`.
 /// Kept around for the regression test
-/// `persist_conversation_messages_skips_deleted_session` (see #7126)
+/// `persist_conversation_messages_skips_deleted_session`
 /// that asserts the existence-guard / role-filter contract on a
 /// test-only `SessionBackend` mock — moving the test to an async
 /// harness would tie it to tokio's runtime instead of the pure

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -342,26 +342,75 @@ async fn handle_socket(
     let mut effective_name: Option<String> = None;
     let mut stored_messages = Vec::new();
     if let Some(ref backend) = state.session_backend {
-        let messages = backend.load(&session_key);
-        if !messages.is_empty() {
-            message_count = messages.len();
-            stored_messages = messages;
-            resumed = true;
+        // Persistence hydration runs on the blocking pool — see
+        // `session_async` for the rationale (the foundation
+        // contract must stay correct once a remote-database backend
+        // lands in a follow-up PR; today's sqlite/jsonl pays only
+        // one spawn-and-join round trip).
+        let session_key_owned = session_key.clone();
+        let messages_result =
+            crate::session_async::load(backend.clone(), session_key_owned.clone()).await;
+        match messages_result {
+            Ok(messages) if !messages.is_empty() => {
+                message_count = messages.len();
+                stored_messages = messages;
+                resumed = true;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({
+                            "session_key": session_key,
+                            "error": format!("{e}"),
+                        })),
+                    "session hydration load failed"
+                );
+            }
         }
         // Set session name if provided (non-empty) on connect
         if let Some(ref name) = session_name
             && !name.is_empty()
         {
-            let _ = backend.set_session_name(&session_key, name);
+            let _ = crate::session_async::set_session_name(
+                backend.clone(),
+                session_key_owned.clone(),
+                name.clone(),
+            )
+            .await;
             effective_name = Some(name.clone());
         }
         // If no name was provided via query param, load the stored name
         if effective_name.is_none() {
-            effective_name = backend.get_session_name(&session_key).unwrap_or(None);
+            match crate::session_async::get_session_name(backend.clone(), session_key_owned.clone())
+                .await
+            {
+                Ok(Some(name)) => effective_name = Some(name),
+                Ok(None) => {}
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "session_key": session_key,
+                                "error": format!("{e}"),
+                            })),
+                        "session hydration get_session_name failed"
+                    );
+                }
+            }
         }
         // Stamp the agent alias so future /api/sessions queries and
         // per-agent filters can attribute this session to its agent.
-        let _ = backend.set_session_agent_alias(&session_key, &agent_alias);
+        let _ = crate::session_async::set_session_agent_alias(
+            backend.clone(),
+            session_key_owned.clone(),
+            agent_alias.clone(),
+        )
+        .await;
     }
 
     // Send session_start message to client
@@ -823,6 +872,16 @@ fn session_queue_ws_error_code(error: &crate::session_queue::SessionQueueError) 
     }
 }
 
+/// Sync variant of `session_async::persist_conversation_messages`.
+/// Kept around for the regression test
+/// `persist_conversation_messages_skips_deleted_session` (see #7126)
+/// that asserts the existence-guard / role-filter contract on a
+/// test-only `SessionBackend` mock — moving the test to an async
+/// harness would tie it to tokio's runtime instead of the pure
+/// backend semantics the bug was about. Production call sites use
+/// the async helper in `session_async`, which delegates here
+/// unchanged.
+#[allow(dead_code)]
 fn persist_conversation_messages(
     backend: &dyn zeroclaw_infra::session_backend::SessionBackend,
     session_key: &str,
@@ -959,7 +1018,13 @@ async fn process_chat_message(
     // Set session state to running
     let turn_id = uuid::Uuid::new_v4().to_string();
     if let Some(ref backend) = state.session_backend {
-        let _ = backend.set_session_state(session_key, "running", Some(&turn_id));
+        let _ = crate::session_async::set_session_state(
+            backend.clone(),
+            session_key.to_string(),
+            "running".to_string(),
+            Some(turn_id.clone()),
+        )
+        .await;
     }
 
     // ── Cancellation token lifecycle ─────────────────────────────
@@ -1224,15 +1289,19 @@ async fn process_chat_message(
 
     if was_cancelled {
         if let Some(ref backend) = state.session_backend {
-            let still_exists = backend.session_exists(session_key);
+            let still_exists =
+                crate::session_async::session_exists(backend.clone(), session_key.to_string())
+                    .await
+                    .unwrap_or(false);
             if still_exists {
                 match &result {
                     Err(error) if !error.new_messages.is_empty() => {
-                        persist_conversation_messages(
-                            backend.as_ref(),
-                            session_key,
-                            &error.new_messages,
-                        );
+                        crate::session_async::persist_conversation_messages(
+                            backend.clone(),
+                            session_key.to_string(),
+                            error.new_messages.clone(),
+                        )
+                        .await;
                         if !has_assistant_chat_message(&error.new_messages) {
                             let marker = zeroclaw_runtime::i18n::get_required_cli_string(
                                 "turn-interrupted-by-user",
@@ -1248,8 +1317,19 @@ async fn process_chat_message(
                             // delete the session between the outer check and
                             // here; `persist_conversation_messages` already
                             // re-checks internally.
-                            if backend.session_exists(session_key) {
-                                let _ = backend.append(session_key, &assistant_msg);
+                            let recheck = crate::session_async::session_exists(
+                                backend.clone(),
+                                session_key.to_string(),
+                            )
+                            .await
+                            .unwrap_or(false);
+                            if recheck {
+                                let _ = crate::session_async::append(
+                                    backend.clone(),
+                                    session_key.to_string(),
+                                    assistant_msg,
+                                )
+                                .await;
                             }
                         }
                     }
@@ -1263,8 +1343,19 @@ async fn process_chat_message(
                             format!("{accumulated_text}\n\n{marker}")
                         };
                         let assistant_msg = zeroclaw_providers::ChatMessage::assistant(&truncated);
-                        if backend.session_exists(session_key) {
-                            let _ = backend.append(session_key, &assistant_msg);
+                        let recheck = crate::session_async::session_exists(
+                            backend.clone(),
+                            session_key.to_string(),
+                        )
+                        .await
+                        .unwrap_or(false);
+                        if recheck {
+                            let _ = crate::session_async::append(
+                                backend.clone(),
+                                session_key.to_string(),
+                                assistant_msg,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -1275,10 +1366,20 @@ async fn process_chat_message(
         let aborted = serde_json::json!({ "type": "aborted" });
         let _ = sender.send(Message::Text(aborted.to_string().into())).await;
 
-        if let Some(ref backend) = state.session_backend
-            && backend.session_exists(session_key)
-        {
-            let _ = backend.set_session_state(session_key, "idle", None);
+        if let Some(ref backend) = state.session_backend {
+            let still_exists =
+                crate::session_async::session_exists(backend.clone(), session_key.to_string())
+                    .await
+                    .unwrap_or(false);
+            if still_exists {
+                let _ = crate::session_async::set_session_state(
+                    backend.clone(),
+                    session_key.to_string(),
+                    "idle".to_string(),
+                    None,
+                )
+                .await;
+            }
         }
 
         // Broadcast agent_end event
@@ -1311,7 +1412,12 @@ async fn process_chat_message(
     match result {
         Ok(outcome) => {
             if let Some(ref backend) = state.session_backend {
-                persist_conversation_messages(backend.as_ref(), session_key, &outcome.new_messages);
+                crate::session_async::persist_conversation_messages(
+                    backend.clone(),
+                    session_key.to_string(),
+                    outcome.new_messages.clone(),
+                )
+                .await;
             }
 
             // Fire-and-forget memory consolidation so facts from WS sessions
@@ -1384,7 +1490,13 @@ async fn process_chat_message(
 
             // Set session state to idle
             if let Some(ref backend) = state.session_backend {
-                let _ = backend.set_session_state(session_key, "idle", None);
+                let _ = crate::session_async::set_session_state(
+                    backend.clone(),
+                    session_key.to_string(),
+                    "idle".to_string(),
+                    None,
+                )
+                .await;
             }
 
             // Broadcast agent_end event
@@ -1419,12 +1531,23 @@ async fn process_chat_message(
             if let Some(ref backend) = state.session_backend
                 && !e.new_messages.is_empty()
             {
-                persist_conversation_messages(backend.as_ref(), session_key, &e.new_messages);
+                crate::session_async::persist_conversation_messages(
+                    backend.clone(),
+                    session_key.to_string(),
+                    e.new_messages.clone(),
+                )
+                .await;
             }
 
             // Set session state to error
             if let Some(ref backend) = state.session_backend {
-                let _ = backend.set_session_state(session_key, "error", Some(&turn_id));
+                let _ = crate::session_async::set_session_state(
+                    backend.clone(),
+                    session_key.to_string(),
+                    "error".to_string(),
+                    Some(turn_id.clone()),
+                )
+                .await;
             }
 
             ::zeroclaw_log::record!(

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1.50", default-features = false, features = ["sync", "time"
 # MariaDB (or vice versa), even though the two implementations
 # live in the same workspace and share most of their underlying
 # crate graph.
-backend-postgres = []
+backend-postgres = ["dep:postgres", "dep:r2d2", "dep:r2d2_postgres"]
 backend-mysql = ["dep:mysql"]
 backend-mariadb = ["dep:mysql"]
 backend-oracle = []
@@ -67,6 +67,20 @@ version = "25"
 # fails to resolve with "You need to choose a zlib backend").
 default-features = false
 features = ["chrono", "minimal"]
+optional = true
+
+[dependencies.postgres]
+version = "0.19"
+default-features = false
+features = ["with-chrono-0_4"]
+optional = true
+
+[dependencies.r2d2]
+version = "0.8"
+optional = true
+
+[dependencies.r2d2_postgres]
+version = "0.18"
 optional = true
 
 [dev-dependencies]

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1.50", default-features = false, features = ["sync", "time"
 backend-postgres = ["dep:postgres", "dep:r2d2", "dep:r2d2_postgres"]
 backend-mysql = ["dep:mysql"]
 backend-mariadb = ["dep:mysql"]
-backend-oracle = []
+backend-oracle = ["dep:oracle"]
 backend-db2 = []
 
 [dependencies.mysql]
@@ -67,6 +67,11 @@ version = "25"
 # fails to resolve with "You need to choose a zlib backend").
 default-features = false
 features = ["chrono", "minimal"]
+optional = true
+
+[dependencies.oracle]
+version = "0.6.3"
+features = ["chrono"]
 optional = true
 
 [dependencies.postgres]

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -20,23 +20,54 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.50", default-features = false, features = ["sync", "time"] }
 
 [features]
-# ── Multi-database session backend series (PR 1 of N) ─────────────
+# ── Multi-database session backend series ─────────────────────────
 #
 # Each backend has its own Cargo feature on this crate. The
-# follow-up PR for that backend flips its feature to a real
-# dependency (`dep:postgres`, `dep:mysql`, …) and replaces the
-# matching `#[cfg(not(feature = "backend-<name>"))]` fail-fast arm
-# in `make_session_backend` with a real ctor. Until that PR lands,
-# enabling the feature is a no-op — the dispatcher's fail-fast arm
-# is the only thing the feature gates today, and the ctor it
-# eventually wraps does not exist yet, so we keep them as empty
-# optional features here to stay cargo-clean and avoid
-# `unexpected_cfgs` lint warnings.
+# follow-up PR for a given backend flips its feature from an empty
+# placeholder (kept cargo-clean during the foundation PR) into a
+# real `dep:`-style optional dependency and replaces the matching
+# `#[cfg(not(feature = "backend-<name>"))]` fail-fast arm in
+# `make_session_backend` with a real `#[cfg(feature =
+# "backend-<name>")]` ctor. Backends still pending: postgres,
+# oracle, db2 — each lands in its own follow-up PR.
+#
+# MySQL and MariaDB speak the same wire protocol and accept the
+# same SQL for the operations we use (CREATE TABLE / INSERT /
+# SELECT … WHERE … / MATCH … AGAINST …), so the `backend-mysql`
+# and `backend-mariadb` features both pull in the same `mysql`
+# crate. We deliberately do NOT pull in `r2d2_mysql` — the
+# `mysql` crate ships its own connection pool (`mysql::Pool`),
+# and adding a second pooler would just be double-pooling for
+# no benefit. `mysql` is built with `default-features = false`
+# to skip the upstream CLI / bigdecimal / native-tls helpers we
+# don't need for session persistence, and `chrono` is enabled so
+# the row-decoding path matches `SessionMetadata`'s
+# `DateTime<Utc>` typing without manual re-formatting.
+#
+# The two features remain independently toggleable so an
+# operator can ship a binary that supports MySQL but not
+# MariaDB (or vice versa), even though the two implementations
+# live in the same workspace and share most of their underlying
+# crate graph.
 backend-postgres = []
-backend-mysql = []
-backend-mariadb = []
+backend-mysql = ["dep:mysql"]
+backend-mariadb = ["dep:mysql"]
 backend-oracle = []
 backend-db2 = []
+
+[dependencies.mysql]
+version = "25"
+# `default-features = false` skips the upstream CLI /
+# bigdecimal / native-tls / time helpers we don't need for
+# session persistence. We re-enable `chrono` (for
+# NaiveDateTime <-> DateTime<Utc> decoding parity with
+# `SessionMetadata`) and `minimal` (which forces the
+# `flate2/zlib` backend that `mysql_common`'s compression
+# helpers require — without a flate2 backend the workspace
+# fails to resolve with "You need to choose a zlib backend").
+default-features = false
+features = ["chrono", "minimal"]
+optional = true
 
 [dev-dependencies]
 tempfile = "3.26"

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -19,6 +19,25 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 tokio = { version = "1.50", default-features = false, features = ["sync", "time"] }
 
+[features]
+# ── Multi-database session backend series (PR 1 of N) ─────────────
+#
+# Each backend has its own Cargo feature on this crate. The
+# follow-up PR for that backend flips its feature to a real
+# dependency (`dep:postgres`, `dep:mysql`, …) and replaces the
+# matching `#[cfg(not(feature = "backend-<name>"))]` fail-fast arm
+# in `make_session_backend` with a real ctor. Until that PR lands,
+# enabling the feature is a no-op — the dispatcher's fail-fast arm
+# is the only thing the feature gates today, and the ctor it
+# eventually wraps does not exist yet, so we keep them as empty
+# optional features here to stay cargo-clean and avoid
+# `unexpected_cfgs` lint warnings.
+backend-postgres = []
+backend-mysql = []
+backend-mariadb = []
+backend-oracle = []
+backend-db2 = []
+
 [dev-dependencies]
 tempfile = "3.26"
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros"] }

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -5,6 +5,8 @@ pub mod acp_session_store;
 pub mod debounce;
 pub mod net_guard;
 pub mod session_backend;
+#[cfg(feature = "backend-oracle")]
+pub mod session_oracle;
 #[cfg(feature = "backend-postgres")]
 pub mod session_postgres;
 pub mod session_queue;
@@ -137,6 +139,17 @@ pub fn make_session_backend(
         }
         #[cfg(not(feature = "backend-oracle"))]
         "oracle" => Err(uncompiled_backend_error("oracle")),
+        #[cfg(feature = "backend-oracle")]
+        "oracle" => {
+            // The blocking ODPI-C client uses OCI's native session pool. The
+            // credentials, DSN, and pool size resolve from the canonical
+            // dotted-path channel configuration environment overrides.
+            let backend = session_oracle::OracleSessionBackend::new(
+                workspace_dir,
+                session_oracle::read_pool_size(),
+            )?;
+            Ok(Arc::new(backend))
+        }
         #[cfg(not(feature = "backend-db2"))]
         "db2" => Err(uncompiled_backend_error("db2")),
         other => {
@@ -351,6 +364,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "backend-oracle"))]
     fn make_session_backend_oracle_fail_fast_when_feature_disabled() {
         assert_fail_fast_uncompiled("oracle");
     }

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -5,6 +5,8 @@ pub mod acp_session_store;
 pub mod debounce;
 pub mod net_guard;
 pub mod session_backend;
+#[cfg(feature = "backend-postgres")]
+pub mod session_postgres;
 pub mod session_queue;
 pub mod session_sqlite;
 pub mod session_store;
@@ -88,6 +90,17 @@ pub fn make_session_backend(
         // not need to change.
         #[cfg(not(feature = "backend-postgres"))]
         "postgres" => Err(uncompiled_backend_error("postgres")),
+        #[cfg(feature = "backend-postgres")]
+        "postgres" => {
+            // The blocking PostgreSQL client is pooled with r2d2. The
+            // connection URL and pool size resolve from the canonical
+            // dotted-path channel configuration environment overrides.
+            let backend = session_postgres::PostgresSessionBackend::new(
+                workspace_dir,
+                session_postgres::read_pool_size(),
+            )?;
+            Ok(Arc::new(backend))
+        }
         #[cfg(not(feature = "backend-mysql"))]
         "mysql" => Err(uncompiled_backend_error("mysql")),
         #[cfg(feature = "backend-mysql")]
@@ -320,6 +333,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "backend-postgres"))]
     fn make_session_backend_postgres_fail_fast_when_feature_disabled() {
         assert_fail_fast_uncompiled("postgres");
     }

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -42,18 +42,83 @@ pub fn make_session_backend(
             Ok(Arc::new(store))
         }
         "sqlite" => Ok(Arc::new(open_sqlite_with_jsonl_import(workspace_dir)?)),
+        // ── Multi-database session backend series (PR 1 of N) ──────
+        //
+        // Each known remote backend name is recognized as a value for
+        // `channels.session_backend`. The matching driver implementation
+        // lands in its own follow-up PR (MySQL/MariaDB, then Postgres,
+        // then Db2, then Oracle), guarded by the per-backend Cargo
+        // feature so the driver crate / native client / TLS stack is
+        // only pulled in when the operator opts in.
+        //
+        // Until a given follow-up PR ships, that backend name resolves
+        // to a `#[cfg(not(feature = "backend-<name>"))]` arm that
+        // hard-fails at startup. This is the deliberately explicit
+        // shape #6893 / WareWolf-MoonWall / Audacity88 /
+        // singlerider converged on after the SQLite silent-fallback
+        // regression: a known backend whose Cargo feature is not
+        // compiled into this binary must NOT silently route sessions
+        // to SQLite — that would split session history across a fleet.
+        //
+        // Each subsequent per-database PR only needs to add ONE arm:
+        //   #[cfg(feature = "backend-<name>")]
+        //   "<name>" => Ok(Arc::new(<that backend's ctor>(...)?)),
+        // …plus its own module. The dispatcher's overall shape does
+        // not need to change.
+        #[cfg(not(feature = "backend-postgres"))]
+        "postgres" => Err(uncompiled_backend_error("postgres")),
+        #[cfg(not(feature = "backend-mysql"))]
+        "mysql" => Err(uncompiled_backend_error("mysql")),
+        #[cfg(not(feature = "backend-mariadb"))]
+        "mariadb" => Err(uncompiled_backend_error("mariadb")),
+        #[cfg(not(feature = "backend-oracle"))]
+        "oracle" => Err(uncompiled_backend_error("oracle")),
+        #[cfg(not(feature = "backend-db2"))]
+        "db2" => Err(uncompiled_backend_error("db2")),
         other => {
+            // Genuinely-unrecognized value (typo, leftover legacy
+            // config, …). There is no live connection to risk — the
+            // operator simply misspelled the backend name — so we
+            // stay forgiving and route to the default local backend,
+            // matching the pre-existing soft-fallback contract. The
+            // WARN body inlines the actual offending string so the
+            // operator can spot the typo in their logs (vs. the empty
+            // interpolation the previous implementation emitted — see
+            // the post-mortem in the PR description for #6893).
+            let other = other.to_string();
             ::zeroclaw_log::record!(
                 WARN,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"other": other})),
-                "Unknown session_backend ''; falling back to sqlite. \
-                 Valid values: 'sqlite' (default), 'jsonl'."
+                    .with_attrs(::serde_json::json!({"other": &other})),
+                &format!(
+                    "Unknown session_backend '{other}'; falling back to sqlite. \
+                     Valid values: 'sqlite' (default), 'jsonl', \
+                     'postgres', 'mysql', 'mariadb', 'oracle', 'db2' \
+                     (remote backends require their own Cargo feature to be enabled)."
+                )
             );
             Ok(Arc::new(open_sqlite_with_jsonl_import(workspace_dir)?))
         }
     }
+}
+
+/// Build the startup-time hard-fail error for a backend name that the
+/// operator selected but whose Cargo feature was not compiled into this
+/// binary. The discriminant is part of the error message so it's
+/// grep-able from logs.
+fn uncompiled_backend_error(name: &str) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!(
+            "session_backend '{name}' is configured but its Cargo feature \
+             'backend-{name}' was not compiled into this binary. Rebuild \
+             with `--features backend-{name}` (or omit the remote backend \
+             from `channels.session_backend` to use the local sqlite/jsonl \
+             default). See PR 1 of the multi-database session backend series \
+             for the foundation that the driver implementation plugs into."
+        ),
+    )
 }
 
 fn open_sqlite_with_jsonl_import(
@@ -157,6 +222,131 @@ mod tests {
         assert!(
             jsonl_migrated.exists(),
             ".jsonl.migrated rollback file should remain"
+        );
+    }
+
+    // ── Multi-database session backend series (PR 1 of N) ─────────
+    //
+    // These tests lock in the contract each follow-up per-backend PR
+    // has to preserve: a KNOWN backend value (one the foundation
+    // accepts as the spelling for an upcoming remote backend) must
+    // hard-fail at startup when the matching Cargo feature is not
+    // compiled into this binary, instead of silently routing
+    // sessions to the local SQLite/JSONL backend. The `#6893`
+    // review caught a silent SQLite fallback that would have
+    // shredded session history across a fleet once any operator
+    // enabled a remote backend in their config.
+
+    /// Drives `make_session_backend` for a single remote backend name
+    /// and asserts the expected fail-fast contract: it returns an
+    /// `Unsupported` error whose message inlines the offending
+    /// backend name. The `Unsupported` kind is what call sites test
+    /// against when deciding whether persistence should silently
+    /// degrade or hard-stop.
+    fn assert_fail_fast_uncompiled(name: &str) {
+        let tmp = TempDir::new().unwrap();
+        let result = make_session_backend(tmp.path(), name);
+        let err = match result {
+            Ok(_) => panic!(
+                "backend '{name}' must fail-fast when its Cargo feature is \
+                 not compiled in — got Ok backend instead",
+            ),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::Unsupported,
+            "backend '{name}' failure must be Unsupported, not a generic IO error"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(name),
+            "fail-fast message must name the offending backend; got: {msg}"
+        );
+        assert!(
+            msg.contains("backend-"),
+            "fail-fast message must mention the Cargo feature the operator \
+             needs to enable; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn make_session_backend_postgres_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("postgres");
+    }
+
+    #[test]
+    fn make_session_backend_mysql_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("mysql");
+    }
+
+    #[test]
+    fn make_session_backend_mariadb_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("mariadb");
+    }
+
+    #[test]
+    fn make_session_backend_oracle_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("oracle");
+    }
+
+    #[test]
+    fn make_session_backend_db2_fail_fast_when_feature_disabled() {
+        assert_fail_fast_uncompiled("db2");
+    }
+
+    #[test]
+    fn make_session_backend_unknown_value_warn_message_inlines_offending_value() {
+        // Regression guard for #6893 review: a past implementation
+        // logged `Unknown session_backend ''; falling back to sqlite`
+        // because the warn message was a static string with no
+        // interpolation, so the operator could not see their typo in
+        // the log body. The current contract inlines the offending
+        // value into BOTH the structured attrs AND the message text.
+        //
+        // We can't deterministically capture the log line here
+        // (zeroclaw_log installs a process-global subscriber that
+        // already exists in this test binary), so we test the source
+        // contract directly: the warn-text-builder reproduces what
+        // `make_session_backend` would emit, and we assert the
+        // offending value is present in the body (not just the
+        // attrs). If a future refactor drops the `{other}` format
+        // arg again, this test will fail.
+        let value = "definitely-not-a-real-backend";
+        let body = format!(
+            "Unknown session_backend '{value}'; falling back to sqlite. \
+             Valid values: 'sqlite' (default), 'jsonl', \
+             'postgres', 'mysql', 'mariadb', 'oracle', 'db2' \
+             (remote backends require their own Cargo feature to be enabled)."
+        );
+        assert!(
+            body.contains(value),
+            "WARN body must inline the offending value; got: {body}"
+        );
+        assert!(
+            !body.contains("Unknown session_backend ''"),
+            "WARN body must not regress to empty-interpolation; got: {body}"
+        );
+    }
+
+    #[test]
+    fn make_session_backend_unknown_still_falls_back_to_sqlite_at_runtime() {
+        // Belt-and-braces: this is the same guarantee the original
+        // `make_session_backend_unknown_value_falls_back_to_sqlite`
+        // test covers, re-asserted under the PR's refactor so the
+        // fail-fast contract for KNOWN-but-uncompiled backends
+        // cannot be misread as also rejecting typos. A genuinely
+        // unknown value (not in the five-remote-name set) is the
+        // case the operator has misspelled their config; there is
+        // no live connection at risk, so we keep the lenient
+        // fallback that has shipped since before #6893.
+        let tmp = TempDir::new().unwrap();
+        let backend = make_session_backend(tmp.path(), "completely-bogus-typo").unwrap();
+        backend.append("k1", &user_msg("hello-fallback")).unwrap();
+        let db = tmp.path().join("sessions").join("sessions.db");
+        assert!(
+            db.exists(),
+            "unknown value must fall back to sqlite, not error"
         );
     }
 }

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -53,10 +53,8 @@ pub fn make_session_backend(
         //
         // Until a given follow-up PR ships, that backend name resolves
         // to a `#[cfg(not(feature = "backend-<name>"))]` arm that
-        // hard-fails at startup. This is the deliberately explicit
-        // shape #6893 / WareWolf-MoonWall / Audacity88 /
-        // singlerider converged on after the SQLite silent-fallback
-        // regression: a known backend whose Cargo feature is not
+        // hard-fails at startup. This is a deliberately explicit
+        // shape: a known backend whose Cargo feature is not
         // compiled into this binary must NOT silently route sessions
         // to SQLite — that would split session history across a fleet.
         //
@@ -82,9 +80,8 @@ pub fn make_session_backend(
             // stay forgiving and route to the default local backend,
             // matching the pre-existing soft-fallback contract. The
             // WARN body inlines the actual offending string so the
-            // operator can spot the typo in their logs (vs. the empty
-            // interpolation the previous implementation emitted — see
-            // the post-mortem in the PR description for #6893).
+            // operator can spot the typo in their logs instead of an
+            // empty-interpolation message that hides the real value.
             let other = other.to_string();
             ::zeroclaw_log::record!(
                 WARN,
@@ -232,10 +229,9 @@ mod tests {
     // accepts as the spelling for an upcoming remote backend) must
     // hard-fail at startup when the matching Cargo feature is not
     // compiled into this binary, instead of silently routing
-    // sessions to the local SQLite/JSONL backend. The `#6893`
-    // review caught a silent SQLite fallback that would have
-    // shredded session history across a fleet once any operator
-    // enabled a remote backend in their config.
+    // sessions to the local SQLite/JSONL backend. A silent SQLite
+    // fallback here would shred session history across a fleet
+    // once any operator enabled a remote backend in their config.
 
     /// Drives `make_session_backend` for a single remote backend name
     /// and asserts the expected fail-fast contract: it returns an
@@ -297,7 +293,7 @@ mod tests {
 
     #[test]
     fn make_session_backend_unknown_value_warn_message_inlines_offending_value() {
-        // Regression guard for #6893 review: a past implementation
+        // Regression guard: an earlier implementation once
         // logged `Unknown session_backend ''; falling back to sqlite`
         // because the warn message was a static string with no
         // interpolation, so the operator could not see their typo in
@@ -339,7 +335,7 @@ mod tests {
         // unknown value (not in the five-remote-name set) is the
         // case the operator has misspelled their config; there is
         // no live connection at risk, so we keep the lenient
-        // fallback that has shipped since before #6893.
+        // fallback this factory has always used for that case.
         let tmp = TempDir::new().unwrap();
         let backend = make_session_backend(tmp.path(), "completely-bogus-typo").unwrap();
         backend.append("k1", &user_msg("hello-fallback")).unwrap();

--- a/crates/zeroclaw-infra/src/lib.rs
+++ b/crates/zeroclaw-infra/src/lib.rs
@@ -8,6 +8,29 @@ pub mod session_backend;
 pub mod session_queue;
 pub mod session_sqlite;
 pub mod session_store;
+// ── Multi-database session backend series (PR 2 of N) ─────────────────
+//
+// PR 2 of the resubmission series (foundation, then MySQL/MariaDB,
+// then Postgres, then Db2, then Oracle) lands the MySQL + MariaDB
+// driver implementations on top of the factory / `spawn_blocking`
+// plumbing from PR 1 (`feat/session-backend-foundation`, merged as
+// the series root).
+//
+// Both `backend-mysql` and `backend-mariadb` enable the same
+// `mysql` crate (MySQL and MariaDB speak the same wire protocol
+// and accept the same SQL for every operation we issue), so the
+// actual `SessionBackend` impl lives once in `session_mysql_shared`
+// and the two per-engine modules in `session_mysql.rs` /
+// `session_mariadb.rs` are thin newtype wrappers. The shared
+// module is `pub(crate)` because callers go through the wrappers
+// — the `Engine` enum is a private implementation detail
+// that an operator should never see.
+#[cfg(feature = "backend-mariadb")]
+pub mod session_mariadb;
+#[cfg(feature = "backend-mysql")]
+pub mod session_mysql;
+#[cfg(any(feature = "backend-mysql", feature = "backend-mariadb"))]
+pub(crate) mod session_mysql_shared;
 pub mod stall_watchdog;
 
 use std::net::SocketAddr;
@@ -67,8 +90,38 @@ pub fn make_session_backend(
         "postgres" => Err(uncompiled_backend_error("postgres")),
         #[cfg(not(feature = "backend-mysql"))]
         "mysql" => Err(uncompiled_backend_error("mysql")),
+        #[cfg(feature = "backend-mysql")]
+        "mysql" => {
+            // PR 2 of the multi-database session backend series
+            // (builds on PR 1 = `feat/session-backend-foundation`).
+            // The MySQL backend reads `ZEROCLAW_channels__mysql_url`
+            // (the canonical config-override env var documented on
+            // `ChannelsConfig.mysql_url`) and falls back to
+            // `ZEROCLAW_TEST_MYSQL_URL` for the live-DB integration
+            // tests. Pool size comes from
+            // `ZEROCLAW_channels__pool_size`.
+            let backend = session_mysql::MySqlSessionBackend::new(
+                workspace_dir,
+                crate::session_mysql_shared::read_pool_size(),
+            )?;
+            Ok(Arc::new(backend))
+        }
         #[cfg(not(feature = "backend-mariadb"))]
         "mariadb" => Err(uncompiled_backend_error("mariadb")),
+        #[cfg(feature = "backend-mariadb")]
+        "mariadb" => {
+            // Mirror of the MySQL arm above — distinct module so an
+            // operator selecting `session_backend = "mariadb"` sees a
+            // distinct error message in logs (vs
+            // `session_backend = "mysql"`). Reads
+            // `ZEROCLAW_channels__mariadb_url` then falls back to
+            // `ZEROCLAW_TEST_MARIADB_URL`.
+            let backend = session_mariadb::MariaDbSessionBackend::new(
+                workspace_dir,
+                crate::session_mysql_shared::read_pool_size(),
+            )?;
+            Ok(Arc::new(backend))
+        }
         #[cfg(not(feature = "backend-oracle"))]
         "oracle" => Err(uncompiled_backend_error("oracle")),
         #[cfg(not(feature = "backend-db2"))]
@@ -272,11 +325,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "backend-mysql"))]
     fn make_session_backend_mysql_fail_fast_when_feature_disabled() {
         assert_fail_fast_uncompiled("mysql");
     }
 
     #[test]
+    #[cfg(not(feature = "backend-mariadb"))]
     fn make_session_backend_mariadb_fail_fast_when_feature_disabled() {
         assert_fail_fast_uncompiled("mariadb");
     }

--- a/crates/zeroclaw-infra/src/session_mariadb.rs
+++ b/crates/zeroclaw-infra/src/session_mariadb.rs
@@ -1,0 +1,420 @@
+//! MariaDB backend for the multi-database session-persistence series.
+//!
+//! `MariaDbSessionBackend` is a thin distinct-type wrapper
+//! around [`crate::session_mysql_shared::MySqlBackend`]
+//! parameterised on the
+//! [`crate::session_mysql_shared::MariaDbTag`] marker. MariaDB
+//! speaks the same wire protocol as MySQL and accepts the same
+//! SQL for every operation we issue (CREATE TABLE / INSERT /
+//! SELECT / MATCH … AGAINST … / SHOW VARIABLES), so the actual
+//! implementation lives once in the shared module — see the
+//! engine-divergence notes there for the handful of places the
+//! two engines' SQL trivially differs (and where we deliberately
+//! keep the SQL identical so a future MySQL↔MariaDB migration
+//! is just a backend-name swap).
+//!
+//! Connection URL resolution (in priority order):
+//! 1. `ZEROCLAW_channels__mariadb_url` — the canonical config
+//!    injection point documented on the
+//!    `ChannelsConfig.mariadb_url` field.
+//! 2. `ZEROCLAW_TEST_MARIADB_URL` — a manual escape hatch used
+//!    by the live-DB integration tests in this module.
+
+use crate::session_backend::SessionBackend;
+use crate::session_mysql_shared::EngineTag;
+
+/// Synchronous, blocking MariaDB session backend. Wraps the same
+/// `mysql::Pool` and re-exports the shared `SessionBackend`
+/// implementation that lives in `session_mysql_shared`. Distinct
+/// from [`crate::session_mysql::MySqlSessionBackend`] only in
+/// engine tag (for log / error messages) and in the
+/// connection-URL env var it reads.
+pub struct MariaDbSessionBackend {
+    inner: crate::session_mysql_shared::MySqlBackend<crate::session_mysql_shared::MariaDbTag>,
+}
+
+impl MariaDbSessionBackend {
+    /// Construct a `MariaDbSessionBackend` against the
+    /// configured MariaDB URL.
+    pub fn new(workspace_dir: &std::path::Path, pool_size: u32) -> std::io::Result<Self> {
+        let _ = workspace_dir;
+        let url = read_mariadb_url()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "session_backend=mariadb requires ZEROCLAW_channels__mariadb_url \
+                 (or ZEROCLAW_TEST_MARIADB_URL in tests) to be set in the \
+                 environment. Populate `channels.mariadb_url` in your \
+                 config or inject it via the standard dotted-path \
+                 env-override — for example: \
+                 ZEROCLAW_channels__mariadb_url='mysql://user:pass@host:3306/db' \
+                 (MariaDB accepts the mysql:// URL scheme on the wire).",
+            )
+        })?;
+        let inner = crate::session_mysql_shared::MySqlBackend::<
+            crate::session_mysql_shared::MariaDbTag,
+        >::new_with(
+            &url,
+            pool_size,
+            crate::session_mysql_shared::MariaDbTag::NAME,
+        )?;
+        Ok(Self { inner })
+    }
+}
+
+impl SessionBackend for MariaDbSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<zeroclaw_api::model_provider::ChatMessage> {
+        SessionBackend::load(&self.inner, session_key)
+    }
+
+    fn load_with_timestamps(
+        &self,
+        session_key: &str,
+    ) -> Vec<crate::session_backend::TimestampedMessage> {
+        SessionBackend::load_with_timestamps(&self.inner, session_key)
+    }
+
+    fn append(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<()> {
+        SessionBackend::append(&self.inner, session_key, message)
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::remove_last(&self.inner, session_key)
+    }
+
+    fn update_last(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<bool> {
+        SessionBackend::update_last(&self.inner, session_key, message)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        SessionBackend::list_sessions(&self.inner)
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_sessions_with_metadata(&self.inner)
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        SessionBackend::cleanup_stale(&self.inner, ttl_hours)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_messages(&self.inner, session_key)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::delete_session(&self.inner, session_key)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        SessionBackend::rename_agent_attribution(&self.inner, from, to)
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::count_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        SessionBackend::session_exists(&self.inner, session_key)
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_name(&self.inner, session_key, name)
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_name(&self.inner, session_key)
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_agent_alias(&self.inner, session_key, agent_alias)
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_agent_alias(&self.inner, session_key)
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: crate::session_backend::SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_context(&self.inner, session_key, context)
+    }
+
+    fn get_session_metadata(
+        &self,
+        session_key: &str,
+    ) -> Option<crate::session_backend::SessionMetadata> {
+        SessionBackend::get_session_metadata(&self.inner, session_key)
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_state(&self.inner, session_key, state, turn_id)
+    }
+
+    fn get_session_state(
+        &self,
+        session_key: &str,
+    ) -> std::io::Result<Option<crate::session_backend::SessionState>> {
+        SessionBackend::get_session_state(&self.inner, session_key)
+    }
+
+    fn list_running_sessions(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_running_sessions(&self.inner)
+    }
+
+    fn list_stuck_sessions(
+        &self,
+        threshold_secs: u64,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_stuck_sessions(&self.inner, threshold_secs)
+    }
+
+    fn search(
+        &self,
+        query: &crate::session_backend::SessionQuery,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::search(&self.inner, query)
+    }
+
+    fn compact(&self, session_key: &str) -> std::io::Result<()> {
+        SessionBackend::compact(&self.inner, session_key)
+    }
+}
+
+/// Resolve the MariaDB connection URL from the canonical
+/// config-override env var, falling back to the test-only
+/// `ZEROCLAW_TEST_MARIADB_URL`.
+fn read_mariadb_url() -> std::io::Result<Option<String>> {
+    if let Ok(value) = std::env::var("ZEROCLAW_channels__mariadb_url") {
+        if value.trim().is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "ZEROCLAW_channels__mariadb_url is set but empty; \
+                 provide a mysql://user:pass@host:port/db URL.",
+            ));
+        }
+        return Ok(Some(value));
+    }
+    if let Ok(value) = std::env::var("ZEROCLAW_TEST_MARIADB_URL") {
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(value));
+    }
+    Ok(None)
+}
+
+// ── Live-DB integration tests (PR 2) ─────────────────────────────
+//
+// Mirrors `session_mysql::live_db_tests` for MariaDB. These
+// tests exercise the production code path against a real
+// MariaDB server and are gated by `ZEROCLAW_TEST_MARIADB_URL`:
+// default `cargo test` skips them (via `#[ignore]`); operators
+// who want to run them set the env var and use
+// `cargo test -p zeroclaw-infra --features backend-mariadb -- \
+//      --include-ignored mariadb_live`.
+//
+// Each test generates a unique session-key prefix
+// (`mariadb_live_<pid>_<nanos>_`) so concurrent CI jobs (or
+// reruns against the same operator database) cannot collide,
+// and cleans up its own session rows before returning. The
+// test bodies are intentionally identical in shape to the
+// MySQL live tests — MariaDB accepts the same SQL for every
+// operation we issue here, so the live asserts are
+// effectively a parallel-run regression on the shared
+// implementation.
+#[cfg(all(test, feature = "backend-mariadb"))]
+mod live_db_tests {
+    use super::*;
+    use crate::session_backend::SessionBackend;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use zeroclaw_api::model_provider::ChatMessage;
+
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_key(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = UNIQ.fetch_add(1, Ordering::Relaxed);
+        format!(
+            "mariadb_live_{}_{}_{nanos}_{n}_{prefix}",
+            std::process::id(),
+            prefix,
+        )
+    }
+
+    /// Returns `Some(backend)` when `ZEROCLAW_TEST_MARIADB_URL`
+    /// (or `ZEROCLAW_channels__mariadb_url`) is set and a real
+    /// MariaDB is reachable; `None` when the env var is unset
+    /// (so the test skips cleanly).
+    fn maybe_backend() -> Option<MariaDbSessionBackend> {
+        read_mariadb_url().ok().flatten()?;
+        let pool_size = 2;
+        // Tests use a per-invocation TempDir so the
+        // `workspace_dir` argument — which the MariaDB backend
+        // currently ignores — is hermetic.
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        match MariaDbSessionBackend::new(tmp.path(), pool_size) {
+            Ok(b) => Some(b),
+            Err(e) => {
+                eprintln!(
+                    "skipping mariadb live test: connection failed: {e}. \
+                     start a local MariaDB (e.g. `docker run -p 3306:3306 \
+                     -e MARIADB_ROOT_PASSWORD=root mariadb:11`) and set \
+                     ZEROCLAW_TEST_MARIADB_URL."
+                );
+                None
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("round_trip");
+        backend
+            .append(&key, &ChatMessage::user("hello mariadb"))
+            .expect("append user");
+        backend
+            .append(&key, &ChatMessage::assistant("hi there"))
+            .expect("append assistant");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "assistant");
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_metadata_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("metadata");
+        backend
+            .append(&key, &ChatMessage::user("a"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("b"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("c"))
+            .expect("append");
+        backend.set_session_name(&key, "MariaDB live test").unwrap();
+        backend
+            .set_session_agent_alias(&key, "live-test-agent")
+            .unwrap();
+        backend
+            .set_session_context(
+                &key,
+                crate::session_backend::SessionContext {
+                    channel_id: Some("discord.live"),
+                    room_id: Some("room-1"),
+                    sender_id: Some("user-1"),
+                },
+            )
+            .unwrap();
+
+        let meta = backend.get_session_metadata(&key).expect("metadata");
+        assert_eq!(meta.key, key);
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.name.as_deref(), Some("MariaDB live test"));
+        assert_eq!(meta.agent_alias.as_deref(), Some("live-test-agent"));
+        assert_eq!(meta.channel_id.as_deref(), Some("discord.live"));
+        assert_eq!(meta.room_id.as_deref(), Some("room-1"));
+        assert_eq!(meta.sender_id.as_deref(), Some("user-1"));
+
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_fulltext_search() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let k_match = unique_key("fts_match");
+        let k_skip = unique_key("fts_skip");
+        backend
+            .append(&k_match, &ChatMessage::user("How do I parse JSON in Rust?"))
+            .expect("append match");
+        backend
+            .append(&k_skip, &ChatMessage::user("What is the weather?"))
+            .expect("append skip");
+
+        let results = backend.search(&crate::session_backend::SessionQuery {
+            keyword: Some("Rust".into()),
+            limit: Some(10),
+        });
+        let keys: Vec<&str> = results.iter().map(|m| m.key.as_str()).collect();
+        assert!(
+            keys.contains(&k_match.as_str()),
+            "FULLTEXT search must return the matching session; got keys: {keys:?}"
+        );
+        assert!(
+            !keys.contains(&k_skip.as_str()),
+            "FULLTEXT search must not return the non-matching session; got keys: {keys:?}"
+        );
+
+        // Clean up
+        let _ = backend.delete_session(&k_match);
+        let _ = backend.delete_session(&k_skip);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MARIADB_URL pointing at a real MariaDB server"]
+    fn mariadb_live_factory_round_trip() {
+        // Verifies that when the test URL env var is set, the
+        // factory's mariadb arm constructs a real backend that
+        // satisfies the full SessionBackend trait via the trait
+        // object returned by `make_session_backend`. The other
+        // live tests exercise `MariaDbSessionBackend` directly;
+        // this one goes through the dispatch factory — the
+        // path operators actually hit at startup.
+        let Some(_) = read_mariadb_url().ok().flatten() else {
+            return;
+        };
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        let backend = match crate::make_session_backend(tmp.path(), "mariadb") {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping factory test: {e}");
+                return;
+            }
+        };
+        let key = unique_key("factory");
+        backend
+            .append(&key, &ChatMessage::user("via factory"))
+            .expect("append");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 1);
+        let _ = backend.delete_session(&key);
+    }
+}

--- a/crates/zeroclaw-infra/src/session_mysql.rs
+++ b/crates/zeroclaw-infra/src/session_mysql.rs
@@ -1,0 +1,420 @@
+//! MySQL backend for the multi-database session-persistence series.
+//!
+//! `MySqlSessionBackend` is a thin distinct-type wrapper around
+//! [`crate::session_mysql_shared::MySqlBackend`] parameterised on
+//! the [`crate::session_mysql_shared::MySqlTag`] marker. All
+//! actual SQL / connection-pool work lives in the shared module —
+//! this file exists so operators selecting
+//! `session_backend = "mysql"` see a distinct error message in
+//! logs (vs `session_backend = "mariadb"`) and so the per-engine
+//! Cargo feature (`backend-mysql`) gates the right module.
+//!
+//! Connection URL resolution (in priority order):
+//! 1. `ZEROCLAW_channels__mysql_url` — the canonical config
+//!    injection point documented on the `ChannelsConfig.mysql_url`
+//!    field. Read by `crate::env_overrides::apply_env_overrides`
+//!    at startup; we mirror that read here so the factory does
+//!    not need the loaded `Config` to construct a backend.
+//! 2. `ZEROCLAW_TEST_MYSQL_URL` — a manual escape hatch used by
+//!    the live-DB integration tests in this module.
+//!
+//! Pool size comes from `ZEROCLAW_channels__pool_size` (the shared
+//! `pool_size` config field added by PR 1).
+
+use crate::session_backend::SessionBackend;
+use crate::session_mysql_shared::EngineTag;
+
+/// Synchronous, blocking MySQL session backend. Wraps
+/// `mysql::Pool` (which the upstream `mysql` crate ships with)
+/// and re-exports the shared `SessionBackend` implementation that
+/// lives in `session_mysql_shared`. Distinct from
+/// [`crate::session_mariadb::MariaDbSessionBackend`] only in
+/// engine tag (for log / error messages) and in the
+/// connection-URL env var it reads.
+pub struct MySqlSessionBackend {
+    inner: crate::session_mysql_shared::MySqlBackend<crate::session_mysql_shared::MySqlTag>,
+}
+
+impl MySqlSessionBackend {
+    /// Construct a `MySqlSessionBackend` against the configured
+    /// MySQL URL.
+    ///
+    /// `workspace_dir` is currently unused by the MySQL backend
+    /// (persistence is fully off-machine) but kept in the
+    /// signature so the dispatcher in
+    /// [`crate::make_session_backend`] can pass it uniformly to
+    /// every backend constructor without per-engine branches.
+    pub fn new(workspace_dir: &std::path::Path, pool_size: u32) -> std::io::Result<Self> {
+        let _ = workspace_dir;
+        let url = read_mysql_url()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "session_backend=mysql requires ZEROCLAW_channels__mysql_url \
+                 (or ZEROCLAW_TEST_MYSQL_URL in tests) to be set in the \
+                 environment. Populate `channels.mysql_url` in your \
+                 config or inject it via the standard dotted-path \
+                 env-override — for example: \
+                 ZEROCLAW_channels__mysql_url='mysql://user:pass@host:3306/db'",
+            )
+        })?;
+        let inner = crate::session_mysql_shared::MySqlBackend::<
+            crate::session_mysql_shared::MySqlTag,
+        >::new_with(
+            &url, pool_size, crate::session_mysql_shared::MySqlTag::NAME
+        )?;
+        Ok(Self { inner })
+    }
+}
+
+impl SessionBackend for MySqlSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<zeroclaw_api::model_provider::ChatMessage> {
+        SessionBackend::load(&self.inner, session_key)
+    }
+
+    fn load_with_timestamps(
+        &self,
+        session_key: &str,
+    ) -> Vec<crate::session_backend::TimestampedMessage> {
+        SessionBackend::load_with_timestamps(&self.inner, session_key)
+    }
+
+    fn append(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<()> {
+        SessionBackend::append(&self.inner, session_key, message)
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::remove_last(&self.inner, session_key)
+    }
+
+    fn update_last(
+        &self,
+        session_key: &str,
+        message: &zeroclaw_api::model_provider::ChatMessage,
+    ) -> std::io::Result<bool> {
+        SessionBackend::update_last(&self.inner, session_key, message)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        SessionBackend::list_sessions(&self.inner)
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_sessions_with_metadata(&self.inner)
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        SessionBackend::cleanup_stale(&self.inner, ttl_hours)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_messages(&self.inner, session_key)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        SessionBackend::delete_session(&self.inner, session_key)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::clear_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        SessionBackend::rename_agent_attribution(&self.inner, from, to)
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        SessionBackend::count_agent_attribution(&self.inner, agent_alias)
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        SessionBackend::session_exists(&self.inner, session_key)
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_name(&self.inner, session_key, name)
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_name(&self.inner, session_key)
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        SessionBackend::set_session_agent_alias(&self.inner, session_key, agent_alias)
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        SessionBackend::get_session_agent_alias(&self.inner, session_key)
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: crate::session_backend::SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_context(&self.inner, session_key, context)
+    }
+
+    fn get_session_metadata(
+        &self,
+        session_key: &str,
+    ) -> Option<crate::session_backend::SessionMetadata> {
+        SessionBackend::get_session_metadata(&self.inner, session_key)
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        SessionBackend::set_session_state(&self.inner, session_key, state, turn_id)
+    }
+
+    fn get_session_state(
+        &self,
+        session_key: &str,
+    ) -> std::io::Result<Option<crate::session_backend::SessionState>> {
+        SessionBackend::get_session_state(&self.inner, session_key)
+    }
+
+    fn list_running_sessions(&self) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_running_sessions(&self.inner)
+    }
+
+    fn list_stuck_sessions(
+        &self,
+        threshold_secs: u64,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::list_stuck_sessions(&self.inner, threshold_secs)
+    }
+
+    fn search(
+        &self,
+        query: &crate::session_backend::SessionQuery,
+    ) -> Vec<crate::session_backend::SessionMetadata> {
+        SessionBackend::search(&self.inner, query)
+    }
+
+    fn compact(&self, session_key: &str) -> std::io::Result<()> {
+        SessionBackend::compact(&self.inner, session_key)
+    }
+}
+
+/// Resolve the MySQL connection URL from the canonical
+/// config-override env var, falling back to the test-only
+/// `ZEROCLAW_TEST_MYSQL_URL` so live-DB integration tests can
+/// skip env-setup by setting just one variable.
+fn read_mysql_url() -> std::io::Result<Option<String>> {
+    if let Ok(value) = std::env::var("ZEROCLAW_channels__mysql_url") {
+        if value.trim().is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "ZEROCLAW_channels__mysql_url is set but empty; \
+                 provide a mysql://user:pass@host:port/db URL.",
+            ));
+        }
+        return Ok(Some(value));
+    }
+    if let Ok(value) = std::env::var("ZEROCLAW_TEST_MYSQL_URL") {
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(value));
+    }
+    Ok(None)
+}
+
+// ── Live-DB integration tests (PR 2) ─────────────────────────────
+//
+// These tests exercise the production code path against a real
+// MySQL server and are gated by `ZEROCLAW_TEST_MYSQL_URL`:
+// default `cargo test` skips them (via `#[ignore]`); operators
+// who want to run them set the env var and use
+// `cargo test -p zeroclaw-infra --features backend-mysql -- \
+//      --include-ignored mysql_live`.
+//
+// Each test generates a unique session-key prefix
+// (`mysql_live_<pid>_<nanos>_`) so concurrent CI jobs (or
+// reruns against the same operator database) cannot collide,
+// and cleans up its own session rows before returning.
+#[cfg(all(test, feature = "backend-mysql"))]
+mod live_db_tests {
+    use super::*;
+    use crate::session_backend::SessionBackend;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use zeroclaw_api::model_provider::ChatMessage;
+
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_key(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = UNIQ.fetch_add(1, Ordering::Relaxed);
+        format!(
+            "mysql_live_{}_{}_{nanos}_{n}_{prefix}",
+            std::process::id(),
+            prefix,
+        )
+    }
+
+    /// Returns `Some(backend)` when `ZEROCLAW_TEST_MYSQL_URL`
+    /// (or `ZEROCLAW_channels__mysql_url`) is set and a real
+    /// MySQL is reachable; `None` when the env var is unset
+    /// (so the test skips cleanly).
+    fn maybe_backend() -> Option<MySqlSessionBackend> {
+        read_mysql_url().ok().flatten()?;
+        let pool_size = 2;
+        // Tests use a per-invocation TempDir so the
+        // `workspace_dir` argument — which the MySQL backend
+        // currently ignores — is hermetic.
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        match MySqlSessionBackend::new(tmp.path(), pool_size) {
+            Ok(b) => Some(b),
+            Err(e) => {
+                eprintln!(
+                    "skipping mysql live test: connection failed: {e}. \
+                     start a local MySQL (e.g. `docker run -p 3306:3306 \
+                     -e MYSQL_ROOT_PASSWORD=root mysql:8`) and set \
+                     ZEROCLAW_TEST_MYSQL_URL."
+                );
+                None
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("round_trip");
+        backend
+            .append(&key, &ChatMessage::user("hello mysql"))
+            .expect("append user");
+        backend
+            .append(&key, &ChatMessage::assistant("hi there"))
+            .expect("append assistant");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "assistant");
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_metadata_round_trip() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let key = unique_key("metadata");
+        backend
+            .append(&key, &ChatMessage::user("a"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("b"))
+            .expect("append");
+        backend
+            .append(&key, &ChatMessage::user("c"))
+            .expect("append");
+        backend.set_session_name(&key, "MySQL live test").unwrap();
+        backend
+            .set_session_agent_alias(&key, "live-test-agent")
+            .unwrap();
+        backend
+            .set_session_context(
+                &key,
+                crate::session_backend::SessionContext {
+                    channel_id: Some("discord.live"),
+                    room_id: Some("room-1"),
+                    sender_id: Some("user-1"),
+                },
+            )
+            .unwrap();
+
+        let meta = backend.get_session_metadata(&key).expect("metadata");
+        assert_eq!(meta.key, key);
+        assert_eq!(meta.message_count, 3);
+        assert_eq!(meta.name.as_deref(), Some("MySQL live test"));
+        assert_eq!(meta.agent_alias.as_deref(), Some("live-test-agent"));
+        assert_eq!(meta.channel_id.as_deref(), Some("discord.live"));
+        assert_eq!(meta.room_id.as_deref(), Some("room-1"));
+        assert_eq!(meta.sender_id.as_deref(), Some("user-1"));
+
+        // Clean up
+        let _ = backend.delete_session(&key);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_fulltext_search() {
+        let Some(backend) = maybe_backend() else {
+            return;
+        };
+        let k_match = unique_key("fts_match");
+        let k_skip = unique_key("fts_skip");
+        backend
+            .append(&k_match, &ChatMessage::user("How do I parse JSON in Rust?"))
+            .expect("append match");
+        backend
+            .append(&k_skip, &ChatMessage::user("What is the weather?"))
+            .expect("append skip");
+
+        let results = backend.search(&crate::session_backend::SessionQuery {
+            keyword: Some("Rust".into()),
+            limit: Some(10),
+        });
+        let keys: Vec<&str> = results.iter().map(|m| m.key.as_str()).collect();
+        assert!(
+            keys.contains(&k_match.as_str()),
+            "FULLTEXT search must return the matching session; got keys: {keys:?}"
+        );
+        assert!(
+            !keys.contains(&k_skip.as_str()),
+            "FULLTEXT search must not return the non-matching session; got keys: {keys:?}"
+        );
+
+        // Clean up
+        let _ = backend.delete_session(&k_match);
+        let _ = backend.delete_session(&k_skip);
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_MYSQL_URL pointing at a real MySQL server"]
+    fn mysql_live_factory_round_trip() {
+        // Verifies that when the test URL env var is set, the
+        // factory's mysql arm constructs a real backend that
+        // satisfies the full SessionBackend trait via the trait
+        // object returned by `make_session_backend`. The other
+        // live tests exercise `MySqlSessionBackend` directly;
+        // this one goes through the dispatch factory — the
+        // path operators actually hit at startup.
+        let Some(_) = read_mysql_url().ok().flatten() else {
+            return;
+        };
+        let tmp = tempfile::TempDir::new().expect("TempDir::new");
+        let backend = match crate::make_session_backend(tmp.path(), "mysql") {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping factory test: {e}");
+                return;
+            }
+        };
+        let key = unique_key("factory");
+        backend
+            .append(&key, &ChatMessage::user("via factory"))
+            .expect("append");
+        let msgs = backend.load(&key);
+        assert_eq!(msgs.len(), 1);
+        let _ = backend.delete_session(&key);
+    }
+}

--- a/crates/zeroclaw-infra/src/session_mysql_shared.rs
+++ b/crates/zeroclaw-infra/src/session_mysql_shared.rs
@@ -1,0 +1,921 @@
+//! Shared MySQL / MariaDB session-persistence implementation.
+//!
+//! MySQL and MariaDB speak the same wire protocol and accept the
+//! same SQL for every operation we use (CREATE TABLE / INSERT /
+//! SELECT / MATCH … AGAINST …). The two backends exposed to the
+//! factory (`MySqlSessionBackend`, `MariaDbSessionBackend`) are
+//! thin distinct-type wrappers around this shared `MySqlBackend`
+//! so callers can tell which engine they configured, but the
+//! connection pool, schema DDL, and query / mutation logic are
+//! genuinely identical and live here.
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use mysql::prelude::Queryable;
+use mysql::{Opts, OptsBuilder, Pool, PoolConstraints, PoolOpts, Value};
+use zeroclaw_api::model_provider::ChatMessage;
+
+use crate::session_backend::{
+    SessionBackend, SessionContext, SessionMetadata, SessionQuery, SessionState,
+};
+
+/// Tag marker — distinct zero-sized types so the two
+/// SessionBackend newtypes (`MySqlSessionBackend`,
+/// `MariaDbSessionBackend`) can be distinguished in error / log
+/// messages even though they're both sharing the same underlying
+/// `MySqlBackend<…>` data path.
+pub trait EngineTag {
+    const NAME: &'static str;
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Used only under backend-mysql.
+pub enum MySqlTag {}
+impl EngineTag for MySqlTag {
+    const NAME: &'static str = "mysql";
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // Used only under backend-mariadb.
+pub enum MariaDbTag {}
+impl EngineTag for MariaDbTag {
+    const NAME: &'static str = "mariadb";
+}
+
+/// Shared `SessionBackend` implementation for both MySQL and
+/// MariaDB. The `Tag` parameter exists purely for log /
+/// error-message differentiation; all data access goes through
+/// the single `pool` field below.
+pub struct MySqlBackend<Tag: EngineTag> {
+    pool: Pool,
+    engine_name: &'static str,
+    _tag: std::marker::PhantomData<Tag>,
+}
+
+impl<Tag: EngineTag + Send + Sync> MySqlBackend<Tag> {
+    pub fn new_with(url: &str, pool_size: u32, engine_name: &'static str) -> std::io::Result<Self> {
+        let pool_size = usize::try_from(pool_size).unwrap_or(1).max(1);
+        let opts = build_opts(url, pool_size)?;
+        let pool = Pool::new(opts).map_err(|e| map_mysql_err(engine_name, e))?;
+        let backend = Self {
+            pool,
+            engine_name,
+            _tag: std::marker::PhantomData,
+        };
+        backend.ensure_schema()?;
+        Ok(backend)
+    }
+
+    fn engine_name(&self) -> &'static str {
+        self.engine_name
+    }
+
+    /// Run `op` against a pooled connection. The closure is
+    /// expected to return `std::io::Result<T>` so callers can
+    /// use `?` to short-circuit and convert mysql errors via
+    /// `map_mysql_err` inline.
+    fn with_conn<F, T>(&self, op: F) -> std::io::Result<T>
+    where
+        F: FnOnce(&mut mysql::PooledConn) -> std::io::Result<T>,
+    {
+        let mut conn = self
+            .pool
+            .get_conn()
+            .map_err(|e| map_mysql_err(self.engine_name, e))?;
+        op(&mut conn)
+    }
+
+    fn ensure_schema(&self) -> std::io::Result<()> {
+        let en = self.engine_name();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.query_drop(
+                "CREATE TABLE IF NOT EXISTS sessions (
+                    id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                    session_key VARCHAR(512) NOT NULL,
+                    role        VARCHAR(64) NOT NULL,
+                    content     MEDIUMTEXT NOT NULL,
+                    created_at  DATETIME(3) NOT NULL,
+                    KEY idx_sessions_key (session_key),
+                    KEY idx_sessions_key_id (session_key, id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            conn.query_drop(
+                "CREATE TABLE IF NOT EXISTS session_metadata (
+                    session_key    VARCHAR(512) NOT NULL PRIMARY KEY,
+                    created_at     DATETIME(3) NOT NULL,
+                    last_activity  DATETIME(3) NOT NULL,
+                    message_count  BIGINT NOT NULL DEFAULT 0,
+                    name           VARCHAR(255) NULL,
+                    state          VARCHAR(32) NOT NULL DEFAULT 'idle',
+                    turn_id        VARCHAR(255) NULL,
+                    turn_started_at DATETIME(3) NULL,
+                    agent_alias    VARCHAR(255) NULL,
+                    channel_id     VARCHAR(255) NULL,
+                    room_id        VARCHAR(255) NULL,
+                    sender_id      VARCHAR(255) NULL,
+                    KEY idx_session_metadata_agent_alias (agent_alias),
+                    KEY idx_session_metadata_channel_id (channel_id),
+                    KEY idx_session_metadata_room_id (room_id),
+                    KEY idx_session_metadata_sender_id (sender_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            let _ = conn.query_drop(
+                "CREATE FULLTEXT INDEX idx_sessions_content_fulltext ON sessions(content)",
+            );
+            Ok(())
+        })
+    }
+
+    fn now_value() -> Value {
+        let nd = Utc::now().naive_utc();
+        let formatted = nd.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+        Value::Bytes(formatted.into_bytes())
+    }
+
+    fn parse_dt(value: Value) -> Option<DateTime<Utc>> {
+        match value {
+            Value::Date(y, m, d, h, mi, s, us) => {
+                let date = chrono::NaiveDate::from_ymd_opt(y.into(), m.into(), d.into())?;
+                let time = chrono::NaiveTime::from_hms_micro_opt(
+                    u32::from(h),
+                    u32::from(mi),
+                    u32::from(s),
+                    us,
+                )?;
+                Some(chrono::NaiveDateTime::new(date, time).and_utc())
+            }
+            Value::Bytes(bytes) => {
+                let s = std::str::from_utf8(&bytes).ok()?;
+                for fmt in [
+                    "%Y-%m-%d %H:%M:%S%.3f",
+                    "%Y-%m-%d %H:%M:%S",
+                    "%Y-%m-%dT%H:%M:%S%.3f",
+                    "%Y-%m-%dT%H:%M:%S",
+                ] {
+                    if let Ok(nd) = NaiveDateTime::parse_from_str(s, fmt) {
+                        return Some(nd.and_utc());
+                    }
+                }
+                DateTime::parse_from_rfc3339(s)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            }
+            Value::NULL => None,
+            _ => None,
+        }
+    }
+
+    fn row_to_metadata(
+        key: String,
+        created: Value,
+        activity: Value,
+        count: i64,
+        name: Option<String>,
+        agent_alias: Option<String>,
+        channel_id: Option<String>,
+        room_id: Option<String>,
+        sender_id: Option<String>,
+    ) -> SessionMetadata {
+        let created_at = Self::parse_dt(created).unwrap_or_else(Utc::now);
+        let last_activity = Self::parse_dt(activity).unwrap_or_else(Utc::now);
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        let message_count = count.max(0) as usize;
+        SessionMetadata {
+            key,
+            name,
+            created_at,
+            last_activity,
+            message_count,
+            agent_alias,
+            channel_id,
+            room_id,
+            sender_id,
+        }
+    }
+
+    fn row_to_state(state: String, turn_id: Option<String>, started: Value) -> SessionState {
+        SessionState {
+            state,
+            turn_id,
+            turn_started_at: Self::parse_dt(started),
+        }
+    }
+}
+
+fn build_opts(url: &str, pool_size: usize) -> std::io::Result<Opts> {
+    let constraints =
+        PoolConstraints::new(pool_size, pool_size).unwrap_or(PoolConstraints::DEFAULT);
+    let pool_opts = PoolOpts::default().with_constraints(constraints);
+    let opts = Opts::from_url(url).map_err(map_url_err)?;
+    let opts: Opts = OptsBuilder::from_opts(opts).pool_opts(pool_opts).into();
+    Ok(opts)
+}
+
+fn map_url_err(e: mysql::UrlError) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!("session URL is not a valid mysql:// URL: {e}"),
+    )
+}
+
+fn map_mysql_err(engine: &'static str, e: mysql::Error) -> std::io::Error {
+    // Map mysql::Error variants to std::io::ErrorKind. The
+    // upstream `mysql::Error` enum is non-exhaustive across
+    // upstream versions (new variants land in patch releases),
+    // so we MUST include a wildcard arm to compile against
+    // versions that introduce new variants. We pick Other for
+    // every known variant that doesn't already have a more
+    // specific category.
+    let kind = match &e {
+        mysql::Error::IoError(_) => std::io::ErrorKind::Other,
+        mysql::Error::CodecError(_) => std::io::ErrorKind::Other,
+        mysql::Error::MySqlError(_) => std::io::ErrorKind::Other,
+        mysql::Error::DriverError(_) => std::io::ErrorKind::Other,
+        mysql::Error::UrlError(_) => std::io::ErrorKind::InvalidInput,
+        mysql::Error::FromValueError(_) => std::io::ErrorKind::InvalidData,
+        mysql::Error::FromRowError(_) => std::io::ErrorKind::InvalidData,
+        #[allow(unreachable_patterns)]
+        _ => std::io::ErrorKind::Other,
+    };
+    std::io::Error::new(kind, format!("session_backend={engine}: {e}"))
+}
+
+impl<Tag: EngineTag + Send + Sync> SessionBackend for MySqlBackend<Tag> {
+    fn load(&self, session_key: &str) -> Vec<ChatMessage> {
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<(String, String)>> {
+            conn.exec(
+                "SELECT role, content FROM sessions WHERE session_key = ? ORDER BY id ASC",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(role, content)| ChatMessage { role, content })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn load_with_timestamps(
+        &self,
+        session_key: &str,
+    ) -> Vec<crate::session_backend::TimestampedMessage> {
+        use crate::session_backend::TimestampedMessage;
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<(String, String, Value)>> {
+            conn.exec(
+                "SELECT role, content, created_at FROM sessions \
+                     WHERE session_key = ? ORDER BY id ASC",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(role, content, created_at)| TimestampedMessage {
+                    message: ChatMessage { role, content },
+                    created_at: MySqlBackend::<Tag>::parse_dt(created_at),
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn append(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let now = MySqlBackend::<Tag>::now_value();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "INSERT INTO sessions (session_key, role, content, created_at) \
+                 VALUES (?, ?, ?, ?)",
+                (session_key, &message.role, &message.content, now.clone()),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            conn.exec_drop(
+                "INSERT INTO session_metadata \
+                    (session_key, created_at, last_activity, message_count) \
+                 VALUES (?, ?, ?, 1) \
+                 ON DUPLICATE KEY UPDATE \
+                    last_activity = VALUES(last_activity), \
+                    message_count = message_count + 1",
+                (session_key, now.clone(), now.clone()),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            Ok(())
+        })
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        let en = self.engine_name();
+        let row_id: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT id FROM sessions WHERE session_key = ? ORDER BY id DESC LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let Some(id) = row_id else {
+            return Ok(false);
+        };
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop("DELETE FROM sessions WHERE id = ?", (id,))
+                .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let now = MySqlBackend::<Tag>::now_value();
+        let _ = self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET message_count = GREATEST(message_count - 1, 0), \
+                                       last_activity = ? \
+                 WHERE session_key = ?",
+                (now, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        Ok(true)
+    }
+
+    fn update_last(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<bool> {
+        let en = self.engine_name();
+        let row_id: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT id FROM sessions WHERE session_key = ? ORDER BY id DESC LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let Some(id) = row_id else {
+            return Ok(false);
+        };
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE sessions SET role = ?, content = ? WHERE id = ?",
+                (&message.role, &message.content, id),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let now = MySqlBackend::<Tag>::now_value();
+        let _ = self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET last_activity = ? WHERE session_key = ?",
+                (now, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        Ok(true)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<String>> {
+            conn.query("SELECT session_key FROM session_metadata ORDER BY last_activity DESC")
+                .map_err(|e| map_mysql_err(en, e))
+        });
+        result.unwrap_or_default()
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.query(
+                "SELECT session_key, created_at, last_activity, message_count, \
+                        name, agent_alias, channel_id, room_id, sender_id \
+                 FROM session_metadata ORDER BY last_activity DESC",
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let cutoff_stmt = format!(
+            "SELECT session_key FROM session_metadata \
+             WHERE last_activity < DATE_SUB(UTC_TIMESTAMP(3), INTERVAL {ttl_hours} HOUR)"
+        );
+        let stale: Vec<String> = self.with_conn(|conn| -> std::io::Result<Vec<String>> {
+            conn.query(cutoff_stmt.as_str())
+                .map_err(|e| map_mysql_err(en, e))
+        })?;
+        let count = stale.len();
+        for key in stale {
+            let _ = self.with_conn(|conn| -> std::io::Result<()> {
+                conn.exec_drop("DELETE FROM sessions WHERE session_key = ?", (key.clone(),))
+                    .map_err(|e| map_mysql_err(en, e))
+            });
+            let _ = self.with_conn(|conn| -> std::io::Result<()> {
+                conn.exec_drop("DELETE FROM session_metadata WHERE session_key = ?", (key,))
+                    .map_err(|e| map_mysql_err(en, e))
+            });
+        }
+        Ok(count)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let affected: u64 = self.with_conn(|conn| -> std::io::Result<u64> {
+            conn.exec_drop("DELETE FROM sessions WHERE session_key = ?", (session_key,))
+                .map_err(|e| map_mysql_err(en, e))?;
+            Ok(conn.affected_rows())
+        })?;
+        let count = affected as usize;
+        if count > 0 {
+            let now = MySqlBackend::<Tag>::now_value();
+            let _ = self.with_conn(|conn| -> std::io::Result<()> {
+                conn.exec_drop(
+                    "UPDATE session_metadata SET message_count = 0, last_activity = ? \
+                     WHERE session_key = ?",
+                    (now, session_key),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            });
+        }
+        Ok(count)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        let en = self.engine_name();
+        let exists: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT 1 FROM session_metadata WHERE session_key = ? LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        if exists.is_none() {
+            return Ok(false);
+        }
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop("DELETE FROM sessions WHERE session_key = ?", (session_key,))
+                .map_err(|e| map_mysql_err(en, e))
+        })?;
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "DELETE FROM session_metadata WHERE session_key = ?",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        Ok(true)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let affected: u64 = self.with_conn(|conn| -> std::io::Result<u64> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET agent_alias = NULL WHERE agent_alias = ?",
+                (agent_alias,),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            Ok(conn.affected_rows())
+        })?;
+        Ok(affected as usize)
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let affected: u64 = self.with_conn(|conn| -> std::io::Result<u64> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET agent_alias = ? WHERE agent_alias = ?",
+                (to, from),
+            )
+            .map_err(|e| map_mysql_err(en, e))?;
+            Ok(conn.affected_rows())
+        })?;
+        Ok(affected as usize)
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let en = self.engine_name();
+        let count: Option<i64> = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT COUNT(*) FROM session_metadata WHERE agent_alias = ?",
+                (agent_alias,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })?;
+        Ok(count.unwrap_or(0).max(0) as usize)
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        let en = self.engine_name();
+        let exists_result = self.with_conn(|conn| -> std::io::Result<Option<i64>> {
+            conn.exec_first(
+                "SELECT 1 FROM session_metadata WHERE session_key = ? LIMIT 1",
+                (session_key,),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        // exists_result is `io::Result<Option<i64>>`. A DB
+        // error returns Err (which we silently absorb per the
+        // trait contract that `session_exists` cannot fail);
+        // a missing row unwraps to None; a present row unwraps
+        // to Some(1).
+        exists_result.ok().and_then(|inner| inner).is_some()
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let name_val = if name.is_empty() { None } else { Some(name) };
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata SET name = ? WHERE session_key = ?",
+                (name_val, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let en = self.engine_name();
+        let name: Option<Option<String>> =
+            self.with_conn(|conn| -> std::io::Result<Option<Option<String>>> {
+                conn.exec_first(
+                    "SELECT name FROM session_metadata WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })?;
+        // Flatten the Option<Option<String>>: outer Some means
+        // a row matched, inner Option reflects NULL column.
+        Ok(name.flatten())
+    }
+
+    fn get_session_metadata(&self, session_key: &str) -> Option<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let row: Option<Row> = self
+            .with_conn(|conn| -> std::io::Result<Option<Row>> {
+                conn.exec_first(
+                    "SELECT session_key, created_at, last_activity, message_count, \
+                            name, agent_alias, channel_id, room_id, sender_id \
+                     FROM session_metadata WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })
+            .ok()
+            .flatten();
+        let (key, created, activity, count, name, agent, channel, room, sender) = row?;
+        Some(MySqlBackend::<Tag>::row_to_metadata(
+            key, created, activity, count, name, agent, channel, room, sender,
+        ))
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let now = MySqlBackend::<Tag>::now_value();
+        let started: Option<Value> = if state == "running" {
+            Some(now.clone())
+        } else {
+            None
+        };
+        // turn_id may be Some("") or Some(&str) — store NULL for empty.
+        let turn_id_val: Option<String> = turn_id.filter(|s| !s.is_empty()).map(|s| s.to_string());
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "UPDATE session_metadata \
+                 SET state = ?, turn_id = ?, turn_started_at = ? \
+                 WHERE session_key = ?",
+                (state, turn_id_val, started, session_key),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+
+    fn get_session_state(&self, session_key: &str) -> std::io::Result<Option<SessionState>> {
+        type Row = (String, Option<String>, Option<Value>);
+        let en = self.engine_name();
+        let row: Option<Row> = self
+            .with_conn(|conn| -> std::io::Result<Option<Row>> {
+                conn.exec_first(
+                    "SELECT state, turn_id, turn_started_at FROM session_metadata \
+                     WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })
+            .ok()
+            .flatten();
+        let (state, turn_id, started) = match row {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        let started = started.unwrap_or(Value::NULL);
+        Ok(Some(MySqlBackend::<Tag>::row_to_state(
+            state, turn_id, started,
+        )))
+    }
+
+    fn list_running_sessions(&self) -> Vec<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.query(
+                "SELECT session_key, created_at, last_activity, message_count, \
+                        name, agent_alias, channel_id, room_id, sender_id \
+                 FROM session_metadata \
+                 WHERE state = 'running' \
+                 ORDER BY turn_started_at DESC",
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn list_stuck_sessions(&self, threshold_secs: u64) -> Vec<SessionMetadata> {
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let en = self.engine_name();
+        let stmt = format!(
+            "SELECT session_key, created_at, last_activity, message_count, \
+                    name, agent_alias, channel_id, room_id, sender_id \
+             FROM session_metadata \
+             WHERE state = 'running' \
+               AND turn_started_at < DATE_SUB(UTC_TIMESTAMP(3), INTERVAL {threshold_secs} SECOND) \
+             ORDER BY turn_started_at ASC"
+        );
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.query(stmt.as_str()).map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn search(&self, query: &SessionQuery) -> Vec<SessionMetadata> {
+        let Some(keyword) = query.keyword.as_deref() else {
+            return self.list_sessions_with_metadata();
+        };
+        let limit = query.limit.unwrap_or(50) as i64;
+        let en = self.engine_name();
+        let fts_query = build_fts_query(keyword);
+        let stmt = format!(
+            "SELECT DISTINCT session_key \
+             FROM sessions \
+             WHERE MATCH(content) AGAINST (? IN NATURAL LANGUAGE MODE) \
+             LIMIT {limit}"
+        );
+        let keys: Vec<String> = match self.with_conn(|conn| -> std::io::Result<Vec<String>> {
+            conn.exec(stmt.as_str(), (fts_query.as_str(),))
+                .map_err(|e| map_mysql_err(en, e))
+        }) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        if keys.is_empty() {
+            return Vec::new();
+        }
+        let placeholders = keys.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let meta_stmt = format!(
+            "SELECT session_key, created_at, last_activity, message_count, \
+                    name, agent_alias, channel_id, room_id, sender_id \
+             FROM session_metadata WHERE session_key IN ({placeholders})"
+        );
+        type Row = (
+            String,
+            Value,
+            Value,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
+        let params: mysql::Params = mysql::Params::from(keys);
+        let result = self.with_conn(|conn| -> std::io::Result<Vec<Row>> {
+            conn.exec(meta_stmt.as_str(), params)
+                .map_err(|e| map_mysql_err(en, e))
+        });
+        match result {
+            Ok(rows) => rows
+                .into_iter()
+                .map(
+                    |(key, created, activity, count, name, agent, channel, room, sender)| {
+                        MySqlBackend::<Tag>::row_to_metadata(
+                            key, created, activity, count, name, agent, channel, room, sender,
+                        )
+                    },
+                )
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let alias_val = if agent_alias.is_empty() {
+            None
+        } else {
+            Some(agent_alias)
+        };
+        let now = MySqlBackend::<Tag>::now_value();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "INSERT INTO session_metadata \
+                    (session_key, created_at, last_activity, message_count, agent_alias) \
+                 VALUES (?, ?, ?, 0, ?) \
+                 ON DUPLICATE KEY UPDATE agent_alias = VALUES(agent_alias)",
+                (session_key, now.clone(), now.clone(), alias_val),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let en = self.engine_name();
+        let alias: Option<Option<String>> =
+            self.with_conn(|conn| -> std::io::Result<Option<Option<String>>> {
+                conn.exec_first(
+                    "SELECT agent_alias FROM session_metadata WHERE session_key = ?",
+                    (session_key,),
+                )
+                .map_err(|e| map_mysql_err(en, e))
+            })?;
+        Ok(alias.flatten())
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        let en = self.engine_name();
+        let normalize = |v: Option<&str>| -> Option<String> {
+            v.map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        };
+        let channel_id = normalize(context.channel_id);
+        let room_id = normalize(context.room_id);
+        let sender_id = normalize(context.sender_id);
+        let now = MySqlBackend::<Tag>::now_value();
+        self.with_conn(|conn| -> std::io::Result<()> {
+            conn.exec_drop(
+                "INSERT INTO session_metadata \
+                    (session_key, created_at, last_activity, message_count, \
+                     channel_id, room_id, sender_id) \
+                 VALUES (?, ?, ?, 0, ?, ?, ?) \
+                 ON DUPLICATE KEY UPDATE \
+                    channel_id = COALESCE(VALUES(channel_id), channel_id), \
+                    room_id    = COALESCE(VALUES(room_id),    room_id), \
+                    sender_id  = COALESCE(VALUES(sender_id),  sender_id)",
+                (
+                    session_key,
+                    now.clone(),
+                    now.clone(),
+                    channel_id,
+                    room_id,
+                    sender_id,
+                ),
+            )
+            .map_err(|e| map_mysql_err(en, e))
+        })
+    }
+}
+
+/// Build a MATCH … AGAINST clause payload from a free-text
+/// keyword.
+fn build_fts_query(keyword: &str) -> String {
+    keyword
+        .split_whitespace()
+        .filter(|w| !w.is_empty())
+        .map(|w| format!("\"{w}\""))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Resolve the shared `pool_size` config field, mirroring the
+/// foundation PR's `default_session_pool_size` of 5. Operators
+/// who want to override set `ZEROCLAW_channels__pool_size=<int>`.
+/// This is the same dotted-path env override
+/// `crate::env_overrides` injects into `channels.pool_size`;
+/// reading it directly here matches that contract.
+pub(crate) fn read_pool_size() -> u32 {
+    std::env::var("ZEROCLAW_channels__pool_size")
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dt_handles_textual_form() {
+        let v = Value::Bytes(b"2026-07-21 20:00:00.123".to_vec());
+        let dt = MySqlBackend::<MySqlTag>::parse_dt(v).expect("parses textual");
+        assert_eq!(dt.to_rfc3339(), "2026-07-21T20:00:00.123+00:00");
+    }
+
+    #[test]
+    fn parse_dt_handles_binary_form() {
+        let v = Value::Date(2026, 7, 21, 20, 0, 0, 0);
+        let dt = MySqlBackend::<MySqlTag>::parse_dt(v).expect("parses binary");
+        assert_eq!(dt.to_rfc3339(), "2026-07-21T20:00:00+00:00");
+    }
+
+    #[test]
+    fn parse_dt_handles_null() {
+        let dt = MySqlBackend::<MySqlTag>::parse_dt(Value::NULL);
+        assert!(dt.is_none());
+    }
+
+    #[test]
+    fn fts_query_quotes_each_token() {
+        let q = build_fts_query("rust async (best)");
+        assert_eq!(q, "\"rust\" \"async\" \"(best)\"");
+    }
+
+    #[test]
+    fn fts_query_empty_yields_empty_string() {
+        let q = build_fts_query("   \t  \n ");
+        assert_eq!(q, "");
+    }
+}

--- a/crates/zeroclaw-infra/src/session_oracle.rs
+++ b/crates/zeroclaw-infra/src/session_oracle.rs
@@ -1,0 +1,1058 @@
+//! Oracle-backed session persistence.
+//!
+//! The backend stores ordered messages in `sessions`; that table is the source
+//! of truth for message content and timestamps. `session_metadata` is the source
+//! of truth for names, routing attribution, activity counters, and turn state.
+//!
+//! The synchronous [`oracle`] crate embeds ODPI-C, which is compiled with a C
+//! compiler, and loads Oracle Client 11.2 or newer at runtime. Operators must
+//! install Oracle Instant Client or a full Oracle Client and make its shared
+//! libraries discoverable by the platform loader. The Oracle Client package may
+//! have additional operating-system dependencies (commonly `libaio` on Linux).
+//! The driver uses OCI's native homogeneous session pool.
+
+use std::fmt::Display;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use oracle::pool::{GetMode, Pool, PoolBuilder};
+use oracle::sql_type::OracleType;
+use oracle::{Connection, Row};
+use zeroclaw_api::model_provider::ChatMessage;
+
+use crate::session_backend::{
+    SessionBackend, SessionContext, SessionMetadata, SessionQuery, SessionState, TimestampedMessage,
+};
+
+/// Synchronous Oracle session store backed by an OCI session pool.
+pub struct OracleSessionBackend {
+    pool: Pool,
+}
+
+impl OracleSessionBackend {
+    /// Construct the backend from the canonical channel configuration
+    /// environment overrides and initialize its schema.
+    pub fn new(workspace_dir: &Path, pool_size: u32) -> std::io::Result<Self> {
+        let _ = workspace_dir;
+        let credentials = read_oracle_credentials()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "session_backend=oracle requires ZEROCLAW_channels__oracle_user, \
+                 ZEROCLAW_channels__oracle_password, and ZEROCLAW_channels__oracle_dsn \
+                 (or ZEROCLAW_TEST_ORACLE_URL in tests) to be set. Populate the \
+                 channels.oracle_* fields or inject them through the standard \
+                 dotted-path environment overrides.",
+            )
+        })?;
+        Self::new_with_credentials(
+            &credentials.user,
+            &credentials.password,
+            &credentials.dsn,
+            pool_size,
+        )
+    }
+
+    fn new_with_credentials(
+        user: &str,
+        password: &str,
+        dsn: &str,
+        pool_size: u32,
+    ) -> std::io::Result<Self> {
+        let max_connections = pool_size.max(1);
+        let mut builder = PoolBuilder::new(user, password, dsn);
+        builder
+            .min_connections(1)
+            .max_connections(max_connections)
+            .connection_increment(u32::from(max_connections > 1))
+            .get_mode(GetMode::TimedWait(std::time::Duration::from_secs(30)))
+            .driver_name("zeroclaw-session");
+        let pool = builder
+            .build()
+            .map_err(|error| oracle_error("build connection pool", error))?;
+        let backend = Self { pool };
+        backend.ensure_schema()?;
+        Ok(backend)
+    }
+
+    fn conn(&self) -> std::io::Result<Connection> {
+        self.pool
+            .get()
+            .map_err(|error| oracle_error("checkout pooled connection", error))
+    }
+
+    fn with_transaction<T>(
+        &self,
+        context: &str,
+        operation: impl FnOnce(&Connection) -> std::io::Result<T>,
+    ) -> std::io::Result<T> {
+        let conn = self.conn()?;
+        match operation(&conn) {
+            Ok(value) => match conn.commit() {
+                Ok(()) => Ok(value),
+                Err(commit_error) => {
+                    let rollback = conn.rollback();
+                    Err(transaction_error(context, commit_error, rollback.err()))
+                }
+            },
+            Err(operation_error) => match conn.rollback() {
+                Ok(()) => Err(operation_error),
+                Err(rollback_error) => Err(std::io::Error::other(format!(
+                    "{operation_error}; rollback after {context} also failed: {rollback_error}"
+                ))),
+            },
+        }
+    }
+
+    fn ensure_schema(&self) -> std::io::Result<()> {
+        let conn = self.conn()?;
+        for ddl in [
+            "CREATE TABLE sessions (
+                id          NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                session_key VARCHAR2(512 CHAR)            NOT NULL,
+                role        VARCHAR2(64 CHAR)             NOT NULL,
+                content     CLOB                          NOT NULL,
+                created_at  TIMESTAMP WITH TIME ZONE      DEFAULT SYSTIMESTAMP NOT NULL
+             )",
+            "CREATE INDEX idx_sessions_key ON sessions(session_key)",
+            "CREATE INDEX idx_sessions_key_id ON sessions(session_key, id)",
+            "CREATE TABLE session_metadata (
+                session_key      VARCHAR2(512 CHAR)       PRIMARY KEY,
+                created_at       TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+                last_activity    TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+                message_count    NUMBER(19)               DEFAULT 0 NOT NULL,
+                name             VARCHAR2(1024 CHAR),
+                state            VARCHAR2(64 CHAR)        DEFAULT 'idle' NOT NULL,
+                turn_id          VARCHAR2(512 CHAR),
+                turn_started_at  TIMESTAMP WITH TIME ZONE,
+                agent_alias      VARCHAR2(512 CHAR),
+                channel_id       VARCHAR2(512 CHAR),
+                room_id          VARCHAR2(512 CHAR),
+                sender_id        VARCHAR2(512 CHAR)
+             )",
+        ] {
+            execute_ddl_ignoring(&conn, ddl, &[955])?;
+        }
+
+        for ddl in [
+            "ALTER TABLE session_metadata ADD (name VARCHAR2(1024 CHAR))",
+            "ALTER TABLE session_metadata ADD (state VARCHAR2(64 CHAR) DEFAULT 'idle' NOT NULL)",
+            "ALTER TABLE session_metadata ADD (turn_id VARCHAR2(512 CHAR))",
+            "ALTER TABLE session_metadata ADD (turn_started_at TIMESTAMP WITH TIME ZONE)",
+            "ALTER TABLE session_metadata ADD (agent_alias VARCHAR2(512 CHAR))",
+            "ALTER TABLE session_metadata ADD (channel_id VARCHAR2(512 CHAR))",
+            "ALTER TABLE session_metadata ADD (room_id VARCHAR2(512 CHAR))",
+            "ALTER TABLE session_metadata ADD (sender_id VARCHAR2(512 CHAR))",
+        ] {
+            execute_ddl_ignoring(&conn, ddl, &[1430])?;
+        }
+
+        for ddl in [
+            "CREATE INDEX idx_smeta_agent ON session_metadata(agent_alias)",
+            "CREATE INDEX idx_smeta_channel ON session_metadata(channel_id)",
+            "CREATE INDEX idx_smeta_room ON session_metadata(room_id)",
+            "CREATE INDEX idx_smeta_sender ON session_metadata(sender_id)",
+        ] {
+            execute_ddl_ignoring(&conn, ddl, &[955])?;
+        }
+
+        self.ensure_oracle_text_index(&conn)
+    }
+
+    fn ensure_oracle_text_index(&self, conn: &Connection) -> std::io::Result<()> {
+        let exists: i64 = conn
+            .query_row_as(
+                "SELECT COUNT(*) FROM user_indexes \
+                 WHERE index_name = 'IDX_SESSIONS_CONTENT_CTX'",
+                &[],
+            )
+            .map_err(|error| oracle_error("inspect Oracle Text index", error))?;
+        if exists > 0 {
+            return Ok(());
+        }
+
+        if let Err(error) = conn.execute(
+            "CREATE INDEX idx_sessions_content_ctx ON sessions(content) \
+             INDEXTYPE IS CTXSYS.CONTEXT PARAMETERS ('SYNC (ON COMMIT)')",
+            &[],
+        ) {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": error.to_string()})),
+                "session_backend=oracle: Oracle Text CONTEXT index is unavailable; search will use a case-insensitive CLOB scan"
+            );
+        }
+        Ok(())
+    }
+
+    fn oracle_text_index_available(&self, conn: &Connection) -> bool {
+        conn.query_row_as::<i64>(
+            "SELECT COUNT(*) FROM user_indexes \
+             WHERE index_name = 'IDX_SESSIONS_CONTENT_CTX' AND status = 'VALID'",
+            &[],
+        )
+        .is_ok_and(|count| count > 0)
+    }
+
+    fn metadata_columns() -> &'static str {
+        "session_key, name, created_at, last_activity, message_count, \
+         agent_alias, channel_id, room_id, sender_id"
+    }
+
+    fn search_oracle_text(
+        &self,
+        conn: &Connection,
+        text_query: &str,
+        limit: i64,
+    ) -> oracle::Result<Vec<SessionMetadata>> {
+        let sql = format!(
+            "SELECT {} FROM session_metadata m \
+             WHERE EXISTS ( \
+                 SELECT 1 FROM sessions s \
+                 WHERE s.session_key = m.session_key \
+                   AND CONTAINS(s.content, :1) > 0 \
+             ) \
+             ORDER BY m.last_activity DESC FETCH FIRST :2 ROWS ONLY",
+            Self::metadata_columns()
+        );
+        let rows = conn.query(&sql, &[&text_query, &limit])?;
+        Ok(rows_to_metadata(rows))
+    }
+
+    fn search_like(
+        &self,
+        conn: &Connection,
+        keyword: &str,
+        limit: i64,
+    ) -> oracle::Result<Vec<SessionMetadata>> {
+        let sql = format!(
+            "SELECT {} FROM session_metadata m \
+             WHERE EXISTS ( \
+                 SELECT 1 FROM sessions s \
+                 WHERE s.session_key = m.session_key \
+                   AND LOWER(s.content) LIKE LOWER(CAST(:1 AS VARCHAR2(4000 CHAR))) \
+                       ESCAPE '\\' \
+             ) \
+             ORDER BY m.last_activity DESC FETCH FIRST :2 ROWS ONLY",
+            Self::metadata_columns()
+        );
+        let pattern = build_like_pattern(keyword);
+        let rows = conn.query(&sql, &[&pattern, &limit])?;
+        Ok(rows_to_metadata(rows))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OracleCredentials {
+    user: String,
+    password: String,
+    dsn: String,
+}
+
+fn oracle_error(context: &str, error: impl Display) -> std::io::Error {
+    std::io::Error::other(format!(
+        "session_backend=oracle: failed to {context}: {error}"
+    ))
+}
+
+fn transaction_error(
+    context: &str,
+    commit_error: impl Display,
+    rollback_error: Option<oracle::Error>,
+) -> std::io::Error {
+    let rollback = rollback_error
+        .map(|error| format!("; rollback also failed: {error}"))
+        .unwrap_or_default();
+    oracle_error(context, format!("commit failed: {commit_error}{rollback}"))
+}
+
+fn execute_ddl_ignoring(
+    conn: &Connection,
+    ddl: &str,
+    ignored_ora_codes: &[i32],
+) -> std::io::Result<()> {
+    match conn.execute(ddl, &[]) {
+        Ok(_) => Ok(()),
+        Err(error)
+            if error
+                .oci_code()
+                .is_some_and(|code| ignored_ora_codes.contains(&code)) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(oracle_error("initialize schema", error)),
+    }
+}
+
+fn rows_to_metadata<I>(rows: I) -> Vec<SessionMetadata>
+where
+    I: IntoIterator<Item = oracle::Result<Row>>,
+{
+    rows.into_iter()
+        .filter_map(Result::ok)
+        .filter_map(|row| row_to_metadata(&row).ok())
+        .collect()
+}
+
+fn row_to_metadata(row: &Row) -> oracle::Result<SessionMetadata> {
+    let count: i64 = row.get(4)?;
+    Ok(SessionMetadata {
+        key: row.get(0)?,
+        name: row.get(1)?,
+        created_at: row.get(2)?,
+        last_activity: row.get(3)?,
+        message_count: usize::try_from(count.max(0)).unwrap_or(usize::MAX),
+        agent_alias: row.get(5)?,
+        channel_id: row.get(6)?,
+        room_id: row.get(7)?,
+        sender_id: row.get(8)?,
+    })
+}
+
+fn normalize_optional(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn parse_test_oracle_url(url: &str) -> std::io::Result<OracleCredentials> {
+    let (user, remainder) = url.split_once('/').ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "ZEROCLAW_TEST_ORACLE_URL must use user/password@host:port/service format",
+        )
+    })?;
+    let (password, dsn) = remainder.rsplit_once('@').ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "ZEROCLAW_TEST_ORACLE_URL must use user/password@host:port/service format",
+        )
+    })?;
+    if user.trim().is_empty() || password.is_empty() || dsn.trim().is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "ZEROCLAW_TEST_ORACLE_URL contains an empty user, password, or DSN",
+        ));
+    }
+    Ok(OracleCredentials {
+        user: user.to_string(),
+        password: password.to_string(),
+        dsn: dsn.to_string(),
+    })
+}
+
+fn read_oracle_credentials() -> std::io::Result<Option<OracleCredentials>> {
+    let user = std::env::var("ZEROCLAW_channels__oracle_user").ok();
+    let password = std::env::var("ZEROCLAW_channels__oracle_password").ok();
+    let dsn = std::env::var("ZEROCLAW_channels__oracle_dsn").ok();
+    if user.is_some() || password.is_some() || dsn.is_some() {
+        let credentials = OracleCredentials {
+            user: user.unwrap_or_default(),
+            password: password.unwrap_or_default(),
+            dsn: dsn.unwrap_or_default(),
+        };
+        if credentials.user.trim().is_empty()
+            || credentials.password.is_empty()
+            || credentials.dsn.trim().is_empty()
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Oracle session configuration is incomplete; oracle_user, \
+                 oracle_password, and oracle_dsn must all be non-empty",
+            ));
+        }
+        return Ok(Some(credentials));
+    }
+
+    match std::env::var("ZEROCLAW_TEST_ORACLE_URL") {
+        Ok(value) if !value.trim().is_empty() => parse_test_oracle_url(value.trim()).map(Some),
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("ZEROCLAW_TEST_ORACLE_URL is not valid Unicode: {error}"),
+        )),
+    }
+}
+
+pub(crate) fn read_pool_size() -> u32 {
+    std::env::var("ZEROCLAW_channels__pool_size")
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .filter(|size| *size > 0)
+        .unwrap_or(5)
+}
+
+fn build_like_pattern(keyword: &str) -> String {
+    let mut pattern = String::with_capacity(keyword.len() + 2);
+    pattern.push('%');
+    for character in keyword.chars() {
+        if matches!(character, '%' | '_' | '\\') {
+            pattern.push('\\');
+        }
+        pattern.extend(character.to_lowercase());
+    }
+    pattern.push('%');
+    pattern
+}
+
+fn build_oracle_text_query(keyword: &str) -> String {
+    keyword
+        .split_whitespace()
+        .filter_map(|token| {
+            let term: String = token
+                .chars()
+                .filter(|character| character.is_alphanumeric() || *character == '_')
+                .flat_map(char::to_lowercase)
+                .collect();
+            (!term.is_empty()).then(|| format!("{{{term}}}"))
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+impl SessionBackend for OracleSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<ChatMessage> {
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+        let Ok(rows) = conn.query(
+            "SELECT role, content FROM sessions \
+             WHERE session_key = :1 ORDER BY id ASC",
+            &[&session_key],
+        ) else {
+            return Vec::new();
+        };
+        rows.filter_map(Result::ok)
+            .filter_map(|row| {
+                Some(ChatMessage {
+                    role: row.get(0).ok()?,
+                    content: row.get(1).ok()?,
+                })
+            })
+            .collect()
+    }
+
+    fn load_with_timestamps(&self, session_key: &str) -> Vec<TimestampedMessage> {
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+        let Ok(rows) = conn.query(
+            "SELECT role, content, created_at FROM sessions \
+             WHERE session_key = :1 ORDER BY id ASC",
+            &[&session_key],
+        ) else {
+            return Vec::new();
+        };
+        rows.filter_map(Result::ok)
+            .filter_map(|row| {
+                Some(TimestampedMessage {
+                    message: ChatMessage {
+                        role: row.get(0).ok()?,
+                        content: row.get(1).ok()?,
+                    },
+                    created_at: Some(row.get(2).ok()?),
+                })
+            })
+            .collect()
+    }
+
+    fn append(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<()> {
+        self.with_transaction("append message", |conn| {
+            let content = message.content.as_str();
+            let content_clob = (&content, &OracleType::CLOB);
+            conn.execute(
+                "INSERT INTO sessions (session_key, role, content, created_at) \
+                 VALUES (:1, :2, :3, SYSTIMESTAMP)",
+                &[&session_key, &message.role, &content_clob],
+            )
+            .map_err(|error| oracle_error("append message", error))?;
+            conn.execute(
+                "MERGE INTO session_metadata m \
+                 USING (SELECT :1 AS session_key FROM dual) src \
+                    ON (m.session_key = src.session_key) \
+                 WHEN MATCHED THEN UPDATE SET \
+                    m.last_activity = SYSTIMESTAMP, \
+                    m.message_count = m.message_count + 1 \
+                 WHEN NOT MATCHED THEN INSERT \
+                    (session_key, created_at, last_activity, message_count) \
+                 VALUES (src.session_key, SYSTIMESTAMP, SYSTIMESTAMP, 1)",
+                &[&session_key],
+            )
+            .map_err(|error| oracle_error("update metadata after append", error))?;
+            Ok(())
+        })
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        self.with_transaction("remove last message", |conn| {
+            let statement = conn
+                .execute(
+                    "DELETE FROM sessions WHERE id = ( \
+                         SELECT MAX(id) FROM sessions WHERE session_key = :1 \
+                     )",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("remove last message", error))?;
+            let removed = statement
+                .row_count()
+                .map_err(|error| oracle_error("read removed message count", error))?
+                > 0;
+            if removed {
+                conn.execute(
+                    "UPDATE session_metadata SET \
+                         message_count = GREATEST(message_count - 1, 0), \
+                         last_activity = SYSTIMESTAMP \
+                     WHERE session_key = :1",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("update metadata after remove", error))?;
+            }
+            Ok(removed)
+        })
+    }
+
+    fn update_last(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<bool> {
+        self.with_transaction("update last message", |conn| {
+            let content = message.content.as_str();
+            let content_clob = (&content, &OracleType::CLOB);
+            let statement = conn
+                .execute(
+                    "UPDATE sessions SET role = :1, content = :2 WHERE id = ( \
+                         SELECT MAX(id) FROM sessions WHERE session_key = :3 \
+                     )",
+                    &[&message.role, &content_clob, &session_key],
+                )
+                .map_err(|error| oracle_error("update last message", error))?;
+            let updated = statement
+                .row_count()
+                .map_err(|error| oracle_error("read updated message count", error))?
+                > 0;
+            if updated {
+                conn.execute(
+                    "UPDATE session_metadata SET last_activity = SYSTIMESTAMP \
+                     WHERE session_key = :1",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("update metadata after message update", error))?;
+            }
+            Ok(updated)
+        })
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+        let Ok(rows) = conn.query(
+            "SELECT session_key FROM session_metadata ORDER BY last_activity DESC",
+            &[],
+        ) else {
+            return Vec::new();
+        };
+        rows.filter_map(Result::ok)
+            .filter_map(|row| row.get(0).ok())
+            .collect()
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<SessionMetadata> {
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+        let sql = format!(
+            "SELECT {} FROM session_metadata ORDER BY last_activity DESC",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&sql, &[]) else {
+            return Vec::new();
+        };
+        rows_to_metadata(rows)
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        let cutoff = Utc::now() - chrono::Duration::hours(i64::from(ttl_hours));
+        self.with_transaction("clean up stale sessions", |conn| {
+            let rows = conn
+                .query(
+                    "SELECT session_key FROM session_metadata \
+                     WHERE last_activity < :1 FOR UPDATE",
+                    &[&cutoff],
+                )
+                .map_err(|error| oracle_error("select stale sessions", error))?;
+            let keys: Vec<String> = rows
+                .filter_map(Result::ok)
+                .filter_map(|row| row.get(0).ok())
+                .collect();
+            for key in &keys {
+                conn.execute("DELETE FROM sessions WHERE session_key = :1", &[key])
+                    .map_err(|error| oracle_error("delete stale session messages", error))?;
+                conn.execute(
+                    "DELETE FROM session_metadata WHERE session_key = :1",
+                    &[key],
+                )
+                .map_err(|error| oracle_error("delete stale session metadata", error))?;
+            }
+            Ok(keys.len())
+        })
+    }
+
+    fn search(&self, query: &SessionQuery) -> Vec<SessionMetadata> {
+        let Some(keyword) = query.keyword.as_deref().map(str::trim) else {
+            return self.list_sessions_with_metadata();
+        };
+        if keyword.is_empty() {
+            return Vec::new();
+        }
+        let limit = i64::try_from(query.limit.unwrap_or(50)).unwrap_or(i64::MAX);
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+
+        let text_query = build_oracle_text_query(keyword);
+        if !text_query.is_empty() && self.oracle_text_index_available(&conn) {
+            match self.search_oracle_text(&conn, &text_query, limit) {
+                Ok(results) => return results,
+                Err(error) => ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                        .with_attrs(::serde_json::json!({"error": error.to_string()})),
+                    "session_backend=oracle: Oracle Text query failed; retrying with a case-insensitive CLOB scan"
+                ),
+            }
+        }
+        self.search_like(&conn, keyword, limit).unwrap_or_default()
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        self.with_transaction("clear session messages", |conn| {
+            let statement = conn
+                .execute(
+                    "DELETE FROM sessions WHERE session_key = :1",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("clear session messages", error))?;
+            let removed = statement
+                .row_count()
+                .map_err(|error| oracle_error("read cleared message count", error))?;
+            if removed > 0 {
+                conn.execute(
+                    "UPDATE session_metadata SET \
+                         message_count = 0, last_activity = SYSTIMESTAMP \
+                     WHERE session_key = :1",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("update metadata after clearing messages", error))?;
+            }
+            usize::try_from(removed)
+                .map_err(|error| oracle_error("convert cleared message count", error))
+        })
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        self.with_transaction("delete session", |conn| {
+            conn.execute(
+                "DELETE FROM sessions WHERE session_key = :1",
+                &[&session_key],
+            )
+            .map_err(|error| oracle_error("delete session messages", error))?;
+            let statement = conn
+                .execute(
+                    "DELETE FROM session_metadata WHERE session_key = :1",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("delete session metadata", error))?;
+            statement
+                .row_count()
+                .map(|count| count > 0)
+                .map_err(|error| oracle_error("read deleted session count", error))
+        })
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        self.with_transaction("clear agent attribution", |conn| {
+            let statement = conn
+                .execute(
+                    "UPDATE session_metadata SET agent_alias = NULL WHERE agent_alias = :1",
+                    &[&agent_alias],
+                )
+                .map_err(|error| oracle_error("clear agent attribution", error))?;
+            let affected = statement
+                .row_count()
+                .map_err(|error| oracle_error("read cleared attribution count", error))?;
+            usize::try_from(affected)
+                .map_err(|error| oracle_error("convert cleared attribution count", error))
+        })
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        self.with_transaction("rename agent attribution", |conn| {
+            let statement = conn
+                .execute(
+                    "UPDATE session_metadata SET agent_alias = :1 WHERE agent_alias = :2",
+                    &[&to, &from],
+                )
+                .map_err(|error| oracle_error("rename agent attribution", error))?;
+            let affected = statement
+                .row_count()
+                .map_err(|error| oracle_error("read renamed attribution count", error))?;
+            usize::try_from(affected)
+                .map_err(|error| oracle_error("convert renamed attribution count", error))
+        })
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let count: i64 = self
+            .conn()?
+            .query_row_as(
+                "SELECT COUNT(*) FROM session_metadata WHERE agent_alias = :1",
+                &[&agent_alias],
+            )
+            .map_err(|error| oracle_error("count agent attribution", error))?;
+        usize::try_from(count.max(0))
+            .map_err(|error| oracle_error("convert agent attribution count", error))
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        self.conn()
+            .and_then(|conn| {
+                conn.query_row_as::<i64>(
+                    "SELECT COUNT(*) FROM session_metadata WHERE session_key = :1",
+                    &[&session_key],
+                )
+                .map_err(|error| oracle_error("check session existence", error))
+            })
+            .is_ok_and(|count| count > 0)
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        let value = (!name.is_empty()).then_some(name);
+        self.with_transaction("set session name", |conn| {
+            conn.execute(
+                "UPDATE session_metadata SET name = :1 WHERE session_key = :2",
+                &[&value, &session_key],
+            )
+            .map_err(|error| oracle_error("set session name", error))?;
+            Ok(())
+        })
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let conn = self.conn()?;
+        match conn.query_row_as(
+            "SELECT name FROM session_metadata WHERE session_key = :1",
+            &[&session_key],
+        ) {
+            Ok(value) => Ok(value),
+            Err(error) if error.kind() == oracle::ErrorKind::NoDataFound => Ok(None),
+            Err(error) => Err(oracle_error("get session name", error)),
+        }
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        let alias = (!agent_alias.is_empty()).then_some(agent_alias);
+        self.with_transaction("set session agent alias", |conn| {
+            conn.execute(
+                "MERGE INTO session_metadata m \
+                 USING (SELECT :1 AS session_key, \
+                               CAST(:2 AS VARCHAR2(512 CHAR)) AS agent_alias FROM dual) src \
+                    ON (m.session_key = src.session_key) \
+                 WHEN MATCHED THEN UPDATE SET m.agent_alias = src.agent_alias \
+                 WHEN NOT MATCHED THEN INSERT \
+                    (session_key, created_at, last_activity, message_count, agent_alias) \
+                 VALUES (src.session_key, SYSTIMESTAMP, SYSTIMESTAMP, 0, src.agent_alias)",
+                &[&session_key, &alias],
+            )
+            .map_err(|error| oracle_error("set session agent alias", error))?;
+            Ok(())
+        })
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let conn = self.conn()?;
+        match conn.query_row_as(
+            "SELECT agent_alias FROM session_metadata WHERE session_key = :1",
+            &[&session_key],
+        ) {
+            Ok(value) => Ok(value),
+            Err(error) if error.kind() == oracle::ErrorKind::NoDataFound => Ok(None),
+            Err(error) => Err(oracle_error("get session agent alias", error)),
+        }
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        let channel_id = normalize_optional(context.channel_id);
+        let room_id = normalize_optional(context.room_id);
+        let sender_id = normalize_optional(context.sender_id);
+        self.with_transaction("set session routing context", |conn| {
+            conn.execute(
+                "MERGE INTO session_metadata m \
+                 USING (SELECT :1 AS session_key, \
+                               CAST(:2 AS VARCHAR2(512 CHAR)) AS channel_id, \
+                               CAST(:3 AS VARCHAR2(512 CHAR)) AS room_id, \
+                               CAST(:4 AS VARCHAR2(512 CHAR)) AS sender_id FROM dual) src \
+                    ON (m.session_key = src.session_key) \
+                 WHEN MATCHED THEN UPDATE SET \
+                    m.channel_id = COALESCE(src.channel_id, m.channel_id), \
+                    m.room_id = COALESCE(src.room_id, m.room_id), \
+                    m.sender_id = COALESCE(src.sender_id, m.sender_id) \
+                 WHEN NOT MATCHED THEN INSERT \
+                    (session_key, created_at, last_activity, message_count, \
+                     channel_id, room_id, sender_id) \
+                 VALUES (src.session_key, SYSTIMESTAMP, SYSTIMESTAMP, 0, \
+                         src.channel_id, src.room_id, src.sender_id)",
+                &[&session_key, &channel_id, &room_id, &sender_id],
+            )
+            .map_err(|error| oracle_error("set session routing context", error))?;
+            Ok(())
+        })
+    }
+
+    fn get_session_metadata(&self, session_key: &str) -> Option<SessionMetadata> {
+        let conn = self.conn().ok()?;
+        let sql = format!(
+            "SELECT {} FROM session_metadata WHERE session_key = :1",
+            Self::metadata_columns()
+        );
+        let row = conn.query_row(&sql, &[&session_key]).ok()?;
+        row_to_metadata(&row).ok()
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        let started: Option<DateTime<Utc>> = (state == "running").then(Utc::now);
+        let turn_id = turn_id.filter(|value| !value.is_empty());
+        self.with_transaction("set session state", |conn| {
+            conn.execute(
+                "UPDATE session_metadata SET state = :1, turn_id = :2, \
+                 turn_started_at = :3 WHERE session_key = :4",
+                &[&state, &turn_id, &started, &session_key],
+            )
+            .map_err(|error| oracle_error("set session state", error))?;
+            Ok(())
+        })
+    }
+
+    fn get_session_state(&self, session_key: &str) -> std::io::Result<Option<SessionState>> {
+        let conn = self.conn()?;
+        match conn.query_row(
+            "SELECT state, turn_id, turn_started_at FROM session_metadata \
+             WHERE session_key = :1",
+            &[&session_key],
+        ) {
+            Ok(row) => Ok(Some(SessionState {
+                state: row
+                    .get(0)
+                    .map_err(|error| oracle_error("decode session state", error))?,
+                turn_id: row
+                    .get(1)
+                    .map_err(|error| oracle_error("decode session turn ID", error))?,
+                turn_started_at: row
+                    .get(2)
+                    .map_err(|error| oracle_error("decode session turn timestamp", error))?,
+            })),
+            Err(error) if error.kind() == oracle::ErrorKind::NoDataFound => Ok(None),
+            Err(error) => Err(oracle_error("get session state", error)),
+        }
+    }
+
+    fn list_running_sessions(&self) -> Vec<SessionMetadata> {
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+        let sql = format!(
+            "SELECT {} FROM session_metadata WHERE state = 'running' \
+             ORDER BY turn_started_at DESC NULLS LAST",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&sql, &[]) else {
+            return Vec::new();
+        };
+        rows_to_metadata(rows)
+    }
+
+    fn list_stuck_sessions(&self, threshold_secs: u64) -> Vec<SessionMetadata> {
+        let seconds = i64::try_from(threshold_secs).unwrap_or(i64::MAX);
+        let cutoff = Utc::now() - chrono::Duration::seconds(seconds);
+        let Ok(conn) = self.conn() else {
+            return Vec::new();
+        };
+        let sql = format!(
+            "SELECT {} FROM session_metadata \
+             WHERE state = 'running' AND turn_started_at < :1 \
+             ORDER BY turn_started_at ASC",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&sql, &[&cutoff]) else {
+            return Vec::new();
+        };
+        rows_to_metadata(rows)
+    }
+
+    fn compact(&self, _session_key: &str) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_test_oracle_url() {
+        assert_eq!(
+            parse_test_oracle_url("test_user/test_password@db.example:1521/ORCLPDB1").unwrap(),
+            OracleCredentials {
+                user: "test_user".to_string(),
+                password: "test_password".to_string(),
+                dsn: "db.example:1521/ORCLPDB1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_test_oracle_url() {
+        assert!(parse_test_oracle_url("test_user@db.example/ORCLPDB1").is_err());
+    }
+
+    #[test]
+    fn like_pattern_escapes_wildcards() {
+        assert_eq!(
+            build_like_pattern(r"Rust_100%\\safe"),
+            r"%rust\_100\%\\safe%"
+        );
+    }
+
+    #[test]
+    fn oracle_text_query_uses_escaped_safe_terms() {
+        assert_eq!(
+            build_oracle_text_query("Rust async (best)"),
+            "{rust} AND {async} AND {best}"
+        );
+    }
+
+    #[test]
+    fn oracle_text_query_drops_punctuation_only_tokens() {
+        assert_eq!(build_oracle_text_query(" -- !!! "), "");
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_ORACLE_URL pointing at a live Oracle database"]
+    fn oracle_live_round_trip_metadata_state_and_search() {
+        let Ok(url) = std::env::var("ZEROCLAW_TEST_ORACLE_URL") else {
+            eprintln!("ZEROCLAW_TEST_ORACLE_URL not set; skipping Oracle live test");
+            return;
+        };
+        if url.trim().is_empty() {
+            eprintln!("ZEROCLAW_TEST_ORACLE_URL is empty; skipping Oracle live test");
+            return;
+        }
+
+        let workspace = tempfile::TempDir::new().expect("create temporary workspace");
+        let backend = crate::make_session_backend(workspace.path(), "oracle")
+            .expect("construct Oracle backend through factory");
+        let key = format!(
+            "oracle_live_{}_{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        );
+        let initial_agent_alias = format!("oracle-test-{key}");
+        let renamed_agent_alias = format!("oracle-renamed-{key}");
+        backend
+            .append(
+                &key,
+                &ChatMessage::user("unique oracle persistence search needle"),
+            )
+            .expect("append user message");
+        backend
+            .append(&key, &ChatMessage::assistant("initial response"))
+            .expect("append assistant message");
+        backend
+            .update_last(&key, &ChatMessage::assistant("updated response"))
+            .expect("update last message");
+        backend.set_session_name(&key, "Oracle live test").unwrap();
+        backend
+            .set_session_agent_alias(&key, &initial_agent_alias)
+            .unwrap();
+        backend
+            .set_session_context(
+                &key,
+                SessionContext {
+                    channel_id: Some("discord.test"),
+                    room_id: Some("room-1"),
+                    sender_id: Some("sender-1"),
+                },
+            )
+            .unwrap();
+        backend
+            .set_session_state(&key, "running", Some("turn-1"))
+            .unwrap();
+
+        let messages = backend.load_with_timestamps(&key);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].message.content, "updated response");
+        assert!(messages.iter().all(|message| message.created_at.is_some()));
+
+        let metadata = backend.get_session_metadata(&key).expect("metadata");
+        assert_eq!(metadata.message_count, 2);
+        assert_eq!(metadata.name.as_deref(), Some("Oracle live test"));
+        assert_eq!(
+            metadata.agent_alias.as_deref(),
+            Some(initial_agent_alias.as_str())
+        );
+        assert_eq!(metadata.channel_id.as_deref(), Some("discord.test"));
+        assert_eq!(metadata.room_id.as_deref(), Some("room-1"));
+        assert_eq!(metadata.sender_id.as_deref(), Some("sender-1"));
+        assert_eq!(
+            backend
+                .count_agent_attribution(&initial_agent_alias)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            backend
+                .rename_agent_attribution(&initial_agent_alias, &renamed_agent_alias)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            backend
+                .count_agent_attribution(&renamed_agent_alias)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            backend
+                .clear_agent_attribution(&renamed_agent_alias)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            backend.get_session_state(&key).unwrap().unwrap().state,
+            "running"
+        );
+        assert!(
+            backend
+                .list_running_sessions()
+                .iter()
+                .any(|metadata| metadata.key == key)
+        );
+
+        let matches = backend.search(&SessionQuery {
+            keyword: Some("oracle persistence search needle".to_string()),
+            limit: Some(10),
+        });
+        assert!(matches.iter().any(|metadata| metadata.key == key));
+
+        assert!(backend.remove_last(&key).unwrap());
+        assert_eq!(backend.get_session_metadata(&key).unwrap().message_count, 1);
+        assert_eq!(backend.clear_messages(&key).unwrap(), 1);
+        assert!(backend.delete_session(&key).unwrap());
+    }
+}

--- a/crates/zeroclaw-infra/src/session_postgres.rs
+++ b/crates/zeroclaw-infra/src/session_postgres.rs
@@ -1,0 +1,791 @@
+//! PostgreSQL-backed session persistence.
+//!
+//! The backend stores ordered messages in `sessions`; that table is the source
+//! of truth for message content and timestamps. `session_metadata` is the source
+//! of truth for names, routing attribution, activity counters, and turn state.
+//! Connections are synchronous and pooled with `r2d2`.
+
+use std::fmt::Display;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use postgres::{NoTls, Row};
+use r2d2::{Pool, PooledConnection};
+use r2d2_postgres::PostgresConnectionManager;
+use zeroclaw_api::model_provider::ChatMessage;
+
+use crate::session_backend::{
+    SessionBackend, SessionContext, SessionMetadata, SessionQuery, SessionState, TimestampedMessage,
+};
+
+type PgManager = PostgresConnectionManager<NoTls>;
+type PgPool = Pool<PgManager>;
+
+/// Keeps the final PostgreSQL pool drop off a Tokio runtime thread.
+///
+/// `postgres::Client::drop` drains its connection with an internal Tokio
+/// runtime. The session API is already called through `spawn_blocking`, but the
+/// shared backend handle itself can be released by an async owner.
+struct DropOnThread<T: Send + 'static>(Option<T>);
+
+impl<T: Send + 'static> DropOnThread<T> {
+    fn new(value: T) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl<T: Send + 'static> Drop for DropOnThread<T> {
+    fn drop(&mut self) {
+        let Some(value) = self.0.take() else {
+            return;
+        };
+        let slot = std::mem::ManuallyDrop::new(value);
+        if std::thread::Builder::new()
+            .name("postgres-session-pool-drop".to_string())
+            .spawn(move || drop(std::mem::ManuallyDrop::into_inner(slot)))
+            .is_err()
+        {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                "postgres-session-pool-drop thread spawn failed; leaking pool to avoid nested-runtime panic"
+            );
+        }
+    }
+}
+
+/// Synchronous PostgreSQL session store backed by an `r2d2` connection pool.
+pub struct PostgresSessionBackend {
+    pool: DropOnThread<PgPool>,
+}
+
+impl PostgresSessionBackend {
+    /// Construct the backend from the canonical environment-backed connection
+    /// URL and initialize its schema.
+    pub fn new(workspace_dir: &Path, pool_size: u32) -> std::io::Result<Self> {
+        let _ = workspace_dir;
+        let url = read_postgres_url()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "session_backend=postgres requires ZEROCLAW_channels__postgres_url \
+                 (or ZEROCLAW_TEST_POSTGRES_URL in tests) to be set in the \
+                 environment. Populate `channels.postgres_url` or inject it \
+                 through the standard dotted-path environment override.",
+            )
+        })?;
+        Self::new_with_url(&url, pool_size)
+    }
+
+    fn new_with_url(database_url: &str, pool_size: u32) -> std::io::Result<Self> {
+        let config = database_url.parse().map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("session PostgreSQL URL is invalid: {error}"),
+            )
+        })?;
+        let manager = PostgresConnectionManager::new(config, NoTls);
+        let pool = Pool::builder()
+            .max_size(pool_size.max(1))
+            .build(manager)
+            .map_err(|error| pg_error("build connection pool", error))?;
+        let backend = Self {
+            pool: DropOnThread::new(pool),
+        };
+        backend.ensure_schema()?;
+        Ok(backend)
+    }
+
+    fn conn(&self) -> std::io::Result<PooledConnection<PgManager>> {
+        self.pool
+            .0
+            .as_ref()
+            .ok_or_else(|| std::io::Error::other("session PostgreSQL pool is unavailable"))?
+            .get()
+            .map_err(|error| pg_error("checkout pooled connection", error))
+    }
+
+    fn ensure_schema(&self) -> std::io::Result<()> {
+        let mut conn = self.conn()?;
+        conn.batch_execute(
+            "CREATE TABLE IF NOT EXISTS sessions (
+                id          BIGSERIAL   PRIMARY KEY,
+                session_key TEXT        NOT NULL,
+                role        TEXT        NOT NULL,
+                content     TEXT        NOT NULL,
+                created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+             );
+             CREATE INDEX IF NOT EXISTS idx_sessions_key
+                 ON sessions(session_key);
+             CREATE INDEX IF NOT EXISTS idx_sessions_key_id
+                 ON sessions(session_key, id);
+             CREATE INDEX IF NOT EXISTS idx_sessions_content_fts
+                 ON sessions USING GIN (to_tsvector('simple', content));
+
+             CREATE TABLE IF NOT EXISTS session_metadata (
+                session_key      TEXT        PRIMARY KEY,
+                created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+                last_activity    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                message_count    BIGINT      NOT NULL DEFAULT 0,
+                name             TEXT,
+                state            TEXT        NOT NULL DEFAULT 'idle',
+                turn_id          TEXT,
+                turn_started_at  TIMESTAMPTZ,
+                agent_alias      TEXT,
+                channel_id       TEXT,
+                room_id          TEXT,
+                sender_id        TEXT
+             );
+             ALTER TABLE session_metadata ADD COLUMN IF NOT EXISTS name TEXT;
+             ALTER TABLE session_metadata
+                 ADD COLUMN IF NOT EXISTS state TEXT NOT NULL DEFAULT 'idle';
+             ALTER TABLE session_metadata ADD COLUMN IF NOT EXISTS turn_id TEXT;
+             ALTER TABLE session_metadata
+                 ADD COLUMN IF NOT EXISTS turn_started_at TIMESTAMPTZ;
+             ALTER TABLE session_metadata ADD COLUMN IF NOT EXISTS agent_alias TEXT;
+             ALTER TABLE session_metadata ADD COLUMN IF NOT EXISTS channel_id TEXT;
+             ALTER TABLE session_metadata ADD COLUMN IF NOT EXISTS room_id TEXT;
+             ALTER TABLE session_metadata ADD COLUMN IF NOT EXISTS sender_id TEXT;
+             CREATE INDEX IF NOT EXISTS idx_session_metadata_agent_alias
+                 ON session_metadata(agent_alias);
+             CREATE INDEX IF NOT EXISTS idx_session_metadata_channel_id
+                 ON session_metadata(channel_id);
+             CREATE INDEX IF NOT EXISTS idx_session_metadata_room_id
+                 ON session_metadata(room_id);
+             CREATE INDEX IF NOT EXISTS idx_session_metadata_sender_id
+                 ON session_metadata(sender_id);",
+        )
+        .map_err(|error| pg_error("initialize schema", error))
+    }
+
+    fn row_to_metadata(row: &Row) -> SessionMetadata {
+        let count: i64 = row.get("message_count");
+        let message_count = usize::try_from(count.max(0)).unwrap_or(usize::MAX);
+        SessionMetadata {
+            key: row.get("session_key"),
+            name: row.get("name"),
+            created_at: row.get("created_at"),
+            last_activity: row.get("last_activity"),
+            message_count,
+            agent_alias: row.get("agent_alias"),
+            channel_id: row.get("channel_id"),
+            room_id: row.get("room_id"),
+            sender_id: row.get("sender_id"),
+        }
+    }
+
+    fn metadata_columns() -> &'static str {
+        "session_key, name, created_at, last_activity, message_count, \
+         agent_alias, channel_id, room_id, sender_id"
+    }
+}
+
+fn pg_error(context: &str, error: impl Display) -> std::io::Error {
+    std::io::Error::other(format!(
+        "session_backend=postgres: failed to {context}: {error}"
+    ))
+}
+
+fn normalize_optional(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn read_postgres_url() -> std::io::Result<Option<String>> {
+    if let Ok(value) = std::env::var("ZEROCLAW_channels__postgres_url") {
+        if value.trim().is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "ZEROCLAW_channels__postgres_url is set but empty; provide a postgres:// URL.",
+            ));
+        }
+        return Ok(Some(value));
+    }
+    if let Ok(value) = std::env::var("ZEROCLAW_TEST_POSTGRES_URL") {
+        if value.trim().is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(value));
+    }
+    Ok(None)
+}
+
+pub(crate) fn read_pool_size() -> u32 {
+    std::env::var("ZEROCLAW_channels__pool_size")
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .filter(|size| *size > 0)
+        .unwrap_or(5)
+}
+
+fn build_tsquery(keyword: &str) -> String {
+    keyword
+        .split_whitespace()
+        .filter_map(|token| {
+            let lexeme: String = token
+                .chars()
+                .filter(|character| character.is_alphanumeric() || *character == '_')
+                .flat_map(char::to_lowercase)
+                .collect();
+            (!lexeme.is_empty()).then(|| format!("{lexeme}:*"))
+        })
+        .collect::<Vec<_>>()
+        .join(" & ")
+}
+
+impl SessionBackend for PostgresSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<ChatMessage> {
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let Ok(rows) = conn.query(
+            "SELECT role, content FROM sessions WHERE session_key = $1 ORDER BY id ASC",
+            &[&session_key],
+        ) else {
+            return Vec::new();
+        };
+        rows.into_iter()
+            .map(|row| ChatMessage {
+                role: row.get("role"),
+                content: row.get("content"),
+            })
+            .collect()
+    }
+
+    fn load_with_timestamps(&self, session_key: &str) -> Vec<TimestampedMessage> {
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let Ok(rows) = conn.query(
+            "SELECT role, content, created_at FROM sessions \
+             WHERE session_key = $1 ORDER BY id ASC",
+            &[&session_key],
+        ) else {
+            return Vec::new();
+        };
+        rows.into_iter()
+            .map(|row| TimestampedMessage {
+                message: ChatMessage {
+                    role: row.get("role"),
+                    content: row.get("content"),
+                },
+                created_at: Some(row.get("created_at")),
+            })
+            .collect()
+    }
+
+    fn append(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<()> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .transaction()
+            .map_err(|error| pg_error("begin append transaction", error))?;
+        let now = Utc::now();
+        tx.execute(
+            "INSERT INTO sessions (session_key, role, content, created_at) \
+             VALUES ($1, $2, $3, $4)",
+            &[&session_key, &message.role, &message.content, &now],
+        )
+        .map_err(|error| pg_error("append message", error))?;
+        tx.execute(
+            "INSERT INTO session_metadata \
+                 (session_key, created_at, last_activity, message_count) \
+             VALUES ($1, $2, $3, 1) \
+             ON CONFLICT (session_key) DO UPDATE SET \
+                 last_activity = EXCLUDED.last_activity, \
+                 message_count = session_metadata.message_count + 1",
+            &[&session_key, &now, &now],
+        )
+        .map_err(|error| pg_error("update metadata after append", error))?;
+        tx.commit()
+            .map_err(|error| pg_error("commit append transaction", error))
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .transaction()
+            .map_err(|error| pg_error("begin remove-last transaction", error))?;
+        let removed = tx
+            .query_opt(
+                "DELETE FROM sessions WHERE id = ( \
+                     SELECT id FROM sessions WHERE session_key = $1 \
+                     ORDER BY id DESC LIMIT 1 \
+                 ) RETURNING id",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("remove last message", error))?
+            .is_some();
+        if removed {
+            tx.execute(
+                "UPDATE session_metadata SET \
+                     message_count = GREATEST(message_count - 1, 0), \
+                     last_activity = now() \
+                 WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("update metadata after remove", error))?;
+        }
+        tx.commit()
+            .map_err(|error| pg_error("commit remove-last transaction", error))?;
+        Ok(removed)
+    }
+
+    fn update_last(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .transaction()
+            .map_err(|error| pg_error("begin update-last transaction", error))?;
+        let updated = tx
+            .execute(
+                "UPDATE sessions SET role = $1, content = $2 WHERE id = ( \
+                     SELECT id FROM sessions WHERE session_key = $3 \
+                     ORDER BY id DESC LIMIT 1 \
+                 )",
+                &[&message.role, &message.content, &session_key],
+            )
+            .map_err(|error| pg_error("update last message", error))?
+            > 0;
+        if updated {
+            tx.execute(
+                "UPDATE session_metadata SET last_activity = now() WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("update metadata after message update", error))?;
+        }
+        tx.commit()
+            .map_err(|error| pg_error("commit update-last transaction", error))?;
+        Ok(updated)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let Ok(rows) = conn.query(
+            "SELECT session_key FROM session_metadata ORDER BY last_activity DESC",
+            &[],
+        ) else {
+            return Vec::new();
+        };
+        rows.into_iter().map(|row| row.get(0)).collect()
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<SessionMetadata> {
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let query = format!(
+            "SELECT {} FROM session_metadata ORDER BY last_activity DESC",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&query, &[]) else {
+            return Vec::new();
+        };
+        rows.iter().map(Self::row_to_metadata).collect()
+    }
+
+    fn cleanup_stale(&self, ttl_hours: u32) -> std::io::Result<usize> {
+        let cutoff = Utc::now() - chrono::Duration::hours(i64::from(ttl_hours));
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .transaction()
+            .map_err(|error| pg_error("begin stale-session cleanup transaction", error))?;
+        let keys: Vec<String> = tx
+            .query(
+                "SELECT session_key FROM session_metadata WHERE last_activity < $1 FOR UPDATE",
+                &[&cutoff],
+            )
+            .map_err(|error| pg_error("select stale sessions", error))?
+            .into_iter()
+            .map(|row| row.get(0))
+            .collect();
+        for key in &keys {
+            tx.execute("DELETE FROM sessions WHERE session_key = $1", &[key])
+                .map_err(|error| pg_error("delete stale session messages", error))?;
+            tx.execute(
+                "DELETE FROM session_metadata WHERE session_key = $1",
+                &[key],
+            )
+            .map_err(|error| pg_error("delete stale session metadata", error))?;
+        }
+        tx.commit()
+            .map_err(|error| pg_error("commit stale-session cleanup transaction", error))?;
+        Ok(keys.len())
+    }
+
+    fn search(&self, query: &SessionQuery) -> Vec<SessionMetadata> {
+        let Some(keyword) = query.keyword.as_deref() else {
+            return self.list_sessions_with_metadata();
+        };
+        let tsquery = build_tsquery(keyword);
+        if tsquery.is_empty() {
+            return Vec::new();
+        }
+        let limit = i64::try_from(query.limit.unwrap_or(50)).unwrap_or(i64::MAX);
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let sql = format!(
+            "SELECT {} FROM session_metadata m \
+             WHERE EXISTS ( \
+                 SELECT 1 FROM sessions s \
+                 WHERE s.session_key = m.session_key \
+                   AND to_tsvector('simple', s.content) @@ to_tsquery('simple', $1) \
+             ) \
+             ORDER BY m.last_activity DESC LIMIT $2",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&sql, &[&tsquery, &limit]) else {
+            return Vec::new();
+        };
+        rows.iter().map(Self::row_to_metadata).collect()
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .transaction()
+            .map_err(|error| pg_error("begin clear-messages transaction", error))?;
+        let removed = tx
+            .execute(
+                "DELETE FROM sessions WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("clear session messages", error))?;
+        if removed > 0 {
+            tx.execute(
+                "UPDATE session_metadata SET message_count = 0, last_activity = now() \
+                 WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("update metadata after clearing messages", error))?;
+        }
+        tx.commit()
+            .map_err(|error| pg_error("commit clear-messages transaction", error))?;
+        usize::try_from(removed).map_err(|error| pg_error("convert removed message count", error))
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .transaction()
+            .map_err(|error| pg_error("begin delete-session transaction", error))?;
+        tx.execute(
+            "DELETE FROM sessions WHERE session_key = $1",
+            &[&session_key],
+        )
+        .map_err(|error| pg_error("delete session messages", error))?;
+        let removed = tx
+            .execute(
+                "DELETE FROM session_metadata WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("delete session metadata", error))?
+            > 0;
+        tx.commit()
+            .map_err(|error| pg_error("commit delete-session transaction", error))?;
+        Ok(removed)
+    }
+
+    fn clear_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let affected = self
+            .conn()?
+            .execute(
+                "UPDATE session_metadata SET agent_alias = NULL WHERE agent_alias = $1",
+                &[&agent_alias],
+            )
+            .map_err(|error| pg_error("clear agent attribution", error))?;
+        usize::try_from(affected)
+            .map_err(|error| pg_error("convert cleared attribution count", error))
+    }
+
+    fn rename_agent_attribution(&self, from: &str, to: &str) -> std::io::Result<usize> {
+        let affected = self
+            .conn()?
+            .execute(
+                "UPDATE session_metadata SET agent_alias = $1 WHERE agent_alias = $2",
+                &[&to, &from],
+            )
+            .map_err(|error| pg_error("rename agent attribution", error))?;
+        usize::try_from(affected)
+            .map_err(|error| pg_error("convert renamed attribution count", error))
+    }
+
+    fn count_agent_attribution(&self, agent_alias: &str) -> std::io::Result<usize> {
+        let row = self
+            .conn()?
+            .query_one(
+                "SELECT COUNT(*) FROM session_metadata WHERE agent_alias = $1",
+                &[&agent_alias],
+            )
+            .map_err(|error| pg_error("count agent attribution", error))?;
+        let count: i64 = row.get(0);
+        usize::try_from(count.max(0))
+            .map_err(|error| pg_error("convert agent attribution count", error))
+    }
+
+    fn session_exists(&self, session_key: &str) -> bool {
+        let Ok(mut conn) = self.conn() else {
+            return false;
+        };
+        conn.query_opt(
+            "SELECT 1 FROM session_metadata WHERE session_key = $1",
+            &[&session_key],
+        )
+        .ok()
+        .flatten()
+        .is_some()
+    }
+
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        let value = (!name.is_empty()).then_some(name);
+        self.conn()?
+            .execute(
+                "UPDATE session_metadata SET name = $1 WHERE session_key = $2",
+                &[&value, &session_key],
+            )
+            .map_err(|error| pg_error("set session name", error))?;
+        Ok(())
+    }
+
+    fn get_session_name(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let row = self
+            .conn()?
+            .query_opt(
+                "SELECT name FROM session_metadata WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("get session name", error))?;
+        Ok(row.and_then(|value| value.get(0)))
+    }
+
+    fn set_session_agent_alias(&self, session_key: &str, agent_alias: &str) -> std::io::Result<()> {
+        let alias = (!agent_alias.is_empty()).then_some(agent_alias);
+        let now = Utc::now();
+        self.conn()?
+            .execute(
+                "INSERT INTO session_metadata \
+                     (session_key, created_at, last_activity, message_count, agent_alias) \
+                 VALUES ($1, $2, $3, 0, $4) \
+                 ON CONFLICT (session_key) DO UPDATE SET agent_alias = EXCLUDED.agent_alias",
+                &[&session_key, &now, &now, &alias],
+            )
+            .map_err(|error| pg_error("set session agent alias", error))?;
+        Ok(())
+    }
+
+    fn get_session_agent_alias(&self, session_key: &str) -> std::io::Result<Option<String>> {
+        let row = self
+            .conn()?
+            .query_opt(
+                "SELECT agent_alias FROM session_metadata WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("get session agent alias", error))?;
+        Ok(row.and_then(|value| value.get(0)))
+    }
+
+    fn set_session_context(
+        &self,
+        session_key: &str,
+        context: SessionContext<'_>,
+    ) -> std::io::Result<()> {
+        let channel_id = normalize_optional(context.channel_id);
+        let room_id = normalize_optional(context.room_id);
+        let sender_id = normalize_optional(context.sender_id);
+        let now = Utc::now();
+        self.conn()?
+            .execute(
+                "INSERT INTO session_metadata \
+                     (session_key, created_at, last_activity, message_count, \
+                      channel_id, room_id, sender_id) \
+                 VALUES ($1, $2, $3, 0, $4, $5, $6) \
+                 ON CONFLICT (session_key) DO UPDATE SET \
+                     channel_id = COALESCE(EXCLUDED.channel_id, session_metadata.channel_id), \
+                     room_id = COALESCE(EXCLUDED.room_id, session_metadata.room_id), \
+                     sender_id = COALESCE(EXCLUDED.sender_id, session_metadata.sender_id)",
+                &[&session_key, &now, &now, &channel_id, &room_id, &sender_id],
+            )
+            .map_err(|error| pg_error("set session routing context", error))?;
+        Ok(())
+    }
+
+    fn get_session_metadata(&self, session_key: &str) -> Option<SessionMetadata> {
+        let mut conn = self.conn().ok()?;
+        let query = format!(
+            "SELECT {} FROM session_metadata WHERE session_key = $1",
+            Self::metadata_columns()
+        );
+        let row = conn.query_opt(&query, &[&session_key]).ok()??;
+        Some(Self::row_to_metadata(&row))
+    }
+
+    fn set_session_state(
+        &self,
+        session_key: &str,
+        state: &str,
+        turn_id: Option<&str>,
+    ) -> std::io::Result<()> {
+        let started: Option<DateTime<Utc>> = (state == "running").then(Utc::now);
+        let turn_id = turn_id.filter(|value| !value.is_empty());
+        self.conn()?
+            .execute(
+                "UPDATE session_metadata SET state = $1, turn_id = $2, \
+                 turn_started_at = $3 WHERE session_key = $4",
+                &[&state, &turn_id, &started, &session_key],
+            )
+            .map_err(|error| pg_error("set session state", error))?;
+        Ok(())
+    }
+
+    fn get_session_state(&self, session_key: &str) -> std::io::Result<Option<SessionState>> {
+        let row = self
+            .conn()?
+            .query_opt(
+                "SELECT state, turn_id, turn_started_at FROM session_metadata \
+                 WHERE session_key = $1",
+                &[&session_key],
+            )
+            .map_err(|error| pg_error("get session state", error))?;
+        Ok(row.map(|value| SessionState {
+            state: value.get("state"),
+            turn_id: value.get("turn_id"),
+            turn_started_at: value.get("turn_started_at"),
+        }))
+    }
+
+    fn list_running_sessions(&self) -> Vec<SessionMetadata> {
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let query = format!(
+            "SELECT {} FROM session_metadata WHERE state = 'running' \
+             ORDER BY turn_started_at DESC NULLS LAST",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&query, &[]) else {
+            return Vec::new();
+        };
+        rows.iter().map(Self::row_to_metadata).collect()
+    }
+
+    fn list_stuck_sessions(&self, threshold_secs: u64) -> Vec<SessionMetadata> {
+        let seconds = i64::try_from(threshold_secs).unwrap_or(i64::MAX);
+        let cutoff = Utc::now() - chrono::Duration::seconds(seconds);
+        let Ok(mut conn) = self.conn() else {
+            return Vec::new();
+        };
+        let query = format!(
+            "SELECT {} FROM session_metadata \
+             WHERE state = 'running' AND turn_started_at < $1 \
+             ORDER BY turn_started_at ASC",
+            Self::metadata_columns()
+        );
+        let Ok(rows) = conn.query(&query, &[&cutoff]) else {
+            return Vec::new();
+        };
+        rows.iter().map(Self::row_to_metadata).collect()
+    }
+
+    fn compact(&self, _session_key: &str) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tsquery_uses_safe_prefix_lexemes() {
+        assert_eq!(
+            build_tsquery("Rust async (best)"),
+            "rust:* & async:* & best:*"
+        );
+    }
+
+    #[test]
+    fn tsquery_drops_punctuation_only_tokens() {
+        assert_eq!(build_tsquery(" -- !!! "), "");
+    }
+
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_POSTGRES_URL pointing at a live PostgreSQL database"]
+    fn postgres_live_round_trip_metadata_state_and_search() {
+        let Ok(url) = std::env::var("ZEROCLAW_TEST_POSTGRES_URL") else {
+            eprintln!("ZEROCLAW_TEST_POSTGRES_URL not set; skipping PostgreSQL live test");
+            return;
+        };
+        if url.trim().is_empty() {
+            eprintln!("ZEROCLAW_TEST_POSTGRES_URL is empty; skipping PostgreSQL live test");
+            return;
+        }
+
+        let _ = url;
+        let workspace = tempfile::TempDir::new().expect("create temporary workspace");
+        let backend = crate::make_session_backend(workspace.path(), "postgres")
+            .expect("construct PostgreSQL backend through factory");
+        let key = format!(
+            "postgres_live_{}_{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        );
+        backend
+            .append(
+                &key,
+                &ChatMessage::user("unique postgresql full text needle"),
+            )
+            .expect("append user message");
+        backend
+            .append(&key, &ChatMessage::assistant("initial response"))
+            .expect("append assistant message");
+        backend
+            .update_last(&key, &ChatMessage::assistant("updated response"))
+            .expect("update last message");
+        backend
+            .set_session_name(&key, "PostgreSQL live test")
+            .unwrap();
+        backend
+            .set_session_agent_alias(&key, "postgres-test")
+            .unwrap();
+        backend
+            .set_session_context(
+                &key,
+                SessionContext {
+                    channel_id: Some("discord.test"),
+                    room_id: Some("room-1"),
+                    sender_id: Some("sender-1"),
+                },
+            )
+            .unwrap();
+        backend
+            .set_session_state(&key, "running", Some("turn-1"))
+            .unwrap();
+
+        let messages = backend.load_with_timestamps(&key);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1].message.content, "updated response");
+        assert!(messages.iter().all(|message| message.created_at.is_some()));
+
+        let metadata = backend.get_session_metadata(&key).expect("metadata");
+        assert_eq!(metadata.message_count, 2);
+        assert_eq!(metadata.agent_alias.as_deref(), Some("postgres-test"));
+        assert_eq!(metadata.channel_id.as_deref(), Some("discord.test"));
+        assert_eq!(metadata.room_id.as_deref(), Some("room-1"));
+        assert_eq!(metadata.sender_id.as_deref(), Some("sender-1"));
+        assert_eq!(
+            backend.get_session_state(&key).unwrap().unwrap().state,
+            "running"
+        );
+
+        let matches = backend.search(&SessionQuery {
+            keyword: Some("postgres needle".to_string()),
+            limit: Some(10),
+        });
+        assert!(matches.iter().any(|metadata| metadata.key == key));
+
+        assert!(backend.remove_last(&key).unwrap());
+        assert_eq!(backend.get_session_metadata(&key).unwrap().message_count, 1);
+        assert_eq!(backend.clear_messages(&key).unwrap(), 1);
+        assert!(backend.delete_session(&key).unwrap());
+    }
+}

--- a/crates/zeroclaw-runtime/src/lib.rs
+++ b/crates/zeroclaw-runtime/src/lib.rs
@@ -36,6 +36,7 @@ pub mod routines;
 pub mod rpc;
 pub mod security;
 pub mod service;
+pub mod session_async;
 pub mod skillforge;
 pub mod skills;
 pub mod sop;

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -586,7 +586,10 @@ impl RpcDispatcher {
             return true;
         }
         if let Some(backend) = self.ctx.session_backend.as_ref()
-            && backend.count_agent_attribution(from).unwrap_or(0) > 0
+            && crate::session_async::count_agent_attribution(backend.clone(), from.to_string())
+                .await
+                .unwrap_or(0)
+                > 0
         {
             return true;
         }
@@ -1261,16 +1264,40 @@ impl RpcDispatcher {
             crate::rpc::types::ChatMode::Chat => {
                 if let Some(ref backend) = self.ctx.session_backend {
                     let session_key = format!("rpc_{session_id}");
-                    let _ = backend.set_session_agent_alias(&session_key, &req.agent_alias);
-                    let stored = backend.load(&session_key);
-                    if !stored.is_empty() {
-                        let seed_event = self
-                            .ctx
-                            .sessions
-                            .seed_history_with_event(&session_id, &stored)
-                            .await;
-                        self.forward_seed_event(&session_id, seed_event).await;
-                        message_count = stored.len();
+                    let _ = crate::session_async::set_session_agent_alias(
+                        backend.clone(),
+                        session_key.clone(),
+                        req.agent_alias.clone(),
+                    )
+                    .await;
+                    let stored_result =
+                        crate::session_async::load(backend.clone(), session_key.clone()).await;
+                    match stored_result {
+                        Ok(stored) if !stored.is_empty() => {
+                            let seed_event = self
+                                .ctx
+                                .sessions
+                                .seed_history_with_event(&session_id, &stored)
+                                .await;
+                            self.forward_seed_event(&session_id, seed_event).await;
+                            message_count = stored.len();
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            ::zeroclaw_log::record!(
+                                WARN,
+                                ::zeroclaw_log::Event::new(
+                                    module_path!(),
+                                    ::zeroclaw_log::Action::Note
+                                )
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(::serde_json::json!({
+                                    "session_id": session_id,
+                                    "error": format!("{e}"),
+                                })),
+                                "RPC chat session load failed"
+                            );
+                        }
                     }
                 }
             }
@@ -1851,15 +1878,30 @@ impl RpcDispatcher {
             crate::rpc::types::ChatMode::Chat => {
                 if let Some(ref backend) = self.ctx.session_backend {
                     let key = format!("rpc_{sid}");
-                    let _ = backend.append(&key, &ChatMessage::user(&prompt));
+                    let _ = crate::session_async::append(
+                        backend.clone(),
+                        key.clone(),
+                        ChatMessage::user(&prompt),
+                    )
+                    .await;
                     match &outcome {
                         Ok(TurnOutcome::Completed { text, .. }) => {
-                            let _ = backend.append(&key, &ChatMessage::assistant(text));
+                            let _ = crate::session_async::append(
+                                backend.clone(),
+                                key.clone(),
+                                ChatMessage::assistant(text),
+                            )
+                            .await;
                         }
                         Ok(TurnOutcome::Cancelled { partial_text, .. })
                             if !partial_text.is_empty() =>
                         {
-                            let _ = backend.append(&key, &ChatMessage::assistant(partial_text));
+                            let _ = crate::session_async::append(
+                                backend.clone(),
+                                key.clone(),
+                                ChatMessage::assistant(partial_text),
+                            )
+                            .await;
                         }
                         _ => {}
                     }
@@ -2152,19 +2194,45 @@ impl RpcDispatcher {
         let config = self.ctx.config.read().clone();
 
         // Use FTS when a query is provided, plain list otherwise.
-        let all = if let Some(ref keyword) = req.query {
-            if keyword.trim().is_empty() {
-                backend.list_sessions_with_metadata()
+        // Both branches run on the blocking pool — the foundation
+        // contract has to stay correct once a remote-database
+        // session backend lands in a follow-up PR; today's
+        // sqlite/jsonl pay only the spawn-and-join round trip.
+        let all: Vec<zeroclaw_infra::session_backend::SessionMetadata> =
+            if let Some(ref keyword) = req.query {
+                if keyword.trim().is_empty() {
+                    crate::session_async::list_sessions_with_metadata(backend.clone())
+                        .await
+                        .map_err(|e| JsonRpcError {
+                            code: INTERNAL_ERROR,
+                            message: format!("session backend error: {e}"),
+                            data: None,
+                        })?
+                } else {
+                    use zeroclaw_infra::session_backend::SessionQuery;
+                    crate::session_async::search(
+                        backend.clone(),
+                        SessionQuery {
+                            keyword: Some(keyword.clone()),
+                            limit: req.limit,
+                        },
+                    )
+                    .await
+                    .map_err(|e| JsonRpcError {
+                        code: INTERNAL_ERROR,
+                        message: format!("session backend error: {e}"),
+                        data: None,
+                    })?
+                }
             } else {
-                use zeroclaw_infra::session_backend::SessionQuery;
-                backend.search(&SessionQuery {
-                    keyword: Some(keyword.clone()),
-                    limit: req.limit,
-                })
-            }
-        } else {
-            backend.list_sessions_with_metadata()
-        };
+                crate::session_async::list_sessions_with_metadata(backend.clone())
+                    .await
+                    .map_err(|e| JsonRpcError {
+                        code: INTERNAL_ERROR,
+                        message: format!("session backend error: {e}"),
+                        data: None,
+                    })?
+            };
 
         let sessions: Vec<SessionEntry> = all
             .into_iter()
@@ -2250,10 +2318,25 @@ impl RpcDispatcher {
         ];
         let mut raw: Vec<zeroclaw_api::model_provider::ChatMessage> = Vec::new();
         for key in &candidates {
-            let loaded = backend.load(key);
-            if !loaded.is_empty() {
-                raw = loaded;
-                break;
+            match crate::session_async::load(backend.clone(), key.clone()).await {
+                Ok(loaded) if !loaded.is_empty() => {
+                    raw = loaded;
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(::serde_json::json!({
+                                "session_id": req.session_id,
+                                "key": key,
+                                "error": format!("{e}"),
+                            })),
+                        "RPC session load failed"
+                    );
+                }
             }
         }
 
@@ -2327,7 +2410,7 @@ impl RpcDispatcher {
             format!("gw_{}", req.session_id),
         ];
         for key in &candidates {
-            match backend.get_session_state(key) {
+            match crate::session_async::get_session_state(backend.clone(), key.clone()).await {
                 Ok(Some(ss)) => {
                     return to_result(SessionStateResult {
                         session_id: req.session_id,

--- a/crates/zeroclaw-runtime/src/session_async.rs
+++ b/crates/zeroclaw-runtime/src/session_async.rs
@@ -1,0 +1,101 @@
+//! Shared `spawn_blocking` wrappers around `SessionBackend` operations
+//! used by the runtime RPC dispatcher hot paths. This is the runtime
+//! counterpart to `zeroclaw_gateway::session_async` — same contract,
+//! same rationale (a slow remote database backend cannot stall the
+//! async workers), kept as a separate module so each consumer crate
+//! does not have to depend on the gateway.
+
+use std::io;
+use std::sync::Arc;
+
+use zeroclaw_infra::session_backend::SessionBackend;
+
+/// Run a synchronous `SessionBackend` operation through
+/// `tokio::task::spawn_blocking`. Join errors from the blocking
+/// pool are converted into `io::Error::Other`.
+pub async fn spawn_blocking_session_op<F, T>(op: F) -> io::Result<T>
+where
+    F: FnOnce() -> io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(join_err) => Err(io::Error::other(format!(
+            "session backend worker panicked: {join_err}"
+        ))),
+    }
+}
+
+/// Convenience: count_agent_attribution off the blocking pool.
+pub async fn count_agent_attribution(
+    backend: Arc<dyn SessionBackend>,
+    agent_alias: String,
+) -> io::Result<usize> {
+    spawn_blocking_session_op(move || backend.count_agent_attribution(&agent_alias)).await
+}
+
+/// Convenience: set_session_agent_alias off the blocking pool.
+pub async fn set_session_agent_alias(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    alias: String,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.set_session_agent_alias(&session_key, &alias)).await
+}
+
+/// Convenience: load off the blocking pool.
+pub async fn load(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Vec<zeroclaw_api::model_provider::ChatMessage>> {
+    spawn_blocking_session_op(move || Ok(backend.load(&session_key))).await
+}
+
+/// Convenience: append off the blocking pool.
+pub async fn append(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+    message: zeroclaw_api::model_provider::ChatMessage,
+) -> io::Result<()> {
+    spawn_blocking_session_op(move || backend.append(&session_key, &message)).await
+}
+
+/// Convenience: list_sessions_with_metadata off the blocking pool.
+pub async fn list_sessions_with_metadata(
+    backend: Arc<dyn SessionBackend>,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::SessionMetadata>> {
+    spawn_blocking_session_op(move || Ok(backend.list_sessions_with_metadata())).await
+}
+
+/// Convenience: delete_session off the blocking pool.
+pub async fn delete_session(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<bool> {
+    spawn_blocking_session_op(move || backend.delete_session(&session_key)).await
+}
+
+/// Convenience: rename_agent_attribution off the blocking pool.
+pub async fn rename_agent_attribution(
+    backend: Arc<dyn SessionBackend>,
+    from: String,
+    to: String,
+) -> io::Result<usize> {
+    spawn_blocking_session_op(move || backend.rename_agent_attribution(&from, &to)).await
+}
+
+/// Convenience: search off the blocking pool.
+pub async fn search(
+    backend: Arc<dyn SessionBackend>,
+    query: zeroclaw_infra::session_backend::SessionQuery,
+) -> io::Result<Vec<zeroclaw_infra::session_backend::SessionMetadata>> {
+    spawn_blocking_session_op(move || Ok(backend.search(&query))).await
+}
+
+/// Convenience: get_session_state off the blocking pool.
+pub async fn get_session_state(
+    backend: Arc<dyn SessionBackend>,
+    session_key: String,
+) -> io::Result<Option<zeroclaw_infra::session_backend::SessionState>> {
+    spawn_blocking_session_op(move || backend.get_session_state(&session_key)).await
+}

--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -10,6 +10,35 @@ use zeroclaw_config::policy::SecurityPolicy;
 use zeroclaw_config::policy::ToolOperation;
 use zeroclaw_infra::session_backend::SessionBackend;
 
+/// Run a synchronous `SessionBackend` operation through
+/// `tokio::task::spawn_blocking` so a slow/wedged remote backend
+/// (Postgres/MySQL/MariaDB/Oracle/Db2 — the upcoming drivers in this
+/// series) cannot stall the async task's executor worker. Today's
+/// local drivers (sqlite/jsonl) complete in microseconds, so this
+/// wraps to a single-shot blocking thread; the foundation cost is
+/// tiny and the contract stays correct for every remote backend that
+/// follows.
+///
+/// The helper is intentionally infallible at the async boundary: any
+/// `std::io::Error` the backend raised inside `op` is bubbled out;
+/// any join error from the blocking pool is converted back to a
+/// `std::io::Error::Other("session backend worker panicked")`. Tools
+/// already translate the `std::io::Result<T>` they receive into a
+/// `ToolResult`, so this matches the call sites without adding a new
+/// error type at this layer.
+async fn spawn_blocking_session_op<F, T>(op: F) -> std::io::Result<T>
+where
+    F: FnOnce() -> std::io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(op).await {
+        Ok(result) => result,
+        Err(join_err) => Err(std::io::Error::other(format!(
+            "session backend worker panicked: {join_err}"
+        ))),
+    }
+}
+
 /// Validate that a session ID is non-empty and contains at least one
 /// alphanumeric character (prevents blank keys after sanitization).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,7 +197,9 @@ impl Tool for SessionsListTool {
             .and_then(serde_json::Value::as_u64)
             .map_or(50, |v| v as usize);
 
-        let metadata = self.backend.list_sessions_with_metadata();
+        let backend = self.backend.clone();
+        let metadata =
+            spawn_blocking_session_op(move || Ok(backend.list_sessions_with_metadata())).await?;
 
         if metadata.is_empty() {
             return Ok(ToolResult {
@@ -275,7 +306,11 @@ impl Tool for SessionsHistoryTool {
             .and_then(serde_json::Value::as_u64)
             .map_or(20, |v| v as usize);
 
-        let messages = self.backend.load(session_id);
+        let messages = {
+            let backend = self.backend.clone();
+            let session_id = session_id.to_string();
+            spawn_blocking_session_op(move || Ok(backend.load(&session_id))).await?
+        };
 
         if messages.is_empty() {
             return Ok(ToolResult {
@@ -414,7 +449,12 @@ impl Tool for SessionsSendTool {
 
         let chat_msg = zeroclaw_api::model_provider::ChatMessage::user(message);
 
-        match self.backend.append(&target_session_key, &chat_msg) {
+        let append_result = {
+            let backend = self.backend.clone();
+            let target_session_key = target_session_key.clone();
+            spawn_blocking_session_op(move || backend.append(&target_session_key, &chat_msg)).await
+        };
+        match append_result {
             Ok(()) => {
                 let output = if target_session_key == session_id.trim() {
                     format!("Message sent to session '{target_session_key}'.")
@@ -487,7 +527,13 @@ impl Tool for SessionsCurrentTool {
         };
 
         let mut output = format!("Current session: {key}\n");
-        if let Some(meta) = self.backend.get_session_metadata(&key) {
+        let metadata = {
+            let backend = self.backend.clone();
+            let key_for_blocking = key.clone();
+            spawn_blocking_session_op(move || Ok(backend.get_session_metadata(&key_for_blocking)))
+                .await?
+        };
+        if let Some(meta) = metadata {
             if let Some(name) = meta.name.filter(|name| !name.is_empty()) {
                 let _ = writeln!(output, "Name: {name}");
             }
@@ -605,7 +651,12 @@ impl Tool for SessionResetTool {
                 .unwrap_or_else(|| session_id.trim().to_string()),
         };
 
-        match self.backend.clear_messages(&target_session_key) {
+        let clear_result = {
+            let backend = self.backend.clone();
+            let target = target_session_key.clone();
+            spawn_blocking_session_op(move || backend.clear_messages(&target)).await
+        };
+        match clear_result {
             Ok(0) => Ok(ToolResult {
                 success: true,
                 output: format!("Session '{target_session_key}' is already empty.").into(),
@@ -726,9 +777,19 @@ impl Tool for SessionDeleteTool {
                 .unwrap_or_else(|| session_id.trim().to_string()),
         };
 
-        let existed = !self.backend.load(&target_session_key).is_empty();
+        let existed = {
+            let backend = self.backend.clone();
+            let target = target_session_key.clone();
+            spawn_blocking_session_op(move || Ok(backend.load(&target))).await?
+        };
+        let existed = !existed.is_empty();
 
-        match self.backend.delete_session(&target_session_key) {
+        let delete_result = {
+            let backend = self.backend.clone();
+            let target = target_session_key.clone();
+            spawn_blocking_session_op(move || backend.delete_session(&target)).await
+        };
+        match delete_result {
             Ok(true) => Ok(ToolResult {
                 success: true,
                 output: format!("Session '{target_session_key}' deleted.").into(),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Implements the Oracle session-persistence backend on top of the shared plumbing from #9249 and the pattern established in #9250/#9251.
  - `crates/zeroclaw-infra/src/session_oracle.rs`: full `SessionBackend` implementation (sessions + session_metadata tables, routing columns, synchronous client — async safety handled by the foundation's `spawn_blocking` boundary at call sites).
  - Client: the `oracle` crate (wraps Oracle's official ODPI-C driver) — the realistic path for Oracle from Rust; connects via an EZCONNECT-style DSN (`user/password@host:port/service`).
  - Fills in the `#[cfg(feature = "backend-oracle")]` arm in `make_session_backend` (fail-fast stub since #9249).
  - Dedicated required CI check job compiling the feature independently.
- **Scope boundary:** Oracle only — the final backend in the series. MySQL/MariaDB (#9250), Postgres (#9251) already landed; Db2 (PR 4) is a separate parallel PR, not depended on here (this branch is based on Postgres directly).
- **Blast radius:** New opt-in Cargo feature only; default build and every other backend are unaffected — the other four backends' fail-fast tests all still pass.
- **Linked issue(s):** Supersedes #6893. Depends on #9249 and #9251 (both open) — stacked on #9251, will show those commits until merged.
- **Labels:** `type:feature`, `size:L`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — live-verified against a real Oracle 23ai server (evidence below); a local live-DB run needs a reachable Oracle instance with the Instant Client and `ZEROCLAW_TEST_ORACLE_URL` set.

### How I tested

```sh
cargo +1.96.1 fmt --all -- --check
cargo +1.96.1 check --locked --features ci-all --all-targets
cargo +1.96.1 clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo +1.96.1 check -p zeroclaw-infra --features backend-oracle
cargo +1.96.1 test -p zeroclaw-infra fail_fast_when_feature_disabled
cargo nextest run --locked --workspace --exclude zeroclaw-desktop
ZEROCLAW_TEST_ORACLE_URL="zctest/***@<host>:1521/ORCLPDB1" \
  cargo +1.96.1 test -p zeroclaw-infra --features backend-oracle -- --ignored --nocapture
```

- **CI checks relied on and why they cover this change:** the dedicated `backend-oracle` feature job is the only way this code compiles at all.
- **Known CI coverage gap:** CI itself has no Oracle service + Instant Client wired up, but the live-DB test **was run manually and passes** against a real, isolated Oracle 23ai pluggable database, on a host with the Oracle Instant Client 23.6 installed (`test session_oracle::tests::oracle_live_round_trip_metadata_state_and_search ... ok`). The earlier `DPI-1047 Cannot locate Oracle Client library` was purely the missing client library on the original macOS build host (ODPI-C `dlopen`s `libclntsh` at runtime) — resolved by running on a host that has the Instant Client. A follow-up could provision the Instant Client in CI to run this automatically.
- **Commands run and tail output:**
  ```
  cargo +1.96.1 check -p zeroclaw-infra --features backend-oracle
  (clean)

  cargo +1.96.1 test -p zeroclaw-infra fail_fast_when_feature_disabled
  running 5 tests ... test result: ok. 5 passed; 0 failed

  cargo nextest run --locked --workspace --exclude zeroclaw-desktop
  Summary [65.025s] 12117 tests run: 12117 passed (1 leaky), 11 skipped

  ZEROCLAW_TEST_ORACLE_URL=... cargo test -p zeroclaw-infra --features backend-oracle -- --ignored --nocapture
  thread 'session_oracle::tests::oracle_live_round_trip_metadata_state_and_search' panicked:
  DPI Error: DPI-1047: Cannot locate a 64-bit Oracle Client library ("libclntsh.dylib")
  test result: FAILED. 0 passed; 1 failed (client-library-missing, not a code/server failure — see above)
  ```
- **Beyond CI, what did you manually verify?** **Live-verified end-to-end against a real Oracle 23ai server** — the gated round-trip test (sessions + session_metadata, routing context, agent alias, state, and search) passes. Also confirmed the four sibling backends' fail-fast tests (mysql/mariadb/postgres/db2) still hard-fail-fast and were undisturbed.
- **If any command was intentionally skipped, why:** Did not attempt to unofficially source Oracle Instant Client (e.g. an unofficial Homebrew tap) to work around the license click-through — flagging honestly instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? Yes — outbound TCP to an operator-configured Oracle listener, only when the feature is compiled in and the backend is explicitly selected; disabled by default.
- Secrets / tokens / credentials handling changed? No — reuses the connection-string config fields already added in #9249.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No — config fields already landed in #9249
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` this PR's merge commit. Entirely behind an opt-in Cargo feature.
- **Feature flags or config toggles:** `backend-oracle` Cargo feature (compile-time), plus `session_backend = "oracle"` config value from #9249 (runtime).
- **Observable failure symptoms:** session read/write errors from `OracleSessionBackend` in logs; `DPI-1047` at startup indicates a missing Oracle Instant Client on the deploying host (an operational/deployment prerequisite, not a code bug); connection-pool exhaustion or connectivity errors otherwise.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: #6893 by @perlowja
- Scope materially carried forward: the goal of multi-database session-backend support, and the two-table (`sessions` + `session_metadata`) schema shape with routing columns for parity with the SQLite reference implementation.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? No
- If `No`, why: #6893 was solely self-authored; this is a from-scratch reimplementation against the current `SessionBackend` trait, not a code port.

