### PR TITLE
fix(tests): scope lifecycle observer test ordering to the target agent

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -15810,6 +15810,107 @@ Let me check the result."#;
         (starts, ends)
     }
 
+    /// The target alias's own `AgentStart`/`AgentEnd` events, in capture order.
+    ///
+    /// The `run()` lifecycle tests install a *process-wide* broadcast hook, so
+    /// the raw capture can interleave events emitted by other agents —
+    /// including other tests executing concurrently under the parallel runtime
+    /// gate. Ordering assertions (first is `AgentStart`, last is `AgentEnd`)
+    /// must therefore scope to the target alias before inspecting the ends of
+    /// the sequence; asserting on the raw stream's `first()`/`last()` is a
+    /// cross-talk flake.
+    fn alias_lifecycle_sequence<'a>(
+        events: &'a [ObserverEvent],
+        alias: &str,
+    ) -> Vec<&'a ObserverEvent> {
+        events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    ObserverEvent::AgentStart { agent_alias, .. }
+                        | ObserverEvent::AgentEnd { agent_alias, .. }
+                        if agent_alias.as_deref() == Some(alias)
+                )
+            })
+            .collect()
+    }
+
+    /// Regression guard for the parallel-gate flake: the `run()` lifecycle tests
+    /// capture through a process-wide hook, so unrelated observer traffic (e.g. a
+    /// concurrent runtime test) can land at the head or tail of the raw stream.
+    /// `alias_lifecycle_sequence` must scope ordering to the target alias so
+    /// foreign `AgentStart`/`AgentEnd` events cannot invalidate the first/last
+    /// assertions. This is deterministic (no scheduling dependence), unlike the
+    /// intermittent CI failure it guards against.
+    #[test]
+    fn alias_lifecycle_sequence_scopes_out_foreign_observer_traffic() {
+        fn start(alias: &str) -> ObserverEvent {
+            ObserverEvent::AgentStart {
+                model_provider: "p".into(),
+                model: "m".into(),
+                channel: None,
+                agent_alias: Some(alias.into()),
+                turn_id: Some("t".into()),
+            }
+        }
+        fn end(alias: &str) -> ObserverEvent {
+            ObserverEvent::AgentEnd {
+                model_provider: "p".into(),
+                model: "m".into(),
+                duration: std::time::Duration::from_millis(0),
+                tokens_used: None,
+                cost_usd: None,
+                channel: None,
+                agent_alias: Some(alias.into()),
+                turn_id: Some("t".into()),
+            }
+        }
+
+        // Foreign events bracket the target's own pair on both ends — exactly
+        // the interleaving that made the raw first()/last() assertions flake.
+        let events = vec![
+            end("other-agent"), // foreign AgentEnd at the head
+            start("target-agent"),
+            start("other-agent"),
+            end("target-agent"),
+            start("other-agent"), // foreign AgentStart at the tail
+        ];
+
+        // Counts stay scoped to the target alias (unchanged behavior).
+        assert_eq!(lifecycle_events_for_alias(&events, "target-agent"), (1, 1));
+
+        // The raw stream's ends are foreign, so the old unscoped assertions
+        // would fail here — which is the bug.
+        assert!(!matches!(
+            events.first(),
+            Some(ObserverEvent::AgentStart { .. })
+        ));
+        assert!(!matches!(
+            events.last(),
+            Some(ObserverEvent::AgentEnd { .. })
+        ));
+
+        // The alias-scoped sequence is exactly [AgentStart, AgentEnd] regardless
+        // of the foreign cross-talk.
+        let lifecycle = alias_lifecycle_sequence(&events, "target-agent");
+        assert!(matches!(
+            lifecycle.as_slice(),
+            [
+                ObserverEvent::AgentStart { .. },
+                ObserverEvent::AgentEnd { .. }
+            ]
+        ));
+        assert!(matches!(
+            lifecycle.first(),
+            Some(ObserverEvent::AgentStart { .. })
+        ));
+        assert!(matches!(
+            lifecycle.last(),
+            Some(ObserverEvent::AgentEnd { .. })
+        ));
+    }
+
     /// A `Config::default()` rooted under a fresh temp dir instead of the
     /// real `$HOME/.zeroclaw`. `Config::default()` points `data_dir` (the
     /// sqlite memory db, `{data_dir}/memory/brain.db`) and `config_path`
