### PR TITLE
chore(codeowners): retire WareWolf-MoonWall, delegate singlerider's former areas to tidux, scope Nillth to the Git forge channel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # Default fallback. Only fires for genuinely uncategorized paths after the
 # explicit legacy/common fallback sections below.
 # ---------------------------------------------------------------------------
-* @WareWolf-MoonWall @Audacity88
+* @JordanTheJet @Audacity88
 
 # ---------------------------------------------------------------------------
 # Audacity-primary areas (runtime, agent, tools, gateway, config, memory)
@@ -16,7 +16,7 @@
 /crates/zeroclaw-runtime/**          @Audacity88
 /crates/zeroclaw-tools/**            @Audacity88
 /crates/zeroclaw-gateway/**          @Audacity88
-/crates/zeroclaw-config/**           @Audacity88 @JordanTheJet
+/crates/zeroclaw-config/**           @Audacity88 @tidux
 /crates/zeroclaw-memory/**           @Audacity88
 /crates/zeroclaw-tool-call-parser/** @Audacity88
 /src/agent/**                        @Audacity88
@@ -27,52 +27,53 @@
 /dev/**                              @Audacity88
 
 # ---------------------------------------------------------------------------
-# JordanTheJet-primary areas (providers, API, infra, hardware, firmware, web)
+# tidux-primary areas (providers, API, infra, hardware, firmware).
+# Web (/web, /dist) stays with @JordanTheJet (+ @IftekharUddin).
 # ---------------------------------------------------------------------------
-/crates/zeroclaw-providers/** @JordanTheJet @Nillth
-/crates/zeroclaw-api/**       @JordanTheJet
-/crates/zeroclaw-infra/**     @JordanTheJet
-/crates/zeroclaw-hardware/**  @JordanTheJet
-/crates/aardvark-sys/**       @JordanTheJet
-/crates/robot-kit/**          @JordanTheJet
-/crates/zeroclaw-macros/**    @JordanTheJet
-/firmware/**                  @JordanTheJet
-/src/providers/**             @JordanTheJet @Nillth
-/src/hardware/**              @JordanTheJet
+/crates/zeroclaw-providers/** @tidux @Nillth
+/crates/zeroclaw-api/**       @tidux
+/crates/zeroclaw-infra/**     @tidux
+/crates/zeroclaw-hardware/**  @tidux
+/crates/aardvark-sys/**       @tidux
+/crates/robot-kit/**          @tidux
+/crates/zeroclaw-macros/**    @tidux
+/firmware/**                  @tidux
+/src/providers/**             @tidux @Nillth
+/src/hardware/**              @tidux
 /web/**                       @JordanTheJet @IftekharUddin
 /dist/**                      @JordanTheJet
-/apps/**                      @JordanTheJet
+/apps/**                      @tidux
 
 # Zerocode TUI: paired. Must come AFTER /apps/** (last match wins) or the
 # broad apps rule strips @Audacity88 from zerocode files.
-/apps/zerocode/**             @JordanTheJet @Audacity88
+/apps/zerocode/**             @tidux @Audacity88
 
 # ---------------------------------------------------------------------------
 # Legacy root crate and common source paths (shared maintainer triage)
 # ---------------------------------------------------------------------------
-/src/main.rs              @WareWolf-MoonWall @Audacity88
-/src/lib.rs               @WareWolf-MoonWall @Audacity88
-/src/bin/**               @WareWolf-MoonWall @Audacity88
-/src/approval/**          @WareWolf-MoonWall @Audacity88
-/src/auth/**              @WareWolf-MoonWall @Audacity88
-/src/commands/**          @WareWolf-MoonWall @Audacity88
-/src/cron/**              @WareWolf-MoonWall @Audacity88
-/src/daemon/**            @WareWolf-MoonWall @Audacity88
-/src/doctor/**            @WareWolf-MoonWall @Audacity88
-/src/health/**            @WareWolf-MoonWall @Audacity88
-/src/hooks/**             @WareWolf-MoonWall @Audacity88
-/src/nodes/**             @WareWolf-MoonWall @Audacity88
-/src/observability/**     @WareWolf-MoonWall @Audacity88
-/src/peripherals/**       @WareWolf-MoonWall @Audacity88
-/src/platform/**          @WareWolf-MoonWall @Audacity88
-/src/rag/**               @WareWolf-MoonWall @Audacity88
-/src/routines/**          @WareWolf-MoonWall @Audacity88
-/src/service/**           @WareWolf-MoonWall @Audacity88
-/src/sop/**               @WareWolf-MoonWall @Audacity88
-/src/trust/**             @WareWolf-MoonWall @Audacity88
-/src/tunnel/**            @WareWolf-MoonWall @Audacity88
-/src/verifiable_intent/** @WareWolf-MoonWall @Audacity88
-/src/config/**            @Audacity88 @JordanTheJet
+/src/main.rs              @tidux @Audacity88
+/src/lib.rs               @tidux @Audacity88
+/src/bin/**               @tidux @Audacity88
+/src/approval/**          @tidux @Audacity88
+/src/auth/**              @tidux @Audacity88
+/src/commands/**          @tidux @Audacity88
+/src/cron/**              @tidux @Audacity88
+/src/daemon/**            @tidux @Audacity88
+/src/doctor/**            @tidux @Audacity88
+/src/health/**            @tidux @Audacity88
+/src/hooks/**             @tidux @Audacity88
+/src/nodes/**             @tidux @Audacity88
+/src/observability/**     @tidux @Audacity88
+/src/peripherals/**       @tidux @Audacity88
+/src/platform/**          @tidux @Audacity88
+/src/rag/**               @tidux @Audacity88
+/src/routines/**          @tidux @Audacity88
+/src/service/**           @tidux @Audacity88
+/src/sop/**               @tidux @Audacity88
+/src/trust/**             @tidux @Audacity88
+/src/tunnel/**            @tidux @Audacity88
+/src/verifiable_intent/** @tidux @Audacity88
+/src/config/**            @Audacity88 @tidux
 /src/cost/**              @Audacity88
 /src/cli_input.rs         @Audacity88
 /src/identity.rs          @Audacity88
@@ -82,74 +83,74 @@
 # ---------------------------------------------------------------------------
 # Tests, benches, fuzzing, and examples (shared maintainer triage)
 # ---------------------------------------------------------------------------
-/tests/**   @WareWolf-MoonWall @Audacity88
-/benches/** @WareWolf-MoonWall @Audacity88
-/fuzz/**    @WareWolf-MoonWall @Audacity88
+/tests/**   @JordanTheJet @Audacity88
+/benches/** @JordanTheJet @Audacity88
+/fuzz/**    @JordanTheJet @Audacity88
 
 # ---------------------------------------------------------------------------
 # Repository metadata and local development tooling
 # ---------------------------------------------------------------------------
-/.actrc                    @WareWolf-MoonWall @Audacity88
-/.cargo/**                 @WareWolf-MoonWall @Audacity88
-/.dockerignore             @WareWolf-MoonWall @Audacity88
-/.editorconfig             @WareWolf-MoonWall @Audacity88
-/.env.example              @WareWolf-MoonWall @Audacity88
-/.envrc                    @WareWolf-MoonWall @Audacity88
-/.gemini/**                @WareWolf-MoonWall @Audacity88
-/.gitattributes            @WareWolf-MoonWall @Audacity88
-/.githooks/**              @WareWolf-MoonWall @Audacity88
-/.gitignore                @WareWolf-MoonWall @Audacity88
-/.markdownlint-cli2.yaml   @WareWolf-MoonWall @Audacity88
-/.vscode/**                @WareWolf-MoonWall @Audacity88
-/CNAME                     @WareWolf-MoonWall @Audacity88
+/.actrc                    @JordanTheJet @Audacity88
+/.cargo/**                 @JordanTheJet @Audacity88
+/.dockerignore             @JordanTheJet @Audacity88
+/.editorconfig             @JordanTheJet @Audacity88
+/.env.example              @JordanTheJet @Audacity88
+/.envrc                    @JordanTheJet @Audacity88
+/.gemini/**                @JordanTheJet @Audacity88
+/.gitattributes            @JordanTheJet @Audacity88
+/.githooks/**              @JordanTheJet @Audacity88
+/.gitignore                @JordanTheJet @Audacity88
+/.markdownlint-cli2.yaml   @JordanTheJet @Audacity88
+/.vscode/**                @JordanTheJet @Audacity88
+/CNAME                     @JordanTheJet @Audacity88
 
 # ---------------------------------------------------------------------------
-# Channels (Audacity primary + JordanTheJet specialist)
+# Channels (Audacity primary + tidux specialist)
 # ---------------------------------------------------------------------------
-/crates/zeroclaw-channels/** @Audacity88 @JordanTheJet @Nillth
-/src/channels/**             @Audacity88 @JordanTheJet @Nillth
+/crates/zeroclaw-channels/** @Audacity88 @tidux @Nillth
+/src/channels/**             @Audacity88 @tidux @Nillth
 
 # ---------------------------------------------------------------------------
 # Skills, plugins (per Jordan's suggested patch on PR #6537)
 # ---------------------------------------------------------------------------
-/crates/zeroclaw-plugins/**                @JordanTheJet @WareWolf-MoonWall @Audacity88
-/crates/zeroclaw-runtime/src/skills/**     @JordanTheJet @WareWolf-MoonWall @Audacity88
-/crates/zeroclaw-runtime/src/skillforge/** @JordanTheJet @WareWolf-MoonWall @Audacity88
-/plugins/**                                @JordanTheJet @WareWolf-MoonWall @Audacity88
-/src/plugins/**                            @JordanTheJet @WareWolf-MoonWall @Audacity88
-/src/skills/**                             @JordanTheJet @WareWolf-MoonWall @Audacity88
-/src/skillforge/**                         @JordanTheJet @WareWolf-MoonWall @Audacity88
-/.claude/skills/**                         @JordanTheJet @WareWolf-MoonWall @Audacity88
+/crates/zeroclaw-plugins/**                @JordanTheJet @Audacity88
+/crates/zeroclaw-runtime/src/skills/**     @JordanTheJet @Audacity88
+/crates/zeroclaw-runtime/src/skillforge/** @JordanTheJet @Audacity88
+/plugins/**                                @JordanTheJet @Audacity88
+/src/plugins/**                            @JordanTheJet @Audacity88
+/src/skills/**                             @JordanTheJet @Audacity88
+/src/skillforge/**                         @JordanTheJet @Audacity88
+/.claude/skills/**                         @JordanTheJet @Audacity88
 
 # ---------------------------------------------------------------------------
 # Desktop app (Tauri)
 # ---------------------------------------------------------------------------
-/apps/tauri/** @JordanTheJet @WareWolf-MoonWall @Audacity88
+/apps/tauri/** @JordanTheJet @Audacity88
 
 # ---------------------------------------------------------------------------
-# Internationalization (JordanTheJet specialist)
+# Internationalization (tidux specialist)
 # ---------------------------------------------------------------------------
-/locales.toml                       @JordanTheJet
-/src/i18n.rs                        @JordanTheJet
-/crates/zeroclaw-runtime/locales/** @JordanTheJet
-/tools/fill-translations/**         @JordanTheJet
-/TRANSLATIONS.md                    @JordanTheJet
+/locales.toml                       @tidux
+/src/i18n.rs                        @tidux
+/crates/zeroclaw-runtime/locales/** @tidux
+/tools/fill-translations/**         @tidux
+/TRANSLATIONS.md                    @tidux
 
 # Explicit i18n files Audacity flagged on PR #6537. Would otherwise resolve
 # to their broader area without the i18n specialist on them.
-/crates/zeroclaw-runtime/src/i18n.rs @Audacity88 @JordanTheJet
+/crates/zeroclaw-runtime/src/i18n.rs @Audacity88 @tidux
 /web/src/lib/i18n.ts                 @JordanTheJet @IftekharUddin
 
 # ---------------------------------------------------------------------------
-# Other docs (Audacity-led + JordanTheJet). Must come BEFORE architecture-doc
+# Other docs (Audacity-led + tidux). Must come BEFORE architecture-doc
 # overrides below so the narrower foundations/RFC rules can win.
 # ---------------------------------------------------------------------------
-/docs/** @Audacity88 @JordanTheJet
+/docs/** @Audacity88 @tidux
 
 # ---------------------------------------------------------------------------
-# Architecture docs (high-risk, paired)
+# Architecture docs (high-risk, paired: Audacity + tidux + JordanTheJet lead)
 # ---------------------------------------------------------------------------
-/docs/book/src/foundations/** @Audacity88 @JordanTheJet
+/docs/book/src/foundations/** @Audacity88 @tidux @JordanTheJet
 
 # ---------------------------------------------------------------------------
 # Maintainer-process docs (PM/process lane). Narrower than /docs/**, so it
@@ -165,8 +166,8 @@
 # Note: CODEOWNERS itself accepts any one listed owner's approval; the
 # required-approval count is enforced by branch protection, not by pairing.
 # ---------------------------------------------------------------------------
-/.github/**             @Audacity88 @JordanTheJet
-/.github/CODEOWNERS     @Audacity88 @JordanTheJet
+/.github/**             @Audacity88 @tidux @JordanTheJet
+/.github/CODEOWNERS     @Audacity88 @tidux @JordanTheJet
 /release-plz.toml       @Audacity88
 /scripts/**             @Audacity88
 /xtask/**               @Audacity88
@@ -192,14 +193,14 @@
 /.github/labeler.yml              @Audacity88 @IftekharUddin
 
 # ---------------------------------------------------------------------------
-# Security (high-risk, paired: Audacity + JordanTheJet)
+# Security (high-risk, paired: Audacity + tidux + JordanTheJet lead)
 # ---------------------------------------------------------------------------
-/SECURITY.md                             @Audacity88 @JordanTheJet
-/deny.toml                               @Audacity88 @JordanTheJet
-/src/security/**                         @Audacity88 @JordanTheJet
-/crates/zeroclaw-runtime/src/security/** @Audacity88 @JordanTheJet
-/.github/codeql/**                       @Audacity88 @JordanTheJet
-/.github/dependabot.yml                  @Audacity88 @JordanTheJet
+/SECURITY.md                             @Audacity88 @tidux @JordanTheJet
+/deny.toml                               @Audacity88 @tidux @JordanTheJet
+/src/security/**                         @Audacity88 @tidux @JordanTheJet
+/crates/zeroclaw-runtime/src/security/** @Audacity88 @tidux @JordanTheJet
+/.github/codeql/**                       @Audacity88 @tidux @JordanTheJet
+/.github/dependabot.yml                  @Audacity88 @tidux @JordanTheJet
 
 # ---------------------------------------------------------------------------
 # Cargo manifests at any depth (legacy stewardship, Jordan)
@@ -210,9 +211,9 @@ Cargo.lock @JordanTheJet
 # ---------------------------------------------------------------------------
 # Root governance Markdown (paired)
 # ---------------------------------------------------------------------------
-/AGENTS.md          @Audacity88 @JordanTheJet
-/CONTRIBUTING.md    @Audacity88 @JordanTheJet
-/CODE_OF_CONDUCT.md @Audacity88 @JordanTheJet
+/AGENTS.md          @Audacity88 @tidux @JordanTheJet
+/CONTRIBUTING.md    @Audacity88 @tidux @JordanTheJet
+/CODE_OF_CONDUCT.md @Audacity88 @tidux @JordanTheJet
 
 # ---------------------------------------------------------------------------
 # Other top-level Markdown, license, notice files (legacy stewardship)
@@ -228,10 +229,10 @@ Cargo.lock @JordanTheJet
 # Specific overrides (must be last)
 # ---------------------------------------------------------------------------
 # Channels-crate Cargo.toml: legacy steward + channels owners
-/crates/zeroclaw-channels/Cargo.toml @Audacity88 @JordanTheJet @Nillth
+/crates/zeroclaw-channels/Cargo.toml @Audacity88 @tidux @JordanTheJet @Nillth
 
 # Matrix backend
-/crates/zeroclaw-channels/src/matrix.rs @tidux @Audacity88 @JordanTheJet
+/crates/zeroclaw-channels/src/matrix.rs @tidux @Audacity88
 
 # ACP server (per @tidux's request on PR #6537)
-/crates/zeroclaw-channels/src/orchestrator/acp_server.rs @tidux @Audacity88 @JordanTheJet
+/crates/zeroclaw-channels/src/orchestrator/acp_server.rs @tidux @Audacity88

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 # tidux-primary areas (providers, API, infra, hardware, firmware).
 # Web (/web, /dist) stays with @JordanTheJet (+ @IftekharUddin).
 # ---------------------------------------------------------------------------
-/crates/zeroclaw-providers/** @tidux @Nillth
+/crates/zeroclaw-providers/** @tidux @Audacity88
 /crates/zeroclaw-api/**       @tidux
 /crates/zeroclaw-infra/**     @tidux
 /crates/zeroclaw-hardware/**  @tidux
@@ -38,7 +38,7 @@
 /crates/robot-kit/**          @tidux
 /crates/zeroclaw-macros/**    @tidux
 /firmware/**                  @tidux
-/src/providers/**             @tidux @Nillth
+/src/providers/**             @tidux @Audacity88
 /src/hardware/**              @tidux
 /web/**                       @JordanTheJet @IftekharUddin
 /dist/**                      @JordanTheJet
@@ -107,8 +107,13 @@
 # ---------------------------------------------------------------------------
 # Channels (Audacity primary + tidux specialist)
 # ---------------------------------------------------------------------------
-/crates/zeroclaw-channels/** @Audacity88 @tidux @Nillth
-/src/channels/**             @Audacity88 @tidux @Nillth
+/crates/zeroclaw-channels/** @Audacity88 @tidux
+/src/channels/**             @Audacity88 @tidux
+
+# Git forge channel: Nillth authored the subsystem (#8609 GitHub provider,
+# #8611 Gitea/Forgejo). Narrower than the channels rules above, so it must
+# come after them (last match wins).
+/crates/zeroclaw-channels/src/git/** @Audacity88 @Nillth
 
 # ---------------------------------------------------------------------------
 # Skills, plugins (per Jordan's suggested patch on PR #6537)
@@ -229,7 +234,7 @@ Cargo.lock @JordanTheJet
 # Specific overrides (must be last)
 # ---------------------------------------------------------------------------
 # Channels-crate Cargo.toml: legacy steward + channels owners
-/crates/zeroclaw-channels/Cargo.toml @Audacity88 @tidux @JordanTheJet @Nillth
+/crates/zeroclaw-channels/Cargo.toml @Audacity88 @tidux @JordanTheJet
 
 # Matrix backend
 /crates/zeroclaw-channels/src/matrix.rs @tidux @Audacity88


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - **tidux takes singlerider's former areas.** #9107 named me successor on all 44 of singlerider's paths. tidux overlapped with singlerider across most of that surface (zerocode, Matrix, ACP, channels) and has offered to take it on; I do not have the review bandwidth to hold it. Moves providers, API, infra, hardware, firmware, macros, aardvark-sys, robot-kit, `/apps`, zerocode, config, channels, i18n, and `/docs` to `@tidux`.
  - **@WareWolf-MoonWall is retired from review routing,** and his areas split by signal: the legacy `/src` block (main, lib, bin, approval, auth, commands, cron, daemon, doctor, health, hooks, nodes, observability, peripherals, platform, rag, routines, service, sop, trust, tunnel, verifiable_intent) goes to `@tidux` with `@Audacity88`; tests, benches, fuzz, repository metadata, the plugins and skills paths, `apps/tauri`, and the default `*` fallback come to me with `@Audacity88`.
  - **@Nillth is scoped to the git forge channel he authored** (added after `@Audacity88`'s review). He owns `/crates/zeroclaw-channels/src/git/**` with `@Audacity88`, and comes off the broad channels tree, the channels-crate `Cargo.toml`, and providers. `@Audacity88` takes the providers slot he asked for. This takes Nillth from 84 open auto-requests to effectively zero while keeping him on the subsystem he is the only expert in.
  - **auth lands with tidux** as part of that legacy `/src` block. He asked for it specifically; it was never singlerider's path, so it arrives here rather than in a separate change.
  - **The project lead stays on high-risk paired paths:** foundations, `/.github`, `/.github/CODEOWNERS`, the six security paths, and root governance Markdown. Keeping the lead on CODEOWNERS itself does not gate future routing changes on a lead approval: GitHub accepts approval from any one listed code owner, as the in-file comment on those lines already states. What it does is keep the lead automatically requested and eligible to approve. The actual gate on routing changes is the explicit Core Team vote required by FND-003 §5.2, plus branch protection, neither of which this file enforces.
  - **Redundant third owners dropped** from `matrix.rs` and `acp_server.rs`, where tidux is already primary.
- **Scope boundary:** No code, config schema, CLI, or test changes; this is review-routing metadata only. Web surfaces (`/web`, `/dist`, `web/src/lib/i18n.ts`) keep their existing owners per the web and PM/process lanes set in #9107. `@Audacity88`'s primary areas (runtime, agent, tools, gateway, memory, release, scripts, build tooling) are untouched. `@IftekharUddin`'s PM/process lane (maintainer docs, issue templates, labeler) is untouched. Pre-existing stewardship of the Cargo manifests, licenses, and root Markdown stays with me. No rule ordering changed, so every "last match wins" override still resolves as before. The maintainer focus-area table in `docs/book/src/contributing/communication.md` is deliberately left for a follow-up so this PR stays routing-only.
- **Blast radius:** Reviewer auto-request routing and branch-protection approval eligibility only; no runtime, build, or packaging effect. Two governance consequences worth stating plainly: `@tidux` becomes an eligible approver on a much larger surface including auth and security, and `@WareWolf-MoonWall` loses code-owner status and automatic routing on the 48 lines that named him. That is narrower than losing review eligibility: any collaborator can still review and comment. `@Nillth` is not retired; he keeps the git forge channel he wrote. Worth stating for the record: this retires the repository's second most active reviewer, so channels now rests entirely on `@Audacity88` and `@tidux`. `@Audacity88` can clearly absorb it (438 PRs reviewed since 2026-07-01 against a 47-PR pending queue). `@tidux` is the capacity risk: his pending queue is already the largest of any owner at 95, and this PR takes him from 2 effective ownership rules to 60. Owner tallies after both commits, counting effective rule lines: `@tidux` 2 to 60, `@Audacity88` 106 to 109, `@JordanTheJet` 51, `@IftekharUddin` 7, `@WareWolf-MoonWall` 48 to 0, `@Nillth` 5 to 1. Every owner named in the resulting file holds write access upstream, so no path is left without an effective reviewer.

  **Update since `@Audacity88`'s review:** `@WareWolf-MoonWall`'s write access has since been revoked, and he is no longer a repository collaborator. CODEOWNERS silently ignores owners without write access, so `master` now reports **48 `Unknown owner` errors, up from the zero** observed during that review. Every affected path retains `@Audacity88`, so nothing is ownerless, but the legacy `src/` tree, tests, benches, fuzz, repository metadata, and the `*` fallback are effectively single-owner until this merges. This PR removes exactly those 48 lines, so it is now a fix for live routing breakage rather than only a governance change.
- **Linked issue(s):** Related #9107. Related #6537.
- **Labels:** Path labeler owns scope labels from `.github/labeler.yml`. Maintainers please set `risk:*` and `size:*`; I would suggest treating this as governance-risk rather than size-risk given the diff is 93 added and 92 removed routing lines across 1 file and zero code lines.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — CODEOWNERS is review-routing metadata with no user-visible or runtime behavior; there is nothing for a reviewer to exercise on a branch. The meaningful verification is GitHub's own CODEOWNERS parser plus the owner-access check below.

### How I tested

Validated the file with GitHub's CODEOWNERS parser and confirmed every named owner can actually receive review requests. Both matter here: a CODEOWNERS entry naming someone without write access is silently ignored, which would leave a path effectively unowned.

- **CI checks relied on and why they cover this change:** No code, Markdown, or link surface changed, so the Rust and docs gates have nothing to cover. GitHub validates `.github/CODEOWNERS` on push and surfaces parse errors in the repository UI; that is the gate for this diff.
- **Known CI coverage gap, if any:** There is no repo CI job that asserts CODEOWNERS owner-access validity, so I checked it out of band via the collaborators API, below.
- **Commands run and tail output:**

Owner write access on `zeroclaw-labs/zeroclaw` (an owner without write access is ignored by CODEOWNERS):

```console
$ for u in tidux Audacity88 JordanTheJet IftekharUddin Nillth WareWolf-MoonWall; do
    printf "%-20s %s\n" "$u" "$(gh api repos/zeroclaw-labs/zeroclaw/collaborators/$u/permission --jq .permission)"
  done
tidux                write
Audacity88           write
JordanTheJet         admin
IftekharUddin        write
Nillth               write
WareWolf-MoonWall    write
```

Parser check. Baseline on upstream `master` is clean, and on this branch every reported error is of kind `Unknown owner`, which is expected when validating against my fork since the fork has no collaborators. No `Invalid pattern`, `Unexpected character`, or other syntax error kinds appear:

```console
$ gh api repos/zeroclaw-labs/zeroclaw/codeowners/errors --jq '.errors | length'
0

$ gh api "repos/JordanTheJet/zeroclaw/codeowners/errors?ref=chore/codeowners-transfer-tidux" \
    --jq '[.errors[].kind] | group_by(.) | map({kind: .[0], count: length})'
[{"kind":"Unknown owner","count":176}]
```

- **Beyond CI, what did you manually verify?** Read the full file top to bottom and confirmed rule ordering is unchanged, so the documented "last match wins" overrides still resolve correctly: `/apps/zerocode/**` still follows `/apps/**`, `/docs/book/src/foundations/**` and `/docs/book/src/maintainers/**` still follow `/docs/**`, `/apps/tauri/**` still follows `/apps/**`, and the `.github` template and codeql overrides still follow `/.github/**`. Verified no path lost all its owners, that `@singlerider` has zero remaining references, and that the web, PM/process, Cargo, and license lanes are byte-identical to `master`. I did **not** verify the resulting branch-protection approval math for any specific path, since required-approval counts are enforced by branch protection settings rather than by this file.
- **If any command was intentionally skipped, why:** `cargo fmt`, `cargo clippy`, and `cargo test` were skipped: no Rust source, manifest, or test file is touched. Markdown gates were skipped: no Markdown is touched.

### Review-activity data behind the Nillth change

`@Audacity88` cited 6 done against 85 requested on open PRs and read that as Nillth not reviewing. Measured it before acting; the picture is more specific.

**The 6 is a query artifact.** `is:open reviewed-by:@nillth` only counts PRs still open. Of the 68 PRs Nillth has reviewed, 59 merged and 3 closed, so 62 are invisible to that filter precisely because his reviews landed and the PRs shipped. From `submitted_at` on the reviews endpoint rather than PR `updated_at`, his record is 86 review submissions between 2026-06-13 and 2026-07-20.

**The genuine signal is recency.** Weekly review submissions: 8, 12, 18, 8, 26, 13, then 1 in the week of 2026-07-20. He ramped from a standing start to 26 in a week and then fell off sharply, which reads as load rather than disengagement.

**Providers was the wrong home, and an earlier revision of this branch got that wrong** by optimising purely for queue size. Reviews alone are a misleading signal for a CODEOWNER, because being an owner generates the auto-requests you then answer. Authorship separates them:

| Signal | Channels | Providers |
|---|---|---|
| PRs authored (last 70) | 22 | 4 |
| PRs reviewed | 29 | 12 |
| Open requests pending | 55 | 21 |
| Review completion | 35% | 36% |

His providers reviews are a by-product of already owning providers; his building is channels. There is also no specialty inside channels to key on: 72% of the channels PRs he reviewed touch the orchestrator, but so do 71% of the ones he did not, so his review mix just mirrors the underlying PR mix.

**What he does own outright is the git forge channel.** He authored it in #8609 (GitHub provider) and #8611 (Gitea/Forgejo); apart from two commits by the departed singlerider, no one else has touched `crates/zeroclaw-channels/src/git`. Routing that path to him keeps him where he is the only expert, and 0 of his 84 pending requests touch it, so the added load is nil.

For scale, PRs reviewed and active since 2026-07-01, same basis for everyone: `@Audacity88` 438, `@WareWolf-MoonWall` 249, `@JordanTheJet` 100, `@tidux` 60, `@Nillth` 32.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — no code-level permission or filesystem scope changes. Code-owner status and automatic review routing do change, which is a governance matter rather than a capability grant, and no one loses the ability to review or comment; it is described under Blast radius and needs the sign-offs requested at the bottom of this description.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — GitHub handles only, which this file has always contained.
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

Worth flagging for the security reviewer specifically: `/src/security/**`, `/crates/zeroclaw-runtime/src/security/**`, `SECURITY.md`, `deny.toml`, `/.github/codeql/**`, and `/.github/dependabot.yml` all stay paired and all keep both `@Audacity88` and the project lead. `@tidux` is added to them rather than replacing anyone, so the security surface gains a reviewer and loses none.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

Filling these despite the low technical risk, since the governance impact is what matters here.

- **Fast rollback command/path:** `git revert <sha>` restores the previous routing exactly; the change is a single commit touching one file.
- **Feature flags or config toggles:** `None` — CODEOWNERS has no toggle. Interim mitigation without a revert is to add an owner back to a specific path.
- **Observable failure symptoms:** Reviewers stop being auto-requested on paths they expect, or PRs stall because no eligible owner is available to satisfy branch protection. Check the Reviewers sidebar on a fresh PR touching the path, and the repository CODEOWNERS error banner under Insights if a pattern or owner is rejected.

---

Requesting explicit written confirmation before this merges, since it reassigns other people's review load:

- `@tidux` — please confirm you accept this scope. It is substantially larger than the Matrix and ACP paths you hold today: it adds auth, the legacy `/src` block, providers, API, infra, hardware, firmware, channels, i18n, `/docs`, and the security paths.
- `@WareWolf-MoonWall` — please confirm you are stepping back from review routing, and say so here if you would rather keep any of these paths.
- `@Nillth` — you are not being retired. You keep the git forge channel you authored and come off the broad channels tree and providers. Please confirm that works, and say so if you would rather hold more.
- `@Audacity88` — you are the co-owner on nearly every reassigned path, so please sanity-check the split, and confirm you are taking the providers slot.


