### PR TITLE
fix(log): serialize broadcast hook installation

### DIFF
--- a/crates/zeroclaw-log/src/broadcast.rs
+++ b/crates/zeroclaw-log/src/broadcast.rs
@@ -6,6 +6,8 @@ use parking_lot::RwLock;
 use serde_json::Value;
 use tokio::sync::broadcast;
 
+const BROADCAST_CAPACITY: usize = 65_536;
+
 /// Type alias for the canonical log broadcast sender.
 pub type LogBroadcastSender = broadcast::Sender<Value>;
 
@@ -51,8 +53,19 @@ pub fn subscribe_or_install() -> broadcast::Receiver<Value> {
             return sender.subscribe();
         }
     }
-    let (tx, rx) = broadcast::channel(65_536);
-    set_broadcast_hook(tx);
+    subscribe_or_install_after_miss(slot())
+}
+
+fn subscribe_or_install_after_miss(
+    slot: &RwLock<Option<LogBroadcastSender>>,
+) -> broadcast::Receiver<Value> {
+    let mut write = slot.write();
+    if let Some(sender) = write.as_ref() {
+        return sender.subscribe();
+    }
+
+    let (tx, rx) = broadcast::channel(BROADCAST_CAPACITY);
+    *write = Some(tx);
     rx
 }
 
@@ -60,6 +73,8 @@ pub(crate) static HOOK_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::n
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Barrier};
+
     use super::*;
 
     #[tokio::test]
@@ -87,5 +102,38 @@ mod tests {
         let _guard = HOOK_TEST_LOCK.lock();
         clear_broadcast_hook();
         assert!(current_broadcast_hook().is_none());
+    }
+
+    #[test]
+    fn concurrent_subscribe_or_install_shares_installed_sender() {
+        let slot = Arc::new(RwLock::new(None));
+        let start = Arc::new(Barrier::new(2));
+
+        let handles = (0..2)
+            .map(|_| {
+                let slot = Arc::clone(&slot);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    subscribe_or_install_after_miss(&slot)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mut receivers = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("subscriber thread must complete"))
+            .collect::<Vec<_>>();
+        let sender = slot
+            .read()
+            .clone()
+            .expect("one broadcast sender must be installed");
+        assert_eq!(sender.receiver_count(), receivers.len());
+
+        let expected = serde_json::json!({ "shared": true });
+        sender.send(expected.clone()).expect("receivers are alive");
+        for receiver in &mut receivers {
+            assert_eq!(receiver.try_recv().unwrap(), expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Serialize lazy log broadcast installation so concurrent first subscribers share the sender retained in the process-wide hook, with a synchronized regression that verifies both receivers get events from that retained sender.
- **Scope boundary:** Explicit `set_broadcast_hook` replacement and shutdown clearing behavior are unchanged.
- **Blast radius:** In-process consumers that lazily subscribe to the canonical log event stream.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk:medium`, `size:XS`, `observability:log`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The failure requires a controlled concurrent first-install interleaving and is covered by the synchronized regression.

### How I tested

- **CI checks relied on and why they cover this change:** GitHub's code, build, lint, and full test jobs are green. The `Security` job, and therefore the aggregate `CI Required Gate`, is red because `cargo audit` now reports RUSTSEC-2026-0224 for the existing `nostr-relay-pool 0.44.1`; the same job is red on this PR's current `master` base. This PR does not change dependencies or `Cargo.lock`. The repository-wide dependency repair is #9622.
- **Known CI coverage gap, if any:** Local CI-shaped full nextest did not complete successfully, so it is not claimed as passing. Three Lucid timing/process tests failed in the loaded-workspace failure class tracked by #9538. An unrelated Telegram photo test then remained active until the run was interrupted.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

cargo test -p zeroclaw-log --lib
# test result: ok. 107 passed; 0 failed; 0 ignored

cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
# Finished dev profile successfully

cargo nextest run --locked --workspace --exclude zeroclaw-desktop
# Not claimed as passing: 3,884 passed before the unrelated failures and interrupted hang described above
```

- **Beyond CI, what did you manually verify?** The regression synchronizes two post-miss installers, checks that the retained sender has both receivers, and confirms the same event reaches each receiver. No external service or UI was exercised.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert commit `8851ca08290765bc754ccc1841b0e84b7569346a`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A receiver returned by concurrent lazy installation closes early or stops receiving canonical log events because another sender replaced its channel.
