### PR TITLE
fix(channels): gate Slack lifecycle localization helpers

### DIFF
--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "channel-slack")]
 use zeroclaw_api::channel::ProgressEvent;
 
+#[cfg(feature = "channel-slack")]
 pub(crate) fn lifecycle_progress_fluent_key(event: ProgressEvent) -> &'static str {
     match event {
         ProgressEvent::Received => "channel-runtime-progress-received",
@@ -11,6 +13,7 @@ pub(crate) fn lifecycle_progress_fluent_key(event: ProgressEvent) -> &'static st
     }
 }
 
+#[cfg(feature = "channel-slack")]
 pub(crate) fn localized_lifecycle_progress(event: ProgressEvent) -> String {
     zeroclaw_runtime::i18n::get_required_cli_string(lifecycle_progress_fluent_key(event))
 }
@@ -474,6 +477,7 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
 mod tests {
     use super::*;
 
+    #[cfg(feature = "channel-slack")]
     #[test]
     fn lifecycle_progress_maps_typed_events_to_fluent_keys() {
         assert_eq!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Gate the Slack lifecycle localization import, helpers, and mapping test behind `channel-slack` so builds without Slack do not compile unused Slack-only items.
- **Scope boundary:** This PR does not change lifecycle message text, Slack runtime behavior, feature definitions, or CI policy.
- **Blast radius:** Limited to compile-time inclusion of Slack-specific channel helpers and their unit test.
- **Linked issue(s):** Related #8985
- **Labels:** `bug`, `channel`, `channel:slack`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a compile-predicate correction with focused enabled and disabled feature validation below.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passes on the current head, including Lint, Test, Security, and CI Required Gate.
- **Known CI coverage gap, if any:** The Slack-disabled state was validated directly with the crate-scoped Clippy command below.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# exit status: 0 (no output)

cargo clippy --locked -p zeroclaw-channels --no-default-features --all-targets --no-deps -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.60s

cargo test --locked -p zeroclaw-channels --no-default-features --features channel-slack lifecycle_progress_maps_typed_events_to_fluent_keys
# test util::tests::lifecycle_progress_maps_typed_events_to_fluent_keys ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 707 filtered out; finished in 0.06s
```

- **Beyond CI, what did you manually verify?** Verified that the import, both helper functions, and their mapping test use the same `channel-slack` predicate as the sole production caller. No user-facing Slack smoke was run because runtime behavior is unchanged.
- **If any command was intentionally skipped, why:** Broad workspace validation was not run because the focused checks cover both compilation predicates changed by this patch; required CI provides the broader regression signal.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low risk; revert the commit if needed.

## Supersede Attribution (required only when Supersedes is used)

N/A
