### PR TITLE
fix(shell): allow safe Python validation modules

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1132,6 +1132,53 @@ fn command_basename(raw: &str) -> &str {
     after_fwd.rsplit('\\').next().unwrap_or(after_fwd)
 }
 
+fn python_module_is_safe(module: &str, workspace_dir: &Path) -> bool {
+    if matches!(module, "unittest" | "pytest" | "mypy" | "json.tool") {
+        return true;
+    }
+
+    let valid_local_name = module.split('.').all(|component| {
+        let mut chars = component.chars();
+        chars
+            .next()
+            .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+            && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    });
+    if !valid_local_name {
+        return false;
+    }
+
+    let Ok(workspace) = workspace_dir.canonicalize() else {
+        return false;
+    };
+    let relative = module.replace('.', std::path::MAIN_SEPARATOR_STR);
+    let module_file = workspace.join(format!("{relative}.py"));
+    let package_entrypoint = workspace.join(relative).join("__main__.py");
+    [module_file, package_entrypoint]
+        .iter()
+        .filter_map(|candidate| candidate.canonicalize().ok())
+        .any(|candidate| candidate.starts_with(&workspace))
+}
+
+fn python_args_safe(args: &[String], workspace_dir: &Path) -> bool {
+    for (index, arg) in args.iter().enumerate() {
+        if arg.starts_with("-c") {
+            return false;
+        }
+
+        if arg == "-m" {
+            return args
+                .get(index + 1)
+                .is_some_and(|module| python_module_is_safe(module, workspace_dir));
+        }
+        if let Some(module) = arg.strip_prefix("-m").filter(|module| !module.is_empty()) {
+            return python_module_is_safe(module, workspace_dir);
+        }
+    }
+
+    true
+}
+
 /// Strip common Windows executable suffixes (.exe, .cmd, .bat) for uniform
 /// matching against allowlists and risk tables. On non-Windows platforms this
 /// is a no-op that returns the input unchanged.
@@ -1516,9 +1563,7 @@ impl SecurityPolicy {
                             || arg.starts_with("alias.")
                     })
             }
