### PR TITLE
fix(security): waive RUSTSEC-2026-0222 (wasmtime) in audit and deny ignores

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -24,6 +24,7 @@ ignore = [
     # (graph-aware) tolerates. Reconcile and remediate per #8519.
     # RUSTSEC-2026-0149, -0182, -0188 cleared by wasmtime/wasmtime-wasi 43 -> 45.0.3
     # bump in crates/zeroclaw-plugins. Resolved by #8542.
+    "RUSTSEC-2026-0222",  # wasmtime Store type-index confusion between engines; single-Engine plugin runtime is not exposed; no patched 45.x, remediation is the 46/47 bump; tracking #8519
     # GTK3 stack unmaintained via zeroclaw-desktop (tauri -> webkit2gtk); tracking #8519
     "RUSTSEC-2024-0411",  # gdkwayland-sys unmaintained gtk-rs GTK3 bindings; tracking #8519
     "RUSTSEC-2024-0412",  # gdk unmaintained gtk-rs GTK3 bindings; tracking #8519

--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,13 @@ ignore = [
     # audit.toml/deny.toml drift reconcile + wasmtime CVEs; tracking #8519.
     # RUSTSEC-2026-0149, -0182, -0188 cleared by wasmtime/wasmtime-wasi 43 -> 45.0.3
     # bump in crates/zeroclaw-plugins. Resolved by #8542.
+    # wasmtime -- Store type-index confusion between engines (CVSS 3.8 low);
+    # requires multiple Engines with Stores crossing engine boundaries. The
+    # plugin runtime uses a single process-wide Engine (component.rs engine()
+    # OnceLock singleton) and mints every Store from it, so the cross-Engine
+    # precondition cannot occur; no patched 45.x release exists, remediation
+    # is the wasmtime 46.0.2+/47.0.3+ series bump
+    { id = "RUSTSEC-2026-0222", reason = "wasmtime Store type-index confusion between engines; single-Engine plugin runtime is not exposed; no patched 45.x, remediation is the 46/47 bump; tracking #8519" },
     # GTK3 stack unmaintained via zeroclaw-desktop (tauri -> webkit2gtk); tracking #8519.
     { id = "RUSTSEC-2024-0411", reason = "gdkwayland-sys unmaintained gtk-rs GTK3 bindings; tracking #8519" },
     { id = "RUSTSEC-2024-0412", reason = "gdk unmaintained gtk-rs GTK3 bindings; tracking #8519" },


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - RUSTSEC-2026-0222 (wasmtime 45.0.3, "Stores can mix up type indices between engines", CVSS 3.8 low) was published **2026-07-31** and now fails the required `Security` job — and therefore `CI Required Gate` — on **every PR**, via `cargo audit`'s freshly fetched advisory DB. Master's last green run simply predates the advisory.
  - Added the advisory to the ignore lists in **both** `.cargo/audit.toml` and `deny.toml` (the files' own sync discipline: "When a fix lands, remove from BOTH files"), with the exposure analysis in the adjacent comment.
  - Why a waiver is sound here: the advisory requires **multiple Engines with Stores crossing engine boundaries**. The plugin runtime uses a single process-wide `Engine` (`crates/zeroclaw-plugins/src/component.rs` `engine()` `OnceLock` singleton) and mints every `Store` from it via `new_store`, so the cross-Engine precondition cannot occur. wasmtime is the only workspace consumer.
  - There is **no patched 45.x release** — fixed series are 46.0.2+/<47 and 47.0.3+. The real remediation is that major bump in `crates/zeroclaw-plugins`, which is out of scope for the feature-frozen v0.8.4 train and stays tracked in #8519 (same pattern as the last wasmtime round: ignores held the line until the 43→45 bump in #8542, then were removed).
- **Scope boundary:** No dependency changes, no code changes, no `Cargo.lock` changes — shipped binaries are identical. Does not bump wasmtime (follow-up under #8519). Does not touch any other advisory entry.
- **Blast radius:** `Security` job (cargo deny + cargo audit) on all branches; unblocks the required gate repo-wide, including the v0.8.4 release train and #9585.
- **Linked issue(s):** Related #8519 (audit/deny reconcile + wasmtime CVE remediation; the bump that removes this ignore belongs there).
- **Labels:** (applied after open) `dependencies`, `security`, `domain:security`, `priority:p0`, `risk:medium`, `size:XS`, `type:dependencies`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — CI/config-only change; the delta is the Security job itself. To reproduce locally: `cargo audit` on `master` fails with `error: 1 vulnerability found!` (RUSTSEC-2026-0222); on this branch it exits clean.

### How I tested

- **CI checks relied on and why they cover this change:** Required `Security` on this PR runs the exact gate being fixed (`cargo deny check` + `cargo audit` with a fresh advisory DB). All other required jobs are unaffected (no code/dep changes).
- **Known CI coverage gap, if any:** None — the changed surface is the Security job and it runs on this PR.
- **Commands run and tail output:**

```sh
# Same cargo-audit release binary CI pins (v0.22.2), fresh advisory DB
cargo audit
#     Loaded 1177 security advisories (from ~/.cargo/advisory-db)
#     Scanning Cargo.lock for vulnerabilities (1231 crate dependencies)
# warning: 4 allowed warnings found
# (no vulnerability error; the 4 warnings are the pre-existing allowed set)
```

- **Beyond CI, what did you manually verify?** Read the advisory's preconditions (multiple Engines, Stores crossing engine boundaries) and checked them against the plugin runtime: single `OnceLock<Engine>` singleton at `component.rs`, every `Store` created from it; no other `Engine` construction in production code. Confirmed no patched 45.x exists in the advisory's fixed ranges. Confirmed the entry format and tracking-reference style match the existing #8519 entries in both files.
- **If any command was intentionally skipped, why:** `cargo deny check` locally — cargo-deny is not installed on this machine; the required `Security` job runs it on the PR, and the deny.toml edit follows the exact schema of the adjacent entries.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: — Note: this PR waives a low-severity advisory rather than fixing it. The waiver is scoped to one advisory ID, justified by an unreachable-precondition analysis documented in the config comment, and carries a tracking reference (#8519) for the real remediation (wasmtime 46/47 bump). Removing the ignore is part of that follow-up's definition of done.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No` — scanner configs only; no runtime config)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users:

## Rollback (required for medium/high-risk PRs)

Medium-risk scanner-policy change: `git revert af3e31a93` restores the failing gate.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A
