### PR TITLE
fix(runtime): reject non-file absolute shell paths

### DIFF
--- a/crates/zeroclaw-config/src/platform/mod.rs
+++ b/crates/zeroclaw-config/src/platform/mod.rs
@@ -62,17 +62,25 @@ fn validate_shell(shell: &str) -> anyhow::Result<()> {
         );
     }
 
-    // Coarse check: reject only when no execute bit is set at all. A precise
-    // "can *we* execute it" test (uid/gid vs. the file owner) buys little —
-    // the kernel's spawn is the real authority (ACLs, caps, mount flags) — and
-    // this is a fail-fast sanity check, not a security gate.
-    let mode = match resolved.metadata() {
-        Ok(meta) => meta.permissions().mode(),
+    let metadata = match resolved.metadata() {
+        Ok(metadata) => metadata,
         Err(e) => anyhow::bail!(
             "runtime.shell {shell:?} (resolved to {}) could not be inspected: {e}",
             resolved.display()
         ),
     };
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "runtime.shell {shell:?} (resolved to {}) is not a regular file",
+            resolved.display()
+        );
+    }
+
+    // Coarse check: reject only when no execute bit is set at all. A precise
+    // "can *we* execute it" test (uid/gid vs. the file owner) buys little —
+    // the kernel's spawn is the real authority (ACLs, caps, mount flags) — and
+    // this is a fail-fast sanity check, not a security gate.
+    let mode = metadata.permissions().mode();
     if mode & 0o111 == 0 {
         anyhow::bail!(
             "runtime.shell {shell:?} (resolved to {}) is not executable",
@@ -186,6 +194,17 @@ mod tests {
         assert!(
             err.to_string().contains("does not exist"),
             "error should name the missing path, got: {err}"
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "android")))]
+    #[test]
+    fn validate_shell_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = validate_shell(dir.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            err.to_string().contains("not a regular file"),
+            "error should identify the non-file shell target, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Require absolute Unix `runtime.shell` targets to resolve to regular files before checking execute bits, matching the invariant already used for bare shell names resolved through `PATH`.
- **Test coverage:** Add a regression proving an executable directory is rejected during runtime creation instead of failing later at process spawn.
- **Scope boundary:** This does not change Windows or Android shell handling, PATH lookup, symlink behavior, executable permission policy, the runtime schema, or process construction.
- **Blast radius:** Native Unix runtime creation when `runtime.shell` is an absolute path to a directory or another non-regular filesystem object.
- **Linked issue(s):** N/A; this is a self-contained shell-validation correctness fix.
- **Labels:** `bug`, `config`, `distinguished contributor`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the focused unit suite directly exercises the private shell-validation boundary, and a manual process-spawn flow would only reproduce the later failure this validation prevents.

### How I tested

- **CI checks relied on and why they cover this change:** Required PR CI is green on this head, including Test, Lint, cross-target Check jobs, Build, Security, and Semgrep. The focused local run below directly exercises the changed shell-validation branch.
- **Known CI coverage gap, if any:** None for the changed Unix validation branch: the focused regression suite passed, and required CI provided cross-target compilation and workspace coverage.
- **Commands run and tail output:**

```sh
cargo fmt -- --check
# passed

cargo test -p zeroclaw-config platform::tests::validate_shell --lib
# running 7 tests
# test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1164 filtered out

bash scripts/ci/comment_hygiene_gate.sh
# Comment hygiene gate passed.

git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Source review confirmed missing paths retain their existing diagnostic, metadata is read once and reused for the execute-bit check, symlinks to regular files remain accepted, and the Android and Windows branches are unchanged.
- **If any command was intentionally skipped, why:** Broader local tests and Clippy were skipped because the change is isolated to one private helper and its complete focused validation suite; required PR CI supplied broader workspace coverage.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. This is a fail-fast correctness check, not a new security boundary.

## Compatibility (required)

- Backward compatible? `No`; invalid absolute Unix shell values that name directories or other non-regular objects now fail during runtime creation instead of later at process spawn.
- Config / env / CLI surface changed? `Yes`; `runtime.shell` syntax is unchanged, but an absolute value must resolve to a regular file.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: Point `runtime.shell` to a regular executable file, or use a bare shell name available on `PATH`.

## Rollback

- **Fast rollback command/path:** `git revert <merge-sha>`
