### PR TITLE
fix(config): stop claiming inactive context compression is enabled

### DIFF
--- a/crates/zeroclaw-config/src/scattered_types.rs
+++ b/crates/zeroclaw-config/src/scattered_types.rs
@@ -242,7 +242,12 @@ impl Default for EvalHarnessConfig {
 }
 
 fn default_cc_enabled() -> bool {
-    true
+    // The runtime compressor was intentionally removed; no production code path
+    // consumes `ContextCompressionConfig` today. Default to inactive so
+    // generated and inspected configs do not claim compression is enabled when
+    // it has no runtime effect. A future compression architecture would be a
+    // separate decision that could flip this back on.
+    false
 }
 fn default_threshold_ratio() -> f64 {
     0.50
@@ -276,6 +281,9 @@ fn default_tool_result_retrim_chars() -> usize {
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 #[prefix = "agent.context_compression"]
 pub struct ContextCompressionConfig {
+    /// INERT: retained for schema compatibility after the runtime compressor
+    /// was removed. No runtime path consumes this today, so enabling it has no
+    /// effect; `config validate` surfaces a warning when it is set to `true`.
     #[serde(default = "default_cc_enabled")]
     pub enabled: bool,
     #[serde(default = "default_threshold_ratio")]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -18691,6 +18691,7 @@ impl Config {
         self.collect_cross_provider_summary_model_warnings(&mut warnings);
         self.collect_a2a_exposed_skills_warnings(&mut warnings);
         self.collect_memory_semantic_search_warnings(&mut warnings);
+        self.collect_context_compression_inert_warnings(&mut warnings);
         warnings.extend(validate_memory_semantics(&self.memory));
         // `wire_api` is only honored by bring-your-own-endpoint families; on a
         // branded family with a fixed wire protocol it is silently ignored.
@@ -18711,6 +18712,32 @@ impl Config {
             }
         }
         warnings
+    }
+
+    /// Surface `context_compression.enabled = true` on any runtime profile as
+    /// inert. The runtime compressor was removed and no production path consumes
+    /// `ContextCompressionConfig` today, so an operator who turns it on learns
+    /// it has no effect instead of assuming a summarizer is active.
+    ///
+    /// A change that wires a runtime consumer for context compression must drop
+    /// this check in the same change; it mirrors what is inert on the tree.
+    fn collect_context_compression_inert_warnings(
+        &self,
+        warnings: &mut Vec<crate::validation_warnings::ValidationWarning>,
+    ) {
+        for (name, profile) in &self.runtime_profiles {
+            if profile.context_compression.enabled {
+                let path = format!("runtime_profiles.{name}.context_compression.enabled");
+                warnings.push(crate::validation_warnings::ValidationWarning::new(
+                    "context_compression_inert",
+                    format!(
+                        "{path} is set to true but context compression has no runtime consumer \
+                         (the compressor was removed); this setting currently has no effect."
+                    ),
+                    path,
+                ));
+            }
+        }
     }
 
     /// Surface sqlite semantic/hybrid search with no effective embedder. The
@@ -34735,6 +34762,58 @@ allowed_users = []
         assert_eq!(
             warnings[0].path,
             "providers.models.openai.primary.fallback[0]"
+        );
+    }
+
+    #[test]
+    async fn context_compression_disabled_by_default() {
+        // The runtime compressor was removed; the default config must not claim
+        // compression is enabled when nothing consumes it.
+        assert!(
+            !crate::scattered_types::ContextCompressionConfig::default().enabled,
+            "context_compression must default to inactive"
+        );
+    }
+
+    #[test]
+    async fn context_compression_enabled_profile_warns_inert() {
+        let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
+
+        let mut profile = RuntimeProfileConfig::default();
+        profile.context_compression.enabled = true;
+        config.runtime_profiles.insert("fast".to_string(), profile);
+
+        let inert: Vec<_> = config
+            .collect_warnings()
+            .into_iter()
+            .filter(|w| w.code == "context_compression_inert")
+            .collect();
+        assert_eq!(
+            inert.len(),
+            1,
+            "one profile with enabled=true → one warning"
+        );
+        assert_eq!(
+            inert[0].path,
+            "runtime_profiles.fast.context_compression.enabled"
+        );
+    }
+
+    #[test]
+    async fn context_compression_default_profile_is_silent() {
+        let mut config = Config::default();
+        suppress_semantic_memory_warning(&mut config);
+        config
+            .runtime_profiles
+            .insert("fast".to_string(), RuntimeProfileConfig::default());
+
+        assert!(
+            !config
+                .collect_warnings()
+                .into_iter()
+                .any(|w| w.code == "context_compression_inert"),
+            "a profile left at the inactive default must not warn"
         );
     }
 

