### PR TITLE
fix(runtime): guide agents before tool iteration exhaustion

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -5167,14 +5167,27 @@ mod tests {
             .lock()
             .expect("recorded requests lock should be valid");
         assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].len(), 1);
+        assert_eq!(requests[0].len(), 2);
+        let system_message = requests[0]
+            .iter()
+            .find(|message| message.role == "system")
+            .expect("iteration budget warning should be present");
         assert!(
-            requests[0][0]
+            system_message
+                .content
+                .contains("Only 3 tool-call rounds remain")
+        );
+        let user_message = requests[0]
+            .iter()
+            .find(|message| message.role == "user")
+            .expect("degraded user message should be present");
+        assert!(
+            user_message
                 .content
                 .contains("1 attached image(s) could not be loaded")
         );
-        assert!(!requests[0][0].content.contains("[IMAGE:"));
-        assert!(!requests[0][0].content.contains(&oversized_payload));
+        assert!(!user_message.content.contains("[IMAGE:"));
+        assert!(!user_message.content.contains(&oversized_payload));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -5191,6 +5191,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn iteration_budget_warning_request_stays_within_context_budget() {
+        let model_provider = RecordingModelProvider::new();
+        let recorded_requests = Arc::clone(&model_provider.requests);
+        let old_payload = "old-context-".repeat(24);
+        let current_payload = "current-context-".repeat(24);
+        let mut history = vec![
+            ChatMessage::system("system"),
+            ChatMessage::user(format!("old request {old_payload}").as_str()),
+            ChatMessage::assistant(format!("old response {old_payload}").as_str()),
+            ChatMessage::user(format!("current request {current_payload}").as_str()),
+        ];
+        let context_token_budget = crate::agent::history::estimate_history_tokens(&history);
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let observer = NoopObserver;
+        let turn_id = uuid::Uuid::new_v4().to_string();
+
+        let result = run_tool_call_loop(ToolLoop {
+            parent_agent_alias: None,
+            sop_reassembly: None,
+            exec: ResolvedAgentExecution {
+                model_access: ResolvedModelAccess {
+                    model_provider: &model_provider,
+                    provider_name: "mock-provider",
+                    model: "mock-model",
+                    temperature: Some(0.0),
+                },
+                tools_registry: &tools_registry,
+                observer: &observer,
+                silent: true,
+                approval: None,
+                multimodal_config: &zeroclaw_config::schema::MultimodalConfig::default(),
+                config: None,
+                max_tool_iterations: 3,
+                hooks: None,
+                excluded_tools: &[],
+                dedup_exempt_tools: &[],
+                activated_tools: None,
+                model_switch_callback: None,
+                pacing: &zeroclaw_config::schema::PacingConfig::default(),
+                strict_tool_parsing: false,
+                parallel_tools: false,
+                max_tool_result_chars: 0,
+                context_token_budget,
+                receipt_generator: None,
+                knobs: &LoopKnobs::default(),
+            },
+            history: &mut history,
+            channel_name: "cli",
+            channel_reply_target: None,
+            cancellation_token: None,
+            on_delta: None,
+            shared_budget: None,
+            channel: None,
+            collected_receipts: None,
+            event_tx: None,
+            steering: None,
+            new_messages_out: None,
+            image_cache: None,
+            memory: None,
+            ingress: IngressContext::sub_turn(),
+            agent_alias: None,
+            turn_id: &turn_id,
+        })
+        .await
+        .expect("warning-bearing request should reach the provider");
+
+        assert_eq!(result, "done");
+        let requests = recorded_requests
+            .lock()
+            .expect("recorded requests lock should be valid");
+        assert_eq!(requests.len(), 1, "provider should receive one request");
+        let request = &requests[0];
+        assert!(
+            request
+                .iter()
+                .any(|message| message.content.contains("<tool-iteration-budget>")),
+            "near-limit request should retain the iteration warning"
+        );
+        assert!(
+            crate::agent::history::estimate_history_tokens(request) <= context_token_budget,
+            "warning-bearing provider request must stay within the configured context budget"
+        );
+        assert!(
+            request
+                .iter()
+                .all(|message| !message.content.contains(&old_payload)),
+            "oldest turn should be trimmed to reserve warning capacity"
+        );
+        assert!(
+            request
+                .iter()
+                .any(|message| message.content.contains(&current_payload)),
+            "current turn must remain in the provider request"
+        );
+    }
+
+    #[tokio::test]
     async fn run_tool_call_loop_degrades_carried_over_image_on_non_vision_provider() {
         let model_provider = RecordingModelProvider::new();
         let recorded_requests = Arc::clone(&model_provider.requests);

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -280,13 +280,9 @@ impl<'a> TurnState<'a> {
     }
 }
 
