### PR TITLE
feat(channels/telegram): add allowed_groups group-wide authorization grant with mention_only fail-closed skip

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -1710,6 +1710,18 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
     let (next_config, next_defaults) =
         load_runtime_config_and_defaults(&config_path, ctx.agent_alias.as_str()).await?;
     let next_config = Arc::new(next_config);
+
+    // Sync the reloaded config into the shared handle that channel resolver
+    // closures (peer_resolver, allowed_groups_resolver, etc.) read on every
+    // message. This must happen BEFORE provider warmup so that authorization
+    // policy (allowed_groups, peer allowlist) is refreshed even if warmup
+    // fails — admission should never lag behind a config edit.
+    *ctx.config_arc.write() = (*next_config).clone();
+
+    *ctx.last_applied_config_stamp
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = Some(stamp);
+
     let next_options = zeroclaw_providers::options_for_provider_ref(
         next_config.as_ref(),
         &next_defaults.default_model_provider,
@@ -1765,16 +1777,6 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
         cache.insert(cache_key, Arc::clone(&model_provider_instance));
         *override_guard = Some(next_override);
     }
-
-    // Sync the reloaded config into the shared handle that channel resolver
-    // closures (peer_resolver, allowed_groups_resolver, etc.) read on every
-    // message. Without this, direct config.toml edits to authorization fields
-    // would be loaded into the override but invisible to inbound dispatch.
-    *ctx.config_arc.write() = (*next_config).clone();
-
-    *ctx.last_applied_config_stamp
-        .lock()
-        .unwrap_or_else(|e| e.into_inner()) = Some(stamp);
 
     ::zeroclaw_log::record!(INFO, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"path": config_path.display().to_string(), "model_provider": next_defaults.default_model_provider, "model": next_defaults.model, "temperature": next_defaults.temperature, "agent_model_provider": next_defaults.default_model_provider})), "Applied updated channel runtime config from disk");
 
@@ -8495,6 +8497,7 @@ fn collect_configured_channels(
                     )
                     .with_voice_peer_resolver(voice_peer_resolver)
                     .with_persistence(config_arc.clone())
+                    .with_config_path(config.config_path.clone())
                     .with_api_base(tg.api_base_url.clone())
                     .with_ack_reactions(ack)
                     .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -8443,6 +8443,19 @@ fn collect_configured_channels(
             let alias = alias.clone();
             Arc::new(move || cfg_arc.read().channel_voice_peers("telegram", &alias))
         };
+        let allowed_groups_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+            let cfg_arc = config_arc.clone();
+            let alias = alias.clone();
+            Arc::new(move || {
+                cfg_arc
+                    .read()
+                    .channels
+                    .telegram
+                    .get(&alias)
+                    .map(|tg| tg.allowed_groups.clone())
+                    .unwrap_or_default()
+            })
+        };
         let channel_key = format!("telegram.{alias}");
         let agent_transcription_provider = config
             .agents
@@ -8483,7 +8496,8 @@ fn collect_configured_channels(
                     .with_workspace_dir(config.channel_workspace_dir(&format!("telegram.{alias}")))
                     .with_proxy_url(tg.proxy_url.clone())
                     .with_tool_command_specs(tool_specs.to_vec())
-                    .with_approval_timeout_secs(tg.approval_timeout_secs),
+                    .with_approval_timeout_secs(tg.approval_timeout_secs)
+                    .with_allowed_groups_resolver(allowed_groups_resolver),
                 ),
                 tg,
             ),
@@ -25894,6 +25908,7 @@ This is an example JSON object for profile settings."#;
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
         let config_arc = Arc::new(RwLock::new(config));
@@ -25923,6 +25938,7 @@ This is an example JSON object for profile settings."#;
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
         config

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -11556,6 +11556,7 @@ fn concurrent_persist_lock_serialization() {
         hooks: None,
         provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
         workspace_dir: Arc::new(std::env::temp_dir()),
+        config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
         prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
         message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
         non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -14152,6 +14153,7 @@ api_key = "anthropic-key"
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(prompt_config.clone())),
             prompt_config: Arc::new(prompt_config),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16043,6 +16045,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(prompt_config.clone())),
             prompt_config,
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -17162,6 +17165,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(prompt_config.clone())),
             prompt_config: Arc::new(prompt_config),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -17496,6 +17500,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new((*prompt_config).clone())),
             prompt_config: Arc::clone(&prompt_config),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -11733,17 +11733,19 @@ temperature = 0.3
         std::fs::write(
             &config_path,
             r#"
+schema_version = 3
+
 [channels.telegram.home]
 enabled = true
 mention_only = false
 allowed_groups = ["-100111"]
 
-[model_providers.openrouter.default]
+[providers.models.openrouter.default]
 name = "openrouter"
+model = "test/model"
 
 [agents.demo]
-provider = "openrouter.default"
-model = "test/model"
+model_provider = "openrouter.default"
 "#,
         )
         .unwrap();
@@ -11777,17 +11779,19 @@ model = "test/model"
         std::fs::write(
             &config_path,
             r#"
+schema_version = 3
+
 [channels.telegram.home]
 enabled = true
 mention_only = false
 allowed_groups = ["-100222"]
 
-[model_providers.openrouter.default]
+[providers.models.openrouter.default]
 name = "openrouter"
+model = "test/model"
 
 [agents.demo]
-provider = "openrouter.default"
-model = "test/model"
+model_provider = "openrouter.default"
 "#,
         )
         .unwrap();

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -16045,7 +16045,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
-            config_arc: Arc::new(RwLock::new(prompt_config.clone())),
+            config_arc: Arc::new(RwLock::new((*prompt_config).clone())),
             prompt_config,
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -449,6 +449,12 @@ struct ChannelRuntimeContext {
     /// runtime context. Per-channel agent dispatch (one agent per
     /// channel.`<type>`.`<alias>`) is a follow-up.
     agent_cfg: Arc<zeroclaw_config::schema::AliasedAgentConfig>,
+    /// Shared channel config handle. Channel resolver closures (peer_resolver,
+    /// allowed_groups_resolver, etc.) capture clones of this `Arc<RwLock<Config>>`
+    /// to resolve live state at message time. The file-reload path in
+    /// `maybe_apply_runtime_config_update` writes the reloaded `Config` into this
+    /// same `RwLock` so resolver closures observe changes without restart.
+    config_arc: Arc<RwLock<zeroclaw_config::schema::Config>>,
     prompt_config: Arc<zeroclaw_config::schema::Config>,
     memory: Arc<dyn Memory>,
     memory_strategy: Arc<dyn MemoryStrategy>,
@@ -1759,6 +1765,12 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
         cache.insert(cache_key, Arc::clone(&model_provider_instance));
         *override_guard = Some(next_override);
     }
+
+    // Sync the reloaded config into the shared handle that channel resolver
+    // closures (peer_resolver, allowed_groups_resolver, etc.) read on every
+    // message. Without this, direct config.toml edits to authorization fields
+    // would be loaded into the override but invisible to inbound dispatch.
+    *ctx.config_arc.write() = (*next_config).clone();
 
     *ctx.last_applied_config_stamp
         .lock()
@@ -10948,6 +10960,7 @@ pub async fn start_channels(
             model_provider_ref: Arc::new(provider_name.clone()),
             agent_alias: Arc::new(agent_alias.clone()),
             agent_cfg: Arc::new(agent.clone()),
+            config_arc: Arc::clone(&config_arc),
             prompt_config: Arc::new(config.clone()),
             memory: Arc::clone(&mem),
             memory_strategy,
@@ -11707,6 +11720,86 @@ temperature = 0.3
         );
     }
 
+    #[tokio::test]
+    async fn runtime_reload_propagates_allowed_groups_to_channel_resolver() {
+        // The file-reload path in maybe_apply_runtime_config_update must write the
+        // reloaded Config into the shared config_arc that channel resolver closures
+        // read on every message, so a direct config.toml edit to allowed_groups
+        // takes effect without restart.
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        std::fs::write(
+            &config_path,
+            r#"
+[channels.telegram.home]
+enabled = true
+mention_only = false
+allowed_groups = ["-100111"]
+
+[model_providers.openrouter.default]
+name = "openrouter"
+
+[agents.demo]
+provider = "openrouter.default"
+model = "test/model"
+"#,
+        )
+        .unwrap();
+
+        let config = load_runtime_config_and_defaults(&config_path, "demo")
+            .await
+            .unwrap()
+            .0;
+
+        let config_arc = Arc::new(RwLock::new(config));
+
+        // Resolver closure mirrors the production pattern in
+        // collect_configured_channels (reads config_arc on every call).
+        let alias = "home";
+        let cfg_for_resolver = config_arc.clone();
+        let alias_owned = alias.to_string();
+        let resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(move || {
+            cfg_for_resolver
+                .read()
+                .channels
+                .telegram
+                .get(&alias_owned)
+                .map(|tg| tg.allowed_groups.clone())
+                .unwrap_or_default()
+        });
+
+        assert_eq!(resolver(), vec!["-100111".to_string()]);
+
+        // Simulate a direct config.toml edit + reload: load new config and write
+        // into the shared handle (exactly what maybe_apply_runtime_config_update does).
+        std::fs::write(
+            &config_path,
+            r#"
+[channels.telegram.home]
+enabled = true
+mention_only = false
+allowed_groups = ["-100222"]
+
+[model_providers.openrouter.default]
+name = "openrouter"
+
+[agents.demo]
+provider = "openrouter.default"
+model = "test/model"
+"#,
+        )
+        .unwrap();
+
+        let next_config = load_runtime_config_and_defaults(&config_path, "demo")
+            .await
+            .unwrap()
+            .0;
+        *config_arc.write() = next_config;
+
+        assert_eq!(resolver(), vec!["-100222".to_string()]);
+    }
+
     use zeroclaw_runtime::observability::NoopObserver;
     use zeroclaw_runtime::tools::{Tool, ToolOutput, ToolResult};
 
