### PR TITLE
fix(docs): validate mdBook publication links

### DIFF
--- a/docs/book/src/maintainers/release-verification.md
+++ b/docs/book/src/maintainers/release-verification.md
@@ -8,8 +8,8 @@ provenance.
 Attestation proves where and how an artifact was built. It does not prove that a
 human reviewed the source, that dependencies are safe, or that a maintainer
 account, GitHub-hosted runner, or GitHub control plane was not compromised. See
-[SLSA provenance attestation](../../../security/slsa-provenance.md) for the full
-threat model.
+the [SLSA provenance attestation](https://github.com/zeroclaw-labs/zeroclaw/blob/master/docs/security/slsa-provenance.md)
+for the full threat model.
 
 The release workflow currently treats attestations as best-effort Phase A
 output. Check the release notes before relying on verification material; they

--- a/scripts/ci/collect_changed_links.py
+++ b/scripts/ci/collect_changed_links.py
@@ -22,6 +22,7 @@ GENERATED_DOC_TARGETS = {
     "docs/book/src/reference/cli.md",
     "docs/book/src/reference/config.md",
 }
+MDBOOK_SOURCE_ROOT = Path("docs/book/src")
 
 
 def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -135,6 +136,17 @@ def split_link_targets(targets: list[str]) -> tuple[list[str], list[str]]:
         else:
             local_links.append(target)
     return http_links, local_links
+
+
+def mdbook_link_escapes_source(source_path: str, target: str) -> bool:
+    if target.startswith(("http://", "https://")):
+        return False
+
+    source = Path(source_path)
+    if not source.is_relative_to(MDBOOK_SOURCE_ROOT):
+        return False
+
+    return not Path(target).is_relative_to(MDBOOK_SOURCE_ROOT)
 
 
 def check_local_targets(local_links: list[str]) -> bool:
@@ -264,11 +276,19 @@ def main() -> int:
 
     unique_links: list[str] = []
     seen: set[str] = set()
+    invalid_mdbook_links: list[tuple[str, str]] = []
+    seen_invalid_mdbook_links: set[tuple[str, str]] = set()
     for path in existing_files:
         source_contexts = include_contexts_for(path)
         for line in added_lines_for_file(base_sha, path):
             for source_path in source_contexts:
                 for link in extract_links(line, source_path):
+                    if mdbook_link_escapes_source(source_path, link):
+                        invalid_link = (source_path, link)
+                        if invalid_link not in seen_invalid_mdbook_links:
+                            seen_invalid_mdbook_links.add(invalid_link)
+                            invalid_mdbook_links.append(invalid_link)
+                        continue
                     if link not in seen:
                         seen.add(link)
                         unique_links.append(link)
@@ -284,8 +304,15 @@ def main() -> int:
         )
 
     print(f"Collected {len(unique_links)} added link(s) from {len(existing_files)} docs file(s).")
-    if args.check_local_targets and not check_local_targets(local_links):
-        return 1
+    if args.check_local_targets:
+        valid = check_local_targets(local_links)
+        if invalid_mdbook_links:
+            print("Relative mdBook link target(s) outside docs/book/src:")
+            for source_path, target in invalid_mdbook_links:
+                print(f"  {source_path} -> {target}")
+            valid = False
+        if not valid:
+            return 1
     return 0
 
 

