### PR TITLE
fix(deps): update vulnerable Nostr crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6180,9 +6180,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.6"
+version = "0.44.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
+checksum = "c7d3d987ea7078dc36947cde532637c472a229426702e4331dd7667325378bd9"
 dependencies = [
  "aes 0.8.4",
  "base64 0.22.1",
@@ -6225,9 +6225,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.2"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
+checksum = "c85c54d6ca9aae4ae2bf19a7663ba9db5f45f783f1d24aff55f006386b8b99a1"
 dependencies = [
  "async-utility",
  "async-wsocket",


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Update the locked `nostr` package from 0.44.6 to 0.44.7.
  - Update the locked `nostr-relay-pool` package from 0.44.2 to 0.44.3.
  - Remove the package versions affected by RUSTSEC-2026-0225 through RUSTSEC-2026-0232 from the resolved dependency graph.
- **Scope boundary:** This changes only the two transitive lockfile resolutions. It does not change ZeroClaw-owned source code, manifests, features, configuration, or public APIs.
- **Blast radius:** Builds that enable the Nostr channel resolve the patched package versions. Both resolved packages remain on 0.44.x, the existing `nostr-sdk = "0.44"` manifest constraint is unchanged, and the dependency graph gains the upstream fixes for RUSTSEC-2026-0225 through RUSTSEC-2026-0232.
- **Linked issue(s):** None. This repairs the repository-wide Security check exposed by the refreshed RustSec advisory database.
- **Labels:** `type:dependencies`, `risk:medium`, `size:XS`, `dependencies`, `channel:nostr`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a lockfile-only dependency update with no manual user-facing behavior to exercise.

### How I tested

- **CI checks relied on and why they cover this change:** The required Security job reruns `cargo audit` and `cargo deny` against the committed lockfile. The Rust build matrix checks compatibility across the repository's supported targets and feature sets.
- **Known CI coverage gap, if any:** No known repository build or lockfile-validation gap. Upstream semantic changes and declared MSRV differences were not independently reviewed.
- **Commands run and tail output:**

```text
$ cargo metadata --locked --no-deps --format-version 1
Completed successfully.

$ cargo audit --file Cargo.lock
Loaded 1186 security advisories.
No vulnerable packages found.
Four existing allowed warnings remained.

$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok

$ cargo check --locked -p zeroclaw-channels --features channel-nostr
Finished `dev` profile [unoptimized + debuginfo] target(s) in 38m 20s.
```

- **Beyond CI, what did you manually verify?** The lockfile diff changes only the versions and checksums for `nostr` and `nostr-relay-pool`; no other package resolution changed. The audit used cargo-audit 0.22.2 and cargo-deny 0.19.9, matching the pinned Security workflow versions.
- **If any command was intentionally skipped, why:** A separate full-workspace local build was skipped because the focused Nostr feature compile covers the affected integration path and required CI supplies the repository-wide build matrix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No` ZeroClaw-owned change; upstream dependency behavior was not independently audited.)
- New external network calls? (`No` ZeroClaw-owned call-path change; upstream dependency behavior was not independently audited.)
- Secrets / tokens / credentials handling changed? (`No` ZeroClaw-owned change; upstream dependency behavior was not independently audited.)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A. The change removes dependency versions covered by eight RustSec advisories. No ZeroClaw-owned data lifecycle, authorization, or autonomous-invocation logic changes.

## Compatibility (required)

- Backward compatible? (`Yes` for ZeroClaw-owned public API and configuration surfaces; upstream runtime compatibility is expected within the existing 0.44 constraint but was not independently audited beyond the focused compile.)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No` ZeroClaw toolchain-floor change; the patched crates' declared MSRV was not independently compared.)
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Prefer a fix-forward patch. For an emergency regression rollback, `git revert <merge-commit>` restores the prior lockfile resolutions, including the advisory-affected versions.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Nostr-feature compile errors or regressions in Nostr relay connection and event handling after the dependency update.
