### PR TITLE
docs(sop): add conditional routing example

### DIFF
--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -162,13 +162,13 @@ Parser behavior:
   when a step must require approval in any execution mode.
 - `- allow-tools:` and `- deny-tools:` define an explicit per-step tool scope.
 - `- input:` and `- output:` attach JSON Schema-like step boundary contracts.
-- `- when:` is a routing guard evaluated against accumulated completed-step
-  outputs after the current step finishes. When it does not match, the run
-  completes instead of dispatching another step.
+- `- when:` guards an explicit `- next:` jump and is evaluated against
+  accumulated completed-step outputs after the current step finishes. A
+  matching guard takes the explicit jump. A false guard advances to the next
+  linear step (`current_step + 1`), or completes when the current step is
+  terminal.
 - `- next:` and `- depends_on:` route non-linear runs. Ineligible routed steps
   are marked `skipped` and leave the run `pending` instead of dispatching.
-- `- when:` guards an explicit `- next:` jump; when the condition is false, the
-  run advances to the next linear step (`current_step + 1`) instead of completing.
 - `- on_failure:` accepts `fail`, `retry:<count>`, or `goto:<step>` and is
   enforced for reported step failures and output schema failures.
 - `- mode:` overrides the SOP execution mode for that step.

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -178,6 +178,42 @@ Parser behavior:
   `[sop.approval].policies` fails closed (the gate stays waiting) rather than
   clearing on a single approval.
 
+### Copyable conditional-routing example
+
+This complete `SOP.md` routes critical alerts through an approved remediation
+step while recording other alerts without remediation:
+
+```md
+# Alert triage
+
+Classify an incoming alert, remediate critical alerts, and notify the operator.
+
+## Steps
+
+1. **Classify alert** - Normalize the incoming alert severity.
+   - output: {"type":"object","required":["severity"],"properties":{"severity":{"type":"string"}}}
+   - when: $.steps.1.severity == "critical"
+   - next: 3
+
+2. **Record routine alert** - Add the non-critical alert to the incident log.
+   - tools: shell
+   - next: 4
+
+3. **Remediate critical alert** - Run the approved remediation command.
+   - tools: shell
+   - requires_confirmation: true
+   - on_failure: retry:2
+   - next: 4
+
+4. **Notify operator** - Send the outcome to the operations channel.
+   - tools: http_request
+```
+
+When step 1 outputs `{"severity":"critical"}`, its guard matches and `next`
+jumps to step 3. Any other severity falls through to step 2, whose explicit
+`next` skips remediation and joins the critical path at step 4. Run
+`zeroclaw sop validate <name>` after copying the example into an SOP directory.
+
 ### `[sop.approval]` policies and route delivery
 
 A policy may also route its approval out of band to a channel, so an approver can

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -169,6 +169,8 @@ Parser behavior:
   terminal.
 - `- next:` and `- depends_on:` route non-linear runs. Ineligible routed steps
   are marked `skipped` and leave the run `pending` instead of dispatching.
+- `- terminal: true` completes the run instead of advancing to another step.
+  The final step also completes when it has no linear successor.
 - `- on_failure:` accepts `fail`, `retry:<count>`, or `goto:<step>` and is
   enforced for reported step failures and output schema failures.
 - `- mode:` overrides the SOP execution mode for that step.
@@ -211,8 +213,21 @@ Classify an incoming alert, remediate critical alerts, and notify the operator.
 
 When step 1 outputs `{"severity":"critical"}`, its guard matches and `next`
 jumps to step 3. Any other severity falls through to step 2, whose explicit
-`next` skips remediation and joins the critical path at step 4. Run
-`zeroclaw sop validate <name>` after copying the example into an SOP directory.
+`next` skips remediation and joins the critical path at step 4.
+
+The loader only discovers a directory that also contains a `SOP.toml`, so pair
+the steps above with this manifest in `<sops_dir>/alert-triage/`:
+
+```toml
+[sop]
+name = "alert-triage"
+description = "Classify an incoming alert, remediate critical alerts, and notify the operator."
+
+[[triggers]]
+type = "manual"
+```
+
+Then run `zeroclaw sop validate alert-triage`, which reports the SOP as valid.
 
 ### `[sop.approval]` policies and route delivery
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a complete, copyable alert-triage SOP example for the remaining example gap in #8587.
  - Demonstrates conditional routing, explicit branch joins, tool-backed actions, approval, and retry behavior in one small workflow.
  - Includes the minimal `SOP.toml` required for the loader to discover and validate the example.
  - Explains conditional fallback and terminal-step behavior so readers can adapt the syntax safely.
- **Scope boundary:** Documentation only. This does not change the SOP parser or runtime and adds only the minimal companion manifest required to validate the `SOP.md` example.
- **Blast radius:** `docs/book/src/sop/syntax.md` only.
- **Linked issue(s):** Related #8587.
- **Labels:** `docs`, `type:docs`, `risk:low`, `size:XS`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a docs-only example with no runtime behavior change.

### How I tested

- **CI checks relied on and why they cover this change:** The docs quality gate checks Markdown style; the links gate checks newly added links. The refreshed branch will run the required Linux CI suite against current `master`.
- **Known CI coverage gap, if any:** The local Windows links-gate unit tests hit existing path-separator assertions; this diff adds no links, and Linux CI covers the gate in its supported environment.
- **Commands run and tail output:**

```text
BASE_SHA=upstream/master DOCS_FILES=docs/book/src/sop/syntax.md scripts/ci/docs_quality_gate.sh
Linting: 1 file(s)
Summary: 0 error(s)

BASE_SHA=upstream/master DOCS_FILES=docs/book/src/sop/syntax.md scripts/ci/docs_links_gate.sh
# Local Windows run: 4 existing path-separator assertion failures in
# collect_changed_links_test.py; the documentation diff adds no links.

git diff --check upstream/master...HEAD
# no output; exit 0

scripts/check-pr-title.sh 'docs(sop): add conditional routing example'
# no output; exit 0

cargo test -p zeroclaw-runtime --lib sop::route:: -- --test-threads=2
test result: ok. 13 passed; 0 failed; 0 ignored

cargo test -p zeroclaw-runtime --lib sop::tests::parse_steps -- --test-threads=2
test result: ok. 4 passed; 0 failed; 0 ignored
```

- **Beyond CI, what did you manually verify?** Confirmed the loader requires `SOP.toml`, the manifest uses the supported manual trigger, and both documented routes join at step 4 without executing both branches.
- **If any command was intentionally skipped, why:** Full workspace Cargo checks were skipped because the PR changes Markdown only; focused runtime tests cover the documented parser and routing contracts.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk docs-only change: `git revert 75f422717 f8287f2fc edc8d00a4`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another PR.

