### PR TITLE
fix(tests): use a bounded wait for the client count instead of fixed sleeps

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/local.rs
+++ b/crates/zeroclaw-runtime/src/rpc/local.rs
@@ -451,6 +451,28 @@ mod tests {
         panic!("socket never appeared at {}", path.display());
     }
 
+    /// Wait for the server-side client count to reach `expected`, or fail with
+    /// the value actually observed.
+    ///
+    /// `run_local_listener` increments the count in its accept loop but
+    /// decrements it at the end of the per-connection task, so a disconnect
+    /// becomes visible only once the dispatcher has seen EOF and that task has
+    /// finished. Waiting a fixed interval assumes that completes within it;
+    /// under a loaded test harness it may not.
+    #[cfg(unix)]
+    async fn wait_for_client_count(count: &Arc<AtomicUsize>, expected: usize) {
+        for _ in 0..250 {
+            if count.load(Ordering::Relaxed) == expected {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!(
+            "client count never reached {expected}; last observed {}",
+            count.load(Ordering::Relaxed)
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn socket_initialize_handshake() {
@@ -669,16 +691,13 @@ mod tests {
 
         let s1 = tokio::net::UnixStream::connect(&sock_path).await.unwrap();
         let s2 = tokio::net::UnixStream::connect(&sock_path).await.unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(count.load(Ordering::Relaxed), 2);
+        wait_for_client_count(&count, 2).await;
 
         drop(s1);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(count.load(Ordering::Relaxed), 1);
+        wait_for_client_count(&count, 1).await;
 
         drop(s2);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(count.load(Ordering::Relaxed), 0);
+        wait_for_client_count(&count, 0).await;
 
         cancel.cancel();
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `client_count_tracks_connections` slept a fixed 50 ms and then asserted the client count, three times. `run_local_listener` increments the count synchronously in its accept loop but decrements it at the *end of the per-connection task*, after the dispatcher has observed EOF, so a disconnect only becomes visible once that task finishes. A fixed interval assumes that completes within it; under a loaded harness it does not.
  - Replaced the three sleep-then-assert pairs with a bounded condition-based wait that polls the value the assertion depends on.
  - The new `wait_for_client_count` helper is shaped like the `wait_for_socket` helper already in this file: poll every 20 ms, bounded, and panic with a diagnostic. On failure it reports the count actually observed rather than only that it differed from the expectation.
- **Scope boundary:** test-only. No production code changes. Does not touch the model-switch or log-capture work in #9232, and does not touch the daemon heartbeat tests. Leaves #9357 open to track the broader parallel-suite behaviour.
- **Blast radius:** one test module in `crates/zeroclaw-runtime/src/rpc/local.rs`. The new helper is `#[cfg(unix)]` and is called only by this test. No other test in the file asserts on the client count; the others pass a throwaway counter via `test_client_count()`. There is no Windows twin of this test, and the Windows handshake test already uses a bounded poll.
- **Linked issue(s):** Related #9357
- **Labels:** `bug`, `follow-up`, `priority:p1`, `risk:high`, `runtime`, `size:XS`, `type:test`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (test harness only; no user-facing surface changes)
- **Setup / preconditions:** none beyond a normal checkout.
- **Steps to run:**

  ```sh
  # the parallel runtime gate command, repeated
  for run in $(seq 1 20); do
    cargo test --locked --quiet -p zeroclaw-runtime --lib -- --test-threads=16
  done
  ```

- **Expected on this branch (after):** 20 of 20 runs clean.
- **Prior behavior on `master` (before):** the same 20 runs fail 15 times, every failure being `rpc::local::tests::client_count_tracks_connections`.

### How I tested

The controlled comparison is the evidence here, because this test was already failing intermittently rather than deterministically, so a single red-then-green run would prove nothing.

**Before, on `master`:** 20 runs at 16 harness threads, **15 failed, 5 clean, exactly one distinct failing test**, `rpc::local::tests::client_count_tracks_connections`.

**After, on this branch:** 20 runs at 16 harness threads, **20 clean, 0 failures**.

The two samples are directly comparable: `crates/zeroclaw-runtime/` is byte-identical between the two bases apart from this commit, confirmed with `git diff --stat b8b720a9..2764edc8 -- crates/zeroclaw-runtime/`, which is empty.

- **CI checks relied on and why they cover this change:** the workspace test run covers the changed test, and the parallel runtime stress gate is a required job for `zeroclaw-runtime` changes and exercises exactly the 16-thread condition this addresses.
- **Known CI coverage gap:** none introduced. This removes a timing assumption rather than adding one.
- **Commands run and tail output:**

  ```
  # 20 runs at 16 threads, this branch
  runs: 20   clean: 20   failed: 0   distinct failing tests: 0

  # 20 runs at 16 threads, master without this commit
  runs: 20   clean: 5    failed: 15  distinct failing tests: 1
    15/20  rpc::local::tests::client_count_tracks_connections

  cargo test -p zeroclaw-runtime --lib client_count_tracks_connections   (5 consecutive runs)
    test result: ok. 1 passed; 0 failed        x5

  cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings  -> exit 0
  cargo fmt --all -- --check                                     -> exit 0
  scripts/ci/comment_hygiene_gate.py                             -> Comment hygiene gate passed.
  ```

- **Beyond CI, what did you manually verify?** That the failure mode matches the mechanism rather than being assumed: the count is incremented in the accept loop at `local.rs` and decremented inside the spawned per-connection task after `dispatcher.run()` returns, which is why a disconnect is not observable immediately. The focused test also drops from roughly 150 ms of unconditional sleeping to about 0.07 s, since it now returns as soon as the condition holds.

  Not verified: the Windows path, because this test is `#[cfg(unix)]` and has no Windows counterpart.

- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes.** Test-only.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback

- **Fast rollback command/path:** `git revert <merged-commit-sha>`
- **Feature flags or config toggles:** None; this is test-only.
- **Observable failure symptoms:** the `Parallel Runtime Test` check or `rpc::local::tests::client_count_tracks_connections` fails or reaches the five-second diagnostic timeout. There is no production runtime symptom.