--- a/scripts/ci/collect_changed_links_test.py
+++ b/scripts/ci/collect_changed_links_test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from collect_changed_links import mdbook_link_escapes_source, normalize_link_target
+
+
+class MdBookLinkBoundaryTest(unittest.TestCase):
+    SCRIPT = Path(__file__).with_name("collect_changed_links.py").resolve()
+
+    def run_git(self, root: Path, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def run_collector(
+        self, source_path: str, content: str
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.run_git(root, "init", "--quiet")
+            self.run_git(root, "config", "user.name", "Link Gate Test")
+            self.run_git(root, "config", "user.email", "link-gate@example.invalid")
+
+            target = root / "docs/security/slsa-provenance.md"
+            target.parent.mkdir(parents=True)
+            target.write_text("# SLSA provenance\n", encoding="utf-8")
+            self.run_git(root, "add", target.relative_to(root).as_posix())
+            self.run_git(root, "commit", "--quiet", "-m", "base")
+            base = self.run_git(root, "rev-parse", "HEAD")
+
+            source = root / source_path
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text(content, encoding="utf-8")
+            self.run_git(root, "add", source_path)
+            self.run_git(root, "commit", "--quiet", "-m", "add docs link")
+
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(self.SCRIPT),
+                    "--base",
+                    base,
+                    "--docs-files",
+                    source_path,
+                    "--output",
+                    str(root / "links.txt"),
+                    "--check-local-targets",
+                ],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_rejects_repository_relative_target_outside_book_source(self) -> None:
+        source = "docs/book/src/maintainers/release-verification.md"
+        target = normalize_link_target("../../../security/slsa-provenance.md", source)
+
+        self.assertEqual(target, "docs/security/slsa-provenance.md")
+        self.assertTrue(mdbook_link_escapes_source(source, target))
+
+    def test_accepts_target_within_book_source(self) -> None:
+        source = "docs/book/src/maintainers/release-verification.md"
+        target = normalize_link_target("../security/model.md", source)
+
+        self.assertEqual(target, "docs/book/src/security/model.md")
+        self.assertFalse(mdbook_link_escapes_source(source, target))
+
+    def test_does_not_apply_book_boundary_to_other_repository_docs(self) -> None:
+        source = "docs/maintainers/release-attestation-runbook.md"
+        target = normalize_link_target("../security/slsa-provenance.md", source)
+
+        self.assertEqual(target, "docs/security/slsa-provenance.md")
+        self.assertFalse(mdbook_link_escapes_source(source, target))
+
+    def test_accepts_http_target(self) -> None:
+        source = "docs/book/src/maintainers/release-verification.md"
+        target = "https://github.com/zeroclaw-labs/zeroclaw"
+
+        self.assertFalse(mdbook_link_escapes_source(source, target))
+
+    def test_cli_rejects_mdbook_link_outside_source_root(self) -> None:
+        result = self.run_collector(
+            "docs/book/src/maintainers/release-verification.md",
+            "[SLSA](../../../security/slsa-provenance.md)\n",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "Relative mdBook link target(s) outside docs/book/src:", result.stdout
+        )
+        self.assertIn(
+            "docs/book/src/maintainers/release-verification.md -> "
+            "docs/security/slsa-provenance.md",
+            result.stdout,
+        )
+
+    def test_cli_accepts_repository_link_outside_book(self) -> None:
+        result = self.run_collector(
+            "docs/maintainers/release-attestation-runbook.md",
+            "[SLSA](../security/slsa-provenance.md)\n",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/docs_links_gate.sh
+++ b/scripts/ci/docs_links_gate.sh
@@ -9,6 +9,8 @@ LINKS_FILE="$(mktemp)"
 HTTP_LINKS_FILE="$(mktemp)"
 trap 'rm -f "$LINKS_FILE" "$HTTP_LINKS_FILE"' EXIT
 
+python3 ./scripts/ci/collect_changed_links_test.py
+
 python3 ./scripts/ci/collect_changed_links.py \
     --base "$BASE_SHA" \
     --docs-files "$DOCS_FILES_RAW" \


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Rejects added or modified relative links from `docs/book/src` when their normalized targets escape the publishable book source root.
  - Adds focused tests for valid in-book targets, paths that escape the book source tree, ordinary non-book documentation, HTTP links, and command-line accept/reject behavior.
  - Runs the focused tests through the existing Docs Style gate.
- **Scope boundary:** This does not replace the final rendered-site link check, validate context-only link changes such as file moves, or add a full mdBook build to pull-request CI.
- **Blast radius:** Documentation link validation in pull-request CI. Ordinary repository documentation outside `docs/book/src` is unaffected.
- **Linked issue(s):** Related #9211. The immediate broken-link repair landed separately in #9585.
- **Labels:** `bug`, `scripts`, `domain:ci`, `priority:p2`, `risk:low`, `size:S`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The focused tests and Docs Style job exercise the changed boundary.

### How I tested

- **CI checks relied on and why they cover this change:** The required Docs Style job runs the focused unit tests, changed-link validation, and Markdown lint on the submitted head.
- **Known CI coverage gap, if any:** The guard checks links added or modified in a pull request. It does not detect an unchanged link becoming invalid solely because a target file moved.
- **Commands run and tail output:**

```text
$ python3 scripts/ci/collect_changed_links_test.py
Ran 6 tests in 4.291s
OK

$ BASE_SHA=origin/master bash scripts/ci/docs_links_gate.sh
Ran 6 tests in 11.000s
OK
Collected 1 added link(s) from 5 docs file(s).
```

- **Beyond CI, what did you manually verify?** Confirmed that the refreshed branch's effective diff contains only the three CI guard files and that the release-verification page matches `master` after #9585.
- **If any command was intentionally skipped, why:** Optional `lychee` HTTP validation was unavailable locally. The changed behavior concerns local mdBook publication boundaries; CI runs the repository's required documentation checks.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **Yes.**
- Config / env / CLI surface changed? **No.**
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

Low risk. Revert this pull request to restore the prior added-link behavior.
