### PR TITLE
fix(cli): make cron add help examples run as printed (#9672)

### DIFF
--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -233,9 +233,9 @@ cli-cron-long-about =
 
     Examples:
       zeroclaw cron list
-      zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
-      zeroclaw cron add '*/30 * * * *' 'Check system health' --agent
-      zeroclaw cron add '*/5 * * * *' 'echo ok'
+      zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
+      zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
+      zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
       zeroclaw cron add-at 2025-01-15T14:00:00Z 'Send reminder' --agent
       zeroclaw cron add-every 60000 'Ping heartbeat'
       zeroclaw cron once 30m 'Run backup in 30 minutes' --agent

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -197,9 +197,9 @@ cli-cron-long-about =
 
     Ejemplos:
     zeroclaw cron list
-    zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
-    zeroclaw cron add '*/30 * * * *' 'Check system health' --agent
-    zeroclaw cron add '*/5 * * * *' 'echo ok'
+    zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
+    zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
+    zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
     zeroclaw cron add-at 2025-01-15T14:00:00Z 'Send reminder' --agent
     zeroclaw cron add-every 60000 'Ping heartbeat'
     zeroclaw cron once 30m 'Run backup in 30 minutes' --agent

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -197,9 +197,9 @@ cli-cron-long-about =
 
     Exemples :
     zeroclaw cron list
-    zeroclaw cron add '0 9 * * 1-5' 'Bonjour' --tz America/New_York --agent
-    zeroclaw cron add '*/30 * * * *' 'Vérifier la santé du système' --agent
-    zeroclaw cron add '*/5 * * * *' 'echo ok'
+    zeroclaw cron add '0 9 * * 1-5' 'Bonjour' --agent sentinel --prompt --tz America/New_York
+    zeroclaw cron add '*/30 * * * *' 'Vérifier la santé du système' --agent sentinel --prompt
+    zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
     zeroclaw cron add-at 2025-01-15T14:00:00Z 'Envoyer un rappel' --agent
     zeroclaw cron add-every 60000 'Ping de santé'
     zeroclaw cron once 30m 'Lancer une sauvegarde dans 30 minutes' --agent

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -197,9 +197,9 @@ cli-cron-long-about =
 
     例:
     zeroclaw cron list
-    zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
-    zeroclaw cron add '*/30 * * * *' 'Check system health' --agent
-    zeroclaw cron add '*/5 * * * *' 'echo ok'
+    zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
+    zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
+    zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
     zeroclaw cron add-at 2025-01-15T14:00:00Z 'Send reminder' --agent
     zeroclaw cron add-every 60000 'Ping heartbeat'
     zeroclaw cron once 30m 'Run backup in 30 minutes' --agent

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -196,9 +196,9 @@ cli-cron-long-about =
 
     示例：
     zeroclaw cron list
-    zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
-    zeroclaw cron add '*/30 * * * *' 'Check system health' --agent
-    zeroclaw cron add '*/5 * * * *' 'echo ok'
+    zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
+    zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
+    zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
     zeroclaw cron add-at 2025-01-15T14:00:00Z 'Send reminder' --agent
     zeroclaw cron add-every 60000 'Ping heartbeat'
     zeroclaw cron once 30m 'Run backup in 30 minutes' --agent

--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -46,7 +46,7 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
             if jobs.is_empty() {
                 println!("{}", get_required_cli_string("cli-cron-none"));
                 println!("\n{}", get_required_cli_string("cli-cron-usage"));
-                println!("  zeroclaw cron add '0 9 * * *' 'agent -m \"Good morning!\"'"); // i18n-exempt: literal command example
+                println!("  zeroclaw cron add '0 9 * * *' 'echo ok' --agent sentinel"); // i18n-exempt: literal command example
                 return Ok(());
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,9 +613,9 @@ When --tz is omitted, cron schedules use the runtime local timezone. \
 For user-facing schedules, pass --tz with an explicit IANA timezone.
 
 Examples:
-  zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
-  zeroclaw cron add '*/30 * * * *' 'Check system health' --agent
-  zeroclaw cron add '*/5 * * * *' 'echo ok'")]
+  zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
+  zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
+  zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel")]
     Add {
         /// Cron expression
         expression: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -799,9 +799,9 @@ an explicit IANA timezone.
 
 Examples:
   zeroclaw cron list
-  zeroclaw cron add '0 9 * * 1-5' 'Good morning' --tz America/New_York --agent
-  zeroclaw cron add '*/30 * * * *' 'Check system health' --agent
-  zeroclaw cron add '*/5 * * * *' 'echo ok'
+  zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
+  zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
+  zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
   zeroclaw cron add-at 2025-01-15T14:00:00Z 'Send reminder' --agent
   zeroclaw cron add-every 60000 'Ping heartbeat'
   zeroclaw cron once 30m 'Run backup in 30 minutes' --agent

--- a/tests/component/cron_help_examples.rs
+++ b/tests/component/cron_help_examples.rs
@@ -1,4 +1,4 @@
-//! CLI-boundary regression for the corrected `cron` help examples (#9672).
+//! CLI-boundary regression for the corrected `cron` help examples.
 //!
 //! The reported bug: the examples printed by `cron --help` / `cron add --help`
 //! and the empty `cron list` hint could not be run as printed — the prompt
@@ -6,31 +6,48 @@
 //! `--agent` value. These tests spawn the real binary and assert the printed
 //! forms stay runnable, so the fix cannot silently regress in the clap
 //! `long_about` strings or the Fluent empty-state hint.
+//!
+//! Every invocation is locale-hermetic: the binary runs against an isolated
+//! config dir whose `locale = "en"`, so the help and empty-state output are
+//! asserted in English regardless of the developer's environment locale.
 
-use std::process::Command;
+use std::path::Path;
+use std::process::{Command, Output};
 
 const PROMPT_EXAMPLE_TZ: &str = "zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York";
 const PROMPT_EXAMPLE: &str =
     "zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt";
 const SHELL_EXAMPLE: &str = "zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel";
 
-fn run(args: &[&str]) -> std::process::Output {
+/// Isolated config dir that pins the CLI locale to English.
+fn english_config_dir(tmp: &Path) {
+    std::fs::write(tmp.join("config.toml"), "locale = \"en\"\n").unwrap();
+}
+
+fn run(config_dir: &Path, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_zeroclaw"))
+        .env("ZEROCLAW_CONFIG_DIR", config_dir)
+        .env("RUST_LOG", "off")
         .args(args)
         .output()
         .expect("failed to run zeroclaw binary")
 }
 
-#[test]
-fn cron_parent_help_shows_runnable_examples() {
-    let out = run(&["cron", "--help"]);
+fn assert_success(out: &Output) -> String {
     assert!(
         out.status.success(),
-        "cron --help failed: {}\n{}",
+        "command failed: {}\n{}",
         String::from_utf8_lossy(&out.stderr),
         String::from_utf8_lossy(&out.stdout)
     );
-    let stdout = String::from_utf8_lossy(&out.stdout);
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn cron_parent_help_shows_runnable_examples() {
+    let tmp = tempfile::tempdir().unwrap();
+    english_config_dir(tmp.path());
+    let stdout = assert_success(&run(tmp.path(), &["cron", "--help"]));
     for example in [PROMPT_EXAMPLE_TZ, PROMPT_EXAMPLE, SHELL_EXAMPLE] {
         assert!(
             stdout.contains(example),
@@ -41,14 +58,9 @@ fn cron_parent_help_shows_runnable_examples() {
 
 #[test]
 fn cron_add_help_shows_runnable_examples() {
-    let out = run(&["cron", "add", "--help"]);
-    assert!(
-        out.status.success(),
-        "cron add --help failed: {}\n{}",
-        String::from_utf8_lossy(&out.stderr),
-        String::from_utf8_lossy(&out.stdout)
-    );
-    let stdout = String::from_utf8_lossy(&out.stdout);
+    let tmp = tempfile::tempdir().unwrap();
+    english_config_dir(tmp.path());
+    let stdout = assert_success(&run(tmp.path(), &["cron", "add", "--help"]));
     for example in [PROMPT_EXAMPLE_TZ, PROMPT_EXAMPLE, SHELL_EXAMPLE] {
         assert!(
             stdout.contains(example),
@@ -60,19 +72,8 @@ fn cron_add_help_shows_runnable_examples() {
 #[test]
 fn cron_list_empty_state_shows_runnable_hint() {
     let tmp = tempfile::tempdir().unwrap();
-    let out = Command::new(env!("CARGO_BIN_EXE_zeroclaw"))
-        .env("ZEROCLAW_CONFIG_DIR", tmp.path())
-        .env("RUST_LOG", "off")
-        .args(["cron", "list"])
-        .output()
-        .expect("failed to run zeroclaw cron list");
-    assert!(
-        out.status.success(),
-        "cron list with no jobs must succeed: {}\n{}",
-        String::from_utf8_lossy(&out.stderr),
-        String::from_utf8_lossy(&out.stdout)
-    );
-    let stdout = String::from_utf8_lossy(&out.stdout);
+    english_config_dir(tmp.path());
+    let stdout = assert_success(&run(tmp.path(), &["cron", "list"]));
     assert!(
         stdout.contains("No scheduled tasks yet."),
         "empty cron list must show the empty-state notice, got: {stdout}"

--- a/tests/component/cron_help_examples.rs
+++ b/tests/component/cron_help_examples.rs
@@ -1,0 +1,84 @@
+//! CLI-boundary regression for the corrected `cron` help examples (#9672).
+//!
+//! The reported bug: the examples printed by `cron --help` / `cron add --help`
+//! and the empty `cron list` hint could not be run as printed — the prompt
+//! examples were missing `--prompt` and the shell example carried no
+//! `--agent` value. These tests spawn the real binary and assert the printed
+//! forms stay runnable, so the fix cannot silently regress in the clap
+//! `long_about` strings or the Fluent empty-state hint.
+
+use std::process::Command;
+
+const PROMPT_EXAMPLE_TZ: &str = "zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York";
+const PROMPT_EXAMPLE: &str =
+    "zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt";
+const SHELL_EXAMPLE: &str = "zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel";
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_zeroclaw"))
+        .args(args)
+        .output()
+        .expect("failed to run zeroclaw binary")
+}
+
+#[test]
+fn cron_parent_help_shows_runnable_examples() {
+    let out = run(&["cron", "--help"]);
+    assert!(
+        out.status.success(),
+        "cron --help failed: {}\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for example in [PROMPT_EXAMPLE_TZ, PROMPT_EXAMPLE, SHELL_EXAMPLE] {
+        assert!(
+            stdout.contains(example),
+            "cron --help must show a runnable example, missing: {example}"
+        );
+    }
+}
+
+#[test]
+fn cron_add_help_shows_runnable_examples() {
+    let out = run(&["cron", "add", "--help"]);
+    assert!(
+        out.status.success(),
+        "cron add --help failed: {}\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for example in [PROMPT_EXAMPLE_TZ, PROMPT_EXAMPLE, SHELL_EXAMPLE] {
+        assert!(
+            stdout.contains(example),
+            "cron add --help must show a runnable example, missing: {example}"
+        );
+    }
+}
+
+#[test]
+fn cron_list_empty_state_shows_runnable_hint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_zeroclaw"))
+        .env("ZEROCLAW_CONFIG_DIR", tmp.path())
+        .env("RUST_LOG", "off")
+        .args(["cron", "list"])
+        .output()
+        .expect("failed to run zeroclaw cron list");
+    assert!(
+        out.status.success(),
+        "cron list with no jobs must succeed: {}\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("No scheduled tasks yet."),
+        "empty cron list must show the empty-state notice, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("zeroclaw cron add '0 9 * * *' 'echo ok' --agent sentinel"),
+        "empty cron list hint must be runnable (agent value present), got: {stdout}"
+    );
+}

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -3,6 +3,7 @@ mod config_dir_locale_regression;
 mod config_patch_cli;
 mod config_persistence;
 mod config_schema;
+mod cron_help_examples;
 mod daemon_startup_feedback;
 mod dockerignore_test;
 mod gateway;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - The `cron add` examples in the CLI help (`zeroclaw cron add --help`, `zeroclaw cron --help`) printed `--agent` as a bare flag even though `--agent <AGENT_ALIAS>` is required, so every example died at the parser with `a value is required for '--agent <AGENT_ALIAS>'`.
  - The two prompt-shaped examples ("Good morning", "Check system health") also omitted `--prompt`, so the second positional was treated as a shell command and rejected by the security policy (or failed with exit 127 at run time).
  - The empty-state hint from `zeroclaw cron list` printed `zeroclaw cron add '0 9 * * *' 'agent -m "Good morning!"'`, where `agent` is not an executable on the host, so the job reached the scheduler and then failed with `sh: line 1: agent: command not found`.
  - Replaced the examples with forms that parse: value-flagged `--agent sentinel`, `--prompt` on the prompt-shaped examples, and kept the third as the shell case. Mirrored the same command-example fix across the `cli-cron-long-about` Fluent catalogs (all locales), since that key overrides the derive literal at runtime and is what `zeroclaw cron --help` actually shows.
- **Scope boundary:** Fixes only the three `cron add` help examples (in `src/lib.rs`, `src/main.rs`, and the `cli-cron-long-about` Fluent catalogs) plus the `cron list` empty-state hint. Does not touch cron behavior, argument grammar, or the unrelated `add-at`/`once` examples in the parent `Cron` long-about that also end in a bare `--agent` (pre-existing, separate defect not reported in #9672). Does not refresh the generated docs `.po` catalogs, which are refreshed by the docs pipeline (`xtask mdbook refs` + `cargo mdbook sync`).
- **Blast radius:** User-visible `cron` help and empty-`cron list` output for all locales (output-only CLI/handler change). Scheduler, configuration, and persistence behavior are unchanged.
- **Linked issue(s):** Fixes #9672
- **Labels:** `bug`, `core`, `cron`, `tests`, `principal contributor`, `risk:low`, `size:XS`, `type:docs`, `cli`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes — this is a user-visible help-text fix and the manual steps are short.
- **Interface(s) exercised:** `surface` `cli`
- **Setup / preconditions:** A built `zeroclaw` binary; an empty schedule table (fresh config dir) to see the `cron list` hint.
- **Steps to run:**
  1. `zeroclaw cron add --help` — the `Examples:` block should match the issue's suggested forms.
  2. `zeroclaw cron --help` — same three `cron add` examples corrected.
  3. `zeroclaw cron list` with no scheduled jobs — the hint should be `zeroclaw cron add '0 9 * * *' 'echo ok' --agent sentinel`.
- **Expected on this branch (after):** Each example parses (fails only with a config-dependent "Unknown agent" if no `sentinel` agent is configured, never with a parser error), and the empty-state hint runs a real shell command.
- **Prior behavior on `master` (before):** Examples 1–2 fail at the parser (`a value is required for '--agent <AGENT_ALIAS>'`), example 3 fails with `--agent <AGENT_ALIAS>` missing, and the empty-state hint's `agent` command fails with exit 127.

### How I tested

- **CI checks relied on and why they cover this change:** Current required CI is green, including `Test`, `Lint`, `Format`, and `CI Required Gate`. The `Test` job includes the new real-binary component regression, while local `cargo fluent check` validates the `.ftl` syntax.
- **Known CI coverage gap, if any:** `cargo fluent scan` flags `cli-cron-long-about` with `~` on `master` too (a static-analysis limitation of prefix-based i18n lookup, not a regression from this change — confirmed by running the scan on a clean checkout).
- **Commands run and tail output:**
  - `cargo build --bin zeroclaw` — finished clean.
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclawlabs --all-targets -- -D warnings` — finished, no warnings.
  - `cargo test -p zeroclawlabs` — 271 unit + 350 integration + 19 + 13 + 210 doc/integration tests, all passing.
  - `cargo fluent check` — all `.ftl` catalogs `ok`.
  - Manual help checks:
    ```
    $ ./target/debug/zeroclaw cron add --help
    Examples:
      zeroclaw cron add '0 9 * * 1-5' 'Good morning' --agent sentinel --prompt --tz America/New_York
      zeroclaw cron add '*/30 * * * *' 'Check system health' --agent sentinel --prompt
      zeroclaw cron add '*/5 * * * *' 'echo ok' --agent sentinel
    ```
    ```
    $ ./target/debug/zeroclaw --config-dir /tmp/zc-empty cron list
    No scheduled tasks yet.

    Usage:
      zeroclaw cron add '0 9 * * *' 'echo ok' --agent sentinel
    ```
- **Beyond CI, what did you manually verify?** That `zeroclaw cron --help` (rendered from the `cli-cron-long-about` Fluent key, not the derive literal) and `zeroclaw cron add --help` (derive literal) both show the corrected examples; that the empty-state hint is parse-correct. I did NOT verify behavior changes to the cron scheduler (none intended).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes — user-visible `cron` help and empty-`cron list` output changes; no argument grammar, flag, or config-schema change
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.

