### PR TITLE
fix(personality): remove filename labels from rendered personality prompt

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/personality.rs
+++ b/crates/zeroclaw-runtime/src/agent/personality.rs
@@ -69,7 +69,6 @@ impl PersonalityProfile {
     pub fn render(&self) -> String {
         let mut out = String::new();
         for file in &self.files {
-            let _ = writeln!(out, "### {}\n", file.name);
             out.push_str(&file.content);
             if file.truncated {
                 let _ = writeln!(
@@ -227,10 +226,10 @@ mod tests {
 
         let profile = load_personality(&ws);
         let rendered = profile.render();
-        assert!(rendered.contains("### SOUL.md"));
         assert!(rendered.contains("Be kind."));
-        assert!(rendered.contains("### IDENTITY.md"));
         assert!(rendered.contains("Name: Nova"));
+        assert!(!rendered.contains("SOUL.md"));
+        assert!(!rendered.contains("IDENTITY.md"));
 
         let _ = std::fs::remove_dir_all(ws);
     }


### PR DESCRIPTION
## Summary

Remove "### FILENAME.md" heading prefix from `PersonalityProfile::render()`. These labels add unnecessary tokens to the system prompt without providing semantic value.

## Testing

Updated test to verify labels are NOT present. `cargo check -p zeroclaw-runtime` passes.

## Compatibility

Prompt-only change. No config or API impact.