### PR TITLE
fix(config): allow config set on existing hyphenated cron aliases (#9652)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2555,6 +2555,19 @@ fn ensure_map_key_for_prop_path(config: &mut Config, prop_path: &str) -> Result<
         return Ok(false);
     };
 
+    // The alias already exists in the loaded config (e.g. a hyphenated cron
+    // alias the TOML loader accepts and `config get`/`config list` resolve):
+    // leave it alone. `create_map_key` applies the strict new-alias grammar,
+    // which would reject a valid loaded key. Mirror `Config::ensure_map_key_for_path`,
+    // which also skips creation for existing keys so alias validation runs only
+    // when auto-materializing a brand-new alias.
+    if config
+        .get_map_keys(section_path)
+        .is_some_and(|keys| keys.iter().any(|k| k == key))
+    {
+        return Ok(false);
+    }
+
     // Route through the shared `create_map_key_checked` (not raw
     // `create_map_key`) so this CLI path inherits the reserved `default`
     // agent guard from the one place it's defined, rather than re-deriving
@@ -9451,6 +9464,36 @@ mod tests {
                 .unwrap_or_default()
                 .is_empty(),
             "the tentatively-created alias must be rolled back, not left dangling",
+        );
+    }
+
+    #[test]
+    fn ensure_map_key_for_prop_path_leaves_existing_hyphenated_alias_alone() {
+        let mut config = Config::default();
+        config
+            .cron
+            .insert("morning-brief".to_string(), zeroclaw_config::schema::CronJobDecl::default());
+
+        let created = ensure_map_key_for_prop_path(&mut config, "cron.morning-brief.name")
+            .expect("an existing loaded alias must never be rejected by the create grammar");
+        assert!(
+            !created,
+            "the existing `morning-brief` alias must not be reported as newly created"
+        );
+        assert!(
+            config.set_prop("cron.morning-brief.name", "Morning brief").is_ok(),
+            "setting a field on an existing hyphenated cron alias must succeed"
+        );
+        assert_eq!(
+            config.get_prop("cron.morning-brief.name").ok(),
+            Some("Morning brief".to_string())
+        );
+
+        let err = ensure_map_key_for_prop_path(&mut config, "cron.bad-alias.name")
+            .expect_err("creating a NEW hyphenated alias must still be rejected");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "new-alias grammar must be preserved: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9470,9 +9470,10 @@ mod tests {
     #[test]
     fn ensure_map_key_for_prop_path_leaves_existing_hyphenated_alias_alone() {
         let mut config = Config::default();
-        config
-            .cron
-            .insert("morning-brief".to_string(), zeroclaw_config::schema::CronJobDecl::default());
+        config.cron.insert(
+            "morning-brief".to_string(),
+            zeroclaw_config::schema::CronJobDecl::default(),
+        );
 
         let created = ensure_map_key_for_prop_path(&mut config, "cron.morning-brief.name")
             .expect("an existing loaded alias must never be rejected by the create grammar");
@@ -9481,7 +9482,9 @@ mod tests {
             "the existing `morning-brief` alias must not be reported as newly created"
         );
         assert!(
-            config.set_prop("cron.morning-brief.name", "Morning brief").is_ok(),
+            config
+                .set_prop("cron.morning-brief.name", "Morning brief")
+                .is_ok(),
             "setting a field on an existing hyphenated cron alias must succeed"
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `zeroclaw config set cron.<alias>.name ...` rejected any already-loaded cron job whose alias contains a hyphen (`morning-brief`), even though the TOML loader accepts the job, the scheduler runs it, and `config list` / `config get` both resolve it. `config set` went through `ensure_map_key_for_prop_path`, which called `create_map_key_checked` unconditionally, and `create_map_key` applies the strict new-alias grammar (lowercase, digits, single underscores) before its existence check — so an edit to a valid loaded key failed with `alias 'morning-brief' contains invalid character '-'`.
  - Fixed by mirroring `Config::ensure_map_key_for_path`: skip creation (and the new-alias grammar) when the key already exists in the section, and apply alias validation only when auto-materializing a brand-new alias. The underscore-only rule for newly created aliases is unchanged.
- **Scope boundary:** Only the CLI `config set` auto-materialization helper. Does not change the loader, scheduler, `config get`/`config list`, the API path, or the new-alias validation rule itself.
- **Blast radius:** `config set` on dynamic-map sections (cron, agents, risk_profiles, peer_groups, etc.) where the alias already exists. Existing-alias edits that previously errored now succeed; new-alias behavior is identical.
- **Linked issue(s):** Fixes #9652
- **Labels:** `bug`, `core`, `principal contributor`, `risk:medium`, `size:XS`, `cli`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes — this is a user-visible CLI behavior fix with a short A/B.
- **Interface(s) exercised:** `surface` `cli`
- **Setup / preconditions:** A `config.toml` containing a hyphenated declarative cron job, e.g. `[cron.morning-brief]` with `name`, `job_type = "shell"`, `command`, and a `schedule`. Reproduces on `master`.
- **Steps to run:**
  1. `zeroclaw --config-dir <dir> config list` — the job appears under `Cron:`.
  2. `zeroclaw --config-dir <dir> config get cron.morning-brief.name` — returns the value.
  3. `zeroclaw --config-dir <dir> config set cron.morning-brief.name "New name" --no-interactive` — must succeed and persist.
  4. `zeroclaw --config-dir <dir> config set cron.bad-alias.name "x" --no-interactive` — must still be rejected.
- **Expected on this branch (after):** Step 3 prints `cron.morning-brief.name updated.` and `config get` returns the new value after reload; step 4 still fails with the `contains invalid character` diagnostic.
- **Prior behavior on `master` (before):** Step 3 fails with `Error: alias 'morning-brief' contains invalid character '-'` despite the key being listed by `config list`.

### How I tested

- **CI checks relied on and why they cover this change:** None specifically — the change is CLI-handler logic; regression coverage is a new unit test in the `zeroclawlabs` bin's test module plus the manual A/B below.
- **Known CI coverage gap, if any:** No end-to-end component test drives the full `ConfigCommands::Set` handler with a config file; covered here via the in-memory helper test and manual smoke.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclawlabs --all-targets -- -D warnings` — finished, no warnings.
  - `cargo test -p zeroclawlabs` — 271 + 351 (includes the new regression test) + 19 + 13 + 210 + 158 all passing.
  - New unit test `ensure_map_key_for_prop_path_leaves_existing_hyphenated_alias_alone` — asserts an existing `cron.morning-brief` is left alone (no create error), that `set_prop` on it succeeds, and that a NEW `cron.bad-alias` is still rejected.
  - Manual smoke:
    ```
    $ zeroclaw --config-dir /tmp/zc-9652 config set cron.morning-brief.name "Morning brief v2" --no-interactive
    cron.morning-brief.name updated.
    $ zeroclaw --config-dir /tmp/zc-9652 config get cron.morning-brief.name
    Morning brief v2
    $ zeroclaw --config-dir /tmp/zc-9652 config set cron.bad-alias.name "New job" --no-interactive
    Error: alias 'bad-alias' contains invalid character '-' ...
    ```
- **Beyond CI, what did you manually verify?** The full issue reproduction: hyphenated cron job loaded from TOML, listed by `config list`, read by `config get`, edited by `config set`, and the edit persisted across reload (value visible in `config.toml` and via `config get`). I did NOT verify non-cron dynamic-map sections (e.g. `agents`, `risk_profiles`) beyond what the unit tests cover, and did not test the gateway API path.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes — previously-failing edits now succeed; no previously-working behavior changes
- Config / env / CLI surface changed? No — CLI flags and config schema are unchanged; the strict new-alias grammar is preserved
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After squash merge, run `git revert <squash-merge-sha>`, then rerun required CI and the documented existing/new-alias CLI A/B.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `config set` again rejects edits to an existing hyphenated alias, or unexpectedly accepts creation of a new hyphenated alias.
