### PR TITLE
fix(deps): update nostr to 0.44.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6045,9 +6045,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.3"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d8f0fe13526800300a36bf3b7c5f752e62e32ab81c74a8e5caa2865708625a"
+checksum = "0112d3433a5550ba13481970d5b6844714510ddcdaca4d9d0aa6e7b83f270271"
 dependencies = [
  "aes 0.8.4",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Updated the locked `nostr` crate from 0.44.3 to 0.44.5. Version 0.44.5 contains the upstream fix for [RUSTSEC-2026-0216](https://rustsec.org/advisories/RUSTSEC-2026-0216), a remotely triggerable denial of service in NIP-44 v2 ciphertext handling.
- **Scope boundary:** This changes only the resolved `nostr` version and checksum in `Cargo.lock`. It does not change dependency constraints, application source, advisory policy, or ignored advisories.
- **Blast radius:** All consumers resolved through the existing `nostr-sdk 0.44` constraints, including the Nostr channel and wizard key validation, use locked `nostr` 0.44.5. No ZeroClaw source or configuration changes.
- **Linked issue(s):** None. This directly resolves RUSTSEC-2026-0216 in the lockfile.
- **Labels:** `dependencies`, `domain:deps`, `domain:security`, `risk:medium`, `size:XS`, `type:dependencies`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a lockfile-only security patch with automated advisory and integration coverage.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI is green at head `ef24b64ed8`. Security covers dependency integrity and the RustSec advisory database; the build, feature, platform, lint, and Test jobs exercise the updated locked dependency graph.
- **Known CI coverage gap, if any:** No direct exploit reproduction, live relay smoke, or separate wizard-path behavioral smoke was run. Required CI compiles the dependency graph across supported feature and platform checks; focused behavioral coverage is the Nostr channel test module.
- **Commands run and tail output:**

```text
$ cargo audit
Scanning Cargo.lock for vulnerabilities (1217 crate dependencies)
warning: 3 allowed warnings found

$ cargo test --locked -p zeroclaw-channels --features channel-nostr --lib 'nostr::tests::'
running 11 tests
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 1310 filtered out
```

- **Beyond CI, what did you manually verify?** Confirmed the surviving diff contains only `nostr` 0.44.3 to 0.44.5 and the corresponding crates.io checksum. Compared the published crate manifests and confirmed both releases declare Rust 1.70. No direct exploit reproduction, live relay smoke, or separate wizard-path behavioral smoke was performed because this patch changes no ZeroClaw integration code.
- **If any command was intentionally skipped, why:** Direct exploit reproduction and live relay or wizard smoke were skipped; the upstream advisory defines the vulnerable range, `cargo audit` verifies its removal, and the focused channel tests plus required compile checks cover the integration boundary without requiring credentials.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes** — this remains within the existing stable 0.44 dependency line, and the focused tests plus required compile checks pass.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No** — ZeroClaw toolchain configuration is unchanged, and both published `nostr` releases declare Rust 1.70.
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the patch commit to restore the prior `Cargo.lock` entry. This would reintroduce RUSTSEC-2026-0216 and should be used only if the patched crate causes a confirmed regression.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Nostr channel build failures or Nostr messaging regressions after the dependency update.
