### PR TITLE
fix(channels): tie the WhatsApp Cloud approval token to a guard so no exit orphans it

### DIFF
--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -12,6 +12,81 @@ type PendingApprovalsMap = Mutex<HashMap<String, oneshot::Sender<ChannelApproval
 static PENDING_APPROVALS: LazyLock<Arc<PendingApprovalsMap>> =
     LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 
+/// Removes a parked approval token when the requesting future goes away.
+///
+/// `request_approval_attributed` registers a token in [`PENDING_APPROVALS`]
+/// before it does anything else, and the token is a bearer credential for a
+/// tool-call decision: whoever presents it decides that call. An entry left
+/// behind is therefore a decision that stays resolvable for the lifetime of the
+/// process, and the map is process-global, so it is not bounded by a channel
+/// instance either.
+///
+/// Three exits can leave one behind, and none is exotic.
+///
+/// The send is the first thing after registration, so a transient send failure
+/// propagates out with the entry already in the map and nothing later in the
+/// function runs. That one needs no cancellation at all to reach.
+///
+/// The other two are cancellation. Every explicit cleanup lives inside the async
+/// body, so none of it runs if the future is dropped, which a caller-side
+/// timeout or a shutdown both do. `Drop` is the only hook that survives that,
+/// which is why the entry's lifetime is tied to a guard rather than to any code
+/// path.
+///
+/// The guard is disarmed once a decision has been taken through a normal path,
+/// so the existing removals still own their cleanup and nothing is removed
+/// twice. [`remove_pending_and_disarm`] holds the ordering that makes the
+/// disarm safe.
+struct PendingApprovalGuard {
+    token: Option<String>,
+}
+
+impl PendingApprovalGuard {
+    fn new(token: String) -> Self {
+        Self { token: Some(token) }
+    }
+
+    /// The decision was taken through a normal path; stop guarding.
+    fn disarm(&mut self) {
+        self.token = None;
+    }
+}
+
+impl Drop for PendingApprovalGuard {
+    fn drop(&mut self) {
+        let Some(token) = self.token.take() else {
+            return;
+        };
+        // `Drop` is not async, and blocking here would stall whichever runtime
+        // thread is unwinding. Spawn the removal instead: the entry is gone well
+        // before any realistic reply, and a reply that beats it still finds a
+        // receiver whose sender was dropped with this future, so it cannot be
+        // reported as an accepted decision.
+        zeroclaw_spawn::spawn!(async move {
+            PENDING_APPROVALS.lock().await.remove(&token);
+        });
+    }
+}
+
+/// Removes a parked token and then disarms its guard, in that order.
+///
+/// The ordering is the whole point of the helper. Disarming first leaves a
+/// window: acquiring the map lock is an await, so a request future cancelled
+/// while waiting for it drops a guard that is already unarmed, and the removal
+/// below never runs. The entry survives, which is the exact leak this guard
+/// exists to close. Removing first and disarming afterwards means a
+/// cancellation anywhere inside here still drops an *armed* guard, whose `Drop`
+/// completes the removal.
+///
+/// Both runtime-deny arms call this, and the cancellation regression drives
+/// this same function rather than a copy of it, so the test covers the
+/// production path.
+async fn remove_pending_and_disarm(token: &str, guard: &mut PendingApprovalGuard) {
+    let mut map = PENDING_APPROVALS.lock().await;
+    map.remove(token);
+    guard.disarm();
+}
+
 fn ensure_https(url: &str) -> anyhow::Result<()> {
     if !url.starts_with("https://") {
         anyhow::bail!(
@@ -817,12 +892,18 @@ impl Channel for WhatsAppChannel {
             let mut map = PENDING_APPROVALS.lock().await;
             map.insert(token.clone(), tx_approval);
         }
+        // Armed immediately after registration rather than later, because the
+        // send below is the first thing that can leave the function.
+        let mut guard = PendingApprovalGuard::new(token.clone());
 
         let text = crate::util::build_yesno_approval_prompt(
             &token,
             &request.tool_name,
             &request.arguments_summary,
         );
+        // The `?` here is what orphans a live token: it returns with the entry
+        // already registered, and no cleanup below it runs. The guard covers
+        // that path.
         self.send(&SendMessage::new(text, recipient)).await?;
 
         let timeout = std::time::Duration::from_secs(self.approval_timeout_secs);
@@ -830,19 +911,22 @@ impl Channel for WhatsAppChannel {
         // dropped-sender and timeout arms are the runtime denying on its own.
         let attributed = match tokio::time::timeout(timeout, rx_approval).await {
             Ok(Ok(response)) => {
+                // The reply arrived, which means the gateway's reply handler
+                // already removed the entry to take the sender out of the map.
+                // Nothing awaits between here and the disarm, so there is no
+                // cancellation window to cover.
+                guard.disarm();
                 zeroclaw_api::channel::AttributedApprovalResponse::operator(response)
             }
             Ok(Err(_)) => {
-                let mut map = PENDING_APPROVALS.lock().await;
-                map.remove(&token);
+                remove_pending_and_disarm(&token, &mut guard).await;
                 zeroclaw_api::channel::AttributedApprovalResponse::from_runtime(
                     ChannelApprovalResponse::Deny,
                     zeroclaw_api::channel::ApprovalSource::Unreachable,
                 )
             }
             Err(_) => {
-                let mut map = PENDING_APPROVALS.lock().await;
-                map.remove(&token);
+                remove_pending_and_disarm(&token, &mut guard).await;
                 zeroclaw_api::channel::AttributedApprovalResponse::from_runtime(
                     ChannelApprovalResponse::Deny,
                     zeroclaw_api::channel::ApprovalSource::TimedOut,
@@ -2724,6 +2808,134 @@ mod tests {
         assert_eq!(ch.approval_timeout_secs, 300);
         let ch2 = ch.with_approval_timeout_secs(60);
         assert_eq!(ch2.approval_timeout_secs, 60);
+    }
+
+    /// Generous hang guard rather than a timing assertion. The cleanup these
+    /// tests wait on is a spawned task, so the only honest failure is "it never
+    /// happened", not "it took longer than some scheduling budget".
+    const APPROVAL_CLEANUP_HANG_GUARD: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Park a token the way `request_approval_attributed` does, and hand back
+    /// the guard so a test can decide when the requesting future goes away.
+    async fn park_guarded_token(
+        token: &str,
+    ) -> (
+        PendingApprovalGuard,
+        oneshot::Receiver<ChannelApprovalResponse>,
+    ) {
+        let (tx, rx) = oneshot::channel();
+        PENDING_APPROVALS.lock().await.insert(token.to_string(), tx);
+        (PendingApprovalGuard::new(token.to_string()), rx)
+    }
+
+    /// Wait for the guard's spawned removal rather than assuming it has landed.
+    /// `Drop` cannot await, so the removal is a spawned task and a bare assert
+    /// straight after the drop would race it and pass or fail on scheduling.
+    async fn assert_token_cleared(token: &str) {
+        tokio::time::timeout(APPROVAL_CLEANUP_HANG_GUARD, async {
+            while PENDING_APPROVALS.lock().await.contains_key(token) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("token {token} was still registered after its request went away")
+        });
+    }
+
+    /// The send is the first thing after registration, so a transient send
+    /// failure returns with the entry already in the map. That path needs no
+    /// cancellation to reach, which is what makes it the cheapest to exploit.
+    #[tokio::test]
+    async fn send_failure_leaves_no_live_token() {
+        let token = "sendfl";
+        let (guard, _rx) = park_guarded_token(token).await;
+        assert!(
+            PENDING_APPROVALS.lock().await.contains_key(token),
+            "fixture failed to register the token, so the assertion below would pass vacuously"
+        );
+
+        // What `self.send(...).await?` does on the error path: the function
+        // returns and everything it owns, including the guard, is dropped.
+        drop(guard);
+
+        assert_token_cleared(token).await;
+    }
+
+    /// Cancellation is the exit no in-body cleanup can cover, because none of
+    /// that code runs once the future is dropped. A caller-side timeout and a
+    /// shutdown both do exactly this.
+    #[tokio::test]
+    async fn cancelled_request_leaves_no_live_token() {
+        let token = "cancel";
+        let (guard, _rx) = park_guarded_token(token).await;
+        assert!(PENDING_APPROVALS.lock().await.contains_key(token));
+
+        let task = zeroclaw_spawn::spawn!(async move {
+            let _guard = guard;
+            std::future::pending::<()>().await;
+        });
+        task.abort();
+        let _ = task.await;
+
+        assert_token_cleared(token).await;
+    }
+
+    /// The narrow window the guard did not originally cover: a cancellation
+    /// that lands while the cleanup is *waiting for the map lock*.
+    ///
+    /// Disarming before acquiring that lock made the window real, because the
+    /// guard would then drop already-unarmed and the removal never ran. This
+    /// drives the production helper with the lock held, cancels it mid-await,
+    /// and requires the entry to be gone regardless.
+    #[tokio::test]
+    async fn cancellation_while_awaiting_the_map_lock_leaves_no_live_token() {
+        let token = "lockct";
+        let (guard, _rx) = park_guarded_token(token).await;
+
+        // Hold the map lock so the helper cannot get past its first await.
+        let held = PENDING_APPROVALS.lock().await;
+
+        let task = zeroclaw_spawn::spawn!(async move {
+            let mut guard = guard;
+            remove_pending_and_disarm("lockct", &mut guard).await;
+        });
+
+        // Let the task reach the contended lock before cancelling it, so the
+        // cancellation lands inside the await rather than before the call.
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        task.abort();
+        let _ = task.await;
+
+        // Release, so both the aborted task's guard cleanup and the assertion
+        // below can acquire the map.
+        drop(held);
+
+        assert_token_cleared(token).await;
+    }
+
+    /// The control for the three above. A guard that removed unconditionally
+    /// would pass all of them while breaking the normal path, where the reply
+    /// handler has already taken the sender out of the map and a second removal
+    /// would be removing whatever registered next.
+    #[tokio::test]
+    async fn a_disarmed_guard_removes_nothing() {
+        let token = "disarm";
+        let (mut guard, _rx) = park_guarded_token(token).await;
+        guard.disarm();
+        drop(guard);
+
+        // Give a spawned removal every chance to run before concluding it did not.
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            PENDING_APPROVALS.lock().await.contains_key(token),
+            "a disarmed guard must not remove an entry the normal path owns"
+        );
+        PENDING_APPROVALS.lock().await.remove(token);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -58,8 +58,11 @@ impl Drop for PendingApprovalGuard {
             return;
         };
         // `Drop` is not async, and blocking here would stall whichever runtime
-        // thread is unwinding. Spawn the removal instead: the entry is gone well
-        // before any realistic reply, and a reply that beats it still finds a
+        // thread is unwinding. Spawn the removal instead. That makes cleanup
+        // asynchronous rather than immediate, and the delay is scheduler
+        // dependent rather than bounded, so the honest guarantee is eventual
+        // removal and not prompt removal. What is not weakened by the delay is
+        // the decision itself: a reply arriving inside that window still finds a
         // receiver whose sender was dropped with this future, so it cannot be
         // reported as an accepted decision.
         zeroclaw_spawn::spawn!(async move {
@@ -2987,6 +2990,146 @@ mod tests {
             "a disarmed guard must not remove an entry the normal path owns"
         );
         PENDING_APPROVALS.lock().await.remove(token);
+    }
+
+    /// A real operator reply must come back attributed to the operator.
+    ///
+    /// No earlier test reached this arm, and none asserted a return value at
+    /// all, so the whole attribution was uncovered on both sides of the
+    /// refactor. It resolves the token exactly as the gateway does, taking the
+    /// sender out of the map before sending, and asserts the decision AND its
+    /// source: the decision alone would pass against a runtime deny that
+    /// happened to carry the same value.
+    #[tokio::test]
+    async fn an_operator_reply_is_attributed_to_the_operator() {
+        let token = "opappr";
+
+        let task = zeroclaw_spawn::spawn!(async move {
+            run_approval_lifecycle("opappr".to_string(), 300, || async { Ok(()) }).await
+        });
+
+        wait_until_registered(token).await;
+
+        let sender = PENDING_APPROVALS
+            .lock()
+            .await
+            .remove(token)
+            .expect("the lifecycle must register before a reply can resolve it");
+        let _ = sender.send(ChannelApprovalResponse::Approve);
+
+        let attributed = task
+            .await
+            .expect("task should not panic")
+            .expect("a resolved approval is not an error");
+
+        assert_eq!(attributed.response, ChannelApprovalResponse::Approve);
+        assert_eq!(
+            attributed.source,
+            zeroclaw_api::channel::ApprovalSource::Operator,
+            "a human answered, so this must not be reported as a runtime fail-closed"
+        );
+        assert!(
+            !PENDING_APPROVALS.lock().await.contains_key(token),
+            "the reply handler removed the entry; the guard must not re-add one"
+        );
+    }
+
+    /// The success arm must DISARM, not merely finish.
+    ///
+    /// A guard still armed after a resolved approval spawns a removal for a
+    /// token the reply handler has already taken. In isolation that is a no-op,
+    /// which is why asserting the entry is absent cannot see the difference. It
+    /// stops being a no-op the moment the token has been reused: the stale
+    /// removal then deletes the NEWER request. That is the same window the
+    /// documented token-reuse residual names, so this reproduces it directly.
+    ///
+    /// The map lock is held across the whole handover deliberately. A stale
+    /// removal is a spawned task that must take that lock, so a version of this
+    /// test that releases it between the resolution and the re-registration
+    /// lets the removal run first, delete nothing, and report success. That
+    /// version was written, and its mutation control caught it passing against
+    /// a deliberately undisarmed guard. Holding the lock orders the removal
+    /// after the re-registration, which is the sequence the residual describes.
+    #[tokio::test]
+    async fn a_resolved_approval_does_not_delete_a_later_registration() {
+        let token = "reuse1";
+
+        let task = zeroclaw_spawn::spawn!(async move {
+            run_approval_lifecycle("reuse1".to_string(), 300, || async { Ok(()) }).await
+        });
+        wait_until_registered(token).await;
+
+        let mut map = PENDING_APPROVALS.lock().await;
+
+        // The reply handler takes the sender out and resolves the request. The
+        // success arm touches no lock, so the lifecycle still completes here.
+        let sender = map.remove(token).expect("registered");
+        let _ = sender.send(ChannelApprovalResponse::Approve);
+        let _ = task.await.expect("task").expect("lifecycle");
+
+        // A later request reuses the same six-character token.
+        let (tx_next, _rx_next) = oneshot::channel();
+        map.insert(token.to_string(), tx_next);
+        drop(map);
+
+        // Give any spawned removal every chance to run before concluding none did.
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            PENDING_APPROVALS.lock().await.contains_key(token),
+            "a resolved approval must not delete a later request that reused its token"
+        );
+        PENDING_APPROVALS.lock().await.remove(token);
+    }
+
+    /// A sender dropped without a decision is the runtime failing closed, and
+    /// must be attributed `Unreachable` rather than presented as an operator
+    /// denial.
+    #[tokio::test]
+    async fn a_dropped_sender_is_attributed_unreachable() {
+        let token = "unrch";
+
+        let task = zeroclaw_spawn::spawn!(async move {
+            run_approval_lifecycle("unrch".to_string(), 300, || async { Ok(()) }).await
+        });
+
+        wait_until_registered(token).await;
+        drop(
+            PENDING_APPROVALS
+                .lock()
+                .await
+                .remove(token)
+                .expect("registered"),
+        );
+
+        let attributed = task.await.expect("task").expect("lifecycle");
+
+        assert_eq!(attributed.response, ChannelApprovalResponse::Deny);
+        assert_eq!(
+            attributed.source,
+            zeroclaw_api::channel::ApprovalSource::Unreachable
+        );
+        assert_token_cleared(token).await;
+    }
+
+    /// An unanswered prompt must be attributed `TimedOut`, which is a different
+    /// fact about the world from `Unreachable` and from an operator denial.
+    #[tokio::test]
+    async fn an_unanswered_prompt_is_attributed_timed_out() {
+        let token = "tmout";
+
+        let attributed = run_approval_lifecycle(token.to_string(), 0, || async { Ok(()) })
+            .await
+            .expect("a timeout is a decision, not an error");
+
+        assert_eq!(attributed.response, ChannelApprovalResponse::Deny);
+        assert_eq!(
+            attributed.source,
+            zeroclaw_api::channel::ApprovalSource::TimedOut
+        );
+        assert_token_cleared(token).await;
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -87,6 +87,71 @@ async fn remove_pending_and_disarm(token: &str, guard: &mut PendingApprovalGuard
     guard.disarm();
 }
 
+/// Registers an approval token, waits for the operator, and cleans up after
+/// itself however it leaves.
+///
+/// The send is a parameter so this whole lifecycle can be driven without a live
+/// Meta endpoint. `request_approval_attributed` is a thin wrapper that supplies
+/// the real one, so every ownership transition here happens in the code
+/// production runs rather than in a copy of it: a regression that moved the
+/// guard after the send, dropped it, or changed a cleanup arm would fail.
+///
+/// Registration happens first, then the guard is armed, and only then is
+/// anything sent. That order matters because the send is the first thing that
+/// can leave the function, and it leaves through `?` with the entry already in
+/// the map.
+async fn run_approval_lifecycle<F, Fut>(
+    token: String,
+    approval_timeout_secs: u64,
+    send: F,
+) -> anyhow::Result<zeroclaw_api::channel::AttributedApprovalResponse>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    let (tx_approval, rx_approval) = oneshot::channel();
+    {
+        let mut map = PENDING_APPROVALS.lock().await;
+        map.insert(token.clone(), tx_approval);
+    }
+    // Armed immediately after registration rather than later, because the send
+    // below is the first thing that can leave the function.
+    let mut guard = PendingApprovalGuard::new(token.clone());
+
+    // The `?` here is what orphans a live token: it returns with the entry
+    // already registered, and no cleanup below it runs. The guard covers it.
+    send().await?;
+
+    let timeout = std::time::Duration::from_secs(approval_timeout_secs);
+    // Only a real token-echo reply is an operator decision; the dropped-sender
+    // and timeout arms are the runtime denying on its own.
+    let attributed = match tokio::time::timeout(timeout, rx_approval).await {
+        Ok(Ok(response)) => {
+            // The reply arrived, which means the gateway's reply handler has
+            // already removed the entry to take the sender out of the map.
+            // Nothing awaits between here and the disarm, so there is no
+            // cancellation window to cover.
+            guard.disarm();
+            zeroclaw_api::channel::AttributedApprovalResponse::operator(response)
+        }
+        Ok(Err(_)) => {
+            remove_pending_and_disarm(&token, &mut guard).await;
+            zeroclaw_api::channel::AttributedApprovalResponse::from_runtime(
+                ChannelApprovalResponse::Deny,
+                zeroclaw_api::channel::ApprovalSource::Unreachable,
+            )
+        }
+        Err(_) => {
+            remove_pending_and_disarm(&token, &mut guard).await;
+            zeroclaw_api::channel::AttributedApprovalResponse::from_runtime(
+                ChannelApprovalResponse::Deny,
+                zeroclaw_api::channel::ApprovalSource::TimedOut,
+            )
+        }
+    };
+    Ok(attributed)
+}
+
 fn ensure_https(url: &str) -> anyhow::Result<()> {
     if !url.starts_with("https://") {
         anyhow::bail!(
@@ -887,52 +952,15 @@ impl Channel for WhatsAppChannel {
         request: &ChannelApprovalRequest,
     ) -> anyhow::Result<Option<zeroclaw_api::channel::AttributedApprovalResponse>> {
         let token = crate::util::new_approval_token();
-        let (tx_approval, rx_approval) = oneshot::channel();
-        {
-            let mut map = PENDING_APPROVALS.lock().await;
-            map.insert(token.clone(), tx_approval);
-        }
-        // Armed immediately after registration rather than later, because the
-        // send below is the first thing that can leave the function.
-        let mut guard = PendingApprovalGuard::new(token.clone());
-
         let text = crate::util::build_yesno_approval_prompt(
             &token,
             &request.tool_name,
             &request.arguments_summary,
         );
-        // The `?` here is what orphans a live token: it returns with the entry
-        // already registered, and no cleanup below it runs. The guard covers
-        // that path.
-        self.send(&SendMessage::new(text, recipient)).await?;
-
-        let timeout = std::time::Duration::from_secs(self.approval_timeout_secs);
-        // Only a real token-echo reply is an operator decision; the
-        // dropped-sender and timeout arms are the runtime denying on its own.
-        let attributed = match tokio::time::timeout(timeout, rx_approval).await {
-            Ok(Ok(response)) => {
-                // The reply arrived, which means the gateway's reply handler
-                // already removed the entry to take the sender out of the map.
-                // Nothing awaits between here and the disarm, so there is no
-                // cancellation window to cover.
-                guard.disarm();
-                zeroclaw_api::channel::AttributedApprovalResponse::operator(response)
-            }
-            Ok(Err(_)) => {
-                remove_pending_and_disarm(&token, &mut guard).await;
-                zeroclaw_api::channel::AttributedApprovalResponse::from_runtime(
-                    ChannelApprovalResponse::Deny,
-                    zeroclaw_api::channel::ApprovalSource::Unreachable,
-                )
-            }
-            Err(_) => {
-                remove_pending_and_disarm(&token, &mut guard).await;
-                zeroclaw_api::channel::AttributedApprovalResponse::from_runtime(
-                    ChannelApprovalResponse::Deny,
-                    zeroclaw_api::channel::ApprovalSource::TimedOut,
-                )
-            }
-        };
+        let attributed = run_approval_lifecycle(token, self.approval_timeout_secs, || async {
+            self.send(&SendMessage::new(text, recipient)).await
+        })
+        .await?;
         Ok(Some(attributed))
     }
 
@@ -2843,38 +2871,54 @@ mod tests {
         });
     }
 
+    /// Block until the lifecycle under test has registered its token, so a
+    /// later assertion cannot pass vacuously against an entry that was never
+    /// there.
+    async fn wait_until_registered(token: &str) {
+        tokio::time::timeout(APPROVAL_CLEANUP_HANG_GUARD, async {
+            while !PENDING_APPROVALS.lock().await.contains_key(token) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("token {token} was never registered"));
+    }
+
     /// The send is the first thing after registration, so a transient send
     /// failure returns with the entry already in the map. That path needs no
     /// cancellation to reach, which is what makes it the cheapest to exploit.
+    ///
+    /// Drives the production lifecycle with a failing send rather than dropping
+    /// a hand-built guard, so moving the guard after the send or removing it
+    /// from the lifecycle would fail this test.
     #[tokio::test]
     async fn send_failure_leaves_no_live_token() {
         let token = "sendfl";
-        let (guard, _rx) = park_guarded_token(token).await;
-        assert!(
-            PENDING_APPROVALS.lock().await.contains_key(token),
-            "fixture failed to register the token, so the assertion below would pass vacuously"
-        );
 
-        // What `self.send(...).await?` does on the error path: the function
-        // returns and everything it owns, including the guard, is dropped.
-        drop(guard);
+        let result = run_approval_lifecycle(token.to_string(), 300, || async {
+            anyhow::bail!("simulated transport failure")
+        })
+        .await;
 
+        assert!(result.is_err(), "a failing send must propagate");
         assert_token_cleared(token).await;
     }
 
     /// Cancellation is the exit no in-body cleanup can cover, because none of
-    /// that code runs once the future is dropped. A caller-side timeout and a
-    /// shutdown both do exactly this.
+    /// that code runs once the future is dropped. The runtime wraps
+    /// `request_approval` in its own timeout, so a caller-side drop of this
+    /// future is an ordinary production event rather than a test-only one.
     #[tokio::test]
     async fn cancelled_request_leaves_no_live_token() {
         let token = "cancel";
-        let (guard, _rx) = park_guarded_token(token).await;
-        assert!(PENDING_APPROVALS.lock().await.contains_key(token));
 
         let task = zeroclaw_spawn::spawn!(async move {
-            let _guard = guard;
-            std::future::pending::<()>().await;
+            // A send that succeeds, then a wait long enough that the abort
+            // below lands while the lifecycle is parked on the receiver.
+            run_approval_lifecycle("cancel".to_string(), 300, || async { Ok(()) }).await
         });
+
+        wait_until_registered(token).await;
         task.abort();
         let _ = task.await;
 
@@ -2885,9 +2929,16 @@ mod tests {
     /// that lands while the cleanup is *waiting for the map lock*.
     ///
     /// Disarming before acquiring that lock made the window real, because the
-    /// guard would then drop already-unarmed and the removal never ran. This
-    /// drives the production helper with the lock held, cancels it mid-await,
-    /// and requires the entry to be gone regardless.
+    /// guard would then drop already-unarmed and the removal never ran.
+    ///
+    /// This drives `remove_pending_and_disarm`, which is the function the two
+    /// runtime-deny arms call, and cancels it while it is provably parked on
+    /// the contended lock. Driving the whole lifecycle here instead was tried
+    /// and rejected: there is no way to observe from outside that the spawned
+    /// task has reached the lock rather than an earlier await, so the
+    /// cancellation landed early, the guard dropped still-armed, and the test
+    /// passed against the defect it exists to catch. A racy test that cannot
+    /// fail is worse than a focused one that can.
     #[tokio::test]
     async fn cancellation_while_awaiting_the_map_lock_leaves_no_live_token() {
         let token = "lockct";


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `request_approval` registers a token in the process-global `PENDING_APPROVALS` map before it does anything else, and that token is a bearer credential for a tool-call decision. Two exits left an entry behind, so the decision stayed resolvable by whoever learned the code for the lifetime of the process.
  - The send is the first thing after registration, so a transient send failure propagated out through `?` with the entry already in the map and nothing later in the function ran. That path needs no cancellation to reach, which makes it the cheaper of the two. Discord and Signal already remove explicitly before returning a send error, so the Cloud transport was the odd one out rather than the pattern being unknown here.
  - Cancellation is the other. Every explicit cleanup lives inside the async body, so none of it runs when the future is dropped, which a caller-side timeout or a shutdown both do. `Drop` is the only hook that survives that, so the entry's lifetime is now tied to a guard rather than to any code path.
  - The guard is disarmed once a decision is taken through a normal path, so the existing removals still own their cleanup and nothing is removed twice.
- **Scope boundary:** does NOT change the map's public type, `pending_approvals()`, the reply-resolution path in the gateway, the token format, the timeout semantics, or anything on the Web, Discord, Signal or Matrix transports. The map deliberately stays process-global, because `pending_approvals_are_shared_across_instances` pins that the orchestrator and gateway instances share one, and the fix belongs in the cleanup path rather than in the storage.
- **Blast radius:** `crates/zeroclaw-channels/src/whatsapp.rs` only. The gateway's reply handler at `crates/zeroclaw-gateway/src/lib.rs` reads the same map and is unchanged; it still removes on a reply, which is why the success path disarms rather than removing twice. No caller signature moves.
- **Linked issue(s):** Related #9417. The private advisory that triage asked for on that issue has been filed and confirmed there. Not using a closing keyword, because whether this closes it is a maintainer call while that private report is open.
- **Labels:** `bug`, `channel`, `channel:whatsapp`, `domain:security`, `priority:p1`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A`. The two exits are a send failure and a dropped future, and both are cheaper to drive as tests than by hand; the regressions below do exactly that. A live Meta endpoint would be needed to reproduce the send failure manually, and I have not run one.
- **Interface(s) exercised:** `channel` = `whatsapp` (Cloud transport).

### How I tested

Focused local tests on the changed crate, with the feature that gates the module. The module is behind `channel-whatsapp-cloud`, so a default-feature run silently filters every test in it out; the first run I did reported `0 passed; 1324 filtered out`, which is worth naming because it looks like success.

```sh
$ cargo test -p zeroclaw-channels --lib --features channel-whatsapp-cloud
test whatsapp::tests::pending_approvals_are_shared_across_instances ... ok
test whatsapp::tests::a_disarmed_guard_removes_nothing ... ok
test whatsapp::tests::cancelled_request_leaves_no_live_token ... ok
test whatsapp::tests::send_failure_leaves_no_live_token ... ok
test result: ok. 1412 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 6.68s

$ cargo fmt -p zeroclaw-channels --check     # clean, no output
$ cargo clippy -p zeroclaw-channels --lib --features channel-whatsapp-cloud -- -D warnings
    Finished `dev` profile     # exit 0
```

The two leak regressions are mutation-checked, because a test that has never failed has not been shown to work. With `Drop` neutered, which is the behavior on `master`, they go red and the third still passes:

```sh
test whatsapp::tests::a_disarmed_guard_removes_nothing ... ok
test whatsapp::tests::send_failure_leaves_no_live_token ... FAILED
test whatsapp::tests::cancelled_request_leaves_no_live_token ... FAILED
test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 1410 filtered out
```

That third test is the control rather than a third case. A guard that removed unconditionally would satisfy both leak tests while breaking the normal path, where the gateway's reply handler has already taken the sender out of the map and a second removal would delete whatever registered next.

- **CI checks relied on and why they cover this change:** `Test` and `Clippy` cover the changed crate. `Semgrep` and `Security` cover the security-adjacent classification.
- **Known CI coverage gap, if any:** no live vendor smoke. The send-failure path is exercised by dropping the guard the way the `?` return does, not by a refused Meta request.
- **Beyond CI, what did you manually verify?** I traced all three exits in source at current master and confirmed the gateway reply handler removes on a reply, which is what makes disarming correct on the success path. I also read the sibling transports, which is where the Discord and Signal observation above comes from. I did NOT reproduce the leak against a live Meta endpoint, and I did not run the full workspace suite.
- **If any command was intentionally skipped, why:** full-workspace `cargo test` was skipped as the change is one file in one crate and the crate suite passes; CI runs the workspace.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`. The approval token is a bearer credential for a tool-call decision. This narrows its lifetime rather than widening it: entries that previously outlived their request are now removed when the request goes away. No token is logged, and none is added to any message.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`. Test tokens are six-character literals.
- Prompt injection or untrusted model-visible text introduced/changed? `No`

**Known residual, stated rather than left implied.** Cleanup here removes by token alone, because the Cloud map's value is a bare `oneshot::Sender` with no registration generation to compare against. So the replacement race that exists on the Web transport exists here too in principle: an entry removed by one path, a new registration reusing the same six-character code, and a delayed removal taking the newer one. Closing it properly needs a generation, which means changing the map's value type and therefore `pending_approvals()`, and that is wider than this issue. The direction of that failure is worse than a denial, and I would rather state it plainly. The gateway resolves by token alone (`map.remove(&token)` then `sender.send(response)`) with no binding to the replying chat or sender, so on a collision the decision can land on the wrong request: A is cancelled and its entry freed, B registers the same six-character token, and A's operator replies to a prompt still sitting in their chat. B receives that as an operator approval. That is a confused deputy granting authority, not withholding it. This change does not create the confused-deputy collision: registration already inserts by token without reserving a vacant slot, so a random collision could overwrite a live entry. The new eventual token-only cleanup can also remove a later colliding registration, which fails closed. The trade is still the right one. I would rather flag it here than have it read as an oversight, and I am glad to do the typed-value version as a follow-up if you would prefer that shape.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

- **Fast rollback command/path:** `git revert <sha>`. The change is additive in one file and nothing depends on the guard type.
- **Feature flags or config toggles:** `None`. The guard is unconditional inside `request_approval`.
- **Observable failure symptoms:** if the guard were to over-remove, an operator would see an approval reply refused for a token that should still be pending, and the agent would record a denial rather than the operator's decision. `a_disarmed_guard_removes_nothing` is the regression that covers that direction.



