### PR TITLE
test(memory): harden Lucid process timing fixtures

### DIFF
--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -1757,11 +1757,9 @@ if [ "${{1:-}}" = "store" ]; then
   printf 'store-start:%s\n' "${{2:-}}" >> "{}"
   case "${{2:-}}" in
     fast_store:*)
-      sleep 0.1
       printf 'fast-store-complete\n' >> "{}"
       ;;
     slow_store:*)
-      sleep 1.2
       printf 'slow-store-complete\n' >> "{}"
       ;;
   esac
@@ -1769,7 +1767,6 @@ if [ "${{1:-}}" = "store" ]; then
 fi
 if [ "${{1:-}}" = "context" ]; then
   printf 'context-start\n' >> "{}"
-  sleep 1.0
   printf 'context-complete\n' >> "{}"
   cat <<'EOF'
 <lucid-context>
@@ -1824,18 +1821,26 @@ backend = "lucid.selected"
 
 [storage.lucid.selected]
 binary_path = "{selected_cmd}"
-recall_timeout_ms = 200
-store_timeout_ms = 500
+recall_timeout_ms = 10000
+store_timeout_ms = 20000
 
 [storage.lucid.decoy]
 binary_path = "{decoy_cmd}"
-recall_timeout_ms = 900
-store_timeout_ms = 900
+recall_timeout_ms = 30000
+store_timeout_ms = 40000
 "#
         );
         let mut config: Config = toml::from_str(&raw).expect("parse Lucid aliases");
         config.data_dir = tmp.path().to_path_buf();
         config.validate().expect("Lucid aliases must validate");
+
+        let local = SqliteMemory::new("sqlite", tmp.path()).unwrap();
+        let configured =
+            build_lucid_memory(tmp.path(), local, config.resolve_active_storage());
+        let (lucid_cmd, recall_timeout, store_timeout) = configured.test_process_config();
+        assert_eq!(lucid_cmd, selected_cmd);
+        assert_eq!(recall_timeout, std::time::Duration::from_secs(10));
+        assert_eq!(store_timeout, std::time::Duration::from_secs(20));
 
         let memory =
             create_memory_from_config(&config, None).expect("build Lucid memory from parsed alias");
@@ -1860,14 +1865,13 @@ store_timeout_ms = 900
             .unwrap();
         let entries = memory.recall("factory", 5, None, None, None).await.unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_millis(1_300)).await;
         let selected_calls = fs::read_to_string(&selected_log).unwrap_or_default();
         assert!(selected_calls.contains("store-start:fast_store:"));
         assert!(selected_calls.contains("fast-store-complete"));
         assert!(selected_calls.contains("store-start:slow_store:"));
-        assert!(!selected_calls.contains("slow-store-complete"));
+        assert!(selected_calls.contains("slow-store-complete"));
         assert!(selected_calls.contains("context-start"));
-        assert!(!selected_calls.contains("context-complete"));
+        assert!(selected_calls.contains("context-complete"));
         assert!(!decoy_log.exists(), "unselected Lucid alias was invoked");
         assert!(
             entries
@@ -1877,7 +1881,7 @@ store_timeout_ms = 900
         assert!(
             entries
                 .iter()
-                .all(|entry| !entry.content.contains("Factory-selected remote result"))
+                .any(|entry| entry.content.contains("Factory-selected remote result"))
         );
     }
 
@@ -1898,13 +1902,13 @@ backend = "lucid.selected"
 
 [storage.lucid.selected]
 binary_path = "{selected_cmd}"
-recall_timeout_ms = 200
-store_timeout_ms = 500
+recall_timeout_ms = 10000
+store_timeout_ms = 20000
 
 [storage.lucid.decoy]
 binary_path = "{decoy_cmd}"
-recall_timeout_ms = 900
-store_timeout_ms = 900
+recall_timeout_ms = 30000
+store_timeout_ms = 40000
 "#
         );
         let mut config: Config = toml::from_str(&raw).expect("parse Lucid aliases");

--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -1835,8 +1835,7 @@ store_timeout_ms = 40000
         config.validate().expect("Lucid aliases must validate");
 
         let local = SqliteMemory::new("sqlite", tmp.path()).unwrap();
