### PR TITLE
ci(tests): parallelize runtime stress gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,6 +570,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         id: rust-cache
         with:
+          shared-key: test
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Ensure web/dist placeholder exists

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,68 @@ jobs:
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+
+  parallel-runtime-test-changes:
+    name: Detect parallel runtime test changes
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.changed.outputs.run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Test parallel runtime scope classifier
+        run: bash scripts/ci/parallel_runtime_test_scope.test.sh
+      - name: Detect parallel runtime test changes
+        id: changed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              changed_files="$(mktemp)"
+              git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD > "$changed_files"
+              if bash scripts/ci/parallel_runtime_test_scope.sh < "$changed_files"; then
+                echo "run=true" >> "$GITHUB_OUTPUT"
+              else
+                status=$?
+                if [ "$status" -ne 1 ]; then
+                  exit "$status"
+                fi
+                echo "run=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            push|merge_group)
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  parallel-runtime-test:
+    name: Parallel Runtime Test
+    needs: [parallel-runtime-test-changes]
+    if: needs.parallel-runtime-test-changes.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        id: rust-cache
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Ensure web/dist placeholder exists
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Install mold linker
+        run: bash scripts/ci/apt_install.sh mold
       - name: Repeat parallel runtime tests
         run: ./scripts/ci/parallel_runtime_test_gate.sh
         env:
@@ -743,7 +805,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-32bit, bench, test, test-landlock, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-32bit, bench, test, parallel-runtime-test-changes, parallel-runtime-test, test-landlock, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results

--- a/docs/book/src/contributing/testing.md
+++ b/docs/book/src/contributing/testing.md
@@ -54,6 +54,9 @@ The parallel runtime gate repeats the complete `zeroclaw-runtime` and
 `zeroclaw-channels` library test binaries with 16 harness threads. Running the
 whole binaries is intentional: it detects interference between state-mutating
 tests and otherwise unrelated agent turns that filtered test runs cannot expose.
+Required CI runs this gate in a separate job for changes to either crate, the
+workspace dependency manifests, or the gate's own CI files. Other PRs skip it;
+pushes to `master` and merge queue runs retain the full regression backstop.
 Override repetitions with `ZEROCLAW_PARALLEL_TEST_RUNS` and harness threads
 with `ZEROCLAW_PARALLEL_TEST_THREADS`.
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -15,12 +15,13 @@ Composite job with multiple matrix legs:
 - **check**: all features + no-default-features
 - **check-32bit**: `i686-unknown-linux-gnu` with no default features
 - **bench**: benchmarks compile check
-- **test**: the standalone firmware protocol host gate from `scripts/ci/firmware_protocol_gate.sh`, `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`, and repeated same-process parallel runtime/channel tests from `scripts/ci/parallel_runtime_test_gate.sh` on Linux
+- **test**: the standalone firmware protocol host gate from `scripts/ci/firmware_protocol_gate.sh` and `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` on Linux
+- **parallel-runtime-test**: repeated same-process runtime/channel tests from `scripts/ci/parallel_runtime_test_gate.sh`, run in parallel with the main test job for relevant PR paths and unconditionally on `master` pushes and merge queue runs
 - **security**: `cargo deny check`
 - **nix-eval**: evaluates the NixOS module assertions (`nixos-module-eval` flake check)
 - **docs-style**: markdown lint, em-dash prose check, and changed-line link gate via `scripts/ci/docs_quality_gate.sh` and `scripts/ci/docs_links_gate.sh`
 
-`fmt` runs first as the cheap serial gate. Every other job declares `needs: [fmt]` and fans out after formatting passes; `CI Required Gate` aggregates every result. Branch protection pins the composite gate job. A PR cannot merge until this is green. The `master` push run keeps the same quality signal while seeding trusted Rust caches for later PR runs.
+`fmt` runs first as the cheap serial gate. Every other job declares `needs: [fmt]` directly or transitively and fans out after formatting passes; `CI Required Gate` aggregates every result. Branch protection pins the composite gate job. A PR cannot merge until this is green. The `master` push run keeps the same quality signal while seeding trusted Rust caches for later PR runs.
 
 Fresh required CI is normally the shared evidence for the Cargo surfaces it actually runs. A local rerun of the same Cargo command on the same head, target, and feature set is duplicate confidence, not a stronger proof. Before asking for extra Cargo or Clippy, compare the changed surface with the current workflow files and the actual checks on the PR. Extra validation belongs where the required gate does not prove the thing under review:
 