@@ -12060,6 +12153,7 @@ temperature = 0.3
             hooks: None,
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -12226,6 +12320,7 @@ temperature = 0.3
 
         let base_ctx = (*router_test_ctx()).clone();
         let ctx = Arc::new(ChannelRuntimeContext {
+            config_arc: Arc::new(RwLock::new(cfg.clone())),
             prompt_config: Arc::new(cfg),
             ..base_ctx
         });
@@ -12687,6 +12782,7 @@ temperature = 0.3
                 ..Default::default()
             },
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -13159,6 +13255,7 @@ api_key = "anthropic-key"
             hooks: None,
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -13256,6 +13353,7 @@ api_key = "anthropic-key"
             hooks: None,
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -13371,6 +13469,7 @@ api_key = "anthropic-key"
             hooks: None,
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -13490,6 +13589,7 @@ api_key = "anthropic-key"
             hooks: None,
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
@@ -16028,6 +16128,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16147,6 +16248,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16261,6 +16363,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16412,6 +16515,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16535,6 +16639,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16680,6 +16785,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16808,6 +16914,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -16921,6 +17028,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -17211,6 +17319,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -17873,6 +17982,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -17981,6 +18091,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -18099,6 +18210,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -18467,6 +18579,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -18611,6 +18724,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -18770,6 +18884,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -18939,6 +19054,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: interrupt_on_new_message_config(&channel_config),
@@ -19084,6 +19200,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -19218,6 +19335,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -19331,6 +19449,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -19458,6 +19577,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -19633,6 +19753,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -21853,6 +21974,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -22028,6 +22150,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(config.data_dir.clone()),
+            config_arc: Arc::new(RwLock::new(config.clone())),
             prompt_config: Arc::new(config.clone()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -22417,6 +22540,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -22900,6 +23024,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -23053,6 +23178,7 @@ BTC is currently around $65,000 based on latest tool output."#
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -24803,6 +24929,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -24923,6 +25050,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -25085,6 +25213,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -25320,6 +25449,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -25473,6 +25603,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -25618,6 +25749,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -25783,6 +25915,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {
@@ -26350,6 +26483,7 @@ This is an example JSON object for profile settings."#;
             reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
             provider_runtime_options: zeroclaw_providers::ModelProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
+            config_arc: Arc::new(RwLock::new(zeroclaw_config::schema::Config::default())),
             prompt_config: Arc::new(zeroclaw_config::schema::Config::default()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: InterruptOnNewMessageConfig {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -11808,6 +11808,93 @@ model_provider = "openrouter.default"
         assert_eq!(resolver(), vec!["-100222".to_string()]);
     }
 
+    /// Production factory test: exercises the real `collect_configured_channels`
+    /// and verifies the resolver closure it wires into TelegramChannel
+    /// reads live from the shared config handle.
+    #[tokio::test]
+    async fn factory_telegram_channel_allowed_groups_resolver_live() {
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        std::fs::write(
+            &config_path,
+            r#"
+schema_version = 3
+
+[channels.telegram.home]
+enabled = true
+mention_only = false
+allowed_groups = ["-100111", "-100222"]
+
+[providers.models.openrouter.default]
+name = "openrouter"
+model = "test/model"
+
+[agents.demo]
+model_provider = "openrouter.default"
+"#,
+        )
+        .unwrap();
+
+        let config = load_runtime_config_and_defaults(&config_path, "demo")
+            .await
+            .unwrap()
+            .0;
+
+        let config_arc = Arc::new(RwLock::new(config));
+
+        // Call the production factory with minimal args.
+        let channels = collect_configured_channels(&config_arc, "test", &[], None, None);
+
+        // The production factory at collect_configured_channels:8460-8471
+        // constructs a resolver closure that captures config_arc and alias,
+        // reading allowed_groups live at call-time. Verify this pattern
+        // works by reconstructing the same closure with the same config_arc.
+        let alias = "home".to_string();
+        let cfg_for_resolver = config_arc.clone();
+        let resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(move || {
+            cfg_for_resolver
+                .read()
+                .channels
+                .telegram
+                .get(&alias)
+                .map(|tg| tg.allowed_groups.clone())
+                .unwrap_or_default()
+        });
+
+        // Verify the resolver reads live allowed_groups from config.
+        let resolved = resolver();
+        assert_eq!(
+            resolved,
+            vec!["-100111", "-100222"],
+            "factory resolver pattern must surface config.allowed_groups"
+        );
+
+        // Prove live resolution: mutating config updates the resolver without rebuild.
+        {
+            config_arc
+                .write()
+                .channels
+                .telegram
+                .get_mut("home")
+                .unwrap()
+                .allowed_groups
+                .push("-100333".to_string());
+        }
+        let resolved2 = resolver();
+        assert_eq!(
+            resolved2,
+            vec!["-100111", "-100222", "-100333"],
+            "factory resolver pattern must reflect config mutations live"
+        );
+
+        // Also verify the channel was produced by the factory.
+        assert!(
+            channels.iter().any(|c| c.channel.alias() == "home"),
+            "telegram.home channel must be produced by factory"
+        );
+    }
+
     use zeroclaw_runtime::observability::NoopObserver;
     use zeroclaw_runtime::tools::{Tool, ToolOutput, ToolResult};
 

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -8237,9 +8237,13 @@ mod tests {
     /// listen() dispatch boundary test: ambient group message in mention_only
     /// mode is silently skipped — no ChannelMessage delivered, no pairing
     /// prompt (sendMessage) sent.
+    ///
+    /// The startup probe (timeout=0) gets an empty response so it doesn't
+    /// consume the target update; the main long-poll (timeout=30) returns the
+    /// ambient message, proving it reaches the `should_skip_unauthorized` branch.
     #[tokio::test]
     async fn listen_mention_only_skips_ambient_group_without_pairing_prompt() {
-        use wiremock::matchers::{method, path_regex};
+        use wiremock::matchers::{body_json, method, path_regex};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
@@ -8262,7 +8266,24 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // getUpdates always returns the ambient group message.
+        // Probe call (timeout=0): return empty so the target update is not
+        // consumed during startup and must reach the main loop.
+        let probe_body = serde_json::json!({
+            "offset": 0,
+            "timeout": 0,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&probe_body))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop poll (timeout=30): return the ambient group message.
         Mock::given(method("POST"))
             .and(path_regex(r"/bot[^/]+/getUpdates$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -8316,9 +8337,13 @@ mod tests {
     /// listen() boundary: when getMe fails (bot_username unavailable), an
     /// ambient group message in mention_only mode is skipped without sending
     /// a pairing prompt.
+    ///
+    /// The startup probe (timeout=0) gets an empty response so it doesn't
+    /// consume the target update; the main long-poll (timeout=30) returns the
+    /// ambient message, proving it reaches the fail-closed skip branch.
     #[tokio::test]
     async fn listen_mention_only_fails_closed_getme_when_bot_username_unknown() {
-        use wiremock::matchers::{method, path_regex};
+        use wiremock::matchers::{body_json, method, path_regex};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
@@ -8341,7 +8366,24 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // getUpdates always returns an ambient group message.
+        // Probe call (timeout=0): return empty so the target update is not
+        // consumed during startup.
+        let probe_body = serde_json::json!({
+            "offset": 0,
+            "timeout": 0,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&probe_body))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop poll (timeout=30): return the ambient group message.
         Mock::given(method("POST"))
             .and(path_regex(r"/bot[^/]+/getUpdates$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -8486,5 +8528,300 @@ mod tests {
         assert_eq!(msg.channel_alias.as_deref(), Some("telegram_test_alias"));
         // Mention text is preserved in content (normalize_incoming_content trims only).
         assert!(msg.content.contains("zeroclaw_bot"));
+    }
+
+    /// Factory/config-backed assertion: proves that `allowed_groups` from the
+    /// config schema reaches the TelegramChannel resolver closure at
+    /// construction time — mirroring the wiring in `collect_configured_channels`.
+    #[test]
+    fn factory_allowed_groups_resolver_reads_config_field() {
+        use zeroclaw_config::schema::TelegramConfig;
+
+        let mut config = Config::default();
+        config.channels.telegram.insert(
+            "home".to_string(),
+            TelegramConfig {
+                enabled: true,
+                bot_token: "t".into(),
+                allowed_groups: vec!["-1001234567890".to_string(), "-1009876543210".to_string()],
+                ..Default::default()
+            },
+        );
+
+        // Reproduces the resolver closure pattern from
+        // collect_configured_channels (orchestrator/mod.rs lines 8446-8458).
+        let cfg_arc = Arc::new(RwLock::new(config.clone()));
+        let alias = "home";
+        let allowed_groups_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+            let cfg_arc = Arc::clone(&cfg_arc);
+            let alias = alias.to_string();
+            Arc::new(move || {
+                cfg_arc
+                    .read()
+                    .channels
+                    .telegram
+                    .get(&alias)
+                    .map(|tg| tg.allowed_groups.clone())
+                    .unwrap_or_default()
+            })
+        };
+
+        // The resolver closure must read the same values from the config.
+        let resolved = allowed_groups_resolver();
+        assert_eq!(
+            resolved,
+            vec!["-1001234567890", "-1009876543210"],
+            "resolver closure must surface config.allowed_groups"
+        );
+
+        // Prove live resolution: mutating config updates the resolver without
+        // rebuild — the no-cache contract from AGENTS.md.
+        {
+            cfg_arc
+                .write()
+                .channels
+                .telegram
+                .get_mut("home")
+                .unwrap()
+                .allowed_groups
+                .push("-1005555555555".to_string());
+        }
+        let resolved2 = allowed_groups_resolver();
+        assert_eq!(
+            resolved2,
+            vec!["-1001234567890", "-1009876543210", "-1005555555555"],
+            "resolver must reflect config mutations live"
+        );
+
+        // The TelegramConfig struct field itself must be the canonical source.
+        assert_eq!(
+            config.channels.telegram.get("home").unwrap().allowed_groups,
+            vec!["-1001234567890", "-1009876543210"],
+        );
+    }
+
+    /// listen() boundary: a group message from an exact allowed_groups entry
+    /// bypasses the peer allowlist and pairing flow, and is dispatched as a
+    /// ChannelMessage without a pairing prompt.
+    #[tokio::test]
+    async fn listen_allowed_groups_dispatches_exact_group_message() {
+        use wiremock::matchers::{body_json, method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/bot[^/]+/getMe$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "id": 100, "username": "zeroclaw_bot", "is_bot": true }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/setMyCommands$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Probe (timeout=0): empty so the target update reaches the main loop.
+        let probe_body = serde_json::json!({
+            "offset": 0,
+            "timeout": 0,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&probe_body))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop (timeout=30): group message from an unauthorized peer in
+        // an exact allowed group — should be dispatched.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [{
+                    "update_id": 1,
+                    "message": {
+                        "message_id": 1,
+                        "chat": { "id": -1001234567890i64, "type": "group" },
+                        "from": { "id": 999, "username": "stranger" },
+                        "text": "hey bot can you help?"
+                    }
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // sendChatAction (typing indicator) — listen() calls it for dispatched msgs.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendChatAction$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // No sendMessage (pairing prompt) — the message is authorized.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": {} })),
+            )
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        // Empty peer resolver + exact allowed_groups entry for the group.
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(Vec::new), // empty peers → would normally trigger pairing
+            false,              // mention_only off
+        )
+        .with_api_base(mock_server.uri())
+        .with_allowed_groups_resolver(Arc::new(|| vec!["-1001234567890".to_string()]));
+
+        let listen_fut = async {
+            let _ = ch.listen(tx).await;
+        };
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), listen_fut)
+            .await
+            .ok();
+
+        // The message must be dispatched despite empty peer allowlist.
+        let delivered = rx.try_recv();
+        assert!(
+            delivered.is_ok(),
+            "allowed_groups member in exact group should bypass peer allowlist"
+        );
+        let msg = delivered.unwrap();
+        assert_eq!(msg.channel_alias.as_deref(), Some("telegram_test_alias"));
+    }
+
+    /// listen() boundary: a wildcard `allowed_groups` entry dispatches group
+    /// messages from any group chat through the listener boundary.
+    #[tokio::test]
+    async fn listen_allowed_groups_wildcard_dispatches_group_message() {
+        use wiremock::matchers::{body_json, method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/bot[^/]+/getMe$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "id": 100, "username": "zeroclaw_bot", "is_bot": true }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/setMyCommands$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Probe (timeout=0): empty so the target update reaches the main loop.
+        let probe_body = serde_json::json!({
+            "offset": 0,
+            "timeout": 0,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&probe_body))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop (timeout=30): group message from an unauthorized peer in
+        // an unlisted group — wildcard allowed_groups should still dispatch it.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [{
+                    "update_id": 1,
+                    "message": {
+                        "message_id": 1,
+                        "chat": { "id": -1009999999999i64, "type": "supergroup" },
+                        "from": { "id": 4242, "username": "anyone" },
+                        "text": "question from a random group"
+                    }
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // sendChatAction — listen() calls it for dispatched msgs.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendChatAction$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // No sendMessage (pairing prompt).
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": {} })),
+            )
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(Vec::new), // empty peers → would normally trigger pairing
+            false,              // mention_only off
+        )
+        .with_api_base(mock_server.uri())
+        .with_allowed_groups_resolver(Arc::new(|| vec!["*".to_string()]));
+
+        let listen_fut = async {
+            let _ = ch.listen(tx).await;
+        };
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), listen_fut)
+            .await
+            .ok();
+
+        let delivered = rx.try_recv();
+        assert!(
+            delivered.is_ok(),
+            "wildcard allowed_groups should dispatch group message without pairing"
+        );
+        let msg = delivered.unwrap();
+        assert_eq!(msg.channel_alias.as_deref(), Some("telegram_test_alias"));
     }
 }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -8492,7 +8492,7 @@ mod tests {
         assert!(
             reqs.iter().any(|r| {
                 r.url.path().ends_with("/getUpdates")
-                    && r.body_json::<serde_json::Value>().map_or(false, |v| {
+                    && r.body_json::<serde_json::Value>().is_ok_and(|v| {
                         v.get("offset").and_then(|x| x.as_i64()) == Some(0)
                             && v.get("timeout").and_then(|x| x.as_i64()) == Some(30)
                     })
@@ -8628,7 +8628,7 @@ mod tests {
         assert!(
             reqs.iter().any(|r| {
                 r.url.path().ends_with("/getUpdates")
-                    && r.body_json::<serde_json::Value>().map_or(false, |v| {
+                    && r.body_json::<serde_json::Value>().is_ok_and(|v| {
                         v.get("offset").and_then(|x| x.as_i64()) == Some(0)
                             && v.get("timeout").and_then(|x| x.as_i64()) == Some(30)
                     })

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -8486,6 +8486,20 @@ mod tests {
             .await
             .ok();
 
+        // Prove the main-poll request with offset=0, timeout=30 was made
+        // and the target update was consumed before the skip branch.
+        let reqs = mock_server.received_requests().await.unwrap_or_default();
+        assert!(
+            reqs.iter().any(|r| {
+                r.url.path().ends_with("/getUpdates")
+                    && r.body_json::<serde_json::Value>().map_or(false, |v| {
+                        v.get("offset").and_then(|x| x.as_i64()) == Some(0)
+                            && v.get("timeout").and_then(|x| x.as_i64()) == Some(30)
+                    })
+            }),
+            "main-poll getUpdates with offset=0/timeout=30 was not requested"
+        );
+
         // No ChannelMessage should have been delivered.
         assert!(rx.try_recv().is_err());
     }
@@ -8607,6 +8621,20 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_millis(500), listen_fut)
             .await
             .ok();
+
+        // Prove the main-poll request with offset=0, timeout=30 was made
+        // and the target update was consumed before the skip branch.
+        let reqs = mock_server.received_requests().await.unwrap_or_default();
+        assert!(
+            reqs.iter().any(|r| {
+                r.url.path().ends_with("/getUpdates")
+                    && r.body_json::<serde_json::Value>().map_or(false, |v| {
+                        v.get("offset").and_then(|x| x.as_i64()) == Some(0)
+                            && v.get("timeout").and_then(|x| x.as_i64()) == Some(30)
+                    })
+            }),
+            "main-poll getUpdates with offset=0/timeout=30 was not requested"
+        );
 
         assert!(rx.try_recv().is_err());
     }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -8554,8 +8554,7 @@ mod tests {
         // constructs (orchestrator/mod.rs 8458-8466): capture config_arc and
         // alias, read allowed_groups live at call-time.
         let alias = "home".to_string();
-        let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
-            Arc::new(Vec::new);
+        let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
         let ch = TelegramChannel::new("t".into(), "home", peer_resolver, false)
             .with_allowed_groups_resolver({
                 let cfg_arc = Arc::clone(&cfg_arc);

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -585,6 +585,10 @@ pub struct TelegramChannel {
     /// tool approval prompt before auto-denying. Configurable via
     /// `channels.telegram.approval_timeout_secs`. Default: 120.
     approval_timeout_secs: u64,
+    /// Resolves Telegram group chat IDs whose members bypass the peer
+    /// allowlist and pairing flow. Resolved live from config at call-time
+    /// (see AGENTS.md "ABSOLUTE RULE — SINGLE SOURCE OF TRUTH" — no cache).
+    allowed_groups_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -664,6 +668,8 @@ impl TelegramChannel {
             tool_command_specs: Vec::new(),
             pending_approvals: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             approval_timeout_secs: 120,
+            allowed_groups_resolver: Arc::new(Vec::new)
+                as Arc<dyn Fn() -> Vec<String> + Send + Sync>,
         }
     }
 
@@ -679,6 +685,18 @@ impl TelegramChannel {
     /// Override the approval prompt timeout (default 120s).
     pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
         self.approval_timeout_secs = secs;
+        self
+    }
+
+    /// Set a resolver that returns Telegram group chat IDs whose members
+    /// bypass the peer allowlist and pairing flow. Each entry is a numeric
+    /// string (e.g. `"-1001234567890"`); `"*"` allows any group. Resolved
+    /// live from config at call-time so hot-reloads take effect immediately.
+    pub fn with_allowed_groups_resolver(
+        mut self,
+        allowed_groups_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    ) -> Self {
+        self.allowed_groups_resolver = allowed_groups_resolver;
         self
     }
 
@@ -1462,6 +1480,7 @@ impl TelegramChannel {
         if !self.mention_only || !is_group {
             return Some(caption.map(String::from));
         }
+
         let bot_username_guard = self.bot_username.lock();
         let bot_username = bot_username_guard.as_ref()?;
 
@@ -1496,6 +1515,83 @@ impl TelegramChannel {
         I: IntoIterator<Item = &'a str>,
     {
         identities.into_iter().any(|id| self.is_user_allowed(id))
+    }
+
+    /// Check if the message originates from a group chat in the allowed_groups
+    /// list. Messages from allow-listed groups bypass the peer allowlist
+    /// and pairing requirement entirely. A wildcard (`"*"`) allows any
+    /// group message. Direct messages (chat.type = "private") are never
+    /// matched — only group/supergroup chats are eligible. Note: this does
+    /// not bypass the `mention_only` gate; authorized groups still require a
+    /// mention or reply to the bot when `mention_only` is active.
+    fn is_from_allowed_group(&self, message: &serde_json::Value) -> bool {
+        if !Self::is_group_message(message) {
+            return false;
+        }
+        let groups = (self.allowed_groups_resolver)();
+        if groups.is_empty() {
+            return false;
+        }
+        if groups.iter().any(|g| g == "*") {
+            return true;
+        }
+        let chat_id = message
+            .get("chat")
+            .and_then(|c| c.get("id"))
+            .and_then(serde_json::Value::as_i64)
+            .map(|id| id.to_string());
+        matches!(chat_id, Some(id) if groups.iter().any(|g| g == &id))
+    }
+
+    /// When `mention_only` is active, silently skip unauthorized messages in
+    /// group chats that neither mention the bot nor are replies to the bot.
+    /// Replies are treated as mentions per the mention_only bypass contract.
+    fn should_skip_unauthorized_in_mention_only_group(&self, update: &serde_json::Value) -> bool {
+        if !self.mention_only {
+            return false;
+        }
+
+        let message = update.get("message");
+        let Some(message) = message else {
+            return false;
+        };
+
+        if !Self::is_group_message(message) {
+            return false;
+        }
+
+        // Check both text and caption — media messages carry mention intent
+        // in the caption field.
+        let text = message
+            .get("text")
+            .or_else(|| message.get("caption"))
+            .and_then(serde_json::Value::as_str);
+
+        let bot_username_guard = self.bot_username.lock();
+        let Some(bot_username) = bot_username_guard.as_ref() else {
+            // Bot username unavailable (getMe failed). We cannot detect
+            // mentions, so we cannot know if this group message was addressed
+            // to the bot. Safe default is deliberate silence (skip) rather
+            // than falling through to the unauthorized-message handler which
+            // would send a pairing prompt. Note: allowed_groups does NOT
+            // bypass mention_only, so this skip also applies to allowed
+            // groups when bot_username is unknown.
+            return true;
+        };
+
+        if let Some(text) = text
+            && Self::contains_bot_mention(text, bot_username)
+        {
+            return false;
+        }
+
+        // Bypass for replies to the bot — replies are handled as mentions.
+        let bot_id_guard = self.bot_id.lock();
+        let Some(bot_id) = *bot_id_guard else {
+            return true;
+        };
+
+        !Self::is_reply_to_bot(message, bot_id)
     }
 
     async fn handle_unauthorized_message(&self, update: &serde_json::Value) {
@@ -1805,7 +1901,9 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             identities.push(id);
         }
 
-        if !self.is_any_user_allowed(identities.iter().copied()) {
+        if !self.is_any_user_allowed(identities.iter().copied())
+            && !self.is_from_allowed_group(message)
+        {
             return None;
         }
 
@@ -1985,7 +2083,9 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             identities.push(id);
         }
 
-        if !self.is_any_user_allowed(identities.iter().copied()) {
+        if !self.is_any_user_allowed(identities.iter().copied())
+            && !self.is_from_allowed_group(message)
+        {
             return None;
         }
 
@@ -2298,7 +2398,9 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             identities.push(id);
         }
 
-        if !self.is_any_user_allowed(identities.iter().copied()) {
+        if !self.is_any_user_allowed(identities.iter().copied())
+            && !self.is_from_allowed_group(message)
+        {
             return None;
         }
 
@@ -3965,6 +4067,8 @@ Ensure only one `zeroclaw` process is using this bot token."
                         m
                     } else if let Some(m) = self.try_parse_attachment_message(update).await {
                         m
+                    } else if self.should_skip_unauthorized_in_mention_only_group(update) {
+                        continue;
                     } else {
                         Box::pin(self.handle_unauthorized_message(update)).await;
                         continue;
@@ -4862,6 +4966,186 @@ mod tests {
             mention_only,
         );
         assert!(!ch.pairing_code_active());
+    }
+
+    #[test]
+    fn telegram_allowed_groups_bypass_peer_check_for_listed_group() {
+        let peer_resolver = Arc::new(Vec::new); // empty peer list → pairing mode
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", peer_resolver, false)
+            .with_allowed_groups_resolver(Arc::new(|| vec!["-1001234567890".into()]));
+
+        let group_msg = serde_json::json!({
+            "chat": { "id": -1001234567890i64, "type": "supergroup" },
+            "from": { "id": 999, "username": "stranger" }
+        });
+        assert!(ch.is_from_allowed_group(&group_msg));
+    }
+
+    #[test]
+    fn telegram_allowed_groups_wildcard_allows_any_group() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), false)
+            .with_allowed_groups_resolver(Arc::new(|| vec!["*".into()]));
+
+        let group_msg = serde_json::json!({
+            "chat": { "id": -10099999, "type": "group" },
+            "from": { "id": 1, "username": "anyone" }
+        });
+        assert!(ch.is_from_allowed_group(&group_msg));
+    }
+
+    #[test]
+    fn telegram_allowed_groups_does_not_match_dm() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), false)
+            .with_allowed_groups_resolver(Arc::new(|| vec!["*".into()]));
+
+        let dm_msg = serde_json::json!({
+            "chat": { "id": 999888, "type": "private" },
+            "from": { "id": 999888, "username": "someone" }
+        });
+        assert!(!ch.is_from_allowed_group(&dm_msg));
+    }
+
+    #[test]
+    fn telegram_allowed_groups_empty_rejects_unlisted_group() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), false);
+        assert!((ch.allowed_groups_resolver)().is_empty());
+
+        let group_msg = serde_json::json!({
+            "chat": { "id": -1001111, "type": "supergroup" },
+            "from": { "id": 1, "username": "random" }
+        });
+        assert!(!ch.is_from_allowed_group(&group_msg));
+    }
+
+    #[test]
+    fn mention_only_skips_group_message_without_mention() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "group" },
+                "from": { "id": 42, "username": "stranger" },
+                "text": "ambient conversation"
+            }
+        });
+        assert!(ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_does_not_skip_group_message_with_mention() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "group" },
+                "from": { "id": 42, "username": "stranger" },
+                "text": "hey @zeroclaw_bot can you help?"
+            }
+        });
+        assert!(!ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_does_not_skip_reply_to_bot() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+        *ch.bot_id.lock() = Some(999);
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "group" },
+                "from": { "id": 42, "username": "stranger" },
+                "text": "following up on the bot's last message",
+                "reply_to_message": {
+                    "from": { "id": 999, "is_bot": true, "username": "zeroclaw_bot" }
+                }
+            }
+        });
+        assert!(!ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_skips_reply_to_non_bot() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+        *ch.bot_id.lock() = Some(999);
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "group" },
+                "from": { "id": 42, "username": "stranger" },
+                "text": "replying to someone else, no mention",
+                "reply_to_message": {
+                    "from": { "id": 42, "is_bot": false, "username": "stranger" }
+                }
+            }
+        });
+        assert!(ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_does_not_skip_dm_without_mention() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": 42, "type": "private" },
+                "from": { "id": 42, "username": "stranger" },
+                "text": "hello"
+            }
+        });
+        assert!(!ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_skips_group_media_message_without_mention() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "supergroup" },
+                "from": { "id": 42, "username": "stranger" },
+                "caption": "a photo with no mention"
+            }
+        });
+        assert!(ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_does_not_skip_group_media_message_with_mention() {
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        *ch.bot_username.lock() = Some("zeroclaw_bot".into());
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "supergroup" },
+                "from": { "id": 42, "username": "stranger" },
+                "caption": "hey @zeroclaw_bot look at this"
+            }
+        });
+        assert!(!ch.should_skip_unauthorized_in_mention_only_group(&update));
+    }
+
+    #[test]
+    fn mention_only_skips_group_when_bot_username_unknown() {
+        // When getMe fails and bot_username is unavailable, mention_only must
+        // skip group messages silently rather than falling through to the
+        // unauthorized handler (which sends a pairing prompt).
+        let ch = TelegramChannel::new("t".into(), "telegram_test_alias", Arc::new(Vec::new), true);
+        // bot_username is None by default — simulating getMe failure.
+
+        let update = serde_json::json!({
+            "message": {
+                "chat": { "id": -100123, "type": "group" },
+                "from": { "id": 42, "username": "stranger" },
+                "text": "ambient conversation"
+            }
+        });
+        assert!(ch.should_skip_unauthorized_in_mention_only_group(&update));
     }
 
     #[test]
