### PR TITLE
test(updater): isolate web-dist resolver tests from host install state

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -297,7 +297,7 @@ pub async fn run(target_version: Option<&str>, force: bool) -> Result<()> {
             // companion, the `web/dist` dashboard bundle, …). Best-effort:
             // the validated main binary is already in place and must not be
             // rolled back if these fail.
-            install_companion_artifacts(&staging, &current_exe).await;
+            install_companion_artifacts(&staging, &current_exe, &host_dashboard_candidates()).await;
             println!("{}", update_success_message(&update_info.latest_version));
             println!("{}", prebuilt_channel_note_message());
             Ok(())
@@ -992,12 +992,16 @@ async fn smoke_test(binary: &Path) -> Result<()> {
 /// Best-effort by design — the `zeroclaw` binary has already been swapped and
 /// smoke-tested. A failure here (e.g. an unwritable data directory) is logged
 /// and swallowed rather than failing or rolling back an otherwise-good update.
-async fn install_companion_artifacts(staging: &Path, current_exe: &Path) {
+async fn install_companion_artifacts(
+    staging: &Path,
+    current_exe: &Path,
+    host_candidates: &[PathBuf],
+) {
     // 1. Dashboard bundle, if present: swap the whole `web/dist` directory so a
     //    stale file removed in a release is *gone*, not orphaned in place.
     let staged_web_dist = staging.join("web").join("dist");
     if staged_web_dist.is_dir() {
-        match install_web_dist(&staged_web_dist, current_exe).await {
+        match install_web_dist(&staged_web_dist, current_exe, host_candidates).await {
             Ok(target) => ::zeroclaw_log::record!(
                 INFO,
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -1213,8 +1217,12 @@ async fn swap_file(new: &Path, target: &Path) -> Result<()> {
 ///   have open handles), but `remove_dir_all` of the sidelined tree fails as
 ///   long as any file inside is held open. The leftover `.<name>.update-old-*`
 ///   directory is cleaned up by `sweep_update_residue` on the next update.
-async fn install_web_dist(staged_dist: &Path, current_exe: &Path) -> Result<PathBuf> {
-    let target = resolve_web_dist_target(current_exe);
+async fn install_web_dist(
+    staged_dist: &Path,
+    current_exe: &Path,
+    host_candidates: &[PathBuf],
+) -> Result<PathBuf> {
+    let target = resolve_web_dist_target(current_exe, host_candidates);
     let parent = target
         .parent()
         .context("web dashboard target has no parent")?;
@@ -1282,32 +1290,27 @@ async fn install_web_dist(staged_dist: &Path, current_exe: &Path) -> Result<Path
 /// gateway's dashboard auto-detection ([`crates/zeroclaw-gateway/src/lib.rs`])
 /// and `install.sh`:
 ///   1. existing `web/dist` next to the running binary (dev / packaged), or
-///   2. Docker layout `/zeroclaw-data/web/dist`, or
-///   3. system package layout `/usr/share/zeroclawlabs/web/dist`, or
-///   4. platform data dir `…/zeroclaw/web/dist` (prebuilt installer), or
-///   5. **fallback**: `web/dist` next to the running binary, even if it does
+///   2. one of `host_candidates` (Docker / system-package / platform data-dir
+///      layouts — see [`host_dashboard_candidates`]), or
+///   3. **fallback**: `web/dist` next to the running binary, even if it does
 ///      not yet exist — write *somewhere* so a fresh install gets a dashboard.
+///
+/// `host_candidates` is a parameter so unit tests can scope it to `&[]` and
+/// run hermetically against a tempdir binary, regardless of whether the host
+/// already has a dashboard installed (which would otherwise divert the target).
+/// Production callers pass [`host_dashboard_candidates`].
 ///
 /// The custom-config path (`gateway.web_dist_dir`) is intentionally ignored;
 /// reading the config here would couple this command to gateway internals and
 /// the operator can always re-run with `--force` after fixing the layout.
-fn resolve_web_dist_target(current_exe: &Path) -> PathBuf {
+fn resolve_web_dist_target(current_exe: &Path, host_candidates: &[PathBuf]) -> PathBuf {
     let binary_adjacent = current_exe.parent().map(|p| p.join("web").join("dist"));
 
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Some(ref p) = binary_adjacent {
         candidates.push(p.clone());
     }
-    candidates.push(PathBuf::from("/zeroclaw-data/web/dist"));
-    candidates.push(PathBuf::from("/usr/share/zeroclawlabs/web/dist"));
-    if let Some(base) = directories::BaseDirs::new() {
-        candidates.push(
-            base.data_local_dir()
-                .join("zeroclaw")
-                .join("web")
-                .join("dist"),
-        );
-    }
+    candidates.extend_from_slice(host_candidates);
     for c in &candidates {
         if c.join("index.html").is_file() {
             return c.clone();
@@ -1315,6 +1318,28 @@ fn resolve_web_dist_target(current_exe: &Path) -> PathBuf {
     }
     // Fallback: write next to the binary even if nothing existed yet.
     binary_adjacent.unwrap_or_else(|| PathBuf::from("web/dist"))
+}
+
+/// Absolute dashboard install locations outside the binary's own tree, in
+/// precedence order: the Docker layout, the system package layout, and the
+/// prebuilt-installer platform data dir. Extracted from
+/// [`resolve_web_dist_target`] so unit tests can run the resolver hermetically
+/// against a tempdir binary without consulting the real host layout — which
+/// may already hold a ZeroClaw dashboard and so divert the install target.
+fn host_dashboard_candidates() -> Vec<PathBuf> {
+    let mut c = vec![
+        PathBuf::from("/zeroclaw-data/web/dist"),
+        PathBuf::from("/usr/share/zeroclawlabs/web/dist"),
+    ];
+    if let Some(base) = directories::BaseDirs::new() {
+        c.push(
+            base.data_local_dir()
+                .join("zeroclaw")
+                .join("web")
+                .join("dist"),
+        );
+    }
+    c
 }
 
 /// Recursively copy `src` into `dst`. Used as the cross-filesystem fallback
@@ -2143,7 +2168,7 @@ mod tests {
         std::fs::write(bin_dir.join("web/dist/index.html"), b"<html>").unwrap();
         let exe = bin_dir.join("zeroclaw");
 
-        let target = resolve_web_dist_target(&exe);
+        let target = resolve_web_dist_target(&exe, &[]);
         assert_eq!(target, bin_dir.join("web").join("dist"));
     }
 
@@ -2155,12 +2180,37 @@ mod tests {
         let exe = tmp.path().join("bin").join("zeroclaw");
         std::fs::create_dir_all(tmp.path().join("bin")).unwrap();
 
-        let target = resolve_web_dist_target(&exe);
+        let target = resolve_web_dist_target(&exe, &[]);
         // Fallback either lands on the binary-adjacent dir or on the platform
         // data dir, depending on whether `/usr/share/zeroclawlabs/web/dist`
         // happens to exist on the runner. Both are acceptable; what matters is
         // it does not error.
         assert!(target.ends_with("web/dist"));
+    }
+
+    #[test]
+    fn resolve_web_dist_target_ignores_host_dashboard_when_candidates_empty() {
+        // A host that already has a dashboard installed must not divert the
+        // resolver off the binary-adjacent target when the caller scopes host
+        // candidates to none — the hermetic surface the unit tests rely on.
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let exe = bin_dir.join("zeroclaw");
+
+        // Stands in for the platform data dir on a host with an install.
+        let host_dashboard = tmp.path().join("host-install").join("web").join("dist");
+        std::fs::create_dir_all(&host_dashboard).unwrap();
+        std::fs::write(host_dashboard.join("index.html"), b"host").unwrap();
+
+        // With the host candidate injected, the scan still honors it.
+        let diverted = resolve_web_dist_target(&exe, std::slice::from_ref(&host_dashboard));
+        assert_eq!(diverted, host_dashboard);
+
+        // With no host candidates, the host dashboard is ignored and the
+        // resolver falls back to the binary-adjacent path.
+        let hermetic = resolve_web_dist_target(&exe, &[]);
+        assert_eq!(hermetic, bin_dir.join("web").join("dist"));
     }
 
     #[tokio::test]
@@ -2185,7 +2235,7 @@ mod tests {
         std::fs::write(staged_dist.join("index.html"), b"NEW INDEX").unwrap();
         std::fs::write(staged_dist.join("brand-new.txt"), b"fresh").unwrap();
 
-        let installed = install_web_dist(&staged_dist, &exe).await.unwrap();
+        let installed = install_web_dist(&staged_dist, &exe, &[]).await.unwrap();
         // Installs adjacent because old_dist already contains index.html.
         assert_eq!(installed, old_dist);
         assert_eq!(
@@ -2237,7 +2287,7 @@ mod tests {
         std::fs::write(staging.join("zeroclaw"), b"new zeroclaw").unwrap();
         std::fs::write(staging.join("zerocode"), b"new zerocode").unwrap();
 
-        install_companion_artifacts(&staging, &exe).await;
+        install_companion_artifacts(&staging, &exe, &[]).await;
 
         // zerocode swapped in.
         let expected_zerocode = bin_dir.join("zerocode");
@@ -2270,7 +2320,7 @@ mod tests {
         // naming it in its own archive.
         std::fs::write(staging.join("zerodash"), b"unknown artifact").unwrap();
 
-        install_companion_artifacts(&staging, &exe).await;
+        install_companion_artifacts(&staging, &exe, &[]).await;
 
         // Known companion installed.
         assert_eq!(
@@ -2308,7 +2358,7 @@ mod tests {
         std::fs::create_dir_all(staging.join("web").join("dist")).unwrap();
         std::fs::write(staging.join("web/dist/index.html"), b"NEW INDEX").unwrap();
 
-        install_companion_artifacts(&staging, &exe).await;
+        install_companion_artifacts(&staging, &exe, &[]).await;
 
         // Known artifacts installed.
         assert_eq!(
@@ -2395,7 +2445,7 @@ mod tests {
         std::fs::create_dir_all(&staged_dist).unwrap();
         std::fs::write(staged_dist.join("index.html"), b"NEW").unwrap();
 
-        let installed = install_web_dist(&staged_dist, &exe).await.unwrap();
+        let installed = install_web_dist(&staged_dist, &exe, &[]).await.unwrap();
 
         assert_eq!(std::fs::read(installed.join("index.html")).unwrap(), b"NEW");
         // Previous-run sidelined directory must be swept.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `resolve_web_dist_target` (`src/commands/update.rs`) scanned absolute host dashboard locations — `/zeroclaw-data/web/dist`, `/usr/share/zeroclawlabs/web/dist`, and the platform data dir `…/zeroclaw/web/dist` — and returned the first containing `index.html`. On a dev machine that already had a ZeroClaw dashboard installed, the resolver diverted updater unit-test install targets to the host path instead of the test's tempdir, so the suite depended on host state: a local `cargo test` run failed while CI stayed green (runners carry no pre-existing dashboard). This gives the resolver a `host_candidates: &[PathBuf]` parameter (host paths extracted into `host_dashboard_candidates()` as the single source), threaded through `install_web_dist` and `install_companion_artifacts`. Production passes the real host candidates; tests pass `&[]` and run hermetically against a tempdir binary regardless of host state.
- **Scope boundary:** Only `src/commands/update.rs`. No new config keys, env vars, or feature flags; no change to the resolver's precedence order or fallback.
- **Blast radius:** The updater's dashboard install-path selection. The production call site (`install_companion_artifacts` from the update command) now passes `&host_dashboard_candidates()`, which resolves identically to the previously hardcoded list.
- **Linked issue(s):** Closes #9546
- **Labels:** `bug`, `type:test`, `cli`, `risk:medium`, `size:S`

## Testing (required)

### How I tested

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclawlabs --all-targets -- -D warnings
cargo test -p zeroclawlabs --lib update
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (exit 0, no diff).
  - `cargo clippy -p zeroclawlabs --all-targets -- -D warnings` → `Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.62s` (zero warnings; reuses cached dep checks, re-checked the local crate).
  - `cargo test -p zeroclawlabs --lib update` → compile `Finished `test` profile [unoptimized + debuginfo] target(s) in 5m 04s`; `test result: ok. 58 passed; 0 failed; 0 ignored; 0 measured; 213 filtered out; finished in 0.32s`. Relevant:
    ```
    test commands::update::tests::install_companion_artifacts_skips_unknown_top_level_directories ... ok
    test commands::update::tests::resolve_web_dist_target_ignores_host_dashboard_when_candidates_empty ... ok
    test commands::update::tests::resolve_web_dist_target_prefers_binary_adjacent_dir ... ok
    test commands::update::tests::resolve_web_dist_target_falls_back_to_binary_adjacent_when_no_candidate_exists ... ok
    test commands::update::tests::install_web_dist_swaps_directory_dropping_removed_files ... ok
    test commands::update::tests::install_web_dist_cleans_up_residue_from_earlier_runs ... ok
    ```
- **Beyond CI — what did you manually verify?** Added `resolve_web_dist_target_ignores_host_dashboard_when_candidates_empty`, which builds a tempdir "host dashboard" (with `index.html`), asserts the scan still honors it when the candidate is injected, and asserts that with `&[]` the resolver ignores it and falls back to the binary-adjacent path. This directly reproduces #9546's "host already has a dashboard" scenario and pins the hermetic surface. Confirmed the previously host-dependent tests (`install_companion_artifacts_skips_unknown_top_level_directories`, both `install_web_dist_*`) now pass with `&[]` regardless of host state.
- **If any command was intentionally skipped, why:** Clippy and tests were scoped to the affected crate (`-p zeroclawlabs`) since the change is confined to `src/commands/update.rs`; workspace-wide gates run in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — tests use `tempfile::tempdir()` and placeholder byte strings (`b"host"`, `b"NEW INDEX"`, etc.).
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any `Yes`: n/a

## Compatibility (required)

- Backward compatible? **Yes** — the production call site passes `&host_dashboard_candidates()`, the same host paths the resolver previously hardcoded, in the same order; resolution results are identical.
- Config / env / CLI surface changed? **No.**
- Rust/MSRV/toolchain floor changed? **No.**
- If `No` or `Yes` to either: n/a — no upgrade steps.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** updater dashboard files install to the wrong location, or updater tests access a real host dashboard.

