### PR TITLE
chore(ci): use direct release attestation action

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -811,7 +811,7 @@ jobs:
       - id: attest_payloads
         name: Attest release payloads
         continue-on-error: true
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: release-assets/*
 
@@ -915,7 +915,7 @@ jobs:
       - id: attest_checksums
         name: Attest final checksums
         continue-on-error: true
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: release-assets/SHA256SUMS
 
@@ -925,7 +925,7 @@ jobs:
         name: Attest verification archive
         if: ${{ !cancelled() && steps.verification_archive.outcome == 'success' }}
         continue-on-error: true
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: release-assets/zeroclaw-${{ needs.validate.outputs.tag }}-verification.tar.gz
 

--- a/docs/book/src/foundations/fnd-004-engineering-infrastructure.md
+++ b/docs/book/src/foundations/fnd-004-engineering-infrastructure.md
@@ -333,7 +333,7 @@ For ZeroClaw's current scale and team size, **SLSA Level 2** is the appropriate 
 
 SLSA Level 2 provenance means each release artifact ships with a cryptographically signed attestation that records: what source commit produced it, which workflow produced it, and that the workflow ran on the expected platform. Users and package managers can verify this attestation. It closes the gap between "we say this binary came from this source" and "this binary provably came from this source."
 
-GitHub Actions supports SLSA Level 2 provenance generation natively through the `actions/attest-build-provenance` action. The cost to add it is one step per build job.
+GitHub Actions supports SLSA Level 2 provenance generation natively through the `actions/attest` action. The cost to add it is one step per build job.
 
 ### 6.2 Conventional Commits (Already Implied, Formalise It)
 
@@ -482,7 +482,7 @@ Implement the directed release graph from §5.2: `build-kernel-standard`, `build
 
 ##### D3: Add SLSA Level 2 provenance
 
-Add `actions/attest-build-provenance` to each build job. Provenance attestations are attached to GitHub Release assets. Document verification instructions in `SECURITY.md`.
+Add `actions/attest` to each build job. Provenance attestations are attached to GitHub Release assets. Document verification instructions in `SECURITY.md`.
 
 ##### D4: Retire redundant release workflows
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -192,7 +192,7 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `actions/setup-node` (`v6.4.0`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml` | Node toolchain for the web-dashboard build |
 | `actions/upload-artifact` (`v7.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | Upload build artifacts and Trivy SARIF handoff artifacts |
 | `actions/download-artifact` (`v8.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml` | Download build artifacts and Trivy SARIF handoff artifacts |
-| `actions/attest-build-provenance` (`v3.2.0`) | `release-stable-manual.yml` | Generate GitHub-hosted Build Level 2 provenance for release assets |
+| `actions/attest` (`v4.2.1`) | `release-stable-manual.yml` | Generate GitHub-hosted Build Level 2 provenance for release assets |
 | `actions/labeler` (`v6.1.0`) | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
 | `dtolnay/rust-toolchain` (`stable`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml` | Install Rust toolchain |
 | `Swatinem/rust-cache` (`v2.9.1`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching |

--- a/docs/security/slsa-provenance.md
+++ b/docs/security/slsa-provenance.md
@@ -1,6 +1,6 @@
 # SLSA Provenance Attestation
 
-**Last updated:** 2026-07-20
+**Last updated:** 2026-08-06
 
 **Related:** Issue #9101, PR #8277, RFC #8177
 

--- a/docs/security/slsa-provenance.md
+++ b/docs/security/slsa-provenance.md
@@ -9,8 +9,8 @@
 ## Canonical model
 
 Downloadable release assets use GitHub artifact attestations as their single
-provenance mechanism. `actions/attest-build-provenance` records SLSA v1.0
-Build Level 2 provenance in GitHub's artifact-attestation API.
+provenance mechanism. `actions/attest` records SLSA v1.0 Build Level 2
+provenance in GitHub's artifact-attestation API.
 
 A release page produced by the consolidated workflow contains the payloads,
 `SHA256SUMS`, both SBOM formats, and at most one

--- a/scripts/ci/release_attestation_contract_test.py
+++ b/scripts/ci/release_attestation_contract_test.py
@@ -10,6 +10,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = ROOT / ".github/workflows/release-stable-manual.yml"
+ATTEST_ACTION_REF = (
+    "actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1"
+)
 WORKFLOW = WORKFLOW_PATH.read_text(encoding="utf-8")
 
 
@@ -75,12 +78,13 @@ class ReleaseAttestationContractTest(unittest.TestCase):
 
     def test_payload_attestation_is_pinned_and_best_effort(self) -> None:
         step = step_block(self.publish, "attest_payloads")
-        self.assertRegex(
-            step,
-            r"actions/attest-build-provenance@[0-9a-f]{40} # v3\.2\.0",
-        )
+        self.assertIn(f"uses: {ATTEST_ACTION_REF}", step)
         self.assertIn("continue-on-error: true", step)
         self.assertIn("subject-path: release-assets/*", step)
+
+    def test_direct_attestation_action_is_used_exactly_three_times(self) -> None:
+        self.assertEqual(WORKFLOW.count(f"uses: {ATTEST_ACTION_REF}"), 3)
+        self.assertNotIn("actions/attest-build-provenance@", WORKFLOW)
 
     def test_archive_is_built_only_from_verified_offline_material(self) -> None:
         step = step_block(self.publish, "verification_archive")
@@ -140,10 +144,7 @@ class ReleaseAttestationContractTest(unittest.TestCase):
                 step = step_block(self.publish, step_id)
                 self.assertIn(subject, step)
                 self.assertIn("continue-on-error: true", step)
-                self.assertRegex(
-                    step,
-                    r"actions/attest-build-provenance@[0-9a-f]{40} # v3\.2\.0",
-                )
+                self.assertIn(f"uses: {ATTEST_ACTION_REF}", step)
 
     def test_release_uploads_only_the_consolidated_asset_directory(self) -> None:
         self.assertEqual(self.publish.count('gh release create "$TAG" release-assets/*'), 2)


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - replace the three release provenance steps with the recommended direct `actions/attest` action, pinned to the full `v4.2.1` commit SHA;
  - keep the exact repository contract test synchronized with the executable workflow;
  - update the maintained action inventory, canonical SLSA provenance documentation, and ratified infrastructure guidance.
- **Scope boundary:** This does not change attested subject paths, workflow permissions, release sequencing, best-effort failure handling, or the action allowlist.
- **Allowlist impact:** `actions/attest` is covered by the existing `actions/*` allowlist entry; no expansion is required.
- **Blast radius:** The stable manual release workflow's GitHub-hosted provenance generation and its repository-owned static contracts.
- **Linked issue(s):** Supersedes #9698.
- **Labels:** `ci`, `docs`, `scripts`, `risk:high`, `size:XS`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. Exercising the hosted signing boundary requires dispatching the stable release workflow and publishing release artifacts or attestations.

### How I tested

- **CI checks relied on and why they cover this change:** On the current documentation-repair head, `Repository Structure` passed the release attestation contract against the committed workflow, `Docs Style` passed for the synchronized documentation files, and `CI Required Gate` passed.
- **Known CI coverage gap, if any:** No stable release workflow was dispatched, so GitHub-hosted OIDC signing and attestation publication were not exercised end to end. The workflow still has three attestation steps, but no hosted timing comparison was measured, so any release-latency effect remains unquantified.
- **Commands run and tail output:**

```text
$ python3 scripts/ci/release_attestation_contract_test.py
Ran 11 tests in 0.072s
OK

$ DOCS_FILES="$(printf '%s\n' docs/book/src/foundations/fnd-004-engineering-infrastructure.md docs/book/src/maintainers/ci-and-actions.md docs/security/slsa-provenance.md)"; NPM_CONFIG_CACHE="$(mktemp -d)" BASE_SHA=102a975d15150f16cf6c759e689a57ee2ddb6f45 DOCS_FILES="$DOCS_FILES" bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/foundations/fnd-004-engineering-infrastructure.md docs/book/src/maintainers/ci-and-actions.md docs/security/slsa-provenance.md

$ DOCS_FILES="$(printf '%s\n' docs/book/src/foundations/fnd-004-engineering-infrastructure.md docs/book/src/maintainers/ci-and-actions.md docs/security/slsa-provenance.md)"; BASE_SHA=102a975d15150f16cf6c759e689a57ee2ddb6f45 DOCS_FILES="$DOCS_FILES" bash scripts/ci/docs_links_gate.sh
Ran 6 tests in 1.263s
OK
Collected 0 added link(s) from 3 docs file(s).

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check
# no output
```

- **Beyond CI, what did you manually verify?** Verified that all three `subject-path` values, permissions, conditions, step ordering, `continue-on-error` behavior, and the three-step count are unchanged. Verified that the pinned SHA resolves to upstream `actions/attest` `v4.2.1`, that direct `subject-path` use retains build-provenance mode, and that the ratified FND-004 guidance no longer recommends the retired wrapper.
- **If any command was intentionally skipped, why:** No Cargo checks were run because the change contains no Rust or build-system code. The release workflow was not dispatched because it has publication side effects.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any `Yes`, describe the risk and mitigation: N/A. The action implementation changes, while the workflow retains the same OIDC and `attestations: write` permissions, token source, and subject inputs.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the squash-merge commit created for this PR; that restores the wrapper pin, exact contract assertions, and documentation together.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** The three release attestation steps report failure, or expected GitHub artifact attestations are absent from the workflow run and attestation API. The steps remain best effort.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): #9698 by @dependabot[bot].
- Scope materially carried forward: The dependency-update intent. This replacement uses the recommended direct action and also synchronizes repository-owned contracts and documentation.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? No.
- If `No`, why (inspiration-only, no direct code/design carry-over): No contributor code or design was incorporated from the automated pin-only update.
