### PR TITLE
ci(dependabot): monitor web npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,22 @@ updates:
           - minor
           - patch
 
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "web"
+    groups:
+      web-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add weekly Dependabot version updates for the npm project under `/web`.
  - Group minor and patch updates into one stream and cap open version-update PRs at two to limit maintainer noise.
  - Apply the existing `dependencies` and `web` labels to generated PRs.
- **Scope boundary:** This does not update `web/package-lock.json`, remediate the current advisories in #9235, enable auto-merge, enable or disable repository-level security updates, or alter the existing Cargo, GitHub Actions, and Docker schedules. Applicable options may also customize generated security-update PRs.
- **Blast radius:** GitHub-hosted dependency automation may create update PRs for `web/package.json` and `web/package-lock.json`; product runtime behavior is unchanged.
- **Linked issue(s):** Related #9235
- **Labels:** `ci`, `dependencies`, `web`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; Dependabot reads this configuration from the repository's default branch, so there is no useful pre-merge manual product test.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI on the current head covers repository format, structure, and general integration. It does not exercise Dependabot's scheduled service behavior, so the local YAML assertions and post-merge scheduled run are the relevant evidence for that boundary.
- **Known CI coverage gap, if any:** Dependabot's scheduled update execution cannot be triggered from an unmerged branch. The first scheduled run after merge remains the end-to-end verification.
- **Commands run and tail output:**

```text
ruby -e 'require "yaml"; cfg = YAML.load_file(".github/dependabot.yml"); npm = cfg.fetch("updates").find { |u| u["package-ecosystem"] == "npm" && u["directory"] == "/web" }; abort unless npm && npm.dig("schedule", "interval") == "weekly" && npm["open-pull-requests-limit"] == 2 && npm["labels"] == ["dependencies", "web"] && npm.dig("groups", "web-minor-patch", "patterns") == ["*"] && npm.dig("groups", "web-minor-patch", "update-types") == ["minor", "patch"] && !npm.key?("target-branch"); puts "dependabot YAML parsed; npm /web policy verified"'
dependabot YAML parsed; npm /web policy verified

git diff --check
passed with no output

bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** Confirmed that `master` is the repository default branch, `/web` contains the npm manifest and lockfile, the labels exist, and the configuration shape matches GitHub's current Dependabot documentation.
- **If any command was intentionally skipped, why:** Cargo and product tests were skipped because the change only affects GitHub Dependabot configuration and does not touch Rust or runtime behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? Yes. GitHub-hosted Dependabot will periodically query npm dependency metadata for `/web`; no ZeroClaw runtime network behavior changes.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: The added network activity runs within GitHub's existing Dependabot service and is limited to dependency update checks and generated PRs for the web project.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes. Repository automation configuration changes; runtime, environment, and CLI configuration do not.
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: No user upgrade is required; GitHub reads the repository automation configuration after merge.

## Rollback (required for medium/high-risk PRs)

Low risk. Revert the commit to remove the npm update schedule.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