-            "python" | "python3" => !args
-                .iter()
-                .any(|arg| arg.starts_with("-c") || arg.starts_with("-m")),
+            "python" | "python3" => python_args_safe(args, &self.workspace_dir),
             "node" => {
                 // -e/--eval evaluates argument as JavaScript
                 // -p/--print same as --eval but prints the result
@@ -3519,10 +3564,9 @@ mod tests {
         assert!(!p.is_command_allowed("python -c '__import__(\"os\").system(\"id\")'"));
         assert!(!p.is_command_allowed("python3 -m http.server"));
         assert!(!p.is_command_allowed("python3 -m pip install evil"));
-        // Broad -m block: these are intentional collateral
-        assert!(!p.is_command_allowed("python3 -m pytest"));
-        assert!(!p.is_command_allowed("python3 -m mypy src/"));
         assert!(!p.is_command_allowed("python3 -m venv .venv"));
+        assert!(!p.is_command_allowed("python3 -m local_package"));
+        assert!(!p.is_command_allowed("python3 -m"));
         // Glued form: -mhttp.server is one token
         assert!(!p.is_command_allowed("python3 -mhttp.server"));
         // node: -e/--eval evaluates JS, -p/--print evaluates and prints
@@ -3537,6 +3581,33 @@ mod tests {
         assert!(!p.is_command_allowed("node -e'process.exit()'"));
         // Flag with other args before it
         assert!(!p.is_command_allowed("python3 -W ignore -c 'import os'"));
+    }
+
+    #[test]
+    fn python_validation_modules_allowed() {
+        let p = default_policy();
+        assert!(p.is_command_allowed("python3 -m unittest discover -s tests -v"));
+        assert!(p.is_command_allowed("python3 -munittest discover -s tests"));
+        assert!(p.is_command_allowed("python3 -m pytest"));
+        assert!(p.is_command_allowed("python3 -m mypy src/"));
+        assert!(p.is_command_allowed("python3 -m json.tool package.json"));
+    }
+
+    #[test]
+    fn python_local_workspace_module_allowed() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let package = workspace.path().join("receipt");
+        std::fs::create_dir(&package).expect("package directory");
+        std::fs::write(package.join("__main__.py"), "print('ok')\n").expect("package entrypoint");
+        let p = SecurityPolicy {
+            workspace_dir: workspace.path().to_path_buf(),
+            ..default_policy()
+        };
+
+        assert!(p.is_command_allowed("python3 -m receipt"));
+        assert!(p.is_command_allowed("python3 -mreceipt"));
+        assert!(!p.is_command_allowed("python3 -m missing_package"));
+        assert!(!p.is_command_allowed("python3 -m ../receipt"));
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1132,12 +1132,34 @@ fn command_basename(raw: &str) -> &str {
     after_fwd.rsplit('\\').next().unwrap_or(after_fwd)
 }
 
+fn path_resolves_within(path: &Path, root: &Path) -> bool {
+    path.canonicalize()
+        .is_ok_and(|resolved| resolved.starts_with(root))
+}
+
+fn python_package_path_is_safe(components: &[&str], workspace: &Path) -> bool {
+    let mut package_dir = workspace.to_path_buf();
+    for component in components {
+        package_dir.push(component);
+        if !path_resolves_within(&package_dir, workspace) {
+            return false;
+        }
+
+        let initializer = package_dir.join("__init__.py");
+        if initializer.exists() && !path_resolves_within(&initializer, workspace) {
+            return false;
+        }
+    }
+    true
+}
+
 fn python_module_is_safe(module: &str, workspace_dir: &Path) -> bool {
     if matches!(module, "unittest" | "pytest" | "mypy" | "json.tool") {
         return true;
     }
 
-    let valid_local_name = module.split('.').all(|component| {
+    let components = module.split('.').collect::<Vec<_>>();
+    let valid_local_name = components.iter().all(|component| {
         let mut chars = component.chars();
         chars
             .next()
@@ -1151,13 +1173,24 @@ fn python_module_is_safe(module: &str, workspace_dir: &Path) -> bool {
     let Ok(workspace) = workspace_dir.canonicalize() else {
         return false;
     };
-    let relative = module.replace('.', std::path::MAIN_SEPARATOR_STR);
-    let module_file = workspace.join(format!("{relative}.py"));
-    let package_entrypoint = workspace.join(relative).join("__main__.py");
-    [module_file, package_entrypoint]
+    let Some((leaf, parents)) = components.split_last() else {
+        return false;
+    };
+    if !python_package_path_is_safe(parents, &workspace) {
+        return false;
+    }
+
+    let parent_dir = parents
         .iter()
-        .filter_map(|candidate| candidate.canonicalize().ok())
-        .any(|candidate| candidate.starts_with(&workspace))
+        .fold(workspace.clone(), |path, component| path.join(component));
+    let module_file = parent_dir.join(format!("{leaf}.py"));
+    if path_resolves_within(&module_file, &workspace) {
+        return true;
+    }
+
+    let package_components = components.as_slice();
+    python_package_path_is_safe(package_components, &workspace)
+        && path_resolves_within(&parent_dir.join(leaf).join("__main__.py"), &workspace)
 }
 
 fn python_args_safe(args: &[String], workspace_dir: &Path) -> bool {
@@ -1563,7 +1596,7 @@ impl SecurityPolicy {
                             || arg.starts_with("alias.")
                     })
             }
-            "python" | "python3" => python_args_safe(args, &self.workspace_dir),
+            "python" | "python3" => python_args_safe(args_cased, &self.workspace_dir),
             "node" => {
                 // -e/--eval evaluates argument as JavaScript
                 // -p/--print same as --eval but prints the result
@@ -3591,6 +3624,7 @@ mod tests {
         assert!(p.is_command_allowed("python3 -m pytest"));
         assert!(p.is_command_allowed("python3 -m mypy src/"));
         assert!(p.is_command_allowed("python3 -m json.tool package.json"));
+        assert!(!p.is_command_allowed("python3 -m PyTeSt"));
     }
 
     #[test]
@@ -3608,6 +3642,30 @@ mod tests {
         assert!(p.is_command_allowed("python3 -mreceipt"));
         assert!(!p.is_command_allowed("python3 -m missing_package"));
         assert!(!p.is_command_allowed("python3 -m ../receipt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn python_local_module_rejects_symlinked_package_escape() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside directory");
+        std::fs::write(workspace.path().join("task.py"), "print('safe')\n")
+            .expect("workspace module");
+        std::fs::write(outside.path().join("__init__.py"), "print('outside')\n")
+            .expect("outside package initializer");
+        std::os::unix::fs::symlink(
+            workspace.path().join("task.py"),
+            outside.path().join("task.py"),
+        )
+        .expect("module symlink");
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("receipt"))
+            .expect("package symlink");
+        let p = SecurityPolicy {
+            workspace_dir: workspace.path().to_path_buf(),
+            ..default_policy()
+        };
+
+        assert!(!p.is_command_allowed("python3 -m receipt.task"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -325,6 +325,11 @@ impl Tool for ShellTool {
             anyhow::Error::msg(format!("Sandbox error: {e}"))
         })?;
 
+        // Wrapping backends replace the command and therefore discard the
+        // current directory set by the runtime adapter. Reapply the workspace
+        // so the sandboxed shell starts inside the directory its policy grants.
+        cmd.current_dir(&self.security.workspace_dir);
+
         cmd.env_clear();
 
         for var in collect_allowed_shell_env_vars(&self.security) {
@@ -1496,6 +1501,67 @@ mod tests {
         assert_eq!(
             cmd.get_args().map(|a| a.to_os_string()).collect::<Vec<_>>(),
             args_before
+        );
+    }
+
+    #[cfg(unix)]
+    struct ReplacingSandbox;
+
+    #[cfg(unix)]
+    impl Sandbox for ReplacingSandbox {
+        fn wrap_command(&self, cmd: &mut std::process::Command) -> std::io::Result<()> {
+            let program = cmd.get_program().to_os_string();
+            let args = cmd.get_args().map(ToOwned::to_owned).collect::<Vec<_>>();
+            let mut replacement = std::process::Command::new(program);
+            replacement.args(args);
+            *cmd = replacement;
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        fn name(&self) -> &str {
+            "replacing-test-sandbox"
+        }
+
+        fn description(&self) -> &str {
+            "Test sandbox that replaces the command"
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_reapplies_workspace_after_sandbox_wrap() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: workspace.path().to_path_buf(),
+            allowed_commands: vec!["pwd".into()],
+            ..SecurityPolicy::default()
+        });
+        let tool =
+            ShellTool::new_with_sandbox(security, test_runtime(), Arc::new(ReplacingSandbox));
+
+        let result = tool
+            .execute(json!({"command": "pwd"}))
+            .await
+            .expect("pwd should execute");
+
+        assert!(
+            result.success,
+            "unexpected shell failure: {:?}",
+            result.error
+        );
+        assert_eq!(
+            result.output.trim(),
+            workspace
+                .path()
+                .canonicalize()
+                .expect("canonical workspace")
+                .to_string_lossy(),
+            "sandboxed command must run from the configured workspace"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -325,11 +325,6 @@ impl Tool for ShellTool {
             anyhow::Error::msg(format!("Sandbox error: {e}"))
         })?;
 
-        // Wrapping backends replace the command and therefore discard the
-        // current directory set by the runtime adapter. Reapply the workspace
-        // so the sandboxed shell starts inside the directory its policy grants.
-        cmd.current_dir(&self.security.workspace_dir);
-
         cmd.env_clear();
 
         for var in collect_allowed_shell_env_vars(&self.security) {
@@ -1501,67 +1496,6 @@ mod tests {
         assert_eq!(
             cmd.get_args().map(|a| a.to_os_string()).collect::<Vec<_>>(),
             args_before
-        );
-    }
-
-    #[cfg(unix)]
-    struct ReplacingSandbox;
-
-    #[cfg(unix)]
-    impl Sandbox for ReplacingSandbox {
-        fn wrap_command(&self, cmd: &mut std::process::Command) -> std::io::Result<()> {
-            let program = cmd.get_program().to_os_string();
-            let args = cmd.get_args().map(ToOwned::to_owned).collect::<Vec<_>>();
-            let mut replacement = std::process::Command::new(program);
-            replacement.args(args);
-            *cmd = replacement;
-            Ok(())
-        }
-
-        fn is_available(&self) -> bool {
-            true
-        }
-
-        fn name(&self) -> &str {
-            "replacing-test-sandbox"
-        }
-
-        fn description(&self) -> &str {
-            "Test sandbox that replaces the command"
-        }
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn shell_reapplies_workspace_after_sandbox_wrap() {
-        let workspace = tempfile::tempdir().expect("workspace");
-        let security = Arc::new(SecurityPolicy {
-            autonomy: AutonomyLevel::Supervised,
-            workspace_dir: workspace.path().to_path_buf(),
-            allowed_commands: vec!["pwd".into()],
-            ..SecurityPolicy::default()
-        });
-        let tool =
-            ShellTool::new_with_sandbox(security, test_runtime(), Arc::new(ReplacingSandbox));
-
-        let result = tool
-            .execute(json!({"command": "pwd"}))
-            .await
-            .expect("pwd should execute");
-
-        assert!(
-            result.success,
-            "unexpected shell failure: {:?}",
-            result.error
-        );
-        assert_eq!(
-            result.output.trim(),
-            workspace
-                .path()
-                .canonicalize()
-                .expect("canonical workspace")
-                .to_string_lossy(),
-            "sandboxed command must run from the configured workspace"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Permit `python -m` for known validation modules and valid workspace-local modules.
  - Validate module names with their original case and require package directories, initializers, module files, and entry points to resolve inside the canonical workspace.
  - Continue rejecting execution flags, unsafe modules, traversal, differently cased allowlist impersonators, and symlink package escapes.
  - Drop this PR's generic post-wrapper cwd behavior because current `master` now owns Seatbelt cwd preservation in its backend-specific, pinned-launcher implementation from #9401.
- **Scope boundary:** This does not expand the configured command allowlist, weaken shell approvals, permit package installation or arbitrary installed modules, or change Firejail, Bubblewrap, Docker, Landlock, or Seatbelt filesystem and launcher behavior.
- **Blast radius:** Only `python` and `python3` argument policy for `-m` module execution changes.
- **Linked issue(s):** None.
- **Labels:** `bug`, `config`, `security:policy`, `domain:security`, `priority:p2`, `needs-author-action`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes.
  A configured CLI agent can demonstrate the command-policy change.
- **Interface(s) exercised:** `surface=cli`; no messaging channel.
- **Setup / preconditions:** Use a configured agent whose risk profile enables the shell tool and allows `python3`.
  Place a small unittest suite in that agent's workspace.
- **Steps to run:**

```sh
cargo build --bin zeroclaw
target/debug/zeroclaw agent -a assistant -m \
  "Run python3 -m unittest discover -s tests -v in the workspace and report only the test result."
```

- **Expected on this branch (after):** The exact validation command is admitted by policy and runs through the existing backend-specific sandbox path.
- **Prior behavior on `master` (before):** The policy rejects every `python -m` invocation.

### How I tested

- **CI checks relied on and why they cover this change:** The fresh `CI Required Gate`, `Lint`, `Test`, `Format`, `Security`, Landlock, and platform compile checks on the published head are required before merge.
- **Known CI coverage gap, if any:** Real Firejail and Bubblewrap execution are not required for the final diff because the generic cwd change that affected those backends has been removed.
  Windows symlink execution was not exercised locally, while the shared policy path is covered by platform compilation and the symlink escape regression is Unix-gated.
- **Commands run and tail output:**

```sh
cargo test -p zeroclaw-config python_
# test result: ok. 3 passed; 0 failed

cargo test -p zeroclaw-runtime seatbelt_
# test result: ok. 10 passed; 0 failed

cargo test -p zeroclaw-runtime shell_executes_with_sandbox
# test result: ok. 1 passed; 0 failed

cargo clippy -p zeroclaw-config --lib --tests -- -D warnings
# Finished `dev` profile

cargo fmt --all -- --check
git diff --check
```

- **Beyond CI, what did you manually verify?** A retained provider-backed CLI run admitted the validator command, edited the receipt fixture, and passed all four fixture tests inside the sandbox.
  On the current head, the actual Seatbelt execution regression passed and confirmed cwd preservation through the pinned backend launcher.
- **If any command was intentionally skipped, why:** The complete config and runtime suites were not repeated locally after merging current `master`.
  Fresh current-head CI remains the full-suite evidence.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: The shell policy permits a bounded set of `python -m` executions that the prior blanket block rejected.
  Known validators are explicitly allowlisted; local modules must use valid identifiers and resolve entirely inside the canonical workspace; command approvals, configured allowlists, path checks, and sandbox enforcement remain active.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade steps required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert --no-commit 5e1cc9fc092742d153117b28ad03e5f0b0eb2850 5d776e89d8a9c4ad64e5fd310470565357b302c8 cea3069787179ba5bcb58ccca4f0c6764ee47baf && git commit`
- **Feature flags or config toggles:** Remove `python` and `python3` from the applicable risk profile's `allowed_commands`, or disable the shell tool for immediate containment.
- **Observable failure symptoms:** Safe Python module commands are unexpectedly denied, differently cased or external modules are accepted, or symlinked package paths escape the canonical workspace check.