-        let configured =
-            build_lucid_memory(tmp.path(), local, config.resolve_active_storage());
+        let configured = build_lucid_memory(tmp.path(), local, config.resolve_active_storage());
         let (lucid_cmd, recall_timeout, store_timeout) = configured.test_process_config();
         assert_eq!(lucid_cmd, selected_cmd);
         assert_eq!(recall_timeout, std::time::Duration::from_secs(10));

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -641,7 +641,8 @@ mod platform_tests {
         );
         assert_eq!(
             memory.store_timeout,
-            Duration::from_millis(LucidMemory::DEFAULT_STORE_TIMEOUT_MS)
+            Duration::from_secs(3),
+            "the production store timeout must retain the documented cold-start allowance"
         );
     }
 }
@@ -770,17 +771,15 @@ exit 1
         script_path.display().to_string()
     }
 
-    fn write_timeout_lucid_script(dir: &Path, pid_path: &Path, marker_path: &Path) -> String {
+    fn write_timeout_lucid_script(dir: &Path, pid_path: &Path) -> String {
         let script_path = dir.join("timeout-lucid.sh");
         let script = format!(
             r#"#!/bin/sh
 set -eu
 printf '%s\n' "$$" > "{}"
-sleep 1
-printf 'completed\n' > "{}"
+exec sleep 10
 "#,
-            pid_path.display(),
-            marker_path.display()
+            pid_path.display()
         );
 
         fs::write(&script_path, script).unwrap();
@@ -929,13 +928,22 @@ exit 1
     }
 
     #[tokio::test]
-    async fn store_handles_lucid_cold_start_delay_with_default_timeout() {
+    async fn store_waits_for_delayed_lucid_process_with_test_timeout() {
         let tmp = TempDir::new().unwrap();
         let marker_path = tmp.path().join("store-completed.marker");
         let delayed_cmd = write_delayed_store_lucid_script(tmp.path(), &marker_path);
         let sqlite = SqliteMemory::new("test", tmp.path()).unwrap();
-        let memory =
-            LucidMemory::with_overrides("test", tmp.path(), sqlite, Some(delayed_cmd), None, None);
+        let memory = LucidMemory::with_options(
+            "test",
+            tmp.path(),
+            sqlite,
+            delayed_cmd,
+            200,
+            3,
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            Duration::from_secs(2),
+        );
 
         memory
             .store(
@@ -949,7 +957,7 @@ exit 1
 
         assert!(
             marker_path.exists(),
-            "the default store timeout must allow the simulated 1.5s cold start"
+            "the store path must wait for a healthy delayed Lucid process"
         );
     }
 
@@ -957,13 +965,17 @@ exit 1
     async fn timeout_terminates_and_reaps_lucid_child() {
         let tmp = TempDir::new().unwrap();
         let pid_path = tmp.path().join("child.pid");
-        let marker_path = tmp.path().join("completed.marker");
-        let cmd = write_timeout_lucid_script(tmp.path(), &pid_path, &marker_path);
+        let cmd = write_timeout_lucid_script(tmp.path(), &pid_path);
+        let timeout = Duration::from_secs(2);
 
-        let error = LucidMemory::run_lucid_command_raw(&cmd, &[], Duration::from_millis(200))
+        let error = LucidMemory::run_lucid_command_raw(&cmd, &[], timeout)
             .await
             .expect_err("delayed command must time out");
-        assert!(error.to_string().contains("timed out after 200ms"));
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("timed out after {}ms", timeout.as_millis()))
+        );
 
         let pid = fs::read_to_string(&pid_path)
             .expect("fake command must record its PID before the deadline")
@@ -979,12 +991,6 @@ exit 1
         assert!(
             !still_running,
             "timed-out Lucid child PID {pid} still exists"
-        );
-
-        tokio::time::sleep(Duration::from_millis(1_100)).await;
-        assert!(
-            !marker_path.exists(),
-            "timed-out Lucid child continued running and wrote its late marker"
         );
     }
 

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -103,6 +103,15 @@ impl LucidMemory {
         }
     }
 