@@ -15906,13 +16007,18 @@ Let me check the result."#;
         let (starts, ends) = lifecycle_events_for_alias(&events, "run-lifecycle-success-agent");
         assert_eq!(starts, 1, "exactly one AgentStart, got {events:?}");
         assert_eq!(ends, 1, "exactly one AgentEnd, got {events:?}");
+        // Scope ordering to the target agent: the process-wide hook can capture
+        // unrelated events from concurrently executing tests.
+        let lifecycle = alias_lifecycle_sequence(&events, "run-lifecycle-success-agent");
         assert!(
-            matches!(events.first(), Some(ObserverEvent::AgentStart { .. })),
-            "first event must be AgentStart, got {events:?}"
+            matches!(lifecycle.first(), Some(ObserverEvent::AgentStart { .. })),
+            "the target agent's first lifecycle event must be AgentStart, \
+             got {lifecycle:?} (full captured stream: {events:?})"
         );
         assert!(
-            matches!(events.last(), Some(ObserverEvent::AgentEnd { .. })),
-            "last event must be AgentEnd, got {events:?}"
+            matches!(lifecycle.last(), Some(ObserverEvent::AgentEnd { .. })),
+            "the target agent's last lifecycle event must be AgentEnd, \
+             got {lifecycle:?} (full captured stream: {events:?})"
         );
     }
 
@@ -16003,13 +16109,18 @@ Let me check the result."#;
             "AgentEnd must still fire via Drop on the early-return error path \
              (the regression this fix closes), got {events:?}"
         );
+        // Scope ordering to the target agent: the process-wide hook can
+        // capture unrelated events from concurrently executing tests.
+        let lifecycle = alias_lifecycle_sequence(&events, "run-lifecycle-error-agent");
         assert!(
-            matches!(events.first(), Some(ObserverEvent::AgentStart { .. })),
-            "first event must be AgentStart, got {events:?}"
+            matches!(lifecycle.first(), Some(ObserverEvent::AgentStart { .. })),
+            "the target agent's first lifecycle event must be AgentStart, \
+             got {lifecycle:?} (full captured stream: {events:?})"
         );
         assert!(
-            matches!(events.last(), Some(ObserverEvent::AgentEnd { .. })),
-            "last event must be AgentEnd even on the error path, got {events:?}"
+            matches!(lifecycle.last(), Some(ObserverEvent::AgentEnd { .. })),
+            "the target agent's last lifecycle event must be AgentEnd even on the \
+             error path, got {lifecycle:?} (full captured stream: {events:?})"
         );
     }
 
@@ -16138,13 +16249,18 @@ Let me check the result."#;
             ends, 1,
             "a model switch must still close with exactly one AgentEnd, got {events:?}"
         );
+        // Scope ordering to the target agent: the process-wide hook can
+        // capture unrelated events from concurrently executing tests.
+        let lifecycle = alias_lifecycle_sequence(&events, "run-lifecycle-switch-agent");
         assert!(
-            matches!(events.first(), Some(ObserverEvent::AgentStart { .. })),
-            "first event must be AgentStart, got {events:?}"
+            matches!(lifecycle.first(), Some(ObserverEvent::AgentStart { .. })),
+            "the target agent's first lifecycle event must be AgentStart, \
+             got {lifecycle:?} (full captured stream: {events:?})"
         );
         assert!(
-            matches!(events.last(), Some(ObserverEvent::AgentEnd { .. })),
-            "last event must be AgentEnd, got {events:?}"
+            matches!(lifecycle.last(), Some(ObserverEvent::AgentEnd { .. })),
+            "the target agent's last lifecycle event must be AgentEnd, \
+             got {lifecycle:?} (full captured stream: {events:?})"
         );
 
         let end_route = events


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `run()` lifecycle tests added in #9490 install a **process-wide** broadcast observer. Their ordering assertions inspected `events.first()`/`events.last()` on the *entire* captured stream, so under the parallel runtime gate an unrelated concurrent test's event could land at the head/tail and fail `first event must be AgentStart` — a p0 intermittent CI failure (~50% of parallel runs).
  - Scope the ordering assertions to the target alias's own `AgentStart`/`AgentEnd` events via a new `alias_lifecycle_sequence` helper.
  - Add a deterministic regression test that interleaves foreign lifecycle events at the head and tail and proves the scoped assertions hold regardless of cross-talk.