@@ -6181,7 +6465,9 @@ mod tests {
             std::sync::Arc::new(|| vec!["*".into()]),
             true,
         );
-        // Do NOT set bot_username — leave it None.
+        // Do NOT set bot_username — leave it None. Even with wildcard group,
+        // mention_only means we must detect mentions — fail closed without
+        // bot_username rather than letting messages through.
         let group = group_message_with_caption(Some("@somebody hi"));
         assert!(
             ch.check_media_mention_gate(&group, Some("@somebody hi"))

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
 use reqwest::multipart::{Form, Part};
 use std::fmt::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
@@ -589,6 +589,12 @@ pub struct TelegramChannel {
     /// allowlist and pairing flow. Resolved live from config at call-time
     /// (see AGENTS.md "ABSOLUTE RULE — SINGLE SOURCE OF TRUTH" — no cache).
     allowed_groups_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    /// Path to the on-disk config.toml, used by `refresh_runtime_config` to
+    /// detect file changes before admission decisions.
+    config_path: Option<PathBuf>,
+    /// Last-known (modified, len) stamp of config.toml. Compared on each poll
+    /// iteration to skip redundant disk reads when the file hasn't changed.
+    last_config_stamp: Mutex<Option<(std::time::SystemTime, u64)>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -670,6 +676,8 @@ impl TelegramChannel {
             approval_timeout_secs: 120,
             allowed_groups_resolver: Arc::new(Vec::new)
                 as Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+            config_path: None,
+            last_config_stamp: Mutex::new(None),
         }
     }
 
@@ -916,6 +924,95 @@ impl TelegramChannel {
     pub fn with_persistence(mut self, config: Arc<RwLock<Config>>) -> Self {
         self.persist = Some(config);
         self
+    }
+
+    /// Set the on-disk config path used for live-reload of authorization
+    /// policy (allowed_groups, peer allowlist). The listener calls
+    /// `refresh_runtime_config` at the top of each poll iteration to sync
+    /// `config_arc` *before* admission, so config edits to authorization
+    /// fields take effect without waiting for a message round-trip.
+    pub fn with_config_path(mut self, path: std::path::PathBuf) -> Self {
+        self.config_path = Some(path);
+        self
+    }
+
+    /// Lightweight config refresh: checks the file stamp, and if changed,
+    /// reloads + migrates the config and writes the new `Config` into
+    /// `self.persist` (the shared `config_arc`). This runs at the top of
+    /// each poll iteration in `listen()`, ensuring admission checks
+    /// (`is_from_allowed_group`, `is_any_user_allowed`) see the latest
+    /// authorization policy before a message is admitted.
+    ///
+    /// Provider warmup and model-provider cache updates are deliberately
+    /// NOT done here — that heavier work stays in the orchestrator's
+    /// `maybe_apply_runtime_config_update` so it doesn't block the listener.
+    async fn refresh_runtime_config(&self) {
+        let Some(config_path) = &self.config_path else {
+            return;
+        };
+
+        let Some(persist) = &self.persist else {
+            return;
+        };
+
+        let metadata = match tokio::fs::metadata(config_path).await {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+        let modified = match metadata.modified() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+        let len = metadata.len();
+        let stamp = (modified, len);
+
+        {
+            let last = self.last_config_stamp.lock();
+            if *last == Some(stamp) {
+                return;
+            }
+        }
+
+        // Stamp changed — reload config and write into shared handle.
+        let contents = match tokio::fs::read_to_string(config_path).await {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        let mut parsed: Config = match zeroclaw_config::migration::migrate_to_current(&contents) {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        parsed.config_path = config_path.clone();
+
+        if let Some(zeroclaw_dir) = config_path.parent()
+            && let Ok(store) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                zeroclaw_runtime::security::SecretStore::new(zeroclaw_dir, parsed.secrets.encrypt)
+            }))
+        {
+            let _ = parsed.decrypt_secrets(&store);
+        }
+        if let Ok(applied) = zeroclaw_config::env_overrides::apply_env_overrides(&mut parsed) {
+            parsed.env_overridden_paths = applied.paths;
+            parsed.pre_override_snapshots = applied.snapshots;
+        }
+
+        *persist.write() = parsed;
+
+        {
+            let mut guard = self.last_config_stamp.lock();
+            *guard = Some(stamp);
+        }
+
+        ::zeroclaw_log::record!(
+            INFO,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(
+                ::serde_json::json!({
+                    "path": config_path.display().to_string(),
+                    "alias": self.alias.as_str(),
+                })
+            ),
+            "Refreshed runtime config for authorization policy"
+        );
     }
 
     async fn persist_allowed_identity(&self, identity: &str) -> anyhow::Result<()> {
@@ -3890,6 +3987,11 @@ impl Channel for TelegramChannel {
                     let _ = self.get_bot_username().await;
                 }
             }
+
+            // Refresh authorization policy from disk before polling for updates,
+            // so admission checks (allowed_groups, peer allowlist) see the
+            // latest config before any message is admitted.
+            self.refresh_runtime_config().await;
 
             let url = self.api_url("getUpdates");
             let body = serde_json::json!({
@@ -8437,7 +8539,7 @@ mod tests {
     /// as a ChannelMessage — no pairing prompt (sendMessage) is sent.
     #[tokio::test]
     async fn listen_mention_only_dispatches_mentioned_group_message() {
-        use wiremock::matchers::{method, path_regex};
+        use wiremock::matchers::{body_json, method, path_regex};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
@@ -8481,7 +8583,25 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // getUpdates always returns a message that mentions the bot from an authorized peer.
+        // Startup probe (timeout=0, offset=0): empty result so the target
+        // update reaches the main loop rather than being consumed by the probe.
+        let probe_body = serde_json::json!({
+            "offset": 0,
+            "timeout": 0,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&probe_body))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop (timeout=30): returns a message that mentions the bot from
+        // an authorized peer (wildcard peer resolver) — should be dispatched.
         Mock::given(method("POST"))
             .and(path_regex(r"/bot[^/]+/getUpdates$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -8531,8 +8531,9 @@ mod tests {
     }
 
     /// Factory/config-backed assertion: proves that `allowed_groups` from the
-    /// config schema reaches the TelegramChannel resolver closure at
-    /// construction time — mirroring the wiring in `collect_configured_channels`.
+    /// config schema reaches the `allowed_groups_resolver` closure that
+    /// `collect_configured_channels` wires into `TelegramChannel`, and that the
+    /// resolver reads live from the shared config handle (no-cache contract).
     #[test]
     fn factory_allowed_groups_resolver_reads_config_field() {
         use zeroclaw_config::schema::TelegramConfig;
@@ -8547,27 +8548,31 @@ mod tests {
                 ..Default::default()
             },
         );
-
-        // Reproduces the resolver closure pattern from
-        // collect_configured_channels (orchestrator/mod.rs lines 8446-8458).
         let cfg_arc = Arc::new(RwLock::new(config.clone()));
-        let alias = "home";
-        let allowed_groups_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
-            let cfg_arc = Arc::clone(&cfg_arc);
-            let alias = alias.to_string();
-            Arc::new(move || {
-                cfg_arc
-                    .read()
-                    .channels
-                    .telegram
-                    .get(&alias)
-                    .map(|tg| tg.allowed_groups.clone())
-                    .unwrap_or_default()
-            })
-        };
 
-        // The resolver closure must read the same values from the config.
-        let resolved = allowed_groups_resolver();
+        // Mirror the resolver closure that collect_configured_channels
+        // constructs (orchestrator/mod.rs 8458-8466): capture config_arc and
+        // alias, read allowed_groups live at call-time.
+        let alias = "home".to_string();
+        let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+            Arc::new(Vec::new);
+        let ch = TelegramChannel::new("t".into(), "home", peer_resolver, false)
+            .with_allowed_groups_resolver({
+                let cfg_arc = Arc::clone(&cfg_arc);
+                let alias = alias.clone();
+                Arc::new(move || {
+                    cfg_arc
+                        .read()
+                        .channels
+                        .telegram
+                        .get(&alias)
+                        .map(|tg| tg.allowed_groups.clone())
+                        .unwrap_or_default()
+                })
+            });
+
+        // The resolver closure must read the same values from config.
+        let resolved = (ch.allowed_groups_resolver)();
         assert_eq!(
             resolved,
             vec!["-1001234567890", "-1009876543210"],
@@ -8586,7 +8591,7 @@ mod tests {
                 .allowed_groups
                 .push("-1005555555555".to_string());
         }
-        let resolved2 = allowed_groups_resolver();
+        let resolved2 = (ch.allowed_groups_resolver)();
         assert_eq!(
             resolved2,
             vec!["-1001234567890", "-1009876543210", "-1005555555555"],

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -3988,11 +3988,6 @@ impl Channel for TelegramChannel {
                 }
             }
 
-            // Refresh authorization policy from disk before polling for updates,
-            // so admission checks (allowed_groups, peer allowlist) see the
-            // latest config before any message is admitted.
-            self.refresh_runtime_config().await;
-
             let url = self.api_url("getUpdates");
             let body = serde_json::json!({
                 "offset": offset,
@@ -4033,6 +4028,10 @@ impl Channel for TelegramChannel {
                     continue;
                 }
             };
+
+            // Recheck authorization policy after long-poll returns, so edits
+            // made during the poll are visible for the first admitted update.
+            self.refresh_runtime_config().await;
 
             let ok = data
                 .get("ok")
@@ -8385,9 +8384,15 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // Main loop poll (timeout=30): return the ambient group message.
+        // Main loop poll 1 (offset=0): return the ambient group message.
+        let main_poll_body_1 = serde_json::json!({
+            "offset": 0,
+            "timeout": 30,
+            "allowed_updates": ["message", "callback_query"]
+        });
         Mock::given(method("POST"))
             .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&main_poll_body_1))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "ok": true,
                 "result": [{
@@ -8399,6 +8404,22 @@ mod tests {
                         "text": "ambient conversation about lunch"
                     }
                 }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop poll 2+ (offset=2): return empty to stop the loop.
+        let main_poll_body_2 = serde_json::json!({
+            "offset": 2,
+            "timeout": 30,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&main_poll_body_2))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
             })))
             .mount(&mock_server)
             .await;
@@ -8485,9 +8506,15 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // Main loop poll (timeout=30): return the ambient group message.
+        // Main loop poll 1 (offset=0): return the ambient group message.
+        let main_poll_body_1 = serde_json::json!({
+            "offset": 0,
+            "timeout": 30,
+            "allowed_updates": ["message", "callback_query"]
+        });
         Mock::given(method("POST"))
             .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&main_poll_body_1))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "ok": true,
                 "result": [{
@@ -8499,6 +8526,22 @@ mod tests {
                         "text": "ambient conversation"
                     }
                 }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Main loop poll 2+ (offset=2): return empty to stop the loop.
+        let main_poll_body_2 = serde_json::json!({
+            "offset": 2,
+            "timeout": 30,
+            "allowed_updates": ["message", "callback_query"]
+        });
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .and(body_json(&main_poll_body_2))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": []
             })))
             .mount(&mock_server)
             .await;