--- a/crates/zeroclaw-config/src/validation_warnings.rs
+++ b/crates/zeroclaw-config/src/validation_warnings.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 /// - `memory_config_knob_inert`: a `[memory]` knob is set to a non-default
 ///   value but has no runtime consumer yet, so it currently has no effect
 ///   (see `validate_memory_semantics` in `schema.rs` for the current list).
+/// - `context_compression_inert`: a runtime profile sets
+///   `context_compression.enabled = true`, but the compressor was removed and
+///   no runtime path consumes it, so it has no effect.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct ValidationWarning {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Labels:** `bug`, `config`, `risk:medium`, `size:S`
- **What changed and why:** The runtime compressor was removed in #8196 and no production path consumes `ContextCompressionConfig` on `master`, yet `ContextCompressionConfig::default()` set `enabled = true`. Generated, inspected, and edited configs therefore reported context compression as active when enabling or tuning it has no runtime effect — an apparently-enabled safety mechanism that is actually inert. This defaults `context_compression.enabled` to `false` so the surface is truthful, and adds a `context_compression_inert` validation warning when a runtime profile still sets it to `true`.
- **Scope boundary:** Does not restore the removed LLM summary-splice compressor, and does not remove or rename the `context_compression` fields (that schema cut is tracked separately in #8310). Any new compression architecture remains the separate decision in #7673.
- **Blast radius:** `ContextCompressionConfig::default()` now yields `enabled = false`, which flows to `RuntimeProfileConfig` and `ResolvedRuntime` defaults. No runtime consumer reads the flag, so behavior is unchanged; only generated config output and `config validate` warnings change.
- **Linked issue(s):** Fixes #9278

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (`config validate`, generated config)
- **Setup / preconditions:** A runtime profile with `context_compression.enabled = true`.
- **Steps to run:** Run `config validate` (or inspect a freshly generated config).
- **Expected on this branch (after):** Generated config shows `enabled = false`; an explicit `enabled = true` on a profile surfaces a `context_compression_inert` warning noting it has no effect.
- **Prior behavior on `master` (before):** Generated config shows `enabled = true` and no warning, implying compression is active when it is not.

### How I tested

Added focused unit tests: the default is `false`, an enabled profile emits exactly one `context_compression_inert` warning at `runtime_profiles.<name>.context_compression.enabled`, and a default profile stays silent. Ran the full config lib suite and clippy.

```sh
cargo test -p zeroclaw-config --lib context_compression
cargo test -p zeroclaw-config --lib
cargo clippy -p zeroclaw-config --all-targets -- -D warnings
```

- **Commands run and tail output:**
  ```
  test schema::tests::context_compression_disabled_by_default ... ok
  test schema::tests::context_compression_default_profile_is_silent ... ok
  test schema::tests::context_compression_enabled_profile_warns_inert ... ok
  test result: ok. 1140 passed; 0 failed; 0 ignored; 0 measured
  clippy: Finished with no warnings
  ```
- **CI checks relied on and why they cover this change:** The zeroclaw-config Quality Gate runs the lib test suite + clippy on all platforms; the three new `context_compression_*` tests (default is `false`, an enabled profile emits exactly one `context_compression_inert` warning, a default profile stays silent) run there and pin the behavior this PR changes.
- **Known CI coverage gap:** None specific to this change — it is a pure config-layer default flip plus a validation warning, fully exercised by the config lib tests; no runtime path consumes the flag, so there is nothing runtime-side left to cover.
- **Intentionally skipped:** none.
- **Beyond CI, what did you manually verify?** Confirmed no runtime/channel code reads `context_compression` (`git grep` in `zeroclaw-runtime`/`zeroclaw-channels` → none), so flipping the default cannot change runtime behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No — the opposite: prevents an inert flag from implying summarizer model calls.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes — omitted flag resolves to `false`; explicit `true` still loads and is flagged inert.
- Config / env / CLI surface changed? Yes (default value of `context_compression.enabled` flips to `false`; a new non-fatal validation warning may appear). No fields added or removed.
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Toggle:** No feature flag. To keep the old surface without reverting, set `context_compression.enabled = true` explicitly in a runtime profile — it loads as before (and now surfaces the inert warning).
- **Observable symptoms if this misbehaves:** a freshly generated config shows `enabled = false`, or `config validate` prints a `context_compression_inert` warning for a profile that sets it `true`. Neither changes runtime behavior (no consumer reads the flag).
- **Rollback:** `git revert <sha>`. Consequence: generated config again reports `enabled = true` and the inert warning disappears — back to the misleading-but-harmless prior state. No persisted state or migration involved.
