### PR TITLE
fix(deps): update nostr-relay-pool for RUSTSEC-2026-0224

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6225,9 +6225,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b2c039df4f96c4bf7dae52a74fd5516ad6dda83a11c0c69dea91b5255a4f37"
+checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
 dependencies = [
  "async-utility",
  "async-wsocket",


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Updates the locked `nostr-relay-pool` package from `0.44.1` to `0.44.2`.
  - Picks up the upstream fix for verification-cache poisoning reported in RUSTSEC-2026-0224, which could allow forged Nostr events to bypass signature validation.
  - Keeps the existing `nostr-sdk = "0.44"` manifest requirement unchanged.
- **Scope boundary:** Lockfile-only security remediation. The ZeroClaw repository diff does not change runtime code, Nostr configuration, APIs, feature flags, or advisory policy.
- **Blast radius:** Nostr-enabled builds resolve the patched relay-pool release. No other package version or dependency edge changes.
- **Linked issue(s):** Related: [RUSTSEC-2026-0224](https://rustsec.org/advisories/RUSTSEC-2026-0224)
- **Labels:** `type:dependencies`, `dependencies`, `security`, `risk:high`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is a lockfile-only security update; the Security job exercises the relevant advisory and dependency-policy checks.

### How I tested

- **CI checks relied on and why they cover this change:** The required Security job passed on the current head. It ran `cargo deny check`, locked dependency fetching, and RustSec `cargo audit` in an isolated runner.
- **Known CI coverage gap, if any:** None for the advisory-resolution claim after the required Security job passed. The broader required matrix is also required before readiness.
- **Commands run and tail output:**

```text
$ cargo metadata --locked --no-deps --format-version 1
... "version":1 ...

$ cargo fetch --locked
Downloading crates ...
Downloaded nostr-relay-pool v0.44.2

$ git diff --check
# no output
```

- **Beyond CI, what did you manually verify?** Confirmed the complete branch diff changes only the `nostr-relay-pool` version and checksum. Cargo fetched the patched crate successfully without changing the manifest or any other lockfile dependency edge.
- **If any command was intentionally skipped, why:** No runtime smoke was run because this change has no user-facing runtime or configuration surface. Local audit-policy execution is deferred to the required isolated Security job as noted above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A. The dependency update selects the patched release for a known signature-verification vulnerability. The ZeroClaw repository diff adds no permissions or capabilities.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the resulting merge commit if `nostr-relay-pool 0.44.2` causes a compatibility regression. Reverting restores the vulnerable release, so a replacement remediation would be required before shipping.
- **Feature flags or config toggles:** None beyond the existing `channel-nostr` feature.
- **Observable failure symptoms:** Nostr channel compile or runtime regressions after the package update, or the Security job reporting RUSTSEC-2026-0224 again after rollback.