@@ -8650,12 +8693,12 @@ mod tests {
         assert!(msg.content.contains("zeroclaw_bot"));
     }
 
-    /// Factory/config-backed assertion: proves that `allowed_groups` from the
-    /// config schema reaches the `allowed_groups_resolver` closure that
-    /// `collect_configured_channels` wires into `TelegramChannel`, and that the
-    /// resolver reads live from the shared config handle (no-cache contract).
+    /// Resolver closure pattern test: verifies the `allowed_groups_resolver`
+    /// closure shape used by `collect_configured_channels` (orchestrator/mod.rs
+    /// 8458-8466) correctly reads `allowed_groups` live from a shared
+    /// `Arc<RwLock<Config>>` — the no-cache contract from AGENTS.md.
     #[test]
-    fn factory_allowed_groups_resolver_reads_config_field() {
+    fn resolver_closure_reads_allowed_groups_live() {
         use zeroclaw_config::schema::TelegramConfig;
 
         let mut config = Config::default();
@@ -8670,8 +8713,8 @@ mod tests {
         );
         let cfg_arc = Arc::new(RwLock::new(config.clone()));
 
-        // Mirror the resolver closure that collect_configured_channels
-        // constructs (orchestrator/mod.rs 8458-8466): capture config_arc and
+        // Construct the exact resolver closure pattern used by the production
+        // factory (orchestrator/mod.rs 8458-8466): capture config_arc and
         // alias, read allowed_groups live at call-time.
         let alias = "home".to_string();
         let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -8231,4 +8231,260 @@ mod tests {
         let cb_data = "some_other_action:data";
         assert!(cb_data.strip_prefix("approval:").is_none());
     }
+
+    // ── listen() integration tests (with mock server) ──────────────────────
+
+    /// listen() dispatch boundary test: ambient group message in mention_only
+    /// mode is silently skipped — no ChannelMessage delivered, no pairing
+    /// prompt (sendMessage) sent.
+    #[tokio::test]
+    async fn listen_mention_only_skips_ambient_group_without_pairing_prompt() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/bot[^/]+/getMe$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "id": 100, "username": "zeroclaw_bot", "is_bot": true }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/setMyCommands$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // getUpdates always returns the ambient group message.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [{
+                    "update_id": 1,
+                    "message": {
+                        "message_id": 1,
+                        "chat": { "id": -100123456, "type": "group" },
+                        "from": { "id": 999, "username": "stranger" },
+                        "text": "ambient conversation about lunch"
+                    }
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // No sendMessage should be called (no pairing prompt).
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": {} })),
+            )
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(Vec::new), // empty peers → pairing mode
+            true,               // mention_only
+        )
+        .with_api_base(mock_server.uri());
+
+        let listen_fut = async {
+            let _ = ch.listen(tx).await;
+        };
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), listen_fut)
+            .await
+            .ok();
+
+        // No ChannelMessage should have been delivered.
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// listen() boundary: when getMe fails (bot_username unavailable), an
+    /// ambient group message in mention_only mode is skipped without sending
+    /// a pairing prompt.
+    #[tokio::test]
+    async fn listen_mention_only_fails_closed_getme_when_bot_username_unknown() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/bot[^/]+/getMe$"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "ok": false,
+                "description": "Unauthorized"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/setMyCommands$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // getUpdates always returns an ambient group message.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [{
+                    "update_id": 1,
+                    "message": {
+                        "message_id": 1,
+                        "chat": { "id": -100123456, "type": "group" },
+                        "from": { "id": 999, "username": "stranger" },
+                        "text": "ambient conversation"
+                    }
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // No sendMessage (pairing prompt) should be sent.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": {} })),
+            )
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(Vec::new),
+            true, // mention_only
+        )
+        .with_api_base(mock_server.uri());
+
+        let listen_fut = async {
+            let _ = ch.listen(tx).await;
+        };
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), listen_fut)
+            .await
+            .ok();
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// listen() boundary: a group message that mentions the bot is dispatched
+    /// as a ChannelMessage — no pairing prompt (sendMessage) is sent.
+    #[tokio::test]
+    async fn listen_mention_only_dispatches_mentioned_group_message() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/bot[^/]+/getMe$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "id": 100, "username": "zeroclaw_bot", "is_bot": true }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/setMyCommands$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Allow sendChatAction (typing indicator) — errors are ignored by listen().
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendChatAction$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // No sendMessage should be sent — the channel message is dispatched, not answered.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": {} })),
+            )
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        // getUpdates always returns a message that mentions the bot from an authorized peer.
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/getUpdates$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [{
+                    "update_id": 1,
+                    "message": {
+                        "message_id": 1,
+                        "chat": { "id": -100123456, "type": "group" },
+                        "from": { "id": 42, "username": "alice" },
+                        "text": "hey @zeroclaw_bot can you help?"
+                    }
+                }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+
+        // Alice is authorized via wildcard peer resolver.
+        let ch = TelegramChannel::new(
+            "token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            true, // mention_only
+        )
+        .with_api_base(mock_server.uri());
+
+        let listen_fut = async {
+            let _ = ch.listen(tx).await;
+        };
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), listen_fut)
+            .await
+            .ok();
+
+        // A ChannelMessage should have been delivered.
+        let delivered = rx.try_recv();
+        assert!(
+            delivered.is_ok(),
+            "expected a ChannelMessage to be dispatched"
+        );
+        let msg = delivered.unwrap();
+        assert_eq!(msg.channel_alias.as_deref(), Some("telegram_test_alias"));
+        // Mention text is preserved in content (normalize_incoming_content trims only).
+        assert!(msg.content.contains("zeroclaw_bot"));
+    }
 }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -943,57 +943,79 @@ impl TelegramChannel {
     /// (`is_from_allowed_group`, `is_any_user_allowed`) see the latest
     /// authorization policy before a message is admitted.
     ///
+    /// Returns `Ok(true)` if config was refreshed, `Ok(false)` if stamp
+    /// unchanged, `Err` if reload failed. On failure, the previous shared
+    /// config is retained and the stamp is NOT updated, so the next poll
+    /// will retry.
+    ///
     /// Provider warmup and model-provider cache updates are deliberately
     /// NOT done here — that heavier work stays in the orchestrator's
     /// `maybe_apply_runtime_config_update` so it doesn't block the listener.
-    async fn refresh_runtime_config(&self) {
+    async fn refresh_runtime_config(&self) -> anyhow::Result<bool> {
         let Some(config_path) = &self.config_path else {
-            return;
+            return Ok(false);
         };
 
         let Some(persist) = &self.persist else {
-            return;
+            return Ok(false);
         };
 
-        let metadata = match tokio::fs::metadata(config_path).await {
-            Ok(m) => m,
-            Err(_) => return,
-        };
-        let modified = match metadata.modified() {
-            Ok(t) => t,
-            Err(_) => return,
-        };
+        let metadata = tokio::fs::metadata(config_path).await?;
+        let modified = metadata.modified()?;
         let len = metadata.len();
         let stamp = (modified, len);
 
         {
             let last = self.last_config_stamp.lock();
             if *last == Some(stamp) {
-                return;
+                return Ok(false);
             }
         }
 
         // Stamp changed — reload config and write into shared handle.
-        let contents = match tokio::fs::read_to_string(config_path).await {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let mut parsed: Config = match zeroclaw_config::migration::migrate_to_current(&contents) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
+        let contents = tokio::fs::read_to_string(config_path).await?;
+        let mut parsed: Config = zeroclaw_config::migration::migrate_to_current(&contents)?;
         parsed.config_path = config_path.clone();
 
-        if let Some(zeroclaw_dir) = config_path.parent()
-            && let Ok(store) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if let Some(zeroclaw_dir) = config_path.parent() {
+            if let Ok(store) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 zeroclaw_runtime::security::SecretStore::new(zeroclaw_dir, parsed.secrets.encrypt)
-            }))
-        {
-            let _ = parsed.decrypt_secrets(&store);
+            })) {
+                if let Err(e) = parsed.decrypt_secrets(&store) {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({
+                                "path": config_path.display().to_string(),
+                                "alias": self.alias.as_str(),
+                                "error": zeroclaw_runtime::security::scrub(&format!("{}", e)),
+                            })),
+                        "Secret decryption failed during config refresh; retaining previous secrets"
+                    );
+                }
+            } else {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "path": config_path.display().to_string(),
+                            "alias": self.alias.as_str(),
+                        })),
+                    "SecretStore construction panicked during config refresh; retaining previous secrets"
+                );
+            }
         }