--- a/scripts/ci/parallel_runtime_test_scope.sh
+++ b/scripts/ci/parallel_runtime_test_scope.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+while IFS= read -r path; do
+    case "$path" in
+        Cargo.toml|Cargo.lock|\
+        .github/workflows/ci.yml|\
+        crates/zeroclaw-runtime/*|\
+        crates/zeroclaw-channels/*|\
+        scripts/ci/parallel_runtime_test_*.sh)
+            echo "parallel runtime test scope matched: $path"
+            exit 0
+            ;;
+    esac
+done
+
+echo "parallel runtime test scope not matched"
+exit 1

--- a/scripts/ci/parallel_runtime_test_scope.test.sh
+++ b/scripts/ci/parallel_runtime_test_scope.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+classifier="${script_dir}/parallel_runtime_test_scope.sh"
+
+expect_run() {
+    local name="$1"
+    shift
+
+    if ! printf '%s\n' "$@" | bash "$classifier" >/dev/null; then
+        echo "FAIL: expected parallel runtime tests for $name" >&2
+        exit 1
+    fi
+}
+
+expect_skip() {
+    local name="$1"
+    shift
+
+    set +e
+    printf '%s\n' "$@" | bash "$classifier" >/dev/null
+    status=$?
+    set -e
+
+    if [ "$status" -ne 1 ]; then
+        echo "FAIL: expected status 1 while skipping $name, got $status" >&2
+        exit 1
+    fi
+}
+
+expect_run "runtime source" "crates/zeroclaw-runtime/src/agent/loop_.rs"
+expect_run "channel source" "crates/zeroclaw-channels/src/orchestrator/mod.rs"
+expect_run "workspace manifest" "Cargo.toml"
+expect_run "workspace lockfile" "Cargo.lock"
+expect_run "quality workflow" ".github/workflows/ci.yml"
+expect_run "parallel gate" "scripts/ci/parallel_runtime_test_gate.sh"
+expect_run "scope classifier" "scripts/ci/parallel_runtime_test_scope.sh"
+expect_run "mixed paths" "apps/zerocode/src/app.rs" "crates/zeroclaw-runtime/src/lib.rs"
+
+expect_skip "ZeroCode-only changes" "apps/zerocode/src/app.rs"
+expect_skip "web-only changes" "web/src/pages/AgentChat.tsx"
+expect_skip "docs-only changes" "docs/book/src/contributing/testing.md"
+expect_skip "unrelated crate changes" "crates/zeroclaw-providers/src/openai.rs"
+expect_skip "empty input"
+
+echo "parallel runtime test scope tests: pass"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Moved the repeated same-process runtime/channel stress gate out of the main `Test` job and into a separate job in the required Quality Gate graph so it runs alongside the normal workspace tests instead of after them.
  - Added a tested path classifier that runs the stress job for runtime, channel, workspace dependency, and gate-owning CI changes while skipping unrelated PRs.
  - Configured the separate job to restore the established `Test` Rust cache instead of starting with a job-specific cold cache.
  - Kept the complete stress gate on `master` pushes and merge queue runs, and documented the resulting CI contract.
- **Scope boundary:** This does not change the stress command, repetition count, harness thread count, runtime/channel tests, or the flaky tests tracked in #9357.
- **Blast radius:** Required Quality Gate scheduling and path selection. A classifier error or stress-job failure still fails `CI Required Gate`; an intentional path-based skip does not.
- **Linked issue(s):** Follow-up to #9232. Related #9357.
- **Labels:** `type:ci`, `ci`, `docs`, `scripts`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; the Actions job graph is the useful behavior boundary.
- **Interface(s) exercised:** N/A; internal GitHub Actions quality-gate scheduling.
- **Setup / preconditions:** Push the branch or open a PR against `master`.
- **Steps to run:**
  1. Inspect a Quality Gate run for this branch, which changes `.github/workflows/ci.yml`.
  2. Confirm `Test` starts after `Format` and `Parallel Runtime Test` starts after its detector, which also follows `Format`.
  3. Confirm the parallel job restores the `Test` Rust cache rather than a job-specific `parallel-runtime-test` cache.
  4. On an unrelated-only PR, confirm `Detect parallel runtime test changes` succeeds and `Parallel Runtime Test` is skipped.
- **Expected on this branch (after):** Relevant changes run the repeated stress gate in parallel with normal tests and reuse the normal test cache. Unrelated PRs skip the stress runner. Detector or stress failures still fail `CI Required Gate`.
- **Prior behavior on `master` (before):** `Repeat parallel runtime tests` runs inside `Test` after workspace nextest completes, so both durations are added to the required path for every PR.

### How I tested

- **CI checks relied on and why they cover this change:** The current-head Quality Gate passed. `Parallel Runtime Test` passed all six stress runs in 6m09s, restored the exact `v0-rust-test` cache key, and completed alongside the 10m12s normal `Test` job. `CI Required Gate` then passed.
- **Known CI coverage gap, if any:** This relevant-path PR does not exercise the hosted unrelated-path skip; the classifier fixture covers that branch locally. The stress command was not run locally; #9357 tracks current same-process runtime failures on `master`, which this scheduling change does not fix.
- **Commands run and tail output:**

```sh
$ bash scripts/ci/parallel_runtime_test_scope.test.sh
parallel runtime test scope tests: pass

$ bash -n scripts/ci/parallel_runtime_test_scope.sh \
    scripts/ci/parallel_runtime_test_scope.test.sh \
    scripts/ci/parallel_runtime_test_gate.sh
# passed

$ shellcheck scripts/ci/parallel_runtime_test_scope.sh \
    scripts/ci/parallel_runtime_test_scope.test.sh
# passed

$ actionlint .github/workflows/ci.yml
# passed

$ ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml", aliases: true)'
# passed

$ BASE_SHA=uncommitted DOCS_FILES="docs/book/src/contributing/testing.md
docs/book/src/maintainers/ci-and-actions.md" bash scripts/ci/docs_quality_gate.sh
Summary: 0 error(s)

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Verified the classifier runs for runtime, channel, root manifest, workflow, and gate-script paths; skips ZeroCode-only, web-only, docs-only, and unrelated-crate paths; and treats mixed path sets as relevant.
- **If any command was intentionally skipped, why:** No Cargo command was run because this patch changes CI scheduling rather than Rust behavior. The published workflow run will execute the unchanged stress command for this CI-owning diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **Yes** — the separate CI runner repeats the pinned checkout, toolchain, cache, and package-install network activity already used by `Test`; no product-runtime network behavior, workflow permissions, or secret access changes.
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: The added CI network activity uses the repository's existing pinned actions and package-install helper. It runs with the workflow's existing read-only `contents` permission and no new secrets.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `Parallel Runtime Test` runs for unrelated PRs, is absent for relevant changes, or detector/stress failures do not make `CI Required Gate` fail.
