### PR TITLE
fix(tests): make SOP checkpoint error assertion portable

### DIFF
--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -10878,14 +10878,9 @@ mod tests {
             .unwrap();
         let run_id = extract_run_id(&action).to_string();
 
-        let err = engine
+        engine
             .advance_deterministic_step(&run_id, serde_json::json!("s1-out"), None)
             .expect_err("checkpoint state-file write must fail for a file-valued location");
-        assert!(
-            err.to_string().contains("Not a directory")
-                || err.to_string().contains("not a directory"),
-            "unexpected state-file error: {err}"
-        );
         assert_eq!(
             engine.get_run(&run_id).unwrap().status,
             SopRunStatus::Running,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Removed the existing SOP checkpoint regression's assertion against the operating system's rendered directory-error text. Windows reaches the intended state-file write failure but reports error 3 instead of Unix's `Not a directory` wording.
- **What was preserved:** Kept `expect_err` and every assertion covering run status, pending persistence, claim ownership, heartbeat renewal, and claim reaping.
- **Scope boundary:** This change does not alter SOP production behavior, persistence paths, error propagation, or claim lifecycle behavior.
- **Blast radius:** One `zeroclaw-runtime` unit test.
- **Linked issue(s):** Related #7462
- **Labels:** `bug`, `runtime`, `tests`, `risk:high`, `size:XS`, `type:test`, `distinguished contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a unit-test portability correction with no user-visible interface.

### How I tested

- **CI checks relied on and why they cover this change:** All standalone required checks passed on head `3c99004ac2`. The #9398 stacked hosted Windows run at https://github.com/zeroclaw-labs/zeroclaw/actions/runs/30292179009/job/90072124115 passed `checkpoint_state_file_failure_keeps_run_executing_and_claim_renewed` before later stopping in the separate `claude_code_rejects_path_outside_workspace` test.
- **Known CI coverage gap, if any:** None for this test-only portability correction. The hosted Windows suite's later unrelated failure is outside this PR's scope.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

git diff --check
# passed

bash scripts/ci/comment_hygiene_gate.sh
# passed

cargo test -p zeroclaw-runtime checkpoint_state_file_failure_keeps_run_executing_and_claim_renewed -- --nocapture
# local cold compilation was stopped before test execution; no test result
```

- **Beyond CI, what did you manually verify?** Confirmed the test still requires the checkpoint write to fail and still checks every subsequent run-state and claim-lifecycle invariant. No production code changed.
- **If any command was intentionally skipped, why:** The focused runtime test did not finish compiling locally. Hosted Windows is the required platform evidence because the removed assertion depended on Windows error rendering.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit-sha>`.
- **Feature flags or config toggles:** None; this is a test-only assertion change.
- **Observable failure symptoms:** The targeted SOP test fails on Windows solely because it expects Unix-rendered directory-error wording, or it fails one of the retained run-state, pending-persist, claim, heartbeat, or reaping invariants. No production runtime symptom is introduced by this test-only diff.
