### PR TITLE
feat(observability): add Langfuse observer backend

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -4808,6 +4808,10 @@ fn default_google_stt_language_code() -> String {
     "en-US".into()
 }
 
+fn default_langfuse_base_url() -> String {
+    "https://cloud.langfuse.com".to_string()
+}
+
 /// Voice transcription configuration with multi-provider support.
 ///
 /// The top-level `api_url`, `model`, and `api_key` fields remain for backward
@@ -11299,6 +11303,8 @@ pub enum ObservabilityBackend {
     Prometheus,
     #[serde(alias = "opentelemetry", alias = "otlp")]
     Otel,
+    #[serde(alias = "langfuse")]
+    Langfuse,
 }
 
 impl ObservabilityBackend {
@@ -11310,6 +11316,7 @@ impl ObservabilityBackend {
             Self::Verbose => "verbose",
             Self::Prometheus => "prometheus",
             Self::Otel => "otel",
+            Self::Langfuse => "langfuse",
         }
     }
 }
@@ -11524,6 +11531,24 @@ pub struct ObservabilityConfig {
     /// secret reads). Empty by default.
     #[serde(default)]
     pub log_tool_io_denylist: Vec<String>,
+    /// Langfuse public key (username for HTTP Basic auth).
+    #[serde(default)]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub langfuse_public_key: Option<String>,
+    /// Langfuse secret key (password for HTTP Basic auth).
+    #[serde(default)]
+    #[secret]
+    #[credential_class = "encrypted_secret"]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub langfuse_secret_key: Option<String>,
+    /// Langfuse base URL. Defaults to `"https://cloud.langfuse.com"`.
+    #[serde(default = "default_langfuse_base_url")]
+    pub langfuse_base_url: String,
+    /// Whether to include LLM/tool I/O in exported traces. Defaults to `false`.
+    #[serde(default)]
+    pub langfuse_include_io: bool,
 
     /// LLM request payload capture: "off" | "redacted" | "full".
     /// - `off` (default): only `messages_count` lands on the `llm_request`
@@ -11590,6 +11615,10 @@ impl Default for ObservabilityConfig {
             log_tool_io: default_log_tool_io(),
             log_tool_io_truncate_bytes: default_log_tool_io_truncate_bytes(),
             log_tool_io_denylist: Vec::new(),
+            langfuse_public_key: None,
+            langfuse_secret_key: None,
+            langfuse_base_url: default_langfuse_base_url(),
+            langfuse_include_io: false,
             log_llm_request_payload: default_log_llm_request_payload(),
             otel_genai_content: OtelContentPolicy::Off,
             otel_genai_content_max_chars: default_otel_genai_content_max_chars(),

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -102,6 +102,7 @@ encoding_rs = "0.8"
 default = ["observability-prometheus", "schema-export"]
 observability-prometheus = ["dep:prometheus"]
 observability-otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
+observability-langfuse = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
 sandbox-landlock = ["dep:landlock"]
 schema-export = ["dep:schemars", "zeroclaw-config/schema-export", "zeroclaw-sop-graph/schema-export"]
 

--- a/crates/zeroclaw-runtime/src/observability/langfuse.rs
+++ b/crates/zeroclaw-runtime/src/observability/langfuse.rs
@@ -1,0 +1,674 @@
+//! Langfuse observability backend.
+//!
+//! Maps the runtime's [`ObserverEvent`] stream to Langfuse's Trace → Generation
+//! → Span hierarchy by exporting OTLP spans to `{base_url}/api/public/otel/v1/traces`.
+//! Builds on the same OpenTelemetry SDK crates as the OTel observer; the
+//! `observability-langfuse` cargo feature gates this entire module so projects
+//! that don't need Langfuse don't pay for the OTel dependencies.
+//!
+//! Lifecycle mapping:
+//!   - `AgentStart` / `AgentEnd`     → Trace root span (`agent.invocation`)
+//!   - `LlmResponse`                 → Generation (`llm.call`)
+//!   - `ToolCall`                    → Span (`tool.execute`)
+//!   - `LlmRequest`                  → ignored (content capture lives in the
+//!                                     OTel GenAI path via `LlmMessageSnapshot`)
+//!   - `ToolCallStart`               → caches `arguments` for the next
+//!                                     `ToolCall` on the same tool name
+//!
+//! I/O capture is opt-in via the `langfuse_include_io` config; when disabled
+//! the Generation only carries model name, token usage, and timing.
+
+use super::traits::{Observer, ObserverEvent, ObserverMetric};
+use opentelemetry::trace::{Span, SpanKind, Status, TraceContextExt, Tracer, TracerProvider};
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use parking_lot::Mutex as ParkingMutex;
+use std::any::Any;
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+/// Langfuse-backed observer — exports traces to Langfuse via OTLP.
+///
+/// Maps agent lifecycle events to a trace hierarchy:
+///   Trace (AgentStart..AgentEnd)
+///     ├── Generation (LlmResponse — LLM call)
+///     ├── Span      (ToolCall   — tool execution)
+///     ├── Generation (next LLM call)
+///     └── ...
+///
+/// Uses the Langfuse-native OTLP endpoint and sets `langfuse.*` attributes
+/// so Langfuse recognises observation types, model names, and token usage.
+pub struct LangfuseObserver {
+    tracer_provider: SdkTracerProvider,
+    tracer: opentelemetry_sdk::trace::Tracer,
+    /// Root span for the current agent session.  Created by `AgentStart` and
+    /// ended by `AgentEnd`.
+    current_root: ParkingMutex<Option<opentelemetry_sdk::trace::Span>>,
+    /// Pending tool arguments, keyed by tool name.  Written by `ToolCallStart`,
+    /// consumed by `ToolCall`.
+    pending_tool_args: ParkingMutex<HashMap<String, String>>,
+    /// Whether to include LLM input/output content in generation spans.
+    include_io: bool,
+}
+
+impl LangfuseObserver {
+    /// Create a new Langfuse observer.
+    ///
+    /// `base_url` is the Langfuse instance URL (e.g. `"https://cloud.langfuse.com"`).
+    /// The OTLP traces endpoint is `{base_url}/api/public/otel/v1/traces`.
+    pub fn new(
+        public_key: &str,
+        secret_key: &str,
+        base_url: &str,
+        include_io: bool,
+    ) -> Result<Self, String> {
+        let base_url = base_url.trim_end_matches('/');
+        let traces_endpoint = format!("{base_url}/api/public/otel/v1/traces");
+
+        // Langfuse auth is HTTP Basic: public_key = username, secret_key = password.
+        let auth_value = format!(
+            "Basic {}",
+            base64_encode(&format!("{public_key}:{secret_key}"))
+        );
+
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), auth_value);
+        headers.insert("x-langfuse-ingestion-version".to_string(), "4".to_string());
+
+        let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_headers(headers)
+            .with_endpoint(&traces_endpoint)
+            .build()
+            .map_err(|e| format!("Failed to create Langfuse OTLP span exporter: {e}"))?;
+
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter)
+            .with_resource(
+                opentelemetry_sdk::Resource::builder()
+                    .with_service_name("zeroclaw")
+                    .build(),
+            )
+            .build();
+
+        let tracer = tracer_provider.tracer("zeroclaw-langfuse");
+
+        Ok(Self {
+            tracer_provider,
+            tracer,
+            current_root: ParkingMutex::new(None),
+            pending_tool_args: ParkingMutex::new(HashMap::new()),
+            include_io,
+        })
+    }
+
+    fn context_with_root_parent(root: &opentelemetry_sdk::trace::Span) -> Context {
+        // The live root span stays parked in `current_root` until `AgentEnd`, so
+        // we cannot move it into `Context::with_span`. We only need its
+        // `SpanContext` to preserve trace/parent IDs for completed child spans.
+        //
+        // `with_remote_span_context` accepts a raw `SpanContext`; it does not
+        // flip a local parent to remote. The exported `parent_span_is_remote`
+        // flag still comes from `SpanContext::is_remote()`, and SDK-created root
+        // spans are local by default.
+        Context::new().with_remote_span_context(root.span_context().clone())
+    }
+
+    fn usage_details_json(
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+    ) -> serde_json::Value {
+        let prompt_tokens = input_tokens.unwrap_or(0);
+        let completion_tokens = output_tokens.unwrap_or(0);
+        let total_tokens = prompt_tokens + completion_tokens;
+
+        serde_json::json!({
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        })
+    }
+
+    fn cost_details_json(cost_usd: Option<f64>) -> serde_json::Value {
+        serde_json::json!({
+            "total": cost_usd.unwrap_or(0.0),
+        })
+    }
+}
+
+impl Observer for LangfuseObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        match event {
+            // ── Trace start ─────────────────────────────────────────
+            ObserverEvent::AgentStart {
+                model_provider,
+                model,
+                ..
+            } => {
+                let mut root = self.tracer.build(
+                    opentelemetry::trace::SpanBuilder::from_name("agent.invocation")
+                        .with_kind(SpanKind::Server)
+                        .with_attributes(vec![
+                            KeyValue::new("langfuse.observation.type", "agent"),
+                            KeyValue::new("langfuse.trace.name", "ZeroClaw Agent Session"),
+                            KeyValue::new("provider", model_provider.clone()),
+                            KeyValue::new("model", model.clone()),
+                        ]),
+                );
+                root.set_status(Status::Ok);
+                *self.current_root.lock() = Some(root);
+            }
+
+            // ── LLM call (generation) ───────────────────────────────
+            ObserverEvent::LlmResponse {
+                model_provider,
+                model,
+                duration,
+                success,
+                error_message,
+                input_tokens,
+                output_tokens,
+                ..
+            } => {
+                let root_guard = self.current_root.lock();
+                let Some(ref root) = *root_guard else {
+                    return;
+                };
+
+                let secs = duration.as_secs_f64();
+                let start_time = SystemTime::now()
+                    .checked_sub(*duration)
+                    .unwrap_or(SystemTime::now());
+
+                // Serialize usage_details as JSON string (Langfuse attribute convention).
+                let usage_details = Self::usage_details_json(*input_tokens, *output_tokens);
+
+                let mut attrs = vec![
+                    KeyValue::new("langfuse.observation.type", "generation"),
+                    KeyValue::new("langfuse.observation.model.name", model.clone()),
+                    KeyValue::new(
+                        "langfuse.observation.usage_details",
+                        usage_details.to_string(),
+                    ),
+                    KeyValue::new(
+                        "langfuse.observation.metadata.provider",
+                        model_provider.clone(),
+                    ),
+                    KeyValue::new("langfuse.observation.metadata.success", *success),
+                    KeyValue::new("provider", model_provider.clone()),
+                    KeyValue::new("model", model.clone()),
+                    KeyValue::new("duration_s", secs),
+                ];
+                if let Some(msg) = error_message {
+                    attrs.push(KeyValue::new(
+                        "langfuse.observation.status_message",
+                        msg.clone(),
+                    ));
+                }
+
+                let cx = Self::context_with_root_parent(root);
+                let mut generation = self.tracer.build_with_context(
+                    opentelemetry::trace::SpanBuilder::from_name("llm.call")
+                        .with_kind(SpanKind::Internal)
+                        .with_start_time(start_time)
+                        .with_attributes(attrs),
+                    &cx,
+                );
+                if *success {
+                    generation.set_status(Status::Ok);
+                } else {
+                    generation.set_status(Status::error(error_message.clone().unwrap_or_default()));
+                }
+                generation.end();
+            }
+
+            // ── Tool call (span) ────────────────────────────────────
+            ObserverEvent::ToolCallStart {
+                tool, arguments, ..
+            } => {
+                let mut pending = self.pending_tool_args.lock();
+                pending.insert(tool.clone(), arguments.clone().unwrap_or_default());
+            }
+            ObserverEvent::ToolCall {
+                tool,
+                duration,
+                success,
+                arguments,
+                result,
+                ..
+            } => {
+                let root_guard = self.current_root.lock();
+                let Some(ref root) = *root_guard else {
+                    return;
+                };
+
+                let secs = duration.as_secs_f64();
+                let start_time = SystemTime::now()
+                    .checked_sub(*duration)
+                    .unwrap_or(SystemTime::now());
+
+                // Prefer the arguments carried on the matching `ToolCallStart`;
+                // fall back to whatever the agent loop forwarded on `ToolCall`
+                // (some tool paths skip the start event).
+                let args = self
+                    .pending_tool_args
+                    .lock()
+                    .remove(tool.as_str())
+                    .or_else(|| arguments.clone())
+                    .unwrap_or_default();
+
+                let mut attrs = vec![
+                    KeyValue::new("langfuse.observation.type", "span"),
+                    KeyValue::new("langfuse.observation.metadata.tool", tool.clone()),
+                    KeyValue::new("langfuse.observation.metadata.success", *success),
+                    KeyValue::new("langfuse.observation.input", args),
+                    KeyValue::new("tool.name", tool.clone()),
+                    KeyValue::new("duration_s", secs),
+                ];
+                if let Some(output) = result {
+                    attrs.push(KeyValue::new("langfuse.observation.output", output.clone()));
+                }
+
+                let cx = Self::context_with_root_parent(root);
+                let mut span = self.tracer.build_with_context(
+                    opentelemetry::trace::SpanBuilder::from_name("tool.execute")
+                        .with_kind(SpanKind::Internal)
+                        .with_start_time(start_time)
+                        .with_attributes(attrs),
+                    &cx,
+                );
+                if *success {
+                    span.set_status(Status::Ok);
+                } else {
+                    span.set_status(Status::error(""));
+                }
+                span.end();
+            }
+
+            // ── Trace end ───────────────────────────────────────────
+            ObserverEvent::AgentEnd {
+                duration,
+                tokens_used,
+                cost_usd,
+                ..
+            } => {
+                let Some(mut root) = self.current_root.lock().take() else {
+                    return;
+                };
+
+                // Attach aggregate trace metadata before ending.
+                let secs = duration.as_secs_f64();
+                root.set_attribute(KeyValue::new("duration_s", secs));
+                if let Some(t) = tokens_used {
+                    let total_tokens = t.input_tokens + t.output_tokens;
+                    root.set_attribute(KeyValue::new("tokens_used", total_tokens as i64));
+                }
+                if let Some(c) = cost_usd {
+                    root.set_attribute(KeyValue::new(
+                        "langfuse.observation.cost_details",
+                        Self::cost_details_json(Some(*c)).to_string(),
+                    ));
+                }
+                root.end();
+            }
+
+            // ── Ignored events ──────────────────────────────────────
+            ObserverEvent::LlmRequest { .. }
+            | ObserverEvent::TurnComplete
+            | ObserverEvent::ChannelMessage { .. }
+            | ObserverEvent::HeartbeatTick
+            | ObserverEvent::CacheHit { .. }
+            | ObserverEvent::CacheMiss { .. }
+            | ObserverEvent::Error { .. }
+            | ObserverEvent::DeploymentStarted { .. }
+            | ObserverEvent::DeploymentCompleted { .. }
+            | ObserverEvent::DeploymentFailed { .. }
+            | ObserverEvent::RecoveryCompleted { .. }
+            | ObserverEvent::MemoryRecall { .. }
+            | ObserverEvent::MemoryStore { .. }
+            | ObserverEvent::MemoryAudit { .. }
+            | ObserverEvent::RagRetrieve { .. }
+            | ObserverEvent::HistoryTrimmed { .. } => {}
+            _ => {}
+        }
+    }
+
+    fn record_metric(&self, _metric: &ObserverMetric) {
+        // Langfuse receives scores/usage via span attributes rather than
+        // streaming metric signals.  Custom metric backends (Prometheus, OTel
+        // metrics) are the right channel for numeric series.
+    }
+
+    fn flush(&self) {
+        if let Err(e) = self.tracer_provider.force_flush() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"error": e.to_string()})),
+                "Langfuse OTLP flush failed"
+            );
+        }
+    }
+
+    fn name(&self) -> &str {
+        "langfuse"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl Drop for LangfuseObserver {
+    fn drop(&mut self) {
+        // End any dangling root span so the trace is not left open.
+        if let Some(mut root) = self.current_root.lock().take() {
+            root.end();
+        }
+        if let Err(e) = self.tracer_provider.force_flush() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({"error": e.to_string()})),
+                "Langfuse OTLP flush on drop failed"
+            );
+        }
+    }
+}
+
+fn base64_encode(input: &str) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(input.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Helper: construct an observer pointed at an unreachable endpoint.
+    /// All recording must still succeed (export failures are best-effort).
+    fn test_observer() -> LangfuseObserver {
+        LangfuseObserver::new(
+            "pk-test-dummy",
+            "sk-test-dummy",
+            "http://127.0.0.1:19999",
+            false,
+        )
+        .expect("test observer creation")
+    }
+
+    #[test]
+    fn langfuse_observer_name() {
+        assert_eq!(test_observer().name(), "langfuse");
+    }
+
+    #[test]
+    fn usage_details_includes_prompt_and_completion_tokens() {
+        let usage_details = LangfuseObserver::usage_details_json(Some(500), Some(200));
+        assert_eq!(usage_details["prompt_tokens"], 500);
+        assert_eq!(usage_details["completion_tokens"], 200);
+        assert_eq!(usage_details["total_tokens"], 700);
+    }
+
+    #[test]
+    fn records_full_session_without_panic() {
+        let obs = test_observer();
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::LlmRequest {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            messages_count: 5,
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::LlmResponse {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            duration: Duration::from_millis(1200),
+            success: true,
+            error_message: None,
+            input_tokens: Some(500),
+            output_tokens: Some(200),
+            messages: None,
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::ToolCallStart {
+            tool: "shell".into(),
+            tool_call_id: None,
+            arguments: Some(r#"{"cmd":"ls"}"#.into()),
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::ToolCall {
+            tool: "shell".into(),
+            tool_call_id: None,
+            duration: Duration::from_millis(300),
+            success: true,
+            arguments: None,
+            result: None,
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::AgentEnd {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            duration: Duration::from_secs(5),
+            tokens_used: Some(700),
+            cost_usd: Some(0.03),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        obs.flush();
+    }
+
+    #[test]
+    fn llm_response_without_agent_start_is_noop() {
+        let obs = test_observer();
+        obs.record_event(&ObserverEvent::LlmResponse {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            duration: Duration::from_millis(500),
+            success: false,
+            error_message: Some("timeout".into()),
+            input_tokens: None,
+            output_tokens: None,
+            messages: None,
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        // Must not panic.
+    }
+
+    #[test]
+    fn tool_call_without_start_args_uses_empty() {
+        let obs = test_observer();
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        // No ToolCallStart — ToolCall sees empty arguments.
+        obs.record_event(&ObserverEvent::ToolCall {
+            tool: "read_file".into(),
+            tool_call_id: None,
+            duration: Duration::from_millis(100),
+            success: true,
+            arguments: None,
+            result: None,
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::AgentEnd {
+            model_provider: "openai".into(),
+            model: "gpt-4o".into(),
+            duration: Duration::from_secs(1),
+            tokens_used: None,
+            cost_usd: None,
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        obs.flush();
+    }
+
+    #[test]
+    fn zero_duration_and_zero_tokens() {
+        let obs = test_observer();
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "anthropic".into(),
+            model: "claude-3".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::LlmResponse {
+            model_provider: "anthropic".into(),
+            model: "claude-3".into(),
+            duration: Duration::ZERO,
+            success: true,
+            error_message: None,
+            input_tokens: Some(0),
+            output_tokens: Some(0),
+            messages: None,
+            channel: None,
+            agent_alias: None,
+            parent_agent_alias: None,
+            turn_id: None,
+        });
+        obs.record_event(&ObserverEvent::AgentEnd {
+            model_provider: "anthropic".into(),
+            model: "claude-3".into(),
+            duration: Duration::ZERO,
+            tokens_used: Some(0),
+            cost_usd: Some(0.0),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        obs.flush();
+    }
+
+    #[test]
+    fn records_metrics_without_panic() {
+        let obs = test_observer();
+        obs.record_metric(&ObserverMetric::TokensUsed(500));
+        obs.record_metric(&ObserverMetric::RequestLatency(Duration::from_secs(2)));
+        obs.record_metric(&ObserverMetric::ActiveSessions(3));
+        obs.record_metric(&ObserverMetric::QueueDepth(10));
+    }
+
+    #[test]
+    fn drop_ends_dangling_root_span() {
+        let obs = test_observer();
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "openai".into(),
+            model: "gpt-4".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        // AgentEnd never called — Drop should end the span.
+        drop(obs);
+    }
+
+    #[test]
+    fn multiple_llm_calls_in_one_trace() {
+        let obs = test_observer();
+        obs.record_event(&ObserverEvent::AgentStart {
+            model_provider: "openrouter".into(),
+            model: "sonnet".into(),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        for i in 0..3 {
+            obs.record_event(&ObserverEvent::LlmRequest {
+                model_provider: "openrouter".into(),
+                model: "sonnet".into(),
+                messages_count: 10 + i,
+                channel: None,
+                agent_alias: None,
+                parent_agent_alias: None,
+                turn_id: None,
+            });
+            obs.record_event(&ObserverEvent::LlmResponse {
+                model_provider: "openrouter".into(),
+                model: "sonnet".into(),
+                duration: Duration::from_secs(2),
+                success: true,
+                error_message: None,
+                input_tokens: Some(1000),
+                output_tokens: Some(500),
+                messages: None,
+                channel: None,
+                agent_alias: None,
+                parent_agent_alias: None,
+                turn_id: None,
+            });
+        }
+        obs.record_event(&ObserverEvent::AgentEnd {
+            model_provider: "openrouter".into(),
+            model: "sonnet".into(),
+            duration: Duration::from_secs(10),
+            tokens_used: Some(4500),
+            cost_usd: Some(0.15),
+            channel: None,
+            agent_alias: None,
+            turn_id: None,
+        });
+        obs.flush();
+    }
+
+    #[test]
+    fn local_root_span_context_keeps_child_parent_local() {
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("langfuse-context-test");
+
+        let root = tracer.build(
+            opentelemetry::trace::SpanBuilder::from_name("agent.invocation")
+                .with_kind(SpanKind::Server),
+        );
+        let root_span_context = root.span_context().clone();
+        let root_span_id = root_span_context.span_id();
+        let root_trace_id = root_span_context.trace_id();
+
+        assert!(!root_span_context.is_remote());
+
+        let cx = LangfuseObserver::context_with_root_parent(&root);
+        let child = tracer.build_with_context(
+            opentelemetry::trace::SpanBuilder::from_name("llm.call").with_kind(SpanKind::Internal),
+            &cx,
+        );
+
+        let child_data = child.exported_data().expect("child exported data");
+        assert_eq!(child.span_context().trace_id(), root_trace_id);
+        assert_eq!(child_data.parent_span_id, root_span_id);
+        assert!(!child_data.parent_span_is_remote);
+    }
+}

--- a/crates/zeroclaw-runtime/src/observability/langfuse.rs
+++ b/crates/zeroclaw-runtime/src/observability/langfuse.rs
@@ -42,12 +42,14 @@ use std::time::SystemTime;
 pub struct LangfuseObserver {
     tracer_provider: SdkTracerProvider,
     tracer: opentelemetry_sdk::trace::Tracer,
-    /// Root span for the current agent session.  Created by `AgentStart` and
-    /// ended by `AgentEnd`.
-    current_root: ParkingMutex<Option<opentelemetry_sdk::trace::Span>>,
-    /// Pending tool arguments, keyed by tool name.  Written by `ToolCallStart`,
-    /// consumed by `ToolCall`.
-    pending_tool_args: ParkingMutex<HashMap<String, String>>,
+    /// Root spans keyed by `turn_id`.  Concurrent turns (and events lacking a
+    /// `turn_id`) each get their own root so a second `AgentStart` cannot
+    /// overwrite the first and `AgentEnd` closes the matching trace.
+    active_roots: ParkingMutex<HashMap<String, opentelemetry_sdk::trace::Span>>,
+    /// Pending tool arguments keyed by `(turn_id, tool_call_id)`.  Written by
+    /// `ToolCallStart`, consumed by `ToolCall`, so simultaneous calls to the
+    /// same tool do not overwrite each other's arguments.
+    pending_tool_args: ParkingMutex<HashMap<(String, String), String>>,
     /// Whether to include LLM input/output content in generation spans.
     include_io: bool,
 }
@@ -97,14 +99,14 @@ impl LangfuseObserver {
         Ok(Self {
             tracer_provider,
             tracer,
-            current_root: ParkingMutex::new(None),
+            active_roots: ParkingMutex::new(HashMap::new()),
             pending_tool_args: ParkingMutex::new(HashMap::new()),
             include_io,
         })
     }
 
     fn context_with_root_parent(root: &opentelemetry_sdk::trace::Span) -> Context {
-        // The live root span stays parked in `current_root` until `AgentEnd`, so
+        // The live root span stays parked in `active_roots` until `AgentEnd`, so
         // we cannot move it into `Context::with_span`. We only need its
         // `SpanContext` to preserve trace/parent IDs for completed child spans.
         //
@@ -144,6 +146,7 @@ impl Observer for LangfuseObserver {
             ObserverEvent::AgentStart {
                 model_provider,
                 model,
+                turn_id,
                 ..
             } => {
                 let mut root = self.tracer.build(
@@ -157,7 +160,9 @@ impl Observer for LangfuseObserver {
                         ]),
                 );
                 root.set_status(Status::Ok);
-                *self.current_root.lock() = Some(root);
+                self.active_roots
+                    .lock()
+                    .insert(turn_id.clone().unwrap_or_default(), root);
             }
 
             // ── LLM call (generation) ───────────────────────────────
@@ -169,10 +174,12 @@ impl Observer for LangfuseObserver {
                 error_message,
                 input_tokens,
                 output_tokens,
+                turn_id,
                 ..
             } => {
-                let root_guard = self.current_root.lock();
-                let Some(ref root) = *root_guard else {
+                let key = turn_id.clone().unwrap_or_default();
+                let root_guard = self.active_roots.lock();
+                let Some(ref root) = root_guard.get(&key) else {
                     return;
                 };
 
@@ -225,21 +232,32 @@ impl Observer for LangfuseObserver {
 
             // ── Tool call (span) ────────────────────────────────────
             ObserverEvent::ToolCallStart {
-                tool, arguments, ..
+                tool,
+                tool_call_id,
+                arguments,
+                turn_id,
+                ..
             } => {
+                let key = (
+                    turn_id.clone().unwrap_or_default(),
+                    tool_call_id.clone().unwrap_or_else(|| tool.clone()),
+                );
                 let mut pending = self.pending_tool_args.lock();
-                pending.insert(tool.clone(), arguments.clone().unwrap_or_default());
+                pending.insert(key, arguments.clone().unwrap_or_default());
             }
             ObserverEvent::ToolCall {
                 tool,
+                tool_call_id,
                 duration,
                 success,
                 arguments,
                 result,
+                turn_id,
                 ..
             } => {
-                let root_guard = self.current_root.lock();
-                let Some(ref root) = *root_guard else {
+                let turn_key = turn_id.clone().unwrap_or_default();
+                let root_guard = self.active_roots.lock();
+                let Some(ref root) = root_guard.get(&turn_key) else {
                     return;
                 };
 
@@ -251,10 +269,14 @@ impl Observer for LangfuseObserver {
                 // Prefer the arguments carried on the matching `ToolCallStart`;
                 // fall back to whatever the agent loop forwarded on `ToolCall`
                 // (some tool paths skip the start event).
+                let call_key = (
+                    turn_key.clone(),
+                    tool_call_id.clone().unwrap_or_else(|| tool.clone()),
+                );
                 let args = self
                     .pending_tool_args
                     .lock()
-                    .remove(tool.as_str())
+                    .remove(&call_key)
                     .or_else(|| arguments.clone())
                     .unwrap_or_default();
 
@@ -262,12 +284,15 @@ impl Observer for LangfuseObserver {
                     KeyValue::new("langfuse.observation.type", "span"),
                     KeyValue::new("langfuse.observation.metadata.tool", tool.clone()),
                     KeyValue::new("langfuse.observation.metadata.success", *success),
-                    KeyValue::new("langfuse.observation.input", args),
                     KeyValue::new("tool.name", tool.clone()),
                     KeyValue::new("duration_s", secs),
                 ];
-                if let Some(output) = result {
-                    attrs.push(KeyValue::new("langfuse.observation.output", output.clone()));
+                // Gate I/O export on the privacy boundary.
+                if self.include_io {
+                    attrs.push(KeyValue::new("langfuse.observation.input", args));
+                    if let Some(output) = result {
+                        attrs.push(KeyValue::new("langfuse.observation.output", output.clone()));
+                    }
                 }
 
                 let cx = Self::context_with_root_parent(root);
@@ -291,11 +316,15 @@ impl Observer for LangfuseObserver {
                 duration,
                 tokens_used,
                 cost_usd,
+                turn_id,
                 ..
             } => {
-                let Some(mut root) = self.current_root.lock().take() else {
+                let key = turn_id.clone().unwrap_or_default();
+                let Some(mut root) = self.active_roots.lock().remove(&key) else {
                     return;
                 };
+                // Clear any pending arguments for this turn.
+                self.pending_tool_args.lock().retain(|(t, _), _| t != &key);
 
                 // Attach aggregate trace metadata before ending.
                 let secs = duration.as_secs_f64();
@@ -363,18 +392,12 @@ impl Observer for LangfuseObserver {
 
 impl Drop for LangfuseObserver {
     fn drop(&mut self) {
-        // End any dangling root span so the trace is not left open.
-        if let Some(mut root) = self.current_root.lock().take() {
+        // End any dangling root spans so traces are not left open.  No network
+        // I/O here: the batch exporter flushes in the background, and explicit
+        // flushing happens at short-lived invocation boundaries and graceful
+        // shutdown (see `flush()`), not during normal turn teardown.
+        for (_, mut root) in self.active_roots.lock().drain() {
             root.end();
-        }
-        if let Err(e) = self.tracer_provider.force_flush() {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                    .with_attrs(::serde_json::json!({"error": e.to_string()})),
-                "Langfuse OTLP flush on drop failed"
-            );
         }
     }
 }
@@ -388,6 +411,7 @@ fn base64_encode(input: &str) -> String {
 mod tests {
     use super::*;
     use std::time::Duration;
+    use zeroclaw_api::observability_traits::TurnTokenUsage;
 
     /// Helper: construct an observer pointed at an unreachable endpoint.
     /// All recording must still succeed (export failures are best-effort).
@@ -472,7 +496,10 @@ mod tests {
             model_provider: "openai".into(),
             model: "gpt-4o".into(),
             duration: Duration::from_secs(5),
-            tokens_used: Some(700),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 300,
+                output_tokens: 400,
+            }),
             cost_usd: Some(0.03),
             channel: None,
             agent_alias: None,
@@ -565,7 +592,10 @@ mod tests {
             model_provider: "anthropic".into(),
             model: "claude-3".into(),
             duration: Duration::ZERO,
-            tokens_used: Some(0),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            }),
             cost_usd: Some(0.0),
             channel: None,
             agent_alias: None,
@@ -636,7 +666,10 @@ mod tests {
             model_provider: "openrouter".into(),
             model: "sonnet".into(),
             duration: Duration::from_secs(10),
-            tokens_used: Some(4500),
+            tokens_used: Some(TurnTokenUsage {
+                input_tokens: 2000,
+                output_tokens: 2500,
+            }),
             cost_usd: Some(0.15),
             channel: None,
             agent_alias: None,

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -422,6 +422,72 @@ fn create_primary_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
                 Box::new(NoopObserver)
             }
         }
+        ObservabilityBackend::Langfuse => {
+            #[cfg(feature = "observability-langfuse")]
+            {
+                let public_key = match config.langfuse_public_key.as_deref() {
+                    Some(k) if !k.is_empty() => k,
+                    _ => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                            "Langfuse backend requested but langfuse_public_key is not set; falling back to noop."
+                        );
+                        return Box::new(NoopObserver);
+                    }
+                };
+                let secret_key = match config.langfuse_secret_key.as_deref() {
+                    Some(k) if !k.is_empty() => k,
+                    _ => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Note
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                            "Langfuse backend requested but langfuse_secret_key is not set; falling back to noop."
+                        );
+                        return Box::new(NoopObserver);
+                    }
+                };
+                match LangfuseObserver::new(
+                    public_key,
+                    secret_key,
+                    &config.langfuse_base_url,
+                    config.langfuse_include_io,
+                ) {
+                    Ok(obs) => Box::new(obs),
+                    Err(e) => {
+                        ::zeroclaw_log::record!(
+                            ERROR,
+                            ::zeroclaw_log::Event::new(
+                                module_path!(),
+                                ::zeroclaw_log::Action::Fail
+                            )
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
+                            "Failed to create Langfuse observer; falling back to noop."
+                        );
+                        Box::new(NoopObserver)
+                    }
+                }
+            }
+            #[cfg(not(feature = "observability-langfuse"))]
+            {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                    "Langfuse backend requested but observability-langfuse not compiled; falling back to noop."
+                );
+                Box::new(NoopObserver)
+            }
+        }
         ObservabilityBackend::None => Box::new(NoopObserver),
     }
 }

--- a/crates/zeroclaw-runtime/src/observability/mod.rs
+++ b/crates/zeroclaw-runtime/src/observability/mod.rs
@@ -1,4 +1,6 @@
 pub mod dora;
+#[cfg(feature = "observability-langfuse")]
+pub mod langfuse;
 pub mod log;
 pub mod multi;
 pub mod noop;
@@ -18,6 +20,8 @@ pub use self::log::LogObserver;
 pub use self::multi::MultiObserver;
 #[cfg(feature = "observability-otel")]
 use self::otel_config::OtelContentConfig;
+#[cfg(feature = "observability-langfuse")]
+pub use langfuse::LangfuseObserver;
 pub use noop::NoopObserver;
 #[cfg(feature = "observability-otel")]
 pub use otel::OtelObserver;


### PR DESCRIPTION
## Summary

- **What changed and why:** Add Langfuse as an observability backend, allowing agents to export OpenTelemetry traces to Langfuse cloud or self-hosted instances.
- **How:** New `LangfuseObserver` module behind `observability-langfuse` feature. Uses OTel SDK with HTTP Basic auth (public key = username, secret key = password) and targets Langfuse OTLP endpoint.
- **Scope boundary:** Observability backends only. No change to agent loop, tool execution, or channel routing.
- **Blast radius:** 4 new config fields (`langfuse_public_key`, `langfuse_secret_key`, `langfuse_base_url`, `langfuse_include_io`). `ObservabilityBackend` gains `Langfuse` variant. New cargo feature.

## Testing

- Unit tests for event-to-span mapping, metric conversion, token usage attributes.
- `cargo check --no-default-features` and `--features ci-all` pass.

## Security & Privacy Impact

- New external network calls: **Yes** — OTLP trace export to configured Langfuse endpoint.
- Secrets handling: Auth via HTTP Basic with `langfuse_public_key`/`langfuse_secret_key`. Fields annotated `#[secret] #[credential_class = "encrypted_secret"]`.

## Compatibility

- Backward compatible: **Yes** — feature-gated, default backend unchanged.
- Config surface: 4 new optional fields in `[observability]` section.