### PR TITLE
fix(memory): stop consolidation inventing traits and speaking over a persona

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10576,6 +10576,19 @@ pub struct MemoryConfig {
     /// backend globally and on every agent (validated at config load).
     #[serde(default)]
     pub consolidation_extract_facts: bool,
+    /// Record memories in a persona's own voice instead of clinical
+    /// third-person prose.
+    ///
+    /// Consolidation output is injected back into the agent's context, and the
+    /// model treats it as an authorised description of itself. For a task agent
+    /// that is harmless. For a persona it is not: a memory reading "Dislikes
+    /// taking posed selfies" — inferred by the consolidator from a single
+    /// refusal — made a persona agent keep declining photos it was fully
+    /// configured to send. Leave unset for task agents; the prompt is then
+    /// unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[nested]
+    pub persona: Option<MemoryPersonaConfig>,
     /// Move daily/session files to the archive directory after this many days. Keeps the hot working set small without deleting history.
     #[serde(default = "default_archive_after_days")]
     pub archive_after_days: u32,
@@ -10759,6 +10772,27 @@ pub struct MemoryConfig {
     // postgres.*) live on `[storage.<backend>.<alias>]`. The `backend` field
     // carries a dotted alias reference and the runtime looks up the typed
     // config via `Config::resolve_active_storage`.
+}
+
+/// Persona identity for memory consolidation (`[memory.persona]` section).
+///
+/// Both fields are required for the persona block to be emitted: a persona with
+/// a name but no language (or the reverse) falls back to the plain prompt
+/// rather than rendering a half-filled instruction at the model.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "memory.persona"]
+pub struct MemoryPersonaConfig {
+    /// What the persona calls itself, e.g. "Nova". Used in the first-person
+    /// instruction so stored memories read as the persona's own recollection
+    /// rather than an observer's report about it.
+    #[serde(default)]
+    pub name: String,
+    /// Language for stored memories, written the way a model recognises it:
+    /// "français", "English", "日本語". A memory written in a language
+    /// the persona does not speak reads back as somebody else's note.
+    #[serde(default)]
+    pub language: String,
 }
 
 /// Typed memory configuration (`[memory.types]` section).
@@ -11159,6 +11193,8 @@ impl Default for MemoryConfig {
             auto_save: true,
             hygiene_enabled: default_hygiene_enabled(),
             consolidation_extract_facts: false,
+            // Off by default: task agents keep the pre-change prompt exactly.
+            persona: None,
             archive_after_days: default_archive_after_days(),
             purge_after_days: default_purge_after_days(),
             conversation_retention_days: default_conversation_retention_days(),

--- a/crates/zeroclaw-memory/src/consolidation.rs
+++ b/crates/zeroclaw-memory/src/consolidation.rs
@@ -33,6 +33,36 @@ pub struct ConsolidationResult {
     pub kind: Option<String>,
 }
 
+/// Rules that keep consolidation from inventing durable truth out of one turn.
+///
+/// Both prompts share these because both feed the same store, and a memory the
+/// agent later reads is indistinguishable from a fact it was configured with.
+/// Two failures seen in production drive each line:
+///
+/// - A persona agent declined a photo once. Consolidation wrote "Dislikes
+///   taking posed selfies, finding them vain and awkward" — a permanent trait
+///   inferred from a single event. The agent then read that back as who it is
+///   and kept refusing, with the capability sitting enabled and unused.
+/// - Consolidation wrote "The assistant lacks a camera". Nothing in the config
+///   said that; the model guessed at its own limits, stored the guess, and the
+///   guess became a self-imposed boundary.
+///
+/// The rules are stated as constraints on the OUTPUT, not as encouragement to
+/// be cautious: telling a model to "be careful about over-generalizing" makes
+/// it abstain on things it did observe.
+const CONSOLIDATION_GROUNDING_RULES: &str = r#"
+Rules for what may become a durable memory:
+- A behaviour observed ONCE is an event, not a preference. Record what happened
+  ("declined a photo tonight"), never a trait inferred from it ("dislikes
+  photos"). Only record a trait when the turn states it as one, or when it is
+  explicitly presented as habitual.
+- Never write about your own capabilities, limits, or available tools. What the
+  agent can and cannot do is defined by its configuration, not by memory, and a
+  guess stored here becomes a limit that outlives the conversation.
+- Do not infer causes, motives, or feelings that were not stated. "Was quiet
+  after the call" is observable; "was upset about the call" is not.
+- Prefer the smallest claim that stays true tomorrow."#;
+
 const CONSOLIDATION_SYSTEM_PROMPT: &str = r#"You are a memory consolidation engine. Given a conversation turn, extract:
 1. "history_entry": A brief summary of what happened in this turn (1-2 sentences). Include the key topic or action.
 2. "memory_update": Any NEW facts, preferences, decisions, or commitments worth remembering long-term. Return null if nothing new was learned.
@@ -55,6 +85,78 @@ Respond ONLY with valid JSON: {"history_entry": "...", "memory_update": "..." or
 Do not include any text outside the JSON object."#;
 
 const MAX_TYPED_FACTS_PER_TURN: usize = 5;
+
+/// Assemble the consolidation system prompt: base schema, grounding rules, and
+/// (when the agent has one) the persona voice block.
+///
+/// One function builds it for both schema variants on purpose. The rules and
+/// the persona block are the same contract either way, and two call sites
+/// assembling their own prompt is how one of them silently loses a section —
+/// the same divergence trap that erased the weekday from the date header.
+///
+/// `persona` is `None` for ordinary task agents, which keeps their prompt
+/// byte-identical to the pre-change text. It is `Some` only when the operator
+/// configured a persona, so this is additive: nothing changes for an agent
+/// that never asked for it.
+fn build_consolidation_system_prompt(
+    typed: bool,
+    persona: Option<&ConsolidationPersona>,
+) -> String {
+    let base = if typed {
+        CONSOLIDATION_TYPED_SYSTEM_PROMPT
+    } else {
+        CONSOLIDATION_SYSTEM_PROMPT
+    };
+
+    let mut prompt = String::with_capacity(base.len() + CONSOLIDATION_GROUNDING_RULES.len() + 512);
+    prompt.push_str(base);
+    prompt.push('\n');
+    prompt.push_str(CONSOLIDATION_GROUNDING_RULES);
+
+    if let Some(persona) = persona {
+        prompt.push_str(&persona.prompt_block());
+    }
+
+    prompt
+}
+
+/// Who the memory belongs to, when the agent is a persona rather than a tool.
+///
+/// A task agent reading "The user prefers X" back is fine. A persona reading
+/// clinical third-person English about itself is not: the text is injected as
+/// context and the model treats it as an authorised description of who it is,
+/// which flattens the voice it was configured to have. Recording the same turn
+/// in the persona's own voice removes the mismatch at the source instead of
+/// translating it afterwards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsolidationPersona {
+    /// What the persona calls itself, e.g. "Nova".
+    pub name: String,
+    /// Language for stored memories, as a human-readable name the model will
+    /// recognise ("français", "English"). Memories written in a language
+    /// the persona does not speak are re-read as foreign text about a stranger.
+    pub language: String,
+}
+
+impl ConsolidationPersona {
+    fn prompt_block(&self) -> String {
+        format!(
+            "\n\nThese memories belong to {name}, who will read them back as their own \
+             recollection. Write them the way {name} would remember, not the way an \
+             observer would file a report:\n\
+             - Use the FIRST person. \"I told her I'd call tomorrow\", never \"{name} told \
+             the user…\" and never \"the assistant…\".\n\
+             - Write in {language}, whatever language this turn is in. A memory in another \
+             language reads as somebody else's note.\n\
+             - Keep the register of a person recalling their own day. No clinical summary, \
+             no bullet-point profile of the other person.\n\
+             - Never refer to the person in the conversation as \"the user\": use their name \
+             if it is known, otherwise write as if speaking about someone you know.",
+            name = self.name,
+            language = self.language,
+        )
+    }
+}
 
 fn strip_media_markers(text: &str) -> String {
     // Matches [IMAGE:...], [DOCUMENT:...], [FILE:...], [VIDEO:...], [VOICE:...], [AUDIO:...]
@@ -96,15 +198,20 @@ pub async fn consolidate_turn(
 
     // Typed memory must ask for a subtype even when atomic-fact extraction stays
     // disabled. Reusing the extended schema keeps the model contract explicit.
-    let system_prompt = if memory_config.types.enabled || memory_config.consolidation_extract_facts
-    {
-        CONSOLIDATION_TYPED_SYSTEM_PROMPT
-    } else {
-        CONSOLIDATION_SYSTEM_PROMPT
-    };
+    let typed = memory_config.types.enabled || memory_config.consolidation_extract_facts;
+    let persona = memory_config.persona.as_ref().and_then(|p| {
+        // An empty name would render "These memories belong to , who will…".
+        // A half-configured persona is worse than none, so it falls back to the
+        // plain prompt rather than emitting a malformed instruction.
+        (!p.name.trim().is_empty() && !p.language.trim().is_empty()).then(|| ConsolidationPersona {
+            name: p.name.trim().to_string(),
+            language: p.language.trim().to_string(),
+        })
+    });
+    let system_prompt = build_consolidation_system_prompt(typed, persona.as_ref());
 
     let raw = ProviderDispatch::from_ref(model_provider)
-        .chat_with_system(Some(system_prompt), &truncated, model, temperature)
+        .chat_with_system(Some(&system_prompt), &truncated, model, temperature)
         .await?;
 
     let result: ConsolidationResult = parse_consolidation_response(&raw, &turn_text);
@@ -773,7 +880,8 @@ mod tests {
         // Exactly one provider call, with the unchanged default prompt.
         let prompts = provider.system_prompts.lock();
         assert_eq!(prompts.len(), 1);
-        assert_eq!(prompts[0], CONSOLIDATION_SYSTEM_PROMPT);
+        assert!(prompts[0].starts_with(CONSOLIDATION_SYSTEM_PROMPT));
+        assert!(prompts[0].contains(CONSOLIDATION_GROUNDING_RULES));
 
         // Exactly two writes: the Daily history entry through the plain
         // legacy store call, and the Core update with kind unset -- even
@@ -814,6 +922,127 @@ mod tests {
         assert!(!writes.iter().any(|w| w.key().starts_with("core_fact_")));
     }
 
+    /// The rule that would have stopped the selfie bug.
+    ///
+    /// A persona agent declined a photo once; consolidation stored "Dislikes
+    /// taking posed selfies, finding them vain and awkward" as a permanent
+    /// trait, the agent read it back as self-description, and kept refusing
+    /// with the capability enabled and never invoked. The prompt must forbid
+    /// that promotion in the output contract, not merely hint at caution.
+    #[test]
+    fn grounding_rules_forbid_promoting_one_event_into_a_trait() {
+        let prompt = build_consolidation_system_prompt(false, None);
+
+        assert!(
+            prompt.contains("observed ONCE is an event, not a preference"),
+            "consolidation may not turn a single behaviour into a durable trait"
+        );
+        assert!(
+            prompt.contains("Never write about your own capabilities"),
+            "a guessed limit stored as memory outlives the conversation"
+        );
+        // Present in BOTH schema variants: they feed the same store, so a rule
+        // in only one of them leaves the other free to write the same bug.
+        assert!(
+            build_consolidation_system_prompt(true, None).contains(CONSOLIDATION_GROUNDING_RULES)
+        );
+    }
+
+    /// A task agent must see the unchanged prompt: this feature is additive and
+    /// no operator opted into it.
+    #[test]
+    fn without_a_persona_the_prompt_carries_no_persona_block() {
+        let prompt = build_consolidation_system_prompt(false, None);
+
+        assert!(prompt.starts_with(CONSOLIDATION_SYSTEM_PROMPT));
+        assert!(!prompt.contains("These memories belong to"));
+        assert!(!prompt.contains("Use the FIRST person"));
+    }
+
+    /// With a persona configured, the memory is written as the persona's own
+    /// recollection — first person, its language, and never "the user".
+    #[test]
+    fn a_configured_persona_switches_the_memory_voice() {
+        let persona = ConsolidationPersona {
+            name: "Nova".into(),
+            language: "français".into(),
+        };
+        let prompt = build_consolidation_system_prompt(false, Some(&persona));
+
+        assert!(prompt.contains("These memories belong to Nova"));
+        assert!(prompt.contains("Use the FIRST person"));
+        assert!(prompt.contains("Write in français"));
+        assert!(
+            prompt.contains("never refer to the person in the conversation as \"the user\"")
+                || prompt.contains("Never refer to the person in the conversation as \"the user\""),
+            "third-person clinical reference to the other party is what flattens the voice"
+        );
+        // The grounding rules survive the persona block: both must be present.
+        assert!(prompt.contains(CONSOLIDATION_GROUNDING_RULES));
+    }
+
+    /// A half-filled persona must not render "These memories belong to , who…".
+    /// Falling back to the plain prompt is the honest failure mode.
+    #[tokio::test]
+    async fn a_persona_missing_a_field_falls_back_to_the_plain_prompt() {
+        // Minimal well-formed reply: these two tests assert on the system
+        // prompt that goes OUT, not on what comes back.
+        const SIMPLE_RESPONSE: &str =
+            r#"{"history_entry": "Talked for a while.", "memory_update": null}"#;
+        for (name, language) in [("Nova", "  "), ("   ", "français"), ("", "")] {
+            let provider = ScriptedProvider::new(SIMPLE_RESPONSE);
+            let memory = RecordingMemory::default();
+            let config = MemoryConfig {
+                persona: Some(zeroclaw_config::schema::MemoryPersonaConfig {
+                    name: name.into(),
+                    language: language.into(),
+                }),
+                ..MemoryConfig::default()
+            };
+
+            run_consolidation(&provider, &memory, &config)
+                .await
+                .unwrap();
+
+            let prompts = provider.system_prompts.lock();
+            assert!(
+                !prompts[0].contains("These memories belong to"),
+                "half-configured persona ({name:?}, {language:?}) must not emit the block"
+            );
+        }
+    }
+
+    /// The wiring itself: a persona in `MemoryConfig` has to reach the provider.
+    /// Asserting on the constant alone would pass even if nothing read config.
+    #[tokio::test]
+    async fn the_configured_persona_reaches_the_live_consolidation_call() {
+        // Minimal well-formed reply: these two tests assert on the system
+        // prompt that goes OUT, not on what comes back.
+        const SIMPLE_RESPONSE: &str =
+            r#"{"history_entry": "Talked for a while.", "memory_update": null}"#;
+        let provider = ScriptedProvider::new(SIMPLE_RESPONSE);
+        let memory = RecordingMemory::default();
+        let config = MemoryConfig {
+            persona: Some(zeroclaw_config::schema::MemoryPersonaConfig {
+                name: "Nova".into(),
+                language: "français".into(),
+            }),
+            ..MemoryConfig::default()
+        };
+
+        run_consolidation(&provider, &memory, &config)
+            .await
+            .unwrap();
+
+        let prompts = provider.system_prompts.lock();
+        assert!(
+            prompts[0].contains("These memories belong to Nova"),
+            "persona configured but never sent to the model: {}",
+            prompts[0]
+        );
+        assert!(prompts[0].contains("Write in français"));
+    }
+
     #[tokio::test]
     async fn types_enabled_tags_daily_episodic_and_core_kind() {
         let provider = ScriptedProvider::new(TYPED_RESPONSE);
@@ -828,7 +1057,9 @@ mod tests {
             .unwrap();
 
         let prompts = provider.system_prompts.lock();
-        assert_eq!(prompts.as_slice(), [CONSOLIDATION_TYPED_SYSTEM_PROMPT]);
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0].starts_with(CONSOLIDATION_TYPED_SYSTEM_PROMPT));
+        assert!(prompts[0].contains(CONSOLIDATION_GROUNDING_RULES));
 
         let writes = memory.writes.lock();
         assert_eq!(writes.len(), 2);
@@ -1091,7 +1322,8 @@ mod tests {
         // The typed prompt replaces the default one.
         let prompts = provider.system_prompts.lock();
         assert_eq!(prompts.len(), 1);
-        assert_eq!(prompts[0], CONSOLIDATION_TYPED_SYSTEM_PROMPT);
+        assert!(prompts[0].starts_with(CONSOLIDATION_TYPED_SYSTEM_PROMPT));
+        assert!(prompts[0].contains(CONSOLIDATION_GROUNDING_RULES));
 
         // Daily + Core + the two non-blank facts (the whitespace-only third
         // fact is filtered out).


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Consolidation output is injected back into the agent's own context, where the model reads it as an authorised description of itself. Nothing in the prompt stopped it from promoting a one-off behaviour into a permanent trait — so a single refusal was stored as `Dislikes taking posed selfies, finding them vain and awkward`, and the agent then declined every later request while the capability sat enabled, authorised, and never once invoked. Nothing had told it no; its own memory had.
  - It also wrote guesses about its own limits (`The assistant lacks a camera`) that no configuration made true. A guess stored as memory becomes a self-imposed boundary that outlives the conversation.
  - `CONSOLIDATION_GROUNDING_RULES` now constrains the output: a behaviour observed once is an event, never a trait; never write about your own capabilities or limits; do not infer motives that were not stated. Phrased as output constraints rather than "be careful", which makes models abstain on things they did observe.
  - Both schema variants are assembled by one builder (`build_consolidation_system_prompt`). They feed the same store, so a rule added to one and not the other would leave the second free to write the same bug.
  - Optional `[memory.persona]` (name + language) records the turn in the persona's first person and language. A persona reading clinical third-person English about itself has the configured voice overwritten by its own memory.

- **Scope boundary:** does not change what is stored, when consolidation runs, retention/hygiene, recall or ranking, memory backends, or the typed-facts path. Only the system prompt handed to the consolidation model, plus one optional config section.

- **Blast radius:** every agent's consolidation prompt gains the grounding rules — the intended fix, since the failure mode is not persona-specific. The persona block is inert unless configured: with `[memory.persona]` absent the assembled prompt is the pre-change text plus those rules, and `without_a_persona_the_prompt_carries_no_persona_block` pins that. Stored records are untouched; this changes what gets written from here on.

- **Linked issue(s):** none

- **Labels:** currently applied by the path labeler: `config`, `memory`. The change fixes a defect (`bug`) and is 288 non-doc lines, which matches `size:M`; `risk:*` and any remaining manual labels are for a maintainer with label permissions to set.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the failure is a model behaviour, so unit tests can pin the contract but not the outcome.
- **Interface(s) exercised:** `channel` (any messaging channel with memory enabled); consolidation runs off the agent turn, not a user-facing surface.
- **Setup / preconditions:** an agent with `memory.auto_save` on and a model provider configured. For the persona half, add:
  ```toml
  [memory.persona]
  name = "Nova"
  language = "français"
  ```
- **Steps to run:** hold one turn where the agent declines something once for a situational reason ("not tonight, I just got in"). Let consolidation run, then read the stored Core rows.
- **Expected on this branch (after):** the record describes the event ("declined tonight"). No trait like "dislikes X". With a persona configured, the row is first person in the configured language and names the other party instead of "the user".
- **Prior behavior on `master` (before):** same steps produce a durable trait inferred from the single refusal, in third-person English, which the agent then reads back as self-description on later turns.

### How I tested

Focused crate tests plus clippy and fmt, run on this branch rebased onto `upstream/master` (not on the branch it was authored on), so the numbers reflect the PR as a reviewer sees it.

Every gate is mutation-tested. A test that has never failed is a rumour, and the second one below is what catches the "correct constant nobody reads" failure — it asserts through the live `consolidate_turn` call rather than against the constant, so a config that is parsed but never passed to the model cannot pass.

```sh
$ cargo test -p zeroclaw-memory -p zeroclaw-config --lib -- --test-threads=1
test result: ok. 1239 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.31s
test result: ok. 506 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.37s

$ cargo clippy -p zeroclaw-memory -p zeroclaw-config --all-targets
  0 errors, 0 warnings

$ cargo fmt --all -- --check
  (clean)
```

Mutation runs, each reverted afterwards:

```sh
# 1. delete the anti-promotion rule from the prompt
grounding_rules_forbid_promoting_one_event_into_a_trait ... FAILED
  panicked: consolidation may not turn a single behaviour into a durable trait

# 2. pass None instead of the configured persona at the call site
the_configured_persona_reaches_the_live_consolidation_call ... FAILED
  panicked: persona configured but never sent to the model: You are a memory
  consolidation engine. Given a conversation turn, extract:
```

Repo-mandated gate (`./scripts/ci/rust_quality_gate.sh`, per `CONTRIBUTING.md`), run on this branch:

```sh
$ ./scripts/ci/rust_quality_gate.sh
==> rust quality: cargo fmt --all -- --check                                    [pass]
==> rust quality: cargo clippy --locked --workspace --exclude zeroclaw-desktop \
                  --all-targets -- -D clippy::correctness                       [pass]
==> rust quality: provider dispatch gate                                        [FAIL]
❌ Direct ModelProvider method calls found outside the dispatcher:
crates/zeroclaw-runtime/src/sop/capability/llm_generate.rs:206:
                    .chat_with_system(system.as_deref(), &prompt, &model, None)
```

That failure is pre-existing on `master` and unrelated to this PR: `llm_generate.rs` is not in this diff, and the same line is present in `upstream/master` untouched (`git show upstream/master:crates/zeroclaw-runtime/src/sop/capability/llm_generate.rs`). Reporting it rather than filtering it out — happy to open a separate issue if it is not already tracked. My own new provider call goes through `ProviderDispatch::from_ref`, which is why the gate does not flag it.

Two `dead_code` warnings in `zeroclaw-channels` (`localized_lifecycle_progress`) are likewise pre-existing and in a crate this PR does not touch.

Secret scan, since `gitleaks` was not installed when the commit was made:

```sh
$ gitleaks detect --source . --log-opts="upstream/master..HEAD" --redact
INF 1 commits scanned.
INF no leaks found
```

- **CI checks relied on and why they cover this change:** the Rust test and clippy jobs cover both changed crates; the change is a prompt string plus a config field, with no platform-specific surface.
- **Known CI coverage gap, if any:** no test asserts what a real model returns for these prompts — that is a model behaviour, not a contract, and pinning it would be a flaky test that asserts a vendor's output. The tests pin the instruction reaching the model; the reviewer steps above cover the outcome.
- **Commands run and tail output:** above.
- **Beyond CI, what did you manually verify?** Ran a persona agent on a build carrying this change: the deployed binary contains the rules and the persona block (`strings` on the installed artifact), the daemon comes up with all components healthy, and the config section parses without warnings. I did NOT verify that a given model always obeys the rules — over enough turns some drift is expected, which is why the rules are stated as output constraints rather than advice.
- **If any command was intentionally skipped, why:** did not run the full workspace suite. The diff touches two crates with no cross-crate API change (the new field is additive with a `Default`), so full-workspace output would not have proven anything narrower evidence missed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — examples use `Nova`, the persona name already used in `personality_templates` and `prompt.rs`.
- Prompt injection or untrusted model-visible text introduced/changed? **Yes** — `memory.persona.name` and `.language` are interpolated into the consolidation system prompt. Both are operator-set config, in the same trust class as the rest of the prompt, and are never populated from conversation content; an operator who can set them can already set the whole prompt. Empty or whitespace-only values fall back to the plain prompt rather than rendering a malformed instruction. The values are not echoed to users and do not widen tool or capability access.
- If any `Yes`, describe the risk and mitigation: above.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes** — new optional `[memory.persona]` section (`name`, `language`). Absent by default; existing configs parse and behave unchanged, with no migration needed.
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

`git revert <sha>` is the plan. Operators wanting only the voice change reverted can delete `[memory.persona]` from config, which restores the previous prompt without a rebuild; the grounding rules are unconditional by design, since the inference bug is not persona-specific.
