### PR TITLE
test(ci): validate PR 9497 with Windows grep

### DIFF
--- a/.github/workflows/validate-pr-9497-windows-grep.yml
+++ b/.github/workflows/validate-pr-9497-windows-grep.yml
@@ -1,0 +1,56 @@
+name: Validate PR 9497 Windows grep
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/validate-pr-9497-windows-grep.yml
+
+permissions:
+  contents: read
+
+jobs:
+  content-search:
+    name: Windows content_search with Git grep
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ad00d690339fc547e602e0414901b5dfaf1a667f
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: false
+      - name: Ensure web/dist placeholder exists
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force web/dist | Out-Null
+          New-Item -ItemType File -Force web/dist/.gitkeep | Out-Null
+      - name: Run focused content_search tests with Git grep
+        shell: pwsh
+        run: |
+          $rg = Get-Command rg -ErrorAction SilentlyContinue
+          if ($rg) {
+            $rgDir = Split-Path -Parent $rg.Source
+            $env:PATH = (($env:PATH -split ';') | Where-Object { $_ -ne $rgDir }) -join ';'
+          }
+
+          $gitUsrBin = Join-Path $env:ProgramFiles 'Git\usr\bin'
+          if (-not (Test-Path (Join-Path $gitUsrBin 'grep.exe'))) {
+            throw "Git-for-Windows grep.exe not found at $gitUsrBin"
+          }
+          $env:PATH = "$gitUsrBin;$env:PATH"
+
+          if (Get-Command rg -ErrorAction SilentlyContinue) {
+            throw 'ripgrep remains available on PATH'
+          }
+          $grep = Get-Command grep -ErrorAction Stop
+          if ($grep.Source -ne (Join-Path $gitUsrBin 'grep.exe')) {
+            throw "unexpected grep selected: $($grep.Source)"
+          }
+
+          Write-Host "Selected grep: $($grep.Source)"
+          cargo test --locked -p zeroclaw-tools content_search -- --nocapture


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Adds a one-off GitHub Actions job on `windows-latest` to supply the native Windows execution evidence requested for #9497. The job checks out exact reviewed head `ad00d690339fc547e602e0414901b5dfaf1a667f`, removes `rg` from `PATH`, selects Git-for-Windows `grep.exe`, and runs the focused `zeroclaw-tools` `content_search` tests.
- **Scope boundary:** No product source, tests, configuration, dependencies, or standing CI policy change. This validation-only branch is not intended to land; its Actions result is evidence for #9497.
- **Blast radius:** One read-only, manually scoped Windows Actions job. It uses no repository secrets and does not save a new Rust cache.
- **Linked issue(s):** Related #9497 and #9480.
- **Labels:** `type:test`, `domain:ci`, `risk:low`, `size:XS`, `principal contributor`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the GitHub-hosted Windows job is the requested verification surface.

### How I tested

- **CI checks relied on and why they cover this change:** The new `Windows content_search with Git grep` job must prove that `rg` is unavailable, Git-for-Windows `grep.exe` is selected, and the focused tests pass on the exact #9497 head.
- **Known CI coverage gap, if any:** The Windows job has not run yet.
- **Commands run and tail output:** `git diff --check`, YAML parsing, and `scripts/ci/comment_hygiene_gate.sh` passed.
- **Beyond CI, what did you manually verify?** Confirmed the job uses read-only permissions, checks out the exact approved #9497 SHA, asserts backend selection before testing, and follows existing Windows setup patterns. The PowerShell steps were not executed locally.
- **If any command was intentionally skipped, why:** Local Cargo validation cannot exercise the Windows-only path or Git-for-Windows `grep.exe`; the hosted Windows job is the purpose of this change.

## Security & Privacy Impact (required)

All impact questions: **No**.

## Compatibility (required)

Backward compatible: **Yes**. No config, environment, CLI, or toolchain-floor changes.