- **Visual (before/after flow):** https://claude.ai/code/artifact/2ee85dbd-567d-46cf-a065-ea14b5dc088f
- **Scope boundary:** Test-only; no production code changes. The alias-scoped exact-count checks (`lifecycle_events_for_alias`) and the model-switch route assertion are **unchanged**, so the regressions those tests exist to catch — a missing `AgentEnd` on the error path, a second `AgentStart` on model switch — are still caught. The `agent_turn_*` bracket test is untouched: it uses a *local* observer passed directly into `agent_turn(...)`, not the process-wide hook, so it was never exposed to cross-talk.
- **Blast radius:** One file, `crates/zeroclaw-runtime/src/agent/loop_.rs`, entirely inside `#[cfg(test)]`. No runtime behavior changes.
- **Linked issue(s):** Closes #9518
- **Labels:** `bug`, `type:test`, `agent`, `runtime`, `priority:p0`, `risk:high`, `size:S`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A — the flake is a test-infra issue; the fix is proven deterministically and by the parallel gate below (no manual verification adds signal).

### How I tested

- **CI checks relied on and why they cover this change:** the `Parallel Runtime Test` gate (`scripts/ci/parallel_runtime_test_gate.sh`) is exactly where the flake surfaced; a green run there covers the change. `cargo fmt`, `clippy`, and the comment-hygiene gate cover the rest.
- **Known CI coverage gap, if any:** None. The new `alias_lifecycle_sequence_scopes_out_foreign_observer_traffic` test reproduces the cross-talk deterministically (no scheduling dependence), so coverage no longer relies on the intermittent parallel schedule.
- **Commands run and tail output:**

```sh
$ cargo fmt --all -- --check
# clean

$ bash scripts/ci/comment_hygiene_gate.sh
# clean

# the issue's exact repro:
$ ZEROCLAW_PARALLEL_TEST_RUNS=3 ZEROCLAW_PARALLEL_TEST_THREADS=16 ./scripts/ci/parallel_runtime_test_gate.sh
# all 6 runs pass (zeroclaw-runtime x3 + zeroclaw-channels x3, 16 threads)

# plus 6 further runtime-only parallel runs (16 threads), all green:
test result: ok. 3464 passed; 0 failed; 2 ignored   # x6  => 9 clean parallel runtime runs total

$ cargo test -p zeroclaw-runtime --lib agent::loop_::tests::run_        # 3 lifecycle tests
$ cargo test -p zeroclaw-runtime --lib agent::loop_::tests::alias_lifecycle_sequence_scopes_out_foreign_observer_traffic
# all pass
```

- **Beyond CI, what did you manually verify?** That the alias-scoped count assertions (which detect the two named regressions) run *before* the ordering assertions in all three tests and are unchanged; that the model-switch route (`AgentEnd` attributed to the switched-to provider/model) check is intact; and that the synthetic test would fail against a broken filter (no alias check / wrong variant). Did not need to run the app.
- **If any command was intentionally skipped, why:** `cargo clippy ... -D warnings` reports style lints in pre-existing untouched files under the local toolchain; `--no-deps` on the changed crate shows zero diagnostics in `loop_.rs`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes** (test-only)
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback

Test-only: `git revert <sha>` is the plan.

