### PR TITLE
fix(memory): clear Windows Clippy blockers

### DIFF
--- a/crates/zeroclaw-memory/src/audit.rs
+++ b/crates/zeroclaw-memory/src/audit.rs
@@ -63,6 +63,7 @@ fn ensure_owner_only_file(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> std::path::PathBuf {
     let mut path = db_path.as_os_str().to_os_string();
     path.push(suffix);

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -604,6 +604,15 @@ impl Memory for LucidMemory {
     }
 }
 
+impl ::zeroclaw_api::attribution::Attributable for LucidMemory {
+    fn role(&self) -> ::zeroclaw_api::attribution::Role {
+        ::zeroclaw_api::attribution::Role::Memory(::zeroclaw_api::attribution::MemoryKind::Lucid)
+    }
+    fn alias(&self) -> &str {
+        &self.alias
+    }
+}
+
 #[cfg(test)]
 mod platform_tests {
     use super::*;
@@ -1140,14 +1149,5 @@ exit 1
 
         let calls = tokio::fs::read_to_string(&marker).await.unwrap_or_default();
         assert_eq!(calls.lines().count(), 1);
-    }
-}
-
-impl ::zeroclaw_api::attribution::Attributable for LucidMemory {
-    fn role(&self) -> ::zeroclaw_api::attribution::Role {
-        ::zeroclaw_api::attribution::Role::Memory(::zeroclaw_api::attribution::MemoryKind::Lucid)
-    }
-    fn alias(&self) -> &str {
-        &self.alias
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Compile `sqlite_sidecar_path` only on Unix, matching its sole caller.
  - Keep the Lucid attribution implementation before test modules so Windows configuration does not leave a production item after `platform_tests`.
  - Clear both `zeroclaw-memory` blockers exposed by Cross-Platform Clippy under `-D warnings`.
- **Scope boundary:** This does not change SQLite audit behavior, Lucid behavior, attribution, sidecar hardening, or runtime configuration. The separate `zeroclaw-config` Windows failure remains tracked by #9414.
- **Blast radius:** Compile-time item selection and source ordering in `zeroclaw-memory`; runtime behavior is unchanged.
- **Linked issue(s):** Related #7462
- **Labels:** `bug`, `distinguished contributor`, `memory`, `memory:backend`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A - this is a compile-time platform guard; the hosted Windows Clippy job is the useful behavior boundary.

### How I tested

- **CI checks relied on and why they cover this change:** Personal-fork Cross-Platform Clippy run [30265361010](https://github.com/Audacity88/zeroclaw/actions/runs/30265361010) compiled the workspace for `x86_64-pc-windows-msvc` with `-D warnings`. It checked `zeroclaw-memory` successfully after both changes, then failed later in unchanged `zeroclaw-config` on the `EnvValueGuard` problem tracked by #9414. The macOS Clippy job passed. Required PR CI also passed on the current head, including the normal Windows check, Lint, Test, and CI Required Gate.
- **Known CI coverage gap, if any:** The full Windows Clippy workflow cannot turn green until the separate #9414 config fix lands; no changed `zeroclaw-memory` lint failure remains in the hosted run.
- **Commands run and tail output:**

```sh
git diff --check
# exit 0, no output

bash scripts/ci/comment_hygiene_gate.sh
# exit 0, no output
```

- **Beyond CI, what did you manually verify?** Confirmed the helper is called only by the Unix-gated sidecar-hardening implementation, the non-Unix implementation remains a no-op, and the Lucid attribution implementation is unchanged apart from its position before test modules. No runtime smoke was performed.
- **If any command was intentionally skipped, why:** Local Windows-target Clippy was skipped because the macOS host does not provide the Windows/MSVC build environment; hosted Windows CI is the authoritative validation for this failure.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback

Low risk: revert the squash commit.