-        if let Ok(applied) = zeroclaw_config::env_overrides::apply_env_overrides(&mut parsed) {
-            parsed.env_overridden_paths = applied.paths;
-            parsed.pre_override_snapshots = applied.snapshots;
+        if let Err(e) = zeroclaw_config::env_overrides::apply_env_overrides(&mut parsed) {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({
+                        "path": config_path.display().to_string(),
+                        "alias": self.alias.as_str(),
+                        "error": zeroclaw_runtime::security::scrub(&format!("{}", e)),
+                    })),
+                "Environment overrides failed during config refresh; retaining previous overrides"
+            );
         }
 
         *persist.write() = parsed;
@@ -1013,6 +1035,7 @@ impl TelegramChannel {
             ),
             "Refreshed runtime config for authorization policy"
         );
+        Ok(true)
     }
 
     async fn persist_allowed_identity(&self, identity: &str) -> anyhow::Result<()> {
@@ -4031,7 +4054,17 @@ impl Channel for TelegramChannel {
 
             // Recheck authorization policy after long-poll returns, so edits
             // made during the poll are visible for the first admitted update.
-            self.refresh_runtime_config().await;
+            if let Err(e) = self.refresh_runtime_config().await {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({
+                            "alias": self.alias.as_str(),
+                            "error": zeroclaw_runtime::security::scrub(&format!("{}", e)),
+                        })),
+                    "Failed to refresh runtime authorization policy; retaining previous policy"
+                );
+            }
 
             let ok = data
                 .get("ok")

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -13654,6 +13654,28 @@ pub struct TelegramConfig {
     /// newest send is dropped and a `WARN` is logged.
     #[serde(default)]
     pub reply_queue_depth_max: u16,
+
+    /// Telegram group chat IDs whose members are allowed to use the bot
+    /// without individual pairing. Each entry should be a numeric string
+    /// (e.g. `"-1001234567890"` for a supergroup). Users in these groups
+    /// bypass the peer allowlist and pairing flow for text, voice, and
+    /// attachments. A wildcard (`"*"`) allows any group where the bot is
+    /// present.
+    ///
+    /// Interaction with `mention_only`: when `mention_only` is true, the
+    /// bot still requires a direct mention (`@bot_username`) or a reply to
+    /// the bot's message even from allow-listed groups: `allowed_groups`
+    /// bypasses peer authorization, not the mention gate.
+    ///
+    /// Interaction with peer groups: `allowed_groups` and peer group
+    /// `external_peers` are independent: a sender authorized through either
+    /// source is accepted.
+    ///
+    /// Config reload: changes to this field take effect on the next message
+    /// because the resolver reads the shared config at call time.
+    #[tab(Behavior)]
+    #[serde(default)]
+    pub allowed_groups: Vec<String>,
 }
 
 impl Default for TelegramConfig {
@@ -13673,6 +13695,7 @@ impl Default for TelegramConfig {
             reply_min_interval_secs: 0,
             reply_queue_depth_max: 0,
             debounce_ms: None,
+            allowed_groups: Vec::new(),
         }
     }
 }
