### PR TITLE
docs(maintainers): fix dead SLSA provenance link in release-verification

### DIFF
--- a/docs/book/src/maintainers/release-verification.md
+++ b/docs/book/src/maintainers/release-verification.md
@@ -8,8 +8,7 @@ provenance.
 Attestation proves where and how an artifact was built. It does not prove that a
 human reviewed the source, that dependencies are safe, or that a maintainer
 account, GitHub-hosted runner, or GitHub control plane was not compromised. See
-[SLSA provenance attestation](../../../security/slsa-provenance.md) for the full
-threat model.
+`docs/security/slsa-provenance.md` in the repository for the full threat model.
 
 The release workflow currently treats attestations as best-effort Phase A
 output. Check the release notes before relying on verification material; they


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `docs/book/src/maintainers/release-verification.md` linked `../../../security/slsa-provenance.md` (introduced in #9211). The target exists in the repository (`docs/security/slsa-provenance.md`) but sits **outside the mdBook source tree**, so the rendered site has no such page and the xtask internal link check fails every `docs-deploy` run on `master` since the merge (runs on 2026-07-31 03:19Z and 16:22Z both failed with `dead links found: maintainers/release-verification.html -> ../../../security/slsa-provenance.html`).
  - Replaced the Markdown link with a backticked repo path, matching the established convention for out-of-book references (`release-runbook.md` cites `docs/maintainers/release-attestation-runbook.md` the same way). This was the only out-of-book link in the entire book source (verified by grep).
- **Scope boundary:** Does not move `slsa-provenance.md` into the book, does not touch the threat-model content, does not change #9211's attestation behavior or workflows.
- **Blast radius:** The `docs-deploy` workflow on `master` (currently failing at the link check, so Pages has not updated since #9211 merged) and one sentence on the rendered release-verification page.
- **Linked issue(s):** none filed — regression introduced by the merge of #9211; Related #9211.
- **Labels:** `bug`, `docs`, `priority:p1`, `risk:low`, `size:XS`, `type:docs`, `distinguished contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — one-line docs fix; the delta is visible in the diff, and the before-evidence is the two failed `docs-deploy` runs on `master` (2026-07-31).

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` covers the changed Markdown. The real gate (the xtask internal link check) only runs inside `docs-deploy` on push to `master`; removing the only dead link is what makes it pass, and no new links are added for it to check.
- **Known CI coverage gap, if any:** The link check itself cannot run on a PR (docs-deploy is `push: master` only) — evidence below covers it by construction: the change removes the flagged link and adds none.
- **Commands run and tail output:**

```sh
BASE_SHA=$(git merge-base upstream/master HEAD~1) bash scripts/ci/docs_quality_gate.sh
# Linting: 1 file(s)
# Summary: 0 error(s)

BASE_SHA=$(git merge-base upstream/master HEAD~1) bash scripts/ci/docs_links_gate.sh
# Collected 0 added link(s) from 1 docs file(s).
# No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** Confirmed `docs/security/slsa-provenance.md` exists at the referenced path on `master`; confirmed via `git grep` that no other book page links outside `docs/book/src/`; confirmed the failing runs' error names exactly this link.
- **If any command was intentionally skipped, why:** Full `cargo mdbook build` skipped locally — it builds workspace rustdoc plus all locales for a one-line text change; the link checker's failure mode is fully accounted for by removing the only dead link.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users:

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert 535a20282` restores the link (and the broken deploy).

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
