### PR TITLE
fix(tests): make CLI outside-workspace fixtures portable

### DIFF
--- a/crates/zeroclaw-tools/src/claude_code.rs
+++ b/crates/zeroclaw-tools/src/claude_code.rs
@@ -421,11 +421,20 @@ mod tests {
 
     #[tokio::test]
     async fn claude_code_rejects_path_outside_workspace() {
-        let tool = ClaudeCodeTool::new(test_security(AutonomyLevel::Full), test_config());
+        let workspace = tempfile::TempDir::new().expect("temp workspace");
+        let outside = tempfile::TempDir::new().expect("temp directory outside workspace");
+        let tool = ClaudeCodeTool::new(
+            Arc::new(SecurityPolicy {
+                autonomy: AutonomyLevel::Full,
+                workspace_dir: workspace.path().to_path_buf(),
+                ..SecurityPolicy::default()
+            }),
+            test_config(),
+        );
         let result = tool
             .execute(json!({
                 "prompt": "hello",
-                "working_directory": "/etc"
+                "working_directory": outside.path()
             }))
             .await
             .expect("should return a result for path validation");

--- a/crates/zeroclaw-tools/src/claude_code_runner.rs
+++ b/crates/zeroclaw-tools/src/claude_code_runner.rs
@@ -472,15 +472,21 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_path_outside_workspace() {
+        let workspace = tempfile::TempDir::new().expect("temp workspace");
+        let outside = tempfile::TempDir::new().expect("temp directory outside workspace");
         let tool = ClaudeCodeRunnerTool::new(
-            test_security(AutonomyLevel::Full),
+            Arc::new(SecurityPolicy {
+                autonomy: AutonomyLevel::Full,
+                workspace_dir: workspace.path().to_path_buf(),
+                ..SecurityPolicy::default()
+            }),
             test_config(),
             "http://localhost:3000".into(),
         );
         let result = tool
             .execute(json!({
                 "prompt": "hello",
-                "working_directory": "/etc"
+                "working_directory": outside.path()
             }))
             .await
             .expect("should return a result for path validation");

--- a/crates/zeroclaw-tools/src/codex_cli.rs
+++ b/crates/zeroclaw-tools/src/codex_cli.rs
@@ -328,11 +328,16 @@ mod tests {
 
     #[tokio::test]
     async fn codex_cli_rejects_path_outside_workspace() {
-        let tool = CodexCliTool::new(test_security(AutonomyLevel::Full), test_config());
+        let workspace = tempfile::TempDir::new().expect("temp workspace");
+        let outside = tempfile::TempDir::new().expect("temp directory outside workspace");
+        let tool = CodexCliTool::new(
+            test_security_with_workspace(AutonomyLevel::Full, workspace.path().to_path_buf()),
+            test_config(),
+        );
         let result = tool
             .execute(json!({
                 "prompt": "hello",
-                "working_directory": "/etc"
+                "working_directory": outside.path()
             }))
             .await
             .expect("should return a result for path validation");

--- a/crates/zeroclaw-tools/src/gemini_cli.rs
+++ b/crates/zeroclaw-tools/src/gemini_cli.rs
@@ -307,11 +307,20 @@ mod tests {
 
     #[tokio::test]
     async fn gemini_cli_rejects_path_outside_workspace() {
-        let tool = GeminiCliTool::new(test_security(AutonomyLevel::Full), test_config());
+        let workspace = tempfile::TempDir::new().expect("temp workspace");
+        let outside = tempfile::TempDir::new().expect("temp directory outside workspace");
+        let tool = GeminiCliTool::new(
+            Arc::new(SecurityPolicy {
+                autonomy: AutonomyLevel::Full,
+                workspace_dir: workspace.path().to_path_buf(),
+                ..SecurityPolicy::default()
+            }),
+            test_config(),
+        );
         let result = tool
             .execute(json!({
                 "prompt": "hello",
-                "working_directory": "/etc"
+                "working_directory": outside.path()
             }))
             .await
             .expect("should return a result for path validation");

--- a/crates/zeroclaw-tools/src/opencode_cli.rs
+++ b/crates/zeroclaw-tools/src/opencode_cli.rs
@@ -302,11 +302,20 @@ mod tests {
 
     #[tokio::test]
     async fn opencode_cli_rejects_path_outside_workspace() {
-        let tool = OpenCodeCliTool::new(test_security(AutonomyLevel::Full), test_config());
+        let workspace = tempfile::TempDir::new().expect("temp workspace");
+        let outside = tempfile::TempDir::new().expect("temp directory outside workspace");
+        let tool = OpenCodeCliTool::new(
+            Arc::new(SecurityPolicy {
+                autonomy: AutonomyLevel::Full,
+                workspace_dir: workspace.path().to_path_buf(),
+                ..SecurityPolicy::default()
+            }),
+            test_config(),
+        );
         let result = tool
             .execute(json!({
                 "prompt": "hello",
-                "working_directory": "/etc"
+                "working_directory": outside.path()
             }))
             .await
             .expect("should return a result for path validation");


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replaced Unix-only `/etc` fixtures in five CLI outside-workspace tests with distinct existing temporary workspace and outside directories.
  - Keeps each assertion on the intended containment branch on Windows without assuming a drive letter or Windows installation directory.
- **Scope boundary:** Test fixtures only. Production path validation and CLI behavior are unchanged.
- **Blast radius:** Five `zeroclaw-tools` unit tests for Claude Code, Claude Code Runner, Codex CLI, Gemini CLI, and OpenCode CLI.
- **Linked issue(s):** Related #7462. Related #7461. Related #9398.
- **Labels:** `bug`, `tool`, `tests`, `risk:low`, `size:XS`, `type:test`, `distinguished contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a test-fixture-only change, and the useful cross-platform signal is the hosted Windows suite tracked by #9398.

### How I tested

- **CI checks relied on and why they cover this change:** Standalone [Quality Gate run 30307222946](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/30307222946) passed required CI on exact head `5dc0e323fc`. [Quality Gate run 30340310404](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/30340310404) then exercised a patch-equivalent cherry-pick of this commit on #9398's hosted Windows stack: all five repaired outside-workspace tests passed for Claude Code, Claude Code Runner, Codex CLI, Gemini CLI, and OpenCode CLI.
- **Known CI coverage gap, if any:** None for this test-fixture claim. The hosted Windows suite continued through all 12,157 tests and remained advisory red on separate `content_search` and updater failures tracked by #7462.
- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-tools rejects_path_outside_workspace -- --nocapture
running 7 tests
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1527 filtered out

$ cargo fmt --all -- --check
# passed

$ git diff --check
# passed

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** Confirmed all five tests keep both temporary directories alive through execution, use distinct existing paths, and continue asserting the `outside the workspace` error.
- **If any command was intentionally skipped, why:** A broad local workspace test was skipped because the focused filter covers every changed test; required CI supplied Linux workspace coverage, and #9398 supplied hosted Windows proof.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk test-only change; revert the merge commit.
