### PR TITLE
docs(providers): document MiniMax Anthropic-compatible endpoint

### DIFF
--- a/docs/book/src/providers/catalog.md
+++ b/docs/book/src/providers/catalog.md
@@ -160,6 +160,8 @@ api_key  = "..."
 endpoint = "intl"                            # variants: cn, intl
 ```
 
+For MiniMax's Anthropic-compatible API, use `[providers.models.anthropic.minimax]` with `uri = "https://api.minimax.io/anthropic"` (Global) or `uri = "https://api.minimaxi.com/anthropic"` (China) instead.
+
 ### Z.AI: slot `zai`
 
 For Z.AI's Anthropic-compatible API, use `[providers.models.anthropic.zai]` with `uri = "https://api.z.ai/api/anthropic"` instead.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Documents MiniMax's Anthropic-compatible API endpoint for the Global and China regions.
  - Shows operators how to point the generic `anthropic` provider slot at MiniMax through the existing `uri` override.
- **Scope boundary:** Documentation only. This does not change provider code, configuration parsing, models, or endpoint behavior.
- **Blast radius:** The MiniMax section of the provider catalog only.
- **Linked issue(s):** No linked issue.
- **Labels:** `docs`, `provider`, `provider:minimax`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A - this is a two-line documentation-only addition covered by the docs checks.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` validates the changed Markdown, and the required CI gate is green.
- **Known CI coverage gap, if any:** None specific to this documentation-only change.
- **Commands run and tail output:**

```sh
npx markdownlint-cli2@0.20.0 docs/book/src/providers/catalog.md
# 0 errors
```

- **Beyond CI, what did you manually verify?** Confirmed the addition follows the neighboring Z.AI Anthropic-compatible endpoint pattern and preserves the existing MiniMax OpenAI-compatible guidance.
- **If any command was intentionally skipped, why:** No Rust validation was run because production code is unchanged.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback

Low-risk rollback: revert this PR's merge commit.