-/// Add a provider-only warning when the tool-loop budget is nearly exhausted.
-///
-/// Callers pass the per-iteration prepared-message clone so the warning guides
-/// the active response without becoming part of canonical session history.
-fn inject_iteration_budget_warning(messages: &mut Vec<ChatMessage>, remaining: usize) {
+fn iteration_budget_warning(remaining: usize) -> Option<String> {
     if remaining == 0 || remaining > ITERATION_BUDGET_WARNING_THRESHOLD {
-        return;
+        return None;
     }
 
     let guidance = if remaining == 1 {
@@ -302,11 +298,43 @@ fn inject_iteration_budget_warning(messages: &mut Vec<ChatMessage>, remaining: u
              blocked actions or spend the remaining rounds on optional discovery."
         )
     };
-    let warning = format!(
+    Some(format!(
         "{ITERATION_BUDGET_WARNING_MARKER}\n\
          {guidance}\n\
          </tool-iteration-budget>"
-    );
+    ))
+}
+
+fn iteration_budget_warning_token_cost(messages: &[ChatMessage], warning: &str) -> usize {
+    if let Some(system_message) = messages.iter().find(|message| message.role == "system") {
+        let before =
+            crate::agent::history::estimate_history_tokens(std::slice::from_ref(system_message));
+        let mut augmented = system_message.clone();
+        augmented.content.push_str("\n\n");
+        augmented.content.push_str(warning);
+        crate::agent::history::estimate_history_tokens(std::slice::from_ref(&augmented))
+            .saturating_sub(before)
+    } else {
+        crate::agent::history::estimate_history_tokens(&[ChatMessage::system(warning.to_owned())])
+    }
+}
+
+/// Add a provider-only warning when the tool-loop budget is nearly exhausted.
+///
+/// Callers pass the per-iteration prepared-message clone so the warning guides
+/// the active response without becoming part of canonical session history.
+fn inject_iteration_budget_warning(
+    messages: &mut Vec<ChatMessage>,
+    warning: &str,
+    context_token_budget: usize,
+) -> bool {
+    let estimated_tokens = crate::agent::history::estimate_history_tokens(messages);
+    let warning_tokens = iteration_budget_warning_token_cost(messages, warning);
+    if context_token_budget > 0
+        && estimated_tokens.saturating_add(warning_tokens) > context_token_budget
+    {
+        return false;
+    }
 
     if let Some(system_message) = messages.iter_mut().find(|message| message.role == "system") {
         if !system_message
@@ -314,11 +342,12 @@ fn inject_iteration_budget_warning(messages: &mut Vec<ChatMessage>, remaining: u
             .contains(ITERATION_BUDGET_WARNING_MARKER)
         {
             system_message.content.push_str("\n\n");
-            system_message.content.push_str(&warning);
+            system_message.content.push_str(warning);
         }
     } else {
-        messages.insert(0, ChatMessage::system(warning));
+        messages.insert(0, ChatMessage::system(warning.to_owned()));
     }
+    true
 }
 
 pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
@@ -561,9 +590,30 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
 
         preflight_history_maintenance(turn_state.history);
 
-        if iteration == 0 && context_token_budget > 0 {
+        let warning_candidate = iteration_budget_warning(remaining_iterations);
+        let candidate_token_reserve = warning_candidate.as_deref().map_or(0, |warning| {
+            iteration_budget_warning_token_cost(turn_state.history, warning)
+        });
+        let iteration_budget_warning = warning_candidate.filter(|_| {
+            context_token_budget == 0 || candidate_token_reserve < context_token_budget
+        });
+        let warning_token_reserve = if iteration_budget_warning.is_some() {
+            candidate_token_reserve
+        } else {
+            0
+        };
+        let prepared_history_budget = if context_token_budget > 0 {
+            context_token_budget
+                .saturating_sub(warning_token_reserve)
+                .max(1)
+        } else {
+            0
+        };
+
+        if context_token_budget > 0 && (iteration == 0 || iteration_budget_warning.is_some()) {
             let system_floor =
-                crate::agent::history::estimate_system_floor_tokens(turn_state.history);
+                crate::agent::history::estimate_system_floor_tokens(turn_state.history)
+                    .saturating_add(warning_token_reserve);
             if system_floor >= context_token_budget {
                 let __zc_floor_span = ::zeroclaw_log::info_span!(
                     target: "zeroclaw_log_internal_scope",
@@ -588,7 +638,7 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
                     )
                 );
             }
-            let result = turn_state.trim_to_budget(context_token_budget);
+            let result = turn_state.trim_to_budget(prepared_history_budget);
             if result.trimmed {
                 {
                     let __zc_trim_span = ::zeroclaw_log::info_span!(
@@ -607,6 +657,8 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
                                 "dropped_turns": result.dropped_turns,
                                 "kept_turns": result.kept_turns,
                                 "budget_tokens": context_token_budget,
+                                "prepared_history_budget": prepared_history_budget,
+                                "iteration_warning_tokens": warning_token_reserve,
                                 "tokens_before": result.tokens_before,
                                 "tokens_after": result.tokens_after,
                                 "tokens_reclaimed": result.tokens_before.saturating_sub(result.tokens_after),
@@ -714,7 +766,27 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
             image_cache.as_deref_mut(),
         )
         .await?;
-        inject_iteration_budget_warning(&mut prepared_messages.messages, remaining_iterations);
+        if let Some(warning) = iteration_budget_warning.as_deref()
+            && !inject_iteration_budget_warning(
+                &mut prepared_messages.messages,
+                warning,
+                context_token_budget,
+            )
+        {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_category(::zeroclaw_log::EventCategory::Agent)
+                    .with_attrs(::serde_json::json!({
+                        "remaining_iterations": remaining_iterations,
+                        "budget_tokens": context_token_budget,
+                        "estimated_tokens": crate::agent::history::estimate_history_tokens(
+                            &prepared_messages.messages,
+                        ),
+                    })),
+                "iteration budget warning omitted to keep provider request within context budget"
+            );
+        }
 
         let llm_started_at = announce_llm_request(
             &ctx,
@@ -2291,10 +2363,12 @@ mod surface3_tests {
         let original = make_system_prompt(NATIVE_TOOLS_TASK_FRAMING);
         let mut messages = vec![original.clone(), ChatMessage::user("task")];
 
-        inject_iteration_budget_warning(&mut messages, 4);
+        let warning = iteration_budget_warning(4);
+        assert!(warning.is_none());
         assert_eq!(messages[0].content, original.content);
 
-        inject_iteration_budget_warning(&mut messages, 3);
+        let warning = iteration_budget_warning(3).expect("warning at threshold");
+        assert!(inject_iteration_budget_warning(&mut messages, &warning, 0));
         assert!(
             messages[0]
                 .content
@@ -2314,7 +2388,8 @@ mod surface3_tests {
             ChatMessage::user("task"),
         ];
 
-        inject_iteration_budget_warning(&mut messages, 1);
+        let warning = iteration_budget_warning(1).expect("final-round warning");
+        assert!(inject_iteration_budget_warning(&mut messages, &warning, 0));
 
         assert!(
             messages[0]
@@ -2328,7 +2403,8 @@ mod surface3_tests {
     fn iteration_budget_warning_can_prepare_user_only_history() {
         let mut messages = vec![ChatMessage::user("task")];
 
-        inject_iteration_budget_warning(&mut messages, 1);
+        let warning = iteration_budget_warning(1).expect("final-round warning");
+        assert!(inject_iteration_budget_warning(&mut messages, &warning, 0));
 
         assert_eq!(messages[0].role, "system");
         assert!(
@@ -2337,6 +2413,22 @@ mod surface3_tests {
                 .contains(ITERATION_BUDGET_WARNING_MARKER)
         );
         assert_eq!(messages[1].role, "user");
+    }
+
+    #[test]
+    fn iteration_budget_warning_is_omitted_without_context_headroom() {
+        let mut messages = vec![ChatMessage::user("task")];
+        let context_token_budget = crate::agent::history::estimate_history_tokens(&messages);
+        let warning = iteration_budget_warning(1).expect("final-round warning");
+
+        assert!(!inject_iteration_budget_warning(
+            &mut messages,
+            &warning,
+            context_token_budget,
+        ));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content, "task");
     }
 }
 

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -82,6 +82,13 @@ use zeroclaw_providers::{ChatMessage, ModelProvider};
 /// Maximum malformed internal tool-protocol retries before returning a safe fallback.
 pub(crate) const MAX_MALFORMED_TOOL_PROTOCOL_RETRIES: usize = 2;
 
+/// Number of remaining tool-call rounds at which the model starts receiving
+/// explicit budget guidance. Three rounds leave room to finish the requested
+/// work and perform one essential validation step before graceful shutdown.
+const ITERATION_BUDGET_WARNING_THRESHOLD: usize = 3;
+
+const ITERATION_BUDGET_WARNING_MARKER: &str = "<tool-iteration-budget>";
+
 /// Default maximum agentic tool-use iterations per user message to prevent runaway loops.
 /// Used as a safe fallback when `max_tool_iterations` is unset or configured as zero.
 pub(crate) const DEFAULT_MAX_TOOL_ITERATIONS: usize = 10;
@@ -270,6 +277,47 @@ impl<'a> TurnState<'a> {
         }
         *self.history = history;
         result
+    }
+}
+
+/// Add a provider-only warning when the tool-loop budget is nearly exhausted.
+///
+/// Callers pass the per-iteration prepared-message clone so the warning guides
+/// the active response without becoming part of canonical session history.
+fn inject_iteration_budget_warning(messages: &mut Vec<ChatMessage>, remaining: usize) {
+    if remaining == 0 || remaining > ITERATION_BUDGET_WARNING_THRESHOLD {
+        return;
+    }
+
+    let guidance = if remaining == 1 {
+        "Only 1 tool-call round remains, including the current response. \
+         If the requested work is complete or available validation is blocked, do not call \
+         another tool; return the final answer now. Use a tool only if it is required to \
+         complete the request."
+            .to_string()
+    } else {
+        format!(
+            "Only {remaining} tool-call rounds remain, including the current response. \
+             Prioritize completing the user's request and essential validation. Do not repeat \
+             blocked actions or spend the remaining rounds on optional discovery."
+        )
+    };
+    let warning = format!(
+        "{ITERATION_BUDGET_WARNING_MARKER}\n\
+         {guidance}\n\
+         </tool-iteration-budget>"
+    );
+
+    if let Some(system_message) = messages.iter_mut().find(|message| message.role == "system") {
+        if !system_message
+            .content
+            .contains(ITERATION_BUDGET_WARNING_MARKER)
+        {
+            system_message.content.push_str("\n\n");
+            system_message.content.push_str(&warning);
+        }
+    } else {
+        messages.insert(0, ChatMessage::system(warning));
     }
 }
 
@@ -491,6 +539,8 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
             return Err(ToolLoopCancelled.into());
         }
 
+        let mut remaining_iterations = max_iterations.saturating_sub(iteration);
+
         // Shared iteration budget: parent + subagents share a global counter
         if let Some(ref budget) = shared_budget {
             let remaining = budget.load(std::sync::atomic::Ordering::Relaxed);
@@ -505,6 +555,7 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
                 );
                 break;
             }
+            remaining_iterations = remaining_iterations.min(remaining);
             budget.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         }
 
@@ -656,13 +707,14 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
 
         refresh_prompt_anchor(turn_state.history, use_native_tools);
 
-        let prepared_messages = prepare_messages_for_iteration(
+        let mut prepared_messages = prepare_messages_for_iteration(
             turn_state.history,
             multimodal_config,
             degrade_strip_images,
             image_cache.as_deref_mut(),
         )
         .await?;
+        inject_iteration_budget_warning(&mut prepared_messages.messages, remaining_iterations);
 
         let llm_started_at = announce_llm_request(
             &ctx,
@@ -2232,6 +2284,59 @@ mod surface3_tests {
         let mut history: Vec<ChatMessage> = Vec::new();
         refresh_prompt_anchor(&mut history, false);
         // Just verifying no panic.
+    }
+
+    #[test]
+    fn iteration_budget_warning_starts_with_three_rounds_remaining() {
+        let original = make_system_prompt(NATIVE_TOOLS_TASK_FRAMING);
+        let mut messages = vec![original.clone(), ChatMessage::user("task")];
+
+        inject_iteration_budget_warning(&mut messages, 4);
+        assert_eq!(messages[0].content, original.content);
+
+        inject_iteration_budget_warning(&mut messages, 3);
+        assert!(
+            messages[0]
+                .content
+                .contains("Only 3 tool-call rounds remain")
+        );
+        assert!(
+            messages[0]
+                .content
+                .contains("Do not repeat blocked actions")
+        );
+    }
+
+    #[test]
+    fn iteration_budget_warning_counts_down_to_final_round() {
+        let mut messages = vec![
+            make_system_prompt(NATIVE_TOOLS_TASK_FRAMING),
+            ChatMessage::user("task"),
+        ];
+
+        inject_iteration_budget_warning(&mut messages, 1);
+
+        assert!(
+            messages[0]
+                .content
+                .contains("Only 1 tool-call round remains")
+        );
+        assert!(messages[0].content.contains("return the final answer now"));
+    }
+
+    #[test]
+    fn iteration_budget_warning_can_prepare_user_only_history() {
+        let mut messages = vec![ChatMessage::user("task")];
+
+        inject_iteration_budget_warning(&mut messages, 1);
+
+        assert_eq!(messages[0].role, "system");
+        assert!(
+            messages[0]
+                .content
+                .contains(ITERATION_BUDGET_WARNING_MARKER)
+        );
+        assert_eq!(messages[1].role, "user");
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add transient completion guidance during the final three tool-call rounds so agents prioritize completing requested work and essential validation.
  - Reserve the warning's estimated token cost before bounded history preparation and omit it when the final prepared request cannot fit within the configured context budget.
  - Add the guidance only to the provider-message clone so canonical session history remains free of the transient instruction.
  - When a caller supplies `Some(shared_budget)`, use the smaller local or shared remainder for the countdown.
- **Scope boundary:** This does not increase configured iteration limits, wire shared iteration budgets into current production constructors, alter tool permissions or approvals, persist the warning, or affect requests before the final three rounds.
- **Blast radius:** Current production tool loops use the local iteration remainder.
  The existing optional shared-budget seam follows the same countdown only when a caller supplies it.
- **Linked issue(s):** Related #9201 and #9323 for the separately scoped execution-tree budget design.
- **Labels:** `bug`, `agent`, `runtime`, `agent:prompt`, `priority:p2`, `needs-author-action`, `risk:high`, `size:M`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes.
  Model behavior is nondeterministic, but an A/B run can confirm the intended completion improvement.
- **Interface(s) exercised:** `surface=cli`; no messaging channel.
- **Setup / preconditions:** Use the same provider, model, agent, ten-round runtime profile, and failing multi-step fixture on both `master` and this branch.
- **Steps to run:**

```sh
cargo build --bin zeroclaw
target/debug/zeroclaw agent -a assistant -m \
  "Fix the failing receipt total bug in the workspace, run the focused tests needed to verify it, and report the result."
```

- **Expected on this branch (after):** During the final three rounds, the provider receives static budget guidance when the warning-bearing request fits the configured context budget.
  In the retained runs, the agent completed the edit and essential validation before the limit.
- **Prior behavior on `master` (before):** In the retained master-base reproduction, the agent diagnosed the bug but spent the remaining rounds on additional tool calls and reached the limit without editing the fixture.

### How I tested

- **CI checks relied on and why they cover this change:** The fresh `CI Required Gate`, `Lint`, `Test`, `Format`, `Semgrep`, and platform compile checks on the published head are required before merge.
- **Known CI coverage gap, if any:** Deterministic tests cannot prove that an LLM will always make the desired planning choice.
  Two retained provider-backed CLI runs cover the behavioral intent.
- **Commands run and tail output:**

```sh
cargo test -p zeroclaw-runtime iteration_budget_warning -- --nocapture
# test result: ok. 5 passed; 0 failed

cargo test -p zeroclaw-runtime run_tool_call_loop_skips_oversized_image_payload -- --nocapture
# test result: ok. 1 passed; 0 failed

cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings
# Finished `dev` profile

cargo fmt --all -- --check
git diff --check
```

- **Beyond CI, what did you manually verify?** Two retained CLI runs completed the correct source edit and passed all four external fixture tests.
  The new provider-boundary regression starts from a request exactly at the configured heuristic budget, verifies that the provider receives the warning, verifies that the oldest complete turn is trimmed, and verifies that the final request remains within budget.
- **If any command was intentionally skipped, why:** The complete runtime suite was not repeated locally after merging current `master`.
  Fresh current-head CI remains the full-suite evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `Yes`
- If any `Yes`, describe the risk and mitigation: A static trusted system instruction is added during the final three rounds and can influence completion behavior.
  It contains no user-controlled or tool-controlled content, is bounded to the configured iteration window and context budget, and is never written into canonical history.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert --no-commit b1881067e3f357503585bad8ab1dc9c2c17f06cd cb6cfd850ab4ecbeffeb2c6433a50530410131db && git commit`
- **Feature flags or config toggles:** None.
  Existing `max_tool_iterations` configuration still controls the total local budget.
- **Observable failure symptoms:** Agents return final answers too early during the final three rounds, completion quality regresses near exhaustion, provider requests exceed the configured context budget after warning injection, or provider messages contain `<tool-iteration-budget>` outside the final three rounds.
