### PR TITLE
fix(docker): copy nested plugin fixture manifest in pre-fetch stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,10 @@ COPY --parents crates/*/Cargo.toml ./
 # `zeroclaw_macros::Configurable` unresolved. Copy its real source now so the
 # proc-macro is built from the genuine implementation during the pre-fetch.
 COPY --parents crates/zeroclaw-macros/src/ ./
+# Nested workspace members (e.g. plugin test fixtures) are not matched by the
+# single-level crates/*/Cargo.toml glob above, so copy their manifests
+# explicitly to keep workspace manifest parsing intact during the pre-fetch.
+COPY --parents crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 # apps/zerocode: TUI app not shipped in the server image; copy only its manifest
@@ -119,7 +123,9 @@ RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-tra
     && echo "fn main() {}" > xtask/src/bin/web.rs \
     && mkdir -p crates/zeroclaw-hardware/examples \
     && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
-    && for d in crates/*/; do [ "$d" = "crates/zeroclaw-macros/" ] && continue; mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
+    && for d in crates/*/; do [ "$d" = "crates/zeroclaw-macros/" ] && continue; mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done \
+    && mkdir -p crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src \
+    && printf '' > crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -70,6 +70,10 @@ COPY Cargo.toml Cargo.lock ./
 # no longer requires editing this file.  --parents preserves the
 # crates/<name>/Cargo.toml directory structure.
 COPY --parents crates/*/Cargo.toml ./
+# Nested workspace members (e.g. plugin test fixtures) are not matched by the
+# single-level crates/*/Cargo.toml glob above, so copy their manifests
+# explicitly to keep workspace manifest parsing intact during the pre-fetch.
+COPY --parents crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 # apps/zerocode: TUI app not shipped in the server image; copy only its manifest
@@ -102,7 +106,9 @@ RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-tra
     && echo "fn main() {}" > xtask/src/bin/web.rs \
     && mkdir -p crates/zeroclaw-hardware/examples \
     && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
-    && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
+    && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done \
+    && mkdir -p crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src \
+    && printf '' > crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \


### PR DESCRIPTION
## Summary
- The source `Dockerfile` / `Dockerfile.debian` pre-fetch stage copies workspace-member manifests via `COPY --parents crates/*/Cargo.toml ./`, a single-level glob that does not match the nested workspace member `crates/zeroclaw-plugins/tests/fixtures/channel-fixture` (added in #9124).
- As a result `cargo build --locked` fails during the dependency pre-fetch with `failed to load manifest for workspace member .../channel-fixture` (No such file or directory).
- Fix: explicitly copy the nested fixture manifest and create its stub `src/lib.rs` alongside the other dummy targets, in both `Dockerfile` and `Dockerfile.debian`.

This is a pre-existing defect surfaced by any PR that triggers the `Docker Image PR Check` workflow (e.g. #9527, which touches `release-stable-manual.yml`). It is unrelated to the Rust toolchain.

## Test plan
- [x] Reproduced locally: simulating the pre-fetch stage (manifests + stubs only), `cargo metadata --no-deps` fails without the fixture manifest and succeeds with it.
- [x] CI: `Docker Image PR Check` source builds (Dockerfile amd64/arm64, Dockerfile.debian amd64) go green.