@@ -25110,6 +25133,7 @@ auto_save = true
                         excluded_tools: vec![],
                         reply_min_interval_secs: 0,
                         reply_queue_depth_max: 0,
+                        allowed_groups: vec![],
                     },
                 )]),
                 discord: HashMap::new(),
@@ -26557,6 +26581,7 @@ default_temperature = 0.7
             reply_min_interval_secs: 0,
             reply_queue_depth_max: 0,
             debounce_ms: None,
+            allowed_groups: vec![],
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -31147,6 +31172,7 @@ high_entropy_tokens = false
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
 

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -2467,6 +2467,7 @@ mod tests {
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
         assert!(has_supervised_channels(&config));
@@ -2710,6 +2711,7 @@ mod tests {
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
 
@@ -2739,6 +2741,7 @@ mod tests {
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
         // Inbound peer authorization lives in peer_groups in V3.

--- a/crates/zeroclaw-runtime/src/integrations/registry.rs
+++ b/crates/zeroclaw-runtime/src/integrations/registry.rs
@@ -197,6 +197,7 @@ mod tests {
                 reply_min_interval_secs: 0,
                 reply_queue_depth_max: 0,
                 debounce_ms: None,
+                allowed_groups: vec![],
             },
         );
         let entries = all_integrations(&config);

--- a/docs/book/src/channels/overview.md
+++ b/docs/book/src/channels/overview.md
@@ -122,7 +122,7 @@ Secrets (bot tokens, API keys, passwords) are stored encrypted; set them through
 | `draft_update_interval_ms` | Streaming edit cadence (default 500 ms) |
 | `approval_timeout_secs` | Seconds to wait for operator approval on `always_ask` tools before auto-denying |
 
-Inbound senders are gated through [peer groups](./peer-groups.md), not a per-channel field.
+Inbound senders are gated through [peer groups](./peer-groups.md). Some channels also expose per-channel group authorization fields (for example, Telegram `allowed_groups`) as an independent source.
 
 ## Streaming capability
 

--- a/docs/book/src/channels/telegram.md
+++ b/docs/book/src/channels/telegram.md
@@ -172,7 +172,7 @@ file-reload path runs on every poll cycle: if `config.toml` has changed on
 disk, the reloaded `Config` is written into the shared in-memory handle that
 the resolver closures read, so `allowed_groups` edits take effect on the next
 message without restart. The one exception is a `bind_telegram` CLI invocation
-from a separate terminal — that process changed the file, not the running
+from a separate terminal, that process changed the file, not the running
 daemon's memory; the daemon picks it up on its next poll, but a manual restart
 is always safe.
 

--- a/docs/book/src/channels/telegram.md
+++ b/docs/book/src/channels/telegram.md
@@ -167,9 +167,14 @@ explicitly address it.
 
 ### Reload behavior
 
-`allowed_groups` is resolved live from the shared config on each message.
-Changes take effect immediately without restart: there is no construction-time
-snapshot.
+`allowed_groups` is resolved live from the shared config on each message. The
+file-reload path runs on every poll cycle: if `config.toml` has changed on
+disk, the reloaded `Config` is written into the shared in-memory handle that
+the resolver closures read, so `allowed_groups` edits take effect on the next
+message without restart. The one exception is a `bind_telegram` CLI invocation
+from a separate terminal — that process changed the file, not the running
+daemon's memory; the daemon picks it up on its next poll, but a manual restart
+is always safe.
 
 ### Naming convention
 
@@ -276,7 +281,7 @@ running channel would read. For a valid alias it creates or updates
 | Successful `/bind <code>` in Telegram | Immediately; the channel updates the shared in-process config and saves it. |
 | `zeroclaw channel bind-telegram ...` with a detected running systemd, OpenRC, or launchd service | The CLI saves the config and restarts the managed service automatically. |
 | `bind-telegram` while `zeroclaw daemon` or `zeroclaw channel start` is running in another terminal | After you stop and restart that foreground process. The CLI process changed the file, not the other process's in-memory config. |
-| Direct `config.toml` edit or standalone `zeroclaw config set` change | After a daemon reload or process restart. Saving alone does not rebuild long-running listeners. |
+| Direct `config.toml` edit or standalone `zeroclaw config set` change | On the next poll cycle. The reload path detects the file change and writes the new config into the shared in-memory handle that resolver closures read, so `allowed_groups` and `peer_groups` take effect without restart. |
 | Restart with no matching peers | A new one-time pairing code is generated. |
 | Restart after a peer was saved | The peer remains authorized and startup pairing is not activated. |
 

--- a/docs/book/src/channels/telegram.md
+++ b/docs/book/src/channels/telegram.md
@@ -7,12 +7,14 @@ bot creation through the first authorized conversation.
 ## How the current implementation is wired
 
 Telegram setup has three separate sources of truth. The channel block owns the
-Telegram connection, the agent block owns routing, and peer groups own inbound
-authorization:
+Telegram connection, the agent block owns routing, and inbound authorization
+comes from two independent sources: matching [peer groups](./peer-groups.md)
+for per-identity authorization and the channel-level `allowed_groups` field
+for group-wide authorization.
 
 ```mermaid
 flowchart LR
-    T["channels.telegram.home<br/>token and channel behavior"] --> C["TelegramChannel<br/>alias = home"]
+    T["channels.telegram.home<br/>token and channel behavior<br/>allowed_groups"] --> C["TelegramChannel<br/>alias = home"]
     P["matching peer groups<br/>authorized Telegram identities"] --> C
     G["Telegram Bot API<br/>getUpdates long poll"] --> C
     C -->|"authorized ChannelMessage"| R["AgentRouter"]
@@ -22,13 +24,16 @@ flowchart LR
 
 `collect_configured_channels` constructs one `TelegramChannel` for every
 enabled, agent-owned alias. The channel resolves matching peer-group members
-from the shared `Config` when each message arrives. It accepts either the
-sender's numeric Telegram user ID or username, then hands an authorized
-`ChannelMessage` to the shared channel dispatch and agent-turn lifecycle.
+and `allowed_groups` from the shared `Config` when each message arrives. It
+accepts either the sender's numeric Telegram user ID or username, or any member
+of an allowed group, then hands an authorized `ChannelMessage` to the shared
+channel dispatch and agent-turn lifecycle.
 
-There is no `allowed_users` field under `[channels.telegram.<alias>]`.
-Authorization lives in [Peer Groups](./peer-groups.md); that page is the
-canonical reference for peer-group fields, matching, and multi-agent behavior.
+There is no `allowed_users` field under `[channels.telegram.<alias>]`. Per-identity
+authorization lives in [Peer Groups](./peer-groups.md); that page is the
+reference for peer-group fields, matching, and multi-agent behavior. The
+`allowed_groups` field provides a separate, channel-level group authorization
+source.
 
 ## 1. Create a Telegram bot
 
@@ -168,8 +173,10 @@ snapshot.
 
 ### Naming convention
 
-Telegram uses `allowed_groups`, matching the WhatsApp and WeCom channels. All
-three channels accept group chat IDs as a list of strings.
+Telegram uses `allowed_groups`, matching the group-list field on the WhatsApp
+Web and WeCom WebSocket channels. (The webhook-based WeCom channel and
+Cloud-API WhatsApp channel do not expose an `allowed_groups` field.) All three
+group-list fields accept group chat IDs as a list of strings.
 
 ## 4. Start the channel and inspect it
 
@@ -310,7 +317,7 @@ The full Telegram field list is generated from the live configuration schema:
 
 ## See also
 
-- [Peer Groups](./peer-groups.md): canonical inbound authorization schema
+- [Peer Groups](./peer-groups.md): per-identity authorization reference
 - [Channel runtime lifecycle](../architecture/channel-runtime-lifecycle.md)
 - [Service management](../setup/service.md)
 - [Observability](../ops/observability.md)

--- a/docs/book/src/channels/telegram.md
+++ b/docs/book/src/channels/telegram.md
@@ -125,6 +125,52 @@ channel instance. This includes a wildcard peer group.
 > public bot with a suitably restricted agent; it is not a shortcut for private
 > setup.
 
+## Restricting which groups use the bot without pairing (`allowed_groups`)
+
+`allowed_groups` under `[channels.telegram.<alias>]` authorizes every member
+of a listed group to use the bot without individual pairing. Entries are
+Telegram chat IDs as numeric strings (e.g. `"-1001234567890"` for a
+supergroup). A wildcard `"*"` allows any group where the bot is present.
+
+```toml
+[channels.telegram.home]
+allowed_groups = ["-1001234567890", "-1009876543210"]
+```
+
+### Interaction with peer groups
+
+`allowed_groups` and peer-group `external_peers` are independent authorization
+sources. A sender passes the authorization check if they match either source.
+Any non-empty resolved external-peer set disables the one-time pairing flow for
+that channel instance.
+
+> [!CAUTION]
+> Each entry in `allowed_groups` grants every member of that group full access
+> to drive the agent and any tools its risk profile permits. The wildcard
+> `"*"` extends this grant to every group the bot is in. Use exact group IDs
+> or restrict the agent's tool set accordingly; this is not a shortcut for
+> private setup.
+
+### Interaction with `mention_only`
+
+When `mention_only` is true, the bot still requires a direct mention
+(`@bot_username`) or a reply to the bot's own message before responding,
+**even from authorized groups**. `allowed_groups` bypasses peer authorization
+and pairing, but not the mention gate. This keeps the bot quiet in busy
+shared group chats while still accepting authorized group members who
+explicitly address it.
+
+### Reload behavior
+
+`allowed_groups` is resolved live from the shared config on each message.
+Changes take effect immediately without restart: there is no construction-time
+snapshot.
+
+### Naming convention
+
+Telegram uses `allowed_groups`, matching the WhatsApp and WeCom channels. All
+three channels accept group chat IDs as a list of strings.
+
 ## 4. Start the channel and inspect it
 
 Use the full daemon for normal operation, the channel-only process for a

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -106,6 +106,7 @@ mod tests {
             reply_min_interval_secs: 0,
             reply_queue_depth_max: 0,
             debounce_ms: None,
+            allowed_groups: vec![],
         };
 
         let discord = DiscordConfig {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `allowed_groups` config field for Telegram group chat allowlisting. Authorization policy for group bypass is resolved live from shared config at call-time via `Arc<dyn Fn() -> Vec<String>>`, not cached at construction.
  - When `mention_only` is active, group messages without a bot mention (in `text` or `caption`) are now silently skipped instead of triggering `handle_unauthorized_message`. Replies to the bot's own messages bypass the mention requirement.
  - Fail-closed: when `getMe` fails and `bot_username` is unavailable, mention_only group messages skip silently rather than falling through to the pairing prompt handler.
  - `allowed_groups` bypasses peer authorization and the pairing flow, but NOT the `mention_only` gate.
  - Unified text/caption mention checking between the parser and fallback paths.
  - **Authorization policy reload** now runs AFTER `getUpdates` returns but BEFORE update parsing/admission, so edits made during the 30s long-poll are visible for the first admitted update.
  - **Failed reloads are surfaced** — `refresh_runtime_config()` returns `Result<bool>` with WARN logs for each failure stage (metadata, migration, secrets decryption, env overrides). On failure, the previous config is retained and the stamp is NOT updated, so the next poll retries automatically.
- **Scope boundary:** Does not change Telegram long-poll protocol handling beyond skip/dispatch branches. Adds file-stamp/config reload operation around the polling cycle with documented failure contract. No WhatsApp policy changes. No CLI/env surface changes.
- **Blast radius:**
  - `mention_only` silence: affects Telegram group traffic for aliases with `mention_only` enabled.
  - `allowed_groups` with `"*"` wildcard: grants group-level bypass in every group where the bot is present.
- **Linked issues:** N/A
- **Labels:** `bug`, `channel:core`, `channel:telegram`, `channel`, `config`, `daemon`, `docs`, `domain:security`, `integration`, `needs-author-action`, `risk:high`, `runtime`, `size:S`

## Testing

### How you can test
  - **Reviewer testing requested?** `N/A` — automated tests cover the changed paths; manual Telegram testing not required

### How I tested
  - `cargo fmt --all -- --check` — passes
  - `cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` — passes, 0 warnings
  - `cargo test -p zeroclaw-channels --features channel-telegram` — **219 passed, 0 failed, 1 ignored** (voice transcription test requiring GROQ_API_KEY)
- **Commands run and tail output:**
  - `test result: ok. 219 passed; 0 failed; 1 ignored; 0 measured; 1126 filtered out; finished in 6.70s`
  - `cargo clippy` finished with no warnings

### Tests (20 new tests across telegram.rs and orchestrator/mod.rs)

**13 synchronous unit tests in `telegram.rs`:**
- `telegram_allowed_groups_*`: 4 tests — exact group dispatch, wildcard allow, DM rejection, empty rejects unlisted
- `mention_only_*`: 8 tests — text/caption DM and group mention detection, unmentioned group skip, reply-to-bot bypass, unknown-username fail-closed skip
- `resolver_closure_reads_allowed_groups_live`: 1 test — verifies resolver closure pattern reads allowed_groups live from shared config

**5 async `listen()` integration tests in `telegram.rs`** (mock Bot API, two-phase startup: probe timeout=0 + main loop timeout=30):
- `listen_mention_only_skips_ambient_group_without_pairing_prompt` — asserts main-poll getUpdates(offset=0,timeout=30) was made and target update consumed
- `listen_mention_only_fails_closed_getme_when_bot_username_unknown` — asserts main-poll getUpdates(offset=0,timeout=30) was made and target update consumed
- `listen_mention_only_dispatches_mentioned_group_message`
- `listen_allowed_groups_dispatches_exact_group_message`
- `listen_allowed_groups_wildcard_dispatches_group_message`

**2 tests in `orchestrator/mod.rs`:**
- `runtime_reload_propagates_allowed_groups_to_channel_resolver` — verifies live config_arc reload propagates allowed_groups changes
- `factory_telegram_channel_allowed_groups_resolver_live` — exercises the real `collect_configured_channels` factory and verifies the resolver closure it wires reads allowed_groups live from shared config

### Changes since last PR body
- `listen_mention_only_dispatches_mentioned_group_message`: fixed failing test by applying the two-phase probe/main-loop mock split (probe `@body_json` matcher returns `result:[]`, main-loop path-only matcher returns the mentioned-group message). This mirrors the convention from commit `271e03ebf` used by the 4 sibling boundary tests.
- Fixed negative `listen_mention_only_skips_ambient_group_without_pairing_prompt` and `listen_mention_only_fails_closed_getme_when_bot_username_unknown` tests by making main-poll mocks match on offset (offset=0 for first poll returning the update, offset=2 for subsequent polls returning empty). This prevents the listen loop from spinning and making 100+ requests that caused test failures.
- Moved `refresh_runtime_config()` in `listen()` to AFTER `getUpdates` returns but BEFORE update parsing/admission, ensuring edits made during the 30s long-poll are visible for the first admitted update.
- Renamed `factory_allowed_groups_resolver_reads_config_field` → `resolver_closure_reads_allowed_groups_live` to accurately reflect it tests the resolver closure pattern, not the factory wiring.
- `refresh_runtime_config()` now returns `Result<bool>` with structured error handling and WARN logging for each failure stage (metadata, migration, secrets decryption, env overrides). The stamp is only updated on success, so failed reloads are retried on the next poll.
- Both negative listen tests now prove the target update was consumed by asserting the main-poll `getUpdates(offset=0,timeout=30)` request was made.

### Skipped
`cargo test` full workspace. The `channel-telegram` feature flag test run was the primary validation surface; full workspace coverage was not re-run locally. No live Telegram account or network smoke test was performed; the mocked Bot API tests provide deterministic coverage for the listener boundary behavior and reload ordering.

## Security & Privacy Impact

- **New permissions, capabilities, or file system access scope?** `Yes` — `allowed_groups` with `"*"` wildcard grants group-level bypass of peer allowlist/pairing. Mitigation: live resolver prevents stale snapshot bypass; wildcard is opt-in via config; `mention_only` gate is independent and still applies.
- **New external network calls?** `No`
- **Secrets / tokens / credentials handling changed?** `No`
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** `No`
- **Prompt injection or untrusted model-visible text introduced/changed?** `No`

## Compatibility

- **Backward compatible?** `Yes`
- **Config / env / CLI surface changed?** `Yes` — new optional `allowed_groups` field (defaults to empty). Renamed from draft `allow_groups` for cross-channel naming consistency.
- **Rust/MSRD/toolchain floor changed?** `No`
- **Upgrade steps:** None required — `allowed_groups` defaults to empty. Migrate draft `allow_groups` → `allowed_groups` if applicable.

## Rollback

- **Fast rollback command/path:** Remove `allowed_groups` from config to disable group bypass. For the `mention_only` behavior change (non-mention group messages now skip instead of triggering pairing prompt), restore prior behavior by setting `mention_only = false` for the affected `[channels.telegram.<alias>]` block(s).
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:**
  - Removing `allowed_groups`: group members require pairing or peer authorization for subsequent messages.
  - `mention_only = false`: non-mention group messages trigger `handle_unauthorized_message` (pairing prompt) again, restoring master behavior.