### PR TITLE
fix(infra): preserve session queue serialization during eviction

### DIFF
--- a/crates/zeroclaw-infra/src/session_queue.rs
+++ b/crates/zeroclaw-infra/src/session_queue.rs
@@ -14,6 +14,8 @@ pub struct SessionActorQueue {
     max_queue_depth: usize,
     lock_timeout: Duration,
     idle_ttl: Duration,
+    #[cfg(test)]
+    registration_hook: std::sync::Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 struct SessionSlot {
@@ -24,11 +26,15 @@ struct SessionSlot {
 
 /// RAII guard that releases the session permit on drop.
 pub struct SessionGuard {
-    slot: Arc<SessionSlot>,
     _permit: OwnedSemaphorePermit,
+    _registration: PendingRegistration,
 }
 
-impl Drop for SessionGuard {
+struct PendingRegistration {
+    slot: Arc<SessionSlot>,
+}
+
+impl Drop for PendingRegistration {
     fn drop(&mut self) {
         self.slot.pending.fetch_sub(1, Ordering::Relaxed);
     }
@@ -69,15 +75,17 @@ impl SessionActorQueue {
             max_queue_depth,
             lock_timeout: Duration::from_secs(lock_timeout_secs),
             idle_ttl: Duration::from_secs(idle_ttl_secs),
+            #[cfg(test)]
+            registration_hook: std::sync::Mutex::new(None),
         }
     }
 
     /// Acquire exclusive access to a session. Blocks until the session is free
     /// or the timeout expires. Returns a guard that releases on drop.
     pub async fn acquire(&self, session_id: &str) -> Result<SessionGuard, SessionQueueError> {
-        let slot = {
+        let registration = {
             let mut slots = self.slots.lock().await;
-            slots
+            let slot = slots
                 .entry(session_id.to_string())
                 .or_insert_with(|| {
                     Arc::new(SessionSlot {
@@ -86,36 +94,46 @@ impl SessionActorQueue {
                         pending: AtomicUsize::new(0),
                     })
                 })
-                .clone()
+                .clone();
+
+            #[cfg(test)]
+            if let Some(hook) = self.registration_hook.lock().unwrap().as_ref() {
+                hook();
+            }
+
+            // Register while holding the map lock so idle eviction cannot
+            // remove this slot before it sees the pending request.
+            let current = slot.pending.fetch_add(1, Ordering::Relaxed);
+            let registration = PendingRegistration { slot };
+            if current >= self.max_queue_depth {
+                return Err(SessionQueueError::QueueFull {
+                    session_id: session_id.to_string(),
+                    depth: current,
+                });
+            }
+
+            registration
         };
 
-        // Check queue depth before waiting
-        let current = slot.pending.fetch_add(1, Ordering::Relaxed);
-        if current >= self.max_queue_depth {
-            slot.pending.fetch_sub(1, Ordering::Relaxed);
-            return Err(SessionQueueError::QueueFull {
-                session_id: session_id.to_string(),
-                depth: current,
-            });
-        }
-
         // Acquire owned permit with timeout
-        let sem = slot.semaphore.clone();
+        let sem = registration.slot.semaphore.clone();
         match tokio::time::timeout(self.lock_timeout, sem.acquire_owned()).await {
             Ok(Ok(permit)) => {
-                *slot.last_active.lock().await = Instant::now();
+                *registration.slot.last_active.lock().await = Instant::now();
                 Ok(SessionGuard {
-                    slot,
                     _permit: permit,
+                    _registration: registration,
                 })
             }
-            Ok(Err(_)) | Err(_) => {
-                slot.pending.fetch_sub(1, Ordering::Relaxed);
-                Err(SessionQueueError::Timeout {
-                    session_id: session_id.to_string(),
-                })
-            }
+            Ok(Err(_)) | Err(_) => Err(SessionQueueError::Timeout {
+                session_id: session_id.to_string(),
+            }),
         }
+    }
+
+    #[cfg(test)]
+    fn set_registration_hook(&self, hook: Arc<dyn Fn() + Send + Sync>) {
+        *self.registration_hook.lock().unwrap() = Some(hook);
     }
 
     /// Get the number of pending requests for a session.
@@ -213,6 +231,63 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
         let evicted = queue.evict_idle().await;
         assert_eq!(evicted, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn registration_and_eviction_are_atomic() {
+        let queue = Arc::new(SessionActorQueue::new(8, 5, 0));
+        let selected = Arc::new(std::sync::Barrier::new(2));
+        let resume = Arc::new(std::sync::Barrier::new(2));
+        let hook_selected = selected.clone();
+        let hook_resume = resume.clone();
+        queue.set_registration_hook(Arc::new(move || {
+            hook_selected.wait();
+            hook_resume.wait();
+        }));
+
+        let acquire_queue = queue.clone();
+        let acquire = zeroclaw_spawn::spawn!(async move { acquire_queue.acquire("s1").await });
+        tokio::task::spawn_blocking(move || selected.wait())
+            .await
+            .unwrap();
+
+        let evict_queue = queue.clone();
+        let mut eviction = zeroclaw_spawn::spawn!(async move { evict_queue.evict_idle().await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut eviction)
+                .await
+                .is_err(),
+            "eviction must wait for request registration to release the slot map"
+        );
+        tokio::task::spawn_blocking(move || resume.wait())
+            .await
+            .unwrap();
+
+        let guard = acquire.await.unwrap().unwrap();
+        assert_eq!(eviction.await.unwrap(), 0);
+        assert_eq!(queue.queue_depth("s1").await, 1);
+
+        drop(guard);
+        assert_eq!(queue.evict_idle().await, 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_releases_registration() {
+        let queue = Arc::new(SessionActorQueue::new(8, 30, 0));
+        let guard = queue.acquire("s1").await.unwrap();
+
+        let waiter_queue = queue.clone();
+        let waiter = zeroclaw_spawn::spawn!(async move { waiter_queue.acquire("s1").await });
+        while queue.queue_depth("s1").await < 2 {
+            tokio::task::yield_now().await;
+        }
+
+        waiter.abort();
+        let _ = waiter.await;
+        assert_eq!(queue.queue_depth("s1").await, 1);
+
+        drop(guard);
+        assert_eq!(queue.evict_idle().await, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Register each session request while the session-slot map is still locked, so idle eviction cannot remove a selected slot before its pending count is visible.
- **What changed and why:** Track pending registration with an RAII guard so timeout, cancellation, queue rejection, semaphore closure, and normal guard release each decrement the count exactly once.
- **Scope boundary:** This repairs the existing admission invariant rather than changing the claim/queue contract shape tracked in #9600. It does not change queue limits, timeout policy, idle TTL configuration, session persistence, or the planned session-actor architecture.
- **Blast radius:** Session admission and idle eviction for callers that use `SessionActorQueue`.
- **Linked issue(s):** Related #9487. Related #9600.
- **Labels:** `bug`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The failure is an internal concurrency race with no useful manual reproduction; targeted concurrency tests pause registration at the eviction boundary and cancel a queued waiter.

### How I tested

- **CI checks relied on and why they cover this change:** Required GitHub CI will exercise formatting, lint, and workspace tests on the published head.
- **Known CI coverage gap, if any:** None after focused race tests, workspace-shaped Clippy, and the CI-shaped full workspace test run.
- **Commands run and tail output:**

```text
$ cargo test --locked -p zeroclaw-infra session_queue -- --nocapture
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 103 filtered out

$ cargo clippy --locked -p zeroclaw-infra --all-targets -- -D warnings
Finished `dev` profile

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Finished `dev` profile

$ cargo nextest run --locked --workspace --exclude zeroclaw-desktop
First attempt: stopped on an unrelated provider timeout test; that test passed a focused rerun
Warm retry: PASS
```

- **Beyond CI, what did you manually verify?** I verified that eviction blocks while registration owns the slot-map lock, then preserves the registered slot, and that aborting a queued waiter releases its pending registration. I did not run a user-interface smoke test because this change has no direct interface.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 294f4d6fd`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Concurrent turns for one session can overlap after idle eviction, or a cancelled waiter can leave queue depth permanently elevated.
