### PR TITLE
fix(channels): satisfy clippy::question_mark for matrix media source

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1994,12 +1994,11 @@ mod inbound {
             let encrypted: matrix_sdk::ruma::events::room::EncryptedFile =
                 serde_json::from_value(file.clone()).ok()?;
             matrix_sdk::ruma::events::room::MediaSource::Encrypted(Box::new(encrypted))
-        } else if let Some(url) = content.get("url").and_then(|u| u.as_str()) {
+        } else {
+            let url = content.get("url").and_then(|u| u.as_str())?;
             matrix_sdk::ruma::events::room::MediaSource::Plain(matrix_sdk::ruma::OwnedMxcUri::from(
                 url,
             ))
-        } else {
-            return None;
         };
         Some(MediaInfo::new(source, file_name, mime, kind))
     }


### PR DESCRIPTION
## What

Rewrite the `MediaSource::Plain` URL extraction in `matrix.rs` to use the `?` operator instead of an `else { return None }` branch, satisfying `clippy::question_mark`.

## Why

Rust 1.97 tightened `clippy::question_mark`, which flags this pattern. Surfacing this now so the lint fix lands independently of the toolchain-bump PR.

## Verification

- `cargo clippy` clean on rustc 1.97.1 under both default and `--all-features`.
- Logic unchanged: the `else if let Some(url) = ...` / `else return None` is equivalent to binding via `?`.