### PR TITLE
fix(config): honour a configured multimodal.max_images, and say when it is clamped

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6334,10 +6334,36 @@ fn default_multimodal_max_image_size_mb() -> usize {
     5
 }
 
+/// Upper bound on `multimodal.max_images`.
+///
+/// This is a sanity rail against a typo (`max_images = 100000` would build a
+/// request no provider accepts), not a product limit: it sits at the order of
+/// magnitude mainstream vision APIs document per request, so a deliberate
+/// configuration is honoured as written. The previous value of 16 was below
+/// what a single user message routinely carries — attaching a batch of photos
+/// silently lost most of them, with nothing in the logs to say why.
+pub const MAX_IMAGES_CEILING: usize = 100;
+
 impl MultimodalConfig {
     /// Clamp configured values to safe runtime bounds.
+    ///
+    /// Clamping is reported: a value silently rewritten is a value the
+    /// operator cannot debug.
     pub fn effective_limits(&self) -> (usize, usize) {
-        let max_images = self.max_images.clamp(1, 16);
+        let max_images = self.max_images.clamp(1, MAX_IMAGES_CEILING);
+        if max_images != self.max_images {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "configured_max_images": self.max_images,
+                        "effective_max_images": max_images,
+                        "ceiling": MAX_IMAGES_CEILING,
+                    })),
+                "multimodal: configured max_images is out of bounds — clamped"
+            );
+        }
         let max_image_size_mb = self.max_image_size_mb.clamp(1, 20);
         (max_images, max_image_size_mb)
     }
@@ -22776,6 +22802,39 @@ mod tests {
             nc_cfg(Some(""), Some("   ")).resolve_bot_secret().unwrap(),
             None
         );
+    }
+
+    // A configured `max_images` above the old hard ceiling of 16 was silently
+    // rewritten to 16: an operator asking for 50 got 16 with nothing said. The
+    // ceiling now sits at the order of magnitude mainstream vision providers
+    // actually accept, so ordinary configurations are honoured as written.
+    #[::core::prelude::v1::test]
+    fn multimodal_effective_limits_honour_a_configured_value() {
+        let config = super::MultimodalConfig {
+            max_images: 50,
+            ..Default::default()
+        };
+        assert_eq!(config.effective_limits().0, 50);
+    }
+
+    #[::core::prelude::v1::test]
+    fn multimodal_effective_limits_keep_a_sanity_ceiling() {
+        let config = super::MultimodalConfig {
+            max_images: 5_000,
+            ..Default::default()
+        };
+        assert_eq!(config.effective_limits().0, super::MAX_IMAGES_CEILING);
+    }
+
+    // Zero images would make every multimodal request pointless: the floor
+    // stays.
+    #[::core::prelude::v1::test]
+    fn multimodal_effective_limits_keep_the_floor_of_one() {
+        let config = super::MultimodalConfig {
+            max_images: 0,
+            ..Default::default()
+        };
+        assert_eq!(config.effective_limits().0, 1);
     }
 
     #[::core::prelude::v1::test]


### PR DESCRIPTION
## What

`multimodal.max_images` is honoured as configured, up to a raised sanity
ceiling of 100, and clamping is now reported instead of silent.

## Why

`MultimodalConfig::effective_limits` did this:

```rust
let max_images = self.max_images.clamp(1, 16);
```

An operator writing `max_images = 50` got 16. Nothing in the logs, nothing in
the field docs, no error at load: the configuration surface accepted a value it
did not apply. Debugging that means reading the source — there is no other way
to find out.

Two separate problems:

**The value was overridden.** 16 is below what a single user message routinely
carries. Attaching a batch of photos to one message therefore lost most of them
even on a deployment that had explicitly asked for more.

**The override was silent.** Whatever the ceiling ends up being, a clamped
configuration value should say so once, with the numbers.

## How

- `MAX_IMAGES_CEILING = 100`, the order of magnitude mainstream vision APIs
  document per request. The rail stays — it still guards against a typo such as
  `max_images = 100000` building a request no provider will accept — but it no
  longer overrides a deliberate configuration.
- A `WARN` is emitted when the configured value is out of bounds, naming
  `configured_max_images`, `effective_max_images` and `ceiling`.
- The floor of 1 is unchanged: zero images would make every multimodal request
  pointless.
- `max_image_size_mb` is untouched.

## Tests

| Test | Covers |
|---|---|
| `multimodal_effective_limits_honour_a_configured_value` | 50 stays 50 (was 16) |
| `multimodal_effective_limits_keep_a_sanity_ceiling` | 5000 becomes `MAX_IMAGES_CEILING` |
| `multimodal_effective_limits_keep_the_floor_of_one` | 0 becomes 1 |

`cargo test -p zeroclaw-config`: 1300 passed. `cargo clippy -p zeroclaw-config
--all-targets`: clean.

## Relationship to #9576

Independent — different crate, different file, either can land first.

They are worth reading together though: #9576 fixes `trim_old_images`, which
dropped **whole messages** rather than individual images, so exceeding the
budget by one image cost every image of that message. Raising the ceiling here
without that fix would only move the cliff; with it, a higher ceiling is safe
to expose.
