### PR TITLE
test(agent): refresh parity harness row-1 evidence after Epic A cut-overs

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/parity.rs
+++ b/crates/zeroclaw-runtime/src/agent/parity.rs
@@ -54,12 +54,24 @@ const MATRIX: &[ParityRow] = &[
         surface: "A",
         setting: "built-in filter minted through the one assemble() seam on every path",
         owner_epic: "A",
-        tracking: "gateway + loop_::run + process_message route through assemble(); \
-                   remaining sites cut over one PR at a time",
+        tracking: "every production path routes through assemble() (gateway, loop_::run, \
+                   process_message, from_config #8711, channels startup #8830, \
+                   independent-delegate #8744/#8761); the engine-field seal is the last step",
+        // Every production tool-assembly path now mints its registry through the
+        // one ScopedToolRegistry::assemble seam - the "remaining cut-overs" this
+        // row used to track have all landed. It stays a TrackedDivergence rather
+        // than Tested because uniformity is still CONVENTION-enforced, not
+        // compiler-enforced: the engine field is a raw `&[Box<dyn Tool>]`, so
+        // nothing at the type level stops a future path from hand-rolling a
+        // registry and passing it in (the #8011-style silent un-routing). Only
+        // the engine-field seal (Epic A P2 - making the field type
+        // ScopedToolRegistry) makes that divergence a compile error, at which
+        // point this row converges to a single seam and becomes Tested.
         status: RowStatus::TrackedDivergence,
-        evidence: "gateway/loop_::run/process_message route through assemble(); \
-                   from_config/orchestrator/delegate still hand-roll the same filter, \
-                   tracked by the remaining Epic A cut-overs + the seal",
+        evidence: "all production paths now mint their registry through the one \
+                   ScopedToolRegistry::assemble seam; cross-path uniformity is \
+                   convention-enforced until the engine field seals to ScopedToolRegistry \
+                   (Epic A P2), which makes a hand-rolled registry a compile error",
     },
     ParityRow {
         surface: "A",

--- a/docs/book/src/contributing/agent-policy-parity-harness.md
+++ b/docs/book/src/contributing/agent-policy-parity-harness.md
@@ -124,17 +124,19 @@ other path applied the plain `apply_policy_tool_filter`. #8701 retired that
 variant, so every path now applies the same plain filter (ledger A4, backed
 by an in-file positive parity test rather than a divergence characterization).
 
-The remaining hand-rolled sites - the channels orchestrator (`start_channels`),
-`Agent::from_config`, and the delegate independent-target builder
+The sites that were hand-rolled when this was written have since migrated:
+`Agent::from_config` (#8711), the channels orchestrator's `start_channels`
+startup assembly (#8830), and the delegate independent-target builder
 (`independent_agentic_tools_for_target`, added by #8239 while this program was
-in flight - the recurrence the seal exists to end) - migrate in follow-up PRs.
-Once all sites mint through `assemble`, the engine's tools field
-seals to `ScopedToolRegistry` (a private-field newtype only `assemble` constructs),
-and handing the engine an unscoped registry - or quietly re-inlining a construction
-site, as a cross-merge did to the channel path once already - becomes a compile
-error instead of a review catch. Until that seal, cross-site parity for the
-not-yet-migrated sites remains by convention; what the seam guarantees today is
-that every path routed through it shares one implementation.
+in flight - the recurrence the seal exists to end; #8744/#8761). Every
+production site now mints its registry through `assemble`. The remaining step
+is the seal: the engine's tools field seals to `ScopedToolRegistry` (a
+private-field newtype only `assemble` constructs), so handing the engine an
+unscoped registry - or quietly re-inlining a construction site, as a cross-merge
+did to the channel path once already - becomes a compile error instead of a
+review catch. Until that seal, cross-site parity remains by convention; what the
+seam guarantees today is that every path routed through it shares one
+implementation.
 
 ## The harness
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The agent-policy parity harness row 1 (`crates/zeroclaw-runtime/src/agent/parity.rs`)
    and the matching cut-over-status paragraph in the parity-harness contributor docs
    (`docs/book/src/contributing/agent-policy-parity-harness.md`) still described the
    channels orchestrator, `Agent::from_config`, and the delegate independent-target builder
    as sites that "still hand-roll the same filter, tracked by the remaining Epic A cut-overs."
    Those cut-overs have all landed (from_config #8711, channels startup #8830,
    independent-delegate #8744/#8761), so the text was stale.
  - Rewrote row 1's `tracking`/`evidence` strings and the docs paragraph to state that every
    production tool-assembly path now mints its registry through the one
    `ScopedToolRegistry::assemble` seam.
  - Added a comment on why row 1 stays `TrackedDivergence` rather than `Tested`: cross-path
    uniformity is convention-enforced, not compiler-enforced, because the engine's tools field
    is still a raw `&[Box<dyn Tool>]`. Only the engine-field seal (making the field type
    `ScopedToolRegistry`) turns a hand-rolled registry into a compile error, at which point the
    row converges to a single seam and becomes `Tested`.
- **Scope boundary:** Descriptive text only: the row-1 `tracking`/`evidence` string literals
  plus one explanatory comment in the `#[cfg(test)]` parity matrix, and one prose paragraph in
  the docs page. No production code, config, schema, API, or test *behavior* changes. The
  engine-field seal itself is NOT in this PR.
- **Blast radius:** None at runtime. The MATRIX strings are read only by the parity meta-test;
  the docs page is contributor-facing. No consumer branches on this text.
- **Linked issue(s):** Related #8711, #8830, #8744, #8761 (the cut-overs this reconciles).
  Follows #8659 (the harness scaffold) and #9030 (which already added the SOP-live-parity row
  and its test and flipped row 2 to a positive parity assertion; this is the leftover row-1
  refresh).
- **Labels:** suggested `type:test`, `risk:low`, `size:XS`, `docs`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A: descriptive-text refresh in a test module and docs
  prose; there is no runtime behavior to A/B.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` covers the changed
  Markdown; the runtime crate's test build compiles and runs the parity module (the
  `const MATRIX` is read by `parity_matrix_rows_are_owned_tracked_and_evidenced`, which asserts
  every row still carries a surface, setting, owner, tracking, and evidence).
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```sh
cargo test -p zeroclaw-runtime parity
# running 4 tests
# test agent::agent::parity::parity_matrix_rows_are_owned_tracked_and_evidenced ... ok
# test agent::agent::parity::parity_l2_builtin_filter_semantic_parity ... ok
# test agent::agent::parity::parity_l2_sop_live_step_agent_isolation ... ok
# test agent::agent::parity::parity_l1_engine_honors_excluded_tools ... ok
# test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 3381 filtered out

cargo fmt --all -- --check     # PASS (clean)
cargo clippy --workspace --all-targets --features ci-all --exclude zeroclaw-desktop -- -D warnings   # PASS
cargo test                     # PASS
```

Full local validation battery: `RESULT: PASS` (0 blocking, 0 warning), pinned toolchain
`+1.96.1`.

- **Beyond CI, what did you manually verify?** Confirmed against `upstream/master` that all
  four cut-over PRs (#8711/#8830/#8744/#8761) are in master history, and grepped `docs/` and
  `crates/` to confirm no third file mirrors the stale claim (`feature-matrix-parity.toml` does
  not encode the row-1 state). No code path was changed.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
