### PR TITLE
fix(multimodal): trim images one by one, not whole messages

### DIFF
--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -766,36 +766,45 @@ fn trim_old_images(messages: &[ChatMessage], max_images: usize) -> Vec<ChatMessa
     let total: usize = image_positions.iter().map(|(_, c)| c).sum();
     let mut to_drop = total.saturating_sub(max_images);
 
-    // Collect indices of messages whose images should be stripped.
-    let mut strip_indices = std::collections::HashSet::new();
+    // How many images each message must give up. Dropping is per IMAGE, not
+    // per message: a message that straddles the budget gives up only its
+    // oldest images and keeps the rest. Stripping it whole would send fewer
+    // images than `max_images` allows — one image over budget used to cost
+    // every image of that message, so the model answered about pictures it
+    // had never received.
+    let mut drop_counts: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
     for &(idx, count) in &image_positions {
         if to_drop == 0 {
             break;
         }
-        strip_indices.insert(idx);
-        to_drop = to_drop.saturating_sub(count);
+        let dropped_here = to_drop.min(count);
+        drop_counts.insert(idx, dropped_here);
+        to_drop -= dropped_here;
     }
 
     messages
         .iter()
         .enumerate()
-        .map(|(i, m)| {
-            if strip_indices.contains(&i) {
-                let (cleaned, _) = parse_image_markers(&m.content);
-                let text = if cleaned.trim().is_empty() {
-                    "[image removed from history]".to_string()
-                } else {
-                    cleaned
-                };
-                ChatMessage {
-                    role: m.role.clone(),
-                    content: text,
-                }
-            } else {
-                replay_message_without_stale_tool_images(i, m, &latest_tool_indices)
-            }
+        .map(|(i, m)| match drop_counts.get(&i) {
+            Some(&drop_here) => ChatMessage {
+                role: m.role.clone(),
+                content: drop_oldest_image_markers(&m.content, drop_here),
+            },
+            None => replay_message_without_stale_tool_images(i, m, &latest_tool_indices),
         })
         .collect()
+}
+
+/// Rebuild `content` without its `count` oldest image markers, keeping the
+/// surrounding text. When no image survives and there was no caption, fall
+/// back to the placeholder so the turn keeps its shape.
+fn drop_oldest_image_markers(content: &str, count: usize) -> String {
+    let (cleaned, refs) = parse_image_markers(content);
+    let kept: Vec<String> = refs.into_iter().skip(count).collect();
+    if kept.is_empty() && cleaned.trim().is_empty() {
+        return "[image removed from history]".to_string();
+    }
+    compose_multimodal_message(&cleaned, &kept)
 }
 
 fn compose_multimodal_message(text: &str, data_uris: &[String]) -> String {
@@ -2053,11 +2062,14 @@ mod tests {
     }
 
     #[test]
-    fn trim_old_images_multi_image_message_stripped_as_unit() {
-        // A single message has 3 images. We need to drop 2 to reach max=1.
-        // But trimming works at message granularity — the entire message gets
-        // stripped (all 3 images removed), which over-trims to 0. The newest
-        // message (text-only) is untouched.
+    fn trim_old_images_keeps_the_budget_inside_a_multi_image_message() {
+        // A single message carries 3 images and the budget is 1. Trimming must
+        // drop the 2 oldest images and KEEP the newest one: dropping the whole
+        // message would send zero images for a request that was allowed one.
+        //
+        // This is the common shape when a user attaches several files at once:
+        // one image over budget used to cost every image of that message, so
+        // the model answered about pictures it had never received.
         let messages = vec![
             ChatMessage::user(
                 "[IMAGE:/tmp/a.png]\n[IMAGE:/tmp/b.png]\n[IMAGE:/tmp/c.png]\nThree pics"
@@ -2068,12 +2080,45 @@ mod tests {
 
         let trimmed = trim_old_images(&messages, 1);
         assert_eq!(trimmed.len(), 2);
-        // All images in the first message are gone, but text remains
         let (_, refs0) = parse_image_markers(&trimmed[0].content);
-        assert!(refs0.is_empty());
-        assert!(trimmed[0].content.contains("Three pics"));
-        // Second message unchanged
+        assert_eq!(refs0, vec!["/tmp/c.png".to_string()], "keeps the newest image");
+        assert!(trimmed[0].content.contains("Three pics"), "caption survives");
         assert_eq!(trimmed[1].content, "Just text, no images");
+    }
+
+    #[test]
+    fn trim_old_images_spends_the_whole_budget_across_messages() {
+        // Budget 2 spread over two messages of 2 images each: the oldest
+        // message gives up both, the newest keeps both. Exactly `max_images`
+        // survive — never fewer.
+        let messages = vec![
+            ChatMessage::user("[IMAGE:/tmp/a.png]\n[IMAGE:/tmp/b.png]\nOld".to_string()),
+            ChatMessage::user("[IMAGE:/tmp/c.png]\n[IMAGE:/tmp/d.png]\nNew".to_string()),
+        ];
+
+        let trimmed = trim_old_images(&messages, 2);
+        assert_eq!(count_image_markers(&trimmed), 2);
+        let (_, refs0) = parse_image_markers(&trimmed[0].content);
+        assert!(refs0.is_empty(), "oldest message gives up its images first");
+        let (_, refs1) = parse_image_markers(&trimmed[1].content);
+        assert_eq!(refs1.len(), 2, "newest message keeps both");
+    }
+
+    #[test]
+    fn trim_old_images_partially_trims_only_the_message_that_straddles_the_budget() {
+        // Budget 3, four images spread 2 + 2. The oldest message must give up
+        // exactly one image and keep the other — the straddling message is the
+        // only one trimmed in part.
+        let messages = vec![
+            ChatMessage::user("[IMAGE:/tmp/a.png]\n[IMAGE:/tmp/b.png]\nOld".to_string()),
+            ChatMessage::user("[IMAGE:/tmp/c.png]\n[IMAGE:/tmp/d.png]\nNew".to_string()),
+        ];
+
+        let trimmed = trim_old_images(&messages, 3);
+        assert_eq!(count_image_markers(&trimmed), 3);
+        let (_, refs0) = parse_image_markers(&trimmed[0].content);
+        assert_eq!(refs0, vec!["/tmp/b.png".to_string()], "drops the oldest of the two");
+        assert!(trimmed[0].content.contains("Old"));
     }
 
     #[test]


### PR DESCRIPTION
# Proposition upstream — `fix(multimodal): trim images one by one, not whole messages`

Corps prêt à coller dans la PR vers `zeroclaw-labs/zeroclaw`.
Commit du fork : `a7b111976` (branche `betterclaw`, base `v0.8.3`).

---

## What

`trim_old_images` drops images **per image** instead of per message. A message
that straddles the per-request budget now gives up only its oldest images and
keeps the rest.

## Why

`trim_old_images` marked a message for stripping and then subtracted its
**entire** image count from the drop budget:

```rust
strip_indices.insert(idx);
to_drop = to_drop.saturating_sub(count);
```

So a message holding more images than the overflow lost **all** of them. With
the default `max_images = 4` and five images attached to a single user message,
`to_drop = 1`, the one message is marked, and **zero** images reach the
provider.

The failure is silent and, worse, invisible to the model: the caption survives,
so the model answers about pictures it never received. Measured on a real
deployment (`qwen/qwen3.6-flash` via OpenRouter): with five images attached, the
assistant reported it had "no access to an image decoding tool" and offered to
run a Python script to read the PNG bytes by hand. With the same five images
under the fixed code, it lists all five colours correctly.

This is the common shape, not a corner case: a user attaching several files at
once puts them in **one** message. Being a single image over budget costs every
image of that turn.

`max_images` does not help — raising it only moves the cliff. The behaviour is
all-or-nothing at whatever value is configured.

## How

Replace the per-message strip set with a per-message **drop count**:

```rust
let dropped_here = to_drop.min(count);
drop_counts.insert(idx, dropped_here);
to_drop -= dropped_here;
```

and rebuild each affected message without its `n` oldest markers
(`drop_oldest_image_markers`), reusing `compose_multimodal_message` so the wire
shape is unchanged. Exactly `max_images` images survive — never fewer.

A message left with no image keeps its caption; the existing
`[image removed from history]` placeholder is still used when there was no
caption, so no turn changes shape.

## Tests

`trim_old_images_multi_image_message_stripped_as_unit` asserted the old
behaviour and described it in its own comment as over-trimming to zero. It is
replaced by three tests:

| Test | Covers |
|---|---|
| `trim_old_images_keeps_the_budget_inside_a_multi_image_message` | 3 images, budget 1 → the newest survives (was: none) |
| `trim_old_images_spends_the_whole_budget_across_messages` | 2+2 images, budget 2 → oldest message gives up both |
| `trim_old_images_partially_trims_only_the_message_that_straddles_the_budget` | 2+2 images, budget 3 → the straddling message drops exactly one |

`cargo test -p zeroclaw-providers`: 1099 passed. `cargo clippy -p
zeroclaw-providers --all-targets`: clean.

## Note on the adjacent ceiling

`MultimodalConfig::effective_limits` clamps `max_images` to `1..=16`, silently.
A deployment that configures 50 gets 16 with no warning. That is a separate
concern and is **not** part of this PR — but the clamp is what makes the bug
above unavoidable rather than merely configurable, so it is worth stating: with
per-image trimming, a higher clamp becomes safe to expose.
