### PR TITLE
fix(providers): send string tool-call content for Cloudflare Workers AI

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2110,6 +2110,7 @@ impl OpenAiCompatibleModelProvider {
         allow_user_image_parts: bool,
     ) -> Vec<NativeMessage> {
         let targets_mistral_tool_call_contract = self.targets_mistral_tool_call_contract();
+        let requires_string_tool_call_content = self.requires_string_tool_call_content();
         let mut used_tool_call_ids = std::collections::HashSet::new();
         let mut tool_call_id_map = std::collections::HashMap::new();
         let mut last_assistant_tool_call_ids: Vec<String> = Vec::new();
@@ -2159,7 +2160,11 @@ impl OpenAiCompatibleModelProvider {
                         tool_calls.iter().filter_map(|tc| tc.id.clone()).collect();
 
                     let content = crate::request_payload::non_empty_string_field(&value, "content")
-                        .map(MessageContent::Text);
+                        .map(MessageContent::Text)
+                        .or_else(|| {
+                            requires_string_tool_call_content
+                                .then(|| MessageContent::Text(String::new()))
+                        });
 
                     let (reasoning_content, reasoning) =
                         self.assistant_reasoning_pair_for_replay(&value);
@@ -2351,6 +2356,27 @@ impl OpenAiCompatibleModelProvider {
         }
 
         modified_messages
+    }
+
+    /// Whether this backend requires `content` to be a string on assistant
+    /// tool-call messages.
+    ///
+    /// OpenAI accepts the field absent or null there, and omitting it is the
+    /// default. Cloudflare Workers AI validates against a stricter schema and
+    /// rejects the whole request with HTTP 400 (`AiError: Bad input ...
+    /// required properties at '/messages/N' are 'role,content'`). The failure
+    /// is intermittent in practice: a model that emits text alongside its tool
+    /// call produces a non-empty content and succeeds, while the far more
+    /// common no-text tool call fails.
+    fn requires_string_tool_call_content(&self) -> bool {
+        reqwest::Url::parse(&self.base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(|h| h.to_ascii_lowercase()))
+            .is_some_and(|host| {
+                host == "api.cloudflare.com"
+                    || host == "gateway.ai.cloudflare.com"
+                    || host.ends_with(".cloudflare.com")
+            })
     }
 
     fn targets_mistral_tool_call_contract(&self) -> bool {
@@ -6235,6 +6261,46 @@ mod tests {
         assert_eq!(
             non_empty_json.get("content"),
             Some(&serde_json::json!("I will check"))
+        );
+    }
+
+    #[test]
+    fn convert_messages_for_native_sends_string_tool_call_content_on_cloudflare() {
+        // Cloudflare Workers AI rejects an assistant tool-call message whose
+        // `content` is absent or null (HTTP 400, AiError 5006). Measured:
+        // content=null -> 400, content omitted -> 400, content="" -> 200.
+        // Every other backend keeps the omitting behaviour pinned by
+        // convert_messages_for_native_omits_empty_tool_call_content.
+        let history_json = serde_json::json!({
+            "content": "",
+            "tool_calls": [{
+                "id": "tc_1",
+                "name": "realms_proposal_firewall",
+                "arguments": "{}"
+            }]
+        });
+        let messages = vec![ChatMessage::assistant(history_json.to_string())];
+
+        let cloudflare = make_model_provider(
+            "workers_ai",
+            "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1/chat/completions",
+            None,
+        );
+        let native = cloudflare.convert_messages_for_native(&messages, true);
+        let json = serde_json::to_value(&native[0]).unwrap();
+        assert_eq!(
+            json.get("content"),
+            Some(&serde_json::Value::String(String::new())),
+            "Cloudflare must receive content as a string, not an omitted field"
+        );
+
+        let other = make_model_provider("test", "https://example.com", None);
+        let native = other.convert_messages_for_native(&messages, true);
+        let json = serde_json::to_value(&native[0]).unwrap();
+        assert_eq!(
+            json.get("content"),
+            None,
+            "non-Cloudflare backends keep the existing omitting behaviour"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Cloudflare Workers AI requires `content` to be a string on assistant messages containing tool calls.
  - When a model emits a tool call without accompanying text, ZeroClaw currently omits `content`, causing Workers AI to reject the follow-up request with HTTP 400.
  - Detect Cloudflare API and AI Gateway hosts and serialize empty tool-call content as `content: ""`.
  - Preserve the existing omission behavior for OpenAI and every other compatible backend.
- **Scope boundary:** This does not change normal assistant messages, tool-result messages, non-Cloudflare backends, provider configuration, or model selection.
- **Blast radius:** OpenAI-compatible message conversion when replaying an assistant tool-call message. Only Cloudflare-hosted compatible endpoints receive the new empty string.
- **Linked issue(s):** No linked issue.
- **Labels:** `bug`, `provider`, `provider:compatible`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli`, OpenAI-compatible provider
- **Setup / preconditions:** Configure an OpenAI-compatible provider whose base URL is under `api.cloudflare.com` or `gateway.ai.cloudflare.com`, using a model that supports function calling.
- **Steps to run:**
  1. Ask the agent to perform a tool call that contains no accompanying assistant text.
  2. Observe the follow-up request containing the assistant tool-call message.
- **Expected on this branch (after):** The assistant message contains `"content": ""`, and Workers AI accepts the request.
- **Prior behavior on `master` (before):** The `content` field is omitted and Workers AI rejects the request with HTTP 400 because `role,content` are required.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI should cover the full provider suite. The focused conversion tests exercise both the Cloudflare-specific behavior and preservation of the existing default behavior.
- **Known CI coverage gap, if any:** No automated request is sent to the live Workers AI service.
- **Commands run and tail output:**

```sh
cargo +1.96.1 fmt --all -- --check
cargo +1.96.1 test --locked -p zeroclaw-providers --lib convert_messages_for_native_
cargo +1.96.1 clippy --locked -p zeroclaw-providers --all-targets -- -D warnings
```

```text
running 19 tests
test compatible::tests::convert_messages_for_native_sends_string_tool_call_content_on_cloudflare ... ok
test compatible::tests::convert_messages_for_native_omits_empty_tool_call_content ... ok
test result: ok. 19 passed; 0 failed; 1134 filtered out

Finished `dev` profile
```

- **Beyond CI, what did you manually verify?** Direct API probes confirmed that Workers AI rejects `content: null` and an omitted field but accepts `content: ""`. The patched provider also completed a real tool-call round trip through Workers AI before the branch was rebased onto current `master`.
- **If any command was intentionally skipped, why:** The live provider check was not repeated after rebasing because the focused regression covers the unchanged patch and avoids consuming external service quota.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback

Low-risk rollback: revert this PR's merge commit. Non-Cloudflare behavior is unchanged.

