### PR TITLE
test(runtime): recover zeroclaw_root_crate-gated tests in service and integrations

### DIFF
--- a/crates/zeroclaw-runtime/src/integrations/mod.rs
+++ b/crates/zeroclaw-runtime/src/integrations/mod.rs
@@ -160,7 +160,7 @@ pub fn show_integration_info(config: &Config, name: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(test, zeroclaw_root_crate))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -179,32 +179,20 @@ mod tests {
     #[test]
     fn handle_command_info_is_case_insensitive_for_known_integrations() {
         let config = Config::default();
-        let first_name = registry::all_integrations(&config)
-            .first()
-            .expect("registry should define at least one integration")
-            .name
-            .to_lowercase();
-
-        let result = handle_command(
-            crate::IntegrationCommands::Info { name: first_name },
-            &config,
+        let entries = registry::all_integrations(&config);
+        assert!(
+            !entries.is_empty(),
+            "registry should define at least one integration"
         );
 
-        assert!(result.is_ok());
+        let upper_name = entries[0].name.to_uppercase();
+        assert!(show_integration_info(&config, &upper_name).is_ok());
     }
 
     #[test]
     fn handle_command_info_returns_error_for_unknown_integration() {
         let config = Config::default();
-        let result = handle_command(
-            crate::IntegrationCommands::Info {
-                name: "definitely-not-a-real-integration".into(),
-            },
-            &config,
-        );
-
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("Unknown integration"));
+        let err = show_integration_info(&config, "definitely-not-a-real-integration").unwrap_err();
+        assert!(err.to_string().contains("Unknown integration"));
     }
 }

--- a/crates/zeroclaw-runtime/src/service/mod.rs
+++ b/crates/zeroclaw-runtime/src/service/mod.rs
@@ -1910,8 +1910,8 @@ mod linux_service_tests {
     }
 }
 
-#[cfg(all(test, zeroclaw_root_crate))]
-mod tests {
+#[cfg(test)]
+mod service_helper_tests {
     use super::*;
 
     #[test]
@@ -2067,53 +2067,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn systemd_unit_contains_home_and_pass_environment() {
-        let unit = "[Unit]\n\
-             Description=ZeroClaw daemon\n\
-             After=network.target\n\
-             \n\
-             [Service]\n\
-             Type=simple\n\
-             ExecStart=/usr/local/bin/zeroclaw daemon\n\
-             Restart=always\n\
-             RestartSec=3\n\
-             # Ensure HOME is set so headless browsers can create profile/cache dirs.\n\
-             Environment=HOME=%h\n\
-             # Allow inheriting DISPLAY and XDG_RUNTIME_DIR from the user session\n\
-             # so graphical/headless browsers can function correctly.\n\
-             PassEnvironment=DISPLAY XDG_RUNTIME_DIR\n\
-             \n\
-             [Install]\n\
-             WantedBy=default.target\n"
-            .to_string();
-
-        assert!(
-            unit.contains("Environment=HOME=%h"),
-            "systemd unit must set HOME for headless browser support"
-        );
-        assert!(
-            unit.contains("PassEnvironment=DISPLAY XDG_RUNTIME_DIR"),
-            "systemd unit must pass through display/runtime env vars"
-        );
-    }
-
-    #[test]
-    fn warn_if_binary_in_home_detects_home_path() {
-        use std::path::PathBuf;
-
-        let home_path = PathBuf::from("/home/user/.cargo/bin/zeroclaw");
-        assert!(home_path.to_string_lossy().contains("/home/"));
-        assert!(home_path.to_string_lossy().contains(".cargo/bin"));
-
-        let cargo_path = PathBuf::from("/home/user/.cargo/bin/zeroclaw");
-        assert!(cargo_path.to_string_lossy().contains(".cargo/bin"));
-
-        let system_path = PathBuf::from("/usr/local/bin/zeroclaw");
-        assert!(!system_path.to_string_lossy().contains("/home/"));
-        assert!(!system_path.to_string_lossy().contains(".cargo/bin"));
-    }
-
     #[cfg(unix)]
     #[test]
     fn shell_single_quote_escapes_single_quotes() {
@@ -2177,21 +2130,5 @@ mod tests {
         // tail should succeed on existing file
         let result = tail_file(&log, 3, false);
         assert!(result.is_ok(), "tail on existing file should succeed");
-    }
-
-    #[test]
-    fn logs_variant_is_recognized() {
-        // Ensure the Logs variant can be constructed and matched
-        let cmd = crate::ServiceCommands::Logs {
-            lines: 25,
-            follow: true,
-        };
-        match &cmd {
-            crate::ServiceCommands::Logs { lines, follow } => {
-                assert_eq!(*lines, 25);
-                assert!(*follow);
-            }
-            _ => panic!("Expected Logs variant"),
-        }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace the never-enabled `#[cfg(all(test, zeroclaw_root_crate))]` gates in the runtime service and integrations modules with live `#[cfg(test)]` modules, restoring 23 tests to normal test builds.
- Rewrite the two integration info tests against the public `show_integration_info(config, name)` boundary.
- Delete three tautological service tests that only asserted values constructed inside the tests.
- **Scope boundary:** Test-only. No production code changes. The separate cron cleanup tracked by #9471 and #9491 is out of scope.
- **Blast radius:** Runtime crate test compilation and execution only. The recovered tests exercise existing service helpers and integration lookup behavior.
- **Linked issue(s):** Closes #9473. Related #9471 and #9491.
- **Labels:** `integration`, `runtime`, `service`, `tests`, `risk:low`, `size:S`, `type:test`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is a test-only recovery, and required CI directly executes all current-platform tests in the changed modules.

### How I tested

- **CI checks relied on and why they cover this change:** `Test` executed the 18 non-Windows service tests and all 3 integration tests. `Parallel Runtime Test` ran the runtime suite three times. The required format, lint, platform check, security, and final gate jobs also passed.
- **Known CI coverage gap, if any:** The two `#[cfg(target_os = "windows")]` service tests were not executed by required CI.
- **Commands run and tail output:**

```text
cargo test -p zeroclaw-runtime --lib service::service_helper_tests::
test result: ok. 18 passed; 0 failed

cargo test -p zeroclaw-runtime --lib integrations::tests::
test result: ok. 3 passed; 0 failed

cargo fmt --all -- --check
clean

cargo clippy -p zeroclaw-runtime --tests --no-deps
no new warnings in the changed files

comment-hygiene gate
passed
```

- **Beyond CI, what did you manually verify?** The recovered tests still call existing helpers with matching signatures, the individual platform gates are preserved, and the two integration cases exercise case-insensitive lookup and the unknown-integration error through `show_integration_info`.
- **If any command was intentionally skipped, why:** No additional workspace-wide local run was needed because fresh required CI covered the current-platform runtime test surface; Windows-only execution remains the gap noted above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback

Low-risk test-only change: revert the merge commit.