+    #[cfg(all(test, unix))]
+    pub(super) fn test_process_config(&self) -> (&str, Duration, Duration) {
+        (
+            &self.lucid_cmd,
+            self.recall_timeout,
+            self.store_timeout,
+        )
+    }
+
     fn in_failure_cooldown(&self) -> bool {
         let guard = self.last_failure_at.lock();
         guard

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -105,11 +105,7 @@ impl LucidMemory {
 
     #[cfg(all(test, unix))]
     pub(super) fn test_process_config(&self) -> (&str, Duration, Duration) {
-        (
-            &self.lucid_cmd,
-            self.recall_timeout,
-            self.store_timeout,
-        )
+        (&self.lucid_cmd, self.recall_timeout, self.store_timeout)
     }
 
     fn in_failure_cooldown(&self) -> bool {

--- a/crates/zeroclaw-memory/src/lucid.rs
+++ b/crates/zeroclaw-memory/src/lucid.rs
@@ -239,9 +239,18 @@ impl LucidMemory {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        let mut child = cmd
+        let child = cmd
             .spawn()
             .with_context(|| format!("failed to spawn lucid command {lucid_cmd:?}"))?;
+
+        Self::wait_for_lucid_child(child, lucid_cmd, timeout_window).await
+    }
+
+    async fn wait_for_lucid_child(
+        mut child: tokio::process::Child,
+        lucid_cmd: &str,
+        timeout_window: Duration,
+    ) -> anyhow::Result<String> {
         let mut stdout = child
             .stdout
             .take()
@@ -771,24 +780,6 @@ exit 1
         script_path.display().to_string()
     }
 
-    fn write_timeout_lucid_script(dir: &Path, pid_path: &Path) -> String {
-        let script_path = dir.join("timeout-lucid.sh");
-        let script = format!(
-            r#"#!/bin/sh
-set -eu
-printf '%s\n' "$$" > "{}"
-exec sleep 10
-"#,
-            pid_path.display()
-        );
-
-        fs::write(&script_path, script).unwrap();
-        let mut perms = fs::metadata(&script_path).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&script_path, perms).unwrap();
-        script_path.display().to_string()
-    }
-
     fn write_probe_lucid_script(dir: &Path, marker_path: &Path) -> String {
         let script_path = dir.join("probe-lucid.sh");
         let marker = marker_path.display().to_string();
@@ -887,7 +878,7 @@ exit 1
     }
 
     #[tokio::test]
-    async fn recall_handles_lucid_cold_start_delay_within_timeout() {
+    async fn recall_waits_for_delayed_lucid_process_with_test_timeout() {
         let tmp = TempDir::new().unwrap();
         let delayed_cmd = write_delayed_lucid_script(tmp.path());
         let sqlite = SqliteMemory::new("test", tmp.path()).unwrap();
@@ -898,8 +889,8 @@ exit 1
             delayed_cmd,
             200,
             3,
-            Duration::from_millis(LucidMemory::DEFAULT_RECALL_TIMEOUT_MS),
-            Duration::from_millis(LucidMemory::DEFAULT_STORE_TIMEOUT_MS),
+            Duration::from_secs(10),
+            Duration::from_secs(10),
             Duration::from_secs(2),
         );
 
@@ -963,12 +954,17 @@ exit 1
 
     #[tokio::test]
     async fn timeout_terminates_and_reaps_lucid_child() {
-        let tmp = TempDir::new().unwrap();
-        let pid_path = tmp.path().join("child.pid");
-        let cmd = write_timeout_lucid_script(tmp.path(), &pid_path);
-        let timeout = Duration::from_secs(2);
+        let mut command = Command::new("sleep");
+        command
+            .arg("10")
+            .kill_on_drop(true)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = command.spawn().expect("sleep command must start");
+        let pid = child.id().expect("spawned sleep command must have a PID");
+        let timeout = Duration::from_millis(100);
 
-        let error = LucidMemory::run_lucid_command_raw(&cmd, &[], timeout)
+        let error = LucidMemory::wait_for_lucid_child(child, "sleep", timeout)
             .await
             .expect_err("delayed command must time out");
         assert!(
@@ -977,12 +973,8 @@ exit 1
                 .contains(&format!("timed out after {}ms", timeout.as_millis()))
         );
 
-        let pid = fs::read_to_string(&pid_path)
-            .expect("fake command must record its PID before the deadline")
-            .trim()
-            .to_string();
         let still_running = std::process::Command::new("kill")
-            .args(["-0", &pid])
+            .args(["-0", &pid.to_string()])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
@@ -994,22 +986,26 @@ exit 1
         );
     }
 
-    #[tokio::test]
-    async fn with_overrides_none_matches_new_defaults() {
+    #[test]
+    fn with_overrides_none_matches_new_defaults() {
         let tmp = TempDir::new().unwrap();
-        let delayed_cmd = write_delayed_lucid_script(tmp.path());
         let sqlite = SqliteMemory::new("test", tmp.path()).unwrap();
-        let memory =
-            LucidMemory::with_overrides("test", tmp.path(), sqlite, Some(delayed_cmd), None, None);
+        let memory = LucidMemory::with_overrides(
+            "test",
+            tmp.path(),
+            sqlite,
+            Some("lucid-test".to_string()),
+            None,
+            None,
+        );
 
-        let entries = memory.recall("auth", 5, None, None, None).await.unwrap();
-
-        assert!(
-            entries
-                .iter()
-                .any(|e| e.content.contains("Delayed token refresh guidance")),
-            "with_overrides(None, None, None) must apply the same raised \
-             default timeout as `new`, tolerating the simulated 1.5s cold start"
+        assert_eq!(
+            memory.recall_timeout,
+            Duration::from_millis(LucidMemory::DEFAULT_RECALL_TIMEOUT_MS)
+        );
+        assert_eq!(
+            memory.store_timeout,
+            Duration::from_millis(LucidMemory::DEFAULT_STORE_TIMEOUT_MS)
         );
     }
 

--- a/src/commands/self_test.rs
+++ b/src/commands/self_test.rs
@@ -572,8 +572,8 @@ fi
             "selected".into(),
             LucidStorageConfig {
                 binary_path: Some(script_path.display().to_string()),
-                recall_timeout_ms: Some(500),
-                store_timeout_ms: Some(500),
+                recall_timeout_ms: Some(10_000),
+                store_timeout_ms: Some(10_000),
             },
         );
 


### PR DESCRIPTION
> **Maintainer note (2026-08-02):** I corrected this PR body to reflect the production helper extraction, the completed loaded ARM64 macOS reviewer testing, and the labels applied during review. The implementation and test changes remain contributor-authored; this edit only repairs the public record.

## Summary

- **Base branch:** `master`
- **What changed and why:** Remove scheduler races from Lucid subprocess tests by separating timeout configuration assertions from real-process behavior.
- **What changed and why:** Capture the spawned child PID directly in the timeout/reap test, then verify cleanup after the timeout instead of waiting for the child script to publish its PID.
- **What changed and why:** Give successful delayed-process, factory, migration, and CLI self-test fixtures generous test-owned deadlines, and directly assert the selected factory's binary and timeout wiring.
- **What changed and why:** Extract `wait_for_lucid_child` from `run_lucid_command_raw` without changing timeout, kill/reap, or error behavior so the timeout/reap path is directly testable.
- **Scope boundary:** This PR changes Unix-only test fixtures, test assertions, a test-only accessor, and the behavior-preserving `wait_for_lucid_child` production refactor. It does not change Lucid runtime timeout behavior or configuration.
- **Blast radius:** Limited to Lucid tests in `zeroclaw-memory`, the CLI memory self-test, and the internal helper extraction used by those tests.
- **Linked issue(s):** Related #9538
- **Labels:** `bug`, `memory`, `tests`, `memory:backend`, `priority:p2`, `risk:low`, `size:S`, `type:test`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** Yes. Repeating the Lucid-focused tests on a loaded ARM64 macOS host strengthened coverage because the original failures were scheduling-sensitive.

### How I tested

- **CI checks relied on and why they cover this change:** Required GitHub CI passed on the published head, including `Format`, `Lint`, `Test`, platform checks, and `CI Required Gate`.
- **Known CI coverage gap, if any:** None for the named loaded ARM64 macOS scheduling-sensitive coverage.
- **Commands run and tail output:**

```text
cargo test -p zeroclaw-memory lucid -- --nocapture
test result: ok. 18 passed; 0 failed; 483 filtered out

cargo test -p zeroclawlabs memory_roundtrip_uses_selected_lucid_alias -- --nocapture
test commands::self_test::tests::memory_roundtrip_uses_selected_lucid_alias ... ok
test result: ok. 1 passed; 0 failed

cargo nextest run --locked --workspace --exclude zeroclaw-desktop --no-fail-fast
Summary: 12265 tests run; 12263 passed; 2 failed; 11 skipped
Both failures were duplicate executions of commands::update::tests::install_companion_artifacts_skips_unknown_top_level_directories, an unrelated host-state isolation defect tracked in #9546.

cargo fmt --all -- --check
git diff --check
Comment hygiene gate passed.

Loaded ARM64 macOS reviewer testing
Five rounds of three concurrent Lucid-focused runs, 15 runs total:
18 passed; 0 failed per run under contention, with each run completing in 4.4s-5.5s.
```

- **Beyond CI, what did I manually verify?** A complete nextest run on an integration checkout containing #9413 and #9540 reached every workspace test. All Lucid tests passed. The timeout/reap fixture also verifies that the captured child PID no longer exists after cleanup. The loaded ARM64 macOS repetition completed without failures.
- **If any command was intentionally skipped, why:** Workspace-shaped Clippy was not repeated locally for this low-risk, test-focused change. Required CI `Lint` and platform checks passed on the current head.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback

Low-risk rollback: `git revert <sha>`.
