### PR TITLE
test(auth): cover legacy auth-profile store load end to end

### DIFF
--- a/crates/zeroclaw-providers/src/auth/profiles.rs
+++ b/crates/zeroclaw-providers/src/auth/profiles.rs
@@ -808,4 +808,109 @@ mod tests {
         let after = tokio::fs::read(store.path()).await.unwrap();
         assert_eq!(before, after, "list_profile_ids must not rewrite the store");
     }
+
+    #[tokio::test]
+    async fn legacy_oauth_store_loads_with_flat_tokens_reconstructed() {
+        // A store written by a release before the `provider` -> `model_provider`
+        // rename: it carries the legacy `provider` key and flat OAuth token fields
+        // rather than a nested `token_set`. Loading through the real store path must
+        // map the alias and rebuild the token set, not silently yield `token_set:
+        // None` (an authenticated profile that holds no credentials).
+        let tmp = TempDir::new().unwrap();
+        let store = AuthProfilesStore::new(tmp.path(), false);
+
+        let legacy = r#"{
+            "schema_version": 1,
+            "updated_at": "2026-01-01T00:00:00Z",
+            "active_profiles": {
+                "openai-codex": "openai-codex:default"
+            },
+            "profiles": {
+                "openai-codex:default": {
+                    "provider": "openai-codex",
+                    "profile_name": "default",
+                    "kind": "oauth",
+                    "account_id": "acct_legacy",
+                    "workspace_id": "ws_legacy",
+                    "access_token": "legacy-access",
+                    "refresh_token": "legacy-refresh",
+                    "id_token": "legacy-id",
+                    "expires_at": "2030-01-01T00:00:00Z",
+                    "token_type": "Bearer",
+                    "scope": "openid offline_access"
+                }
+            }
+        }"#;
+        tokio::fs::write(store.path(), legacy).await.unwrap();
+
+        let data = store.load().await.unwrap();
+        let profile = data
+            .profiles
+            .get("openai-codex:default")
+            .expect("legacy profile loads");
+
+        // Legacy `provider` key resolves to the canonical field.
+        assert_eq!(profile.model_provider, "openai-codex");
+        assert_eq!(profile.kind, AuthProfileKind::OAuth);
+        assert_eq!(profile.account_id.as_deref(), Some("acct_legacy"));
+        assert_eq!(profile.workspace_id.as_deref(), Some("ws_legacy"));
+
+        // Flat token fields are reassembled into the token set.
+        let token_set = profile.token_set.as_ref().expect("flat tokens rebuilt");
+        assert_eq!(token_set.access_token, "legacy-access");
+        assert_eq!(token_set.refresh_token.as_deref(), Some("legacy-refresh"));
+        assert_eq!(token_set.id_token.as_deref(), Some("legacy-id"));
+        assert_eq!(token_set.token_type.as_deref(), Some("Bearer"));
+        assert_eq!(token_set.scope.as_deref(), Some("openid offline_access"));
+        assert_eq!(
+            token_set.expires_at,
+            Some(
+                DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc)
+            )
+        );
+
+        // The active-profile pointer survives the load unchanged.
+        assert_eq!(
+            data.active_profiles.get("openai-codex").map(String::as_str),
+            Some("openai-codex:default")
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_token_store_loads_flat_token_field() {
+        // Token-kind sibling of the OAuth case: a legacy `provider` key with a flat
+        // `token` field (no OAuth token set) must load with the token preserved.
+        let tmp = TempDir::new().unwrap();
+        let store = AuthProfilesStore::new(tmp.path(), false);
+
+        let legacy = r#"{
+            "schema_version": 1,
+            "updated_at": "2026-01-01T00:00:00Z",
+            "active_profiles": {
+                "anthropic": "anthropic:default"
+            },
+            "profiles": {
+                "anthropic:default": {
+                    "provider": "anthropic",
+                    "profile_name": "default",
+                    "kind": "token",
+                    "token": "legacy-api-key"
+                }
+            }
+        }"#;
+        tokio::fs::write(store.path(), legacy).await.unwrap();
+
+        let data = store.load().await.unwrap();
+        let profile = data
+            .profiles
+            .get("anthropic:default")
+            .expect("legacy token profile loads");
+
+        assert_eq!(profile.model_provider, "anthropic");
+        assert_eq!(profile.kind, AuthProfileKind::Token);
+        assert!(profile.token_set.is_none());
+        assert_eq!(profile.token.as_deref(), Some("legacy-api-key"));
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds two end-to-end regression tests that drive the real `AuthProfilesStore::load()` path against on-disk *legacy* auth-profile stores — the shape written by releases before the `provider` → `model_provider` rename (legacy `provider` key, flat OAuth token fields rather than a nested `token_set`).
  - The only prior coverage (`persisted_profile_accepts_legacy_provider_key`) was a shallow single-struct `serde` deserialize; it verified field-name mapping but never exercised the store load path or the flat-field → `TokenSet` reconstruction. A refactor that dropped that reconstruction would compile, keep CI green, and silently yield an authenticated profile with `token_set: None`.
  - The new tests load a real legacy fixture from disk and assert the credentials survive intact, locking in the compatibility fix landed in #8982.
- **Scope boundary:** Tests only. **No production code changed.** No change to load/save behavior, serde attributes, or the store API.
- **Blast radius:** Test coverage for auth-profile deserialization only.
- **Linked issue(s):** Follow-up to #9474 (closed as completed) and #8982. Not `Closes` — the production compatibility path already shipped; this adds the stronger end-to-end fixture requested in the #9474 triage.
- **Labels:** `tests`, `provider`, `security:secrets`, `rust`, `risk:low`, `size:S`.

## Validation Evidence

```bash
cargo fmt --all -- --check
```
```text
(no stdout; exited 0)
```

```bash
cargo test -p zeroclaw-providers auth::profiles
```
```text
test auth::profiles::tests::legacy_oauth_store_loads_with_flat_tokens_reconstructed ... ok
test auth::profiles::tests::legacy_token_store_loads_flat_token_field ... ok
...
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1146 filtered out
```

```bash
cargo clippy -p zeroclaw-providers --all-targets --no-deps
```
```text
Finished `dev` profile [...] target(s)  (exit 0, no warnings)
```

```bash
cargo test -p zeroclaw-providers --lib
```
```text
test result: ok. 1154 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- **Beyond CI — what did you manually verify?** Non-vacuity: temporarily removing `#[serde(alias = "provider")]` from `PersistedAuthProfile` made both new tests fail with the exact original defect (`missing field model_provider`); restoring the alias returned them to green. This confirms the tests genuinely guard the alias mapping and the flat-token reconstruction rather than passing trivially.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`) — production credential-handling code is untouched; this PR only adds test coverage.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`) — fixtures use fake placeholder token material (`legacy-access`, `legacy-api-key`, …).

## Compatibility

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- No upgrade steps required.

## Rollback

- **Fast rollback command/path:** `git revert <merge-commit-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** None at runtime (test-only). A failure here would surface as a red `zeroclaw-providers` test run.
