### PR TITLE
docs(observability): document deterministic log pagination

### DIFF
--- a/docs/book/src/ops/observability.md
+++ b/docs/book/src/ops/observability.md
@@ -203,10 +203,7 @@ The dashboard's Logs page is the primary surface. Underneath:
 GET /api/logs
 ```
 
-Top-level filters (query params): `since_ts`, `until_ts`, `until_id`,
-`action`, `category`, `outcome`, `severity_min`, `trace_id`, `q`
-(substring across `message` + `attributes`), `hide_internal` (drops
-`event.category = "internal"`), `limit`.
+Top-level filters (query params): `since_ts`, `until_ts`, `until_line_offset`, `action`, `category`, `outcome`, `severity_min`, `trace_id`, `q` (substring across `message` + `attributes`), `hide_internal` (drops `event.category = "internal"`), `limit`. The legacy `until_id` field remains available for timestamp/ID cursor compatibility.
 
 Every other `?<key>=<value>` is treated as a per-attribution equality
 filter, the gateway validates the key against `is_attribution_field`
@@ -235,10 +232,8 @@ curl "$ZEROCLAW_GATEWAY/api/logs?trace_id=<value-from-a-prior-event>"
 
 </div>
 
-Pagination is reverse-cursor. The response includes
-`next_cursor: [timestamp, id] | null`; pass these back as `until_ts` +
-`until_id` to load older. `at_end: true` means the reader scanned the
-whole file for the current filter.
+Log pagination walks backward with a byte-offset cursor. When `next_cursor_line_offset` is non-null, pass it back as `until_line_offset` to load older events without re-reading newer bytes. The legacy `next_cursor: [timestamp, id] | null` response remains for compatibility; using its timestamp/ID pair as `until_ts` and `until_id` for pagination is deprecated because the lexicographic ID tie-break can silently skip events with the same timestamp.
+`at_end: true` means the reader scanned the whole file for the current filter.
 
 The `/api/status` response includes `daemon_started_at: string` (RFC
 3339), so a dashboard can default to "since daemon start" without an

--- a/docs/book/src/ops/observability.md
+++ b/docs/book/src/ops/observability.md
@@ -232,8 +232,7 @@ curl "$ZEROCLAW_GATEWAY/api/logs?trace_id=<value-from-a-prior-event>"
 
 </div>
 
-Log pagination walks backward with a byte-offset cursor. When `next_cursor_line_offset` is non-null, pass it back as `until_line_offset` to load older events without re-reading newer bytes. The legacy `next_cursor: [timestamp, id] | null` response remains for compatibility; using its timestamp/ID pair as `until_ts` and `until_id` for pagination is deprecated because the lexicographic ID tie-break can silently skip events with the same timestamp.
-`at_end: true` means the reader scanned the whole file for the current filter.
+Log pagination walks backward with a byte-offset cursor. While `at_end` is false, pass a non-null `next_cursor_line_offset` back as `until_line_offset` with the same non-cursor filters to load older events without re-reading newer bytes. Restart from the newest page after changing filters. Treat `at_end: true` as the signal to stop requesting older pages for that pagination walk. The legacy `next_cursor: [timestamp, id] | null` response remains for compatibility; using its timestamp/ID pair as `until_ts` and `until_id` for pagination is deprecated because the lexicographic ID tie-break can silently skip events with the same timestamp.
 
 The `/api/status` response includes `daemon_started_at: string` (RFC
 3339), so a dashboard can default to "since daemon start" without an


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Updates the observability guide to make `next_cursor_line_offset` / `until_line_offset` the primary deterministic log-pagination path. It keeps `until_ts` documented as a supported standalone upper-bound filter and identifies only the legacy timestamp/ID pagination mechanism as deprecated.
- **Scope boundary:** Documentation only. This PR does not change the gateway or RPC API, remove compatibility fields, alter reader behavior, or change the dashboard consumer.
- **Blast radius:** Operator and third-party consumer guidance for `GET /api/logs` pagination.
- **Linked issue(s):** Related #8012; Related #8858
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`, `observability:log`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` - this is a documentation-only correction with no runtime behavior change.

### How I tested

- **CI checks relied on and why they cover this change:** Published-head `Docs Style` CI passed and covers the changed Markdown lines.
- **Known CI coverage gap, if any:** No docs-specific coverage gap identified after the local Markdown and added-link gates and published-head `Docs Style` CI.
- **Commands run and tail output:**

```text
git diff --check
# exit 0

DOCS_FILES=docs/book/src/ops/observability.md BASE_SHA=working-tree bash scripts/ci/docs_quality_gate.sh
# No prose em-dashes in changed docs files.
# Summary: 0 error(s)

bash scripts/ci/docs_links_gate.sh
# No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** Compared the documented field names and deprecation semantics with the gateway response, log reader, RPC types, dashboard consumer, and #8012 migration contract. I did not run Cargo or mdBook because the patch changes no Rust, generated reference, or link target.
- **If any command was intentionally skipped, why:** Cargo and mdBook were skipped because this is a one-file prose correction with no code, generated reference, or link change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low risk. Revert the documentation commit to restore the previous pagination guidance.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
