### PR TITLE
fix(tool-call-parser): satisfy clippy::question_mark on GLM shorthand branch

### DIFF
--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -1629,15 +1629,14 @@ fn parse_glm_shortened_body(body: &str) -> Option<ParsedToolCall> {
             .trim_end_matches('/')
             .trim();
         (tool, attrs)
-    } else if let Some(gt_pos) = body.find('>') {
+    } else {
         // GLM shortened: `tool_name>value`
+        let gt_pos = body.find('>')?;
         let tool = body[..gt_pos].trim();
         let value = body[gt_pos + 1..].trim();
         // Strip trailing self-close markers that some models emit
         let value = value.trim_end_matches("/>").trim_end_matches('/').trim();
         (tool, value)
-    } else {
-        return None;
     };
 
     // Validate tool name: must be alphanumeric + underscore only


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Rust 1.97's `clippy::question_mark` flags the trailing `else if let Some(gt_pos) = body.find('>') { ... } else { return None }` arm in `parse_xml_style_call`. Rewrote it as a plain `else` arm using `body.find('>')?` to short-circuit, clearing the lint. Since this is the last arm, a failed `find` is equivalent to the original `return None`, so behavior is unchanged.
- **Scope boundary:** Only the control-flow shape of that one arm changes. No change to parsing behavior, tool-name/value extraction, or any other branch.
- **Blast radius:** None. A lint-only equivalent rewrite; the GLM shorthand (`tool_name>value`) parse path behaves identically.
- **Linked issue(s):** None
- **Labels:** `type:fix`, `risk:low`, `size:XS`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — lint-only equivalent rewrite with no user-visible behavior change.

### How I tested

- **CI checks relied on and why they cover this change:** CI's `clippy --all-targets -D warnings` confirms the lint is cleared; `test` confirms the parse path does not regress.
- **Known CI coverage gap, if any:** None
- **Commands run and tail output:** Locally ran `cargo fmt -p zeroclaw-tool-call-parser` (no changes). A prior `cargo clippy -p zeroclaw-tool-call-parser --all-targets` finished clean with no warnings. Remaining checks left to CI.
- **Beyond CI, what did you manually verify?** Confirmed by inspection that `find('>')?` in the final arm is equivalent to the original `return None`; logic is unchanged.
- **If any command was intentionally skipped, why:** Did not run the full clippy/test suite locally by request; left to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert <sha>` is the plan.