### PR TITLE
fix(config): keep unknown-property sentinel matching typed

### DIFF
--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -72,18 +72,14 @@ pub fn route_double_hashmap_path<'a>(
 ///
 /// Both constructors build the error as exactly `Unknown property
 /// '{name}'` via `anyhow::Error::msg(String)`, so the downcast is the
-/// common zero-alloc path; `to_string()` is only a fallback for
-/// wrapped/contextualized errors. The comparison is against the full
-/// message, not just a prefix: a genuine nested value error whose text
-/// happens to start with "Unknown property" (a custom validator message,
-/// say) must not be mistaken for this fall-through marker and silently
-/// swallowed as a retry.
+/// typed identity check and still works through `anyhow` context layers.
+/// Display text alone is not sufficient: a different error type can render
+/// the same message but must not be mistaken for this fall-through marker and
+/// silently swallowed as a retry.
 pub fn is_unknown_property_error(e: &anyhow::Error, name: &str) -> bool {
     let expected = format!("Unknown property '{name}'");
-    if let Some(msg) = e.downcast_ref::<String>() {
-        return *msg == expected;
-    }
-    e.to_string() == expected
+    e.downcast_ref::<String>()
+        .is_some_and(|msg| *msg == expected)
 }
 
 pub fn route_vec_path<'a, 'k, I>(
@@ -1102,6 +1098,21 @@ mod tests {
         // Same construction the two real fallbacks use.
         let marker = anyhow::Error::msg(format!("Unknown property '{}'", "gateway.port"));
         assert!(is_unknown_property_error(&marker, "gateway.port"));
+    }
+
+    #[test]
+    fn is_unknown_property_error_matches_a_context_wrapped_typed_sentinel() {
+        let marker = anyhow::Error::msg(format!("Unknown property '{}'", "gateway.port"))
+            .context("while routing a nested property");
+        assert!(is_unknown_property_error(&marker, "gateway.port"));
+    }
+
+    #[test]
+    fn is_unknown_property_error_rejects_an_exact_text_non_string_error() {
+        let lookalike =
+            anyhow::Error::new(std::io::Error::other("Unknown property 'gateway.port'"));
+        assert_eq!(lookalike.to_string(), "Unknown property 'gateway.port'");
+        assert!(!is_unknown_property_error(&lookalike, "gateway.port"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `is_unknown_property_error()` now recognizes only the canonical typed `String` sentinel for the exact attempted property name. An unrelated error type can no longer trigger nested-routing fallback merely by rendering the same display text.
  - Focused regressions preserve direct and context-wrapped sentinel matching while rejecting an exact-text non-`String` lookalike, a prefix collision, and a sentinel for a different property.
- **Scope boundary:** This does not introduce a new sentinel type or change the derive macro or sentinel constructors.
- **Blast radius:** The shared nested `set_prop` delegation classifier used by flattened fields, optional nested config, and dotted-key candidate routing. The behavior changes only when an unrelated non-`String` error renders the exact generated sentinel text.
- **Linked issue(s):** Related #9310.
- **Labels:** `bug`, `config`, `risk:medium`, `size:XS`, `distinguished contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The behavior is an internal error-routing boundary covered directly by focused unit tests; there is no useful manual user-interface path for constructing the non-`String` lookalike.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head required CI passed, including the config crate, supported-target checks, Lint, Test, and the required gate.
- **Known CI coverage gap, if any:** The full config and macro suites were not run locally; the focused helper suite directly covers the changed classifier contract. Required checks must be green before merge.
- **Commands run and tail output:**

```text
$ cargo fmt -- --check
pass

$ cargo test -p zeroclaw-config is_unknown_property_error --lib
running 5 tests
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1167 filtered out

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check
pass
```

- **Beyond CI, what did you manually verify?** Confirmed both production sentinel constructors use `anyhow::Error::msg(String)`, the existing nested delegation sites pass the exact attempted property name, and typed matching still succeeds through an `anyhow` context layer. I did not run an end-to-end config editor smoke because this malformed internal error shape cannot be produced through a supported config surface.
- **If any command was intentionally skipped, why:** Broad local workspace and full config/macro validation were skipped because this one-helper change has direct focused coverage; required CI provides broader workspace and target evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes. Generated typed sentinels retain the existing fallback behavior; only unrelated display-only lookalikes now propagate.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit.
- **Feature flags or config toggles:** None; this classifier is compile-time behavior.
- **Observable failure symptoms:** A legitimate generated unknown-property sentinel unexpectedly propagates instead of allowing sibling or nested candidate routing to continue.
