### PR TITLE
test(config): widen scheduler-latency margin in onepassword non-blocking load test

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -34034,7 +34034,7 @@ api_key = "op://zeroclaw/provider/openai-api-key"
             &bin_dir,
             r#"#!/bin/sh
 if [ "$1" = "read" ] && [ "$2" = "op://zeroclaw/provider/openai-api-key" ]; then
-  sleep 1
+  sleep 3
   printf '%s\n' 'sk-proj-from-onepassword'
   exit 0
 fi
@@ -34068,8 +34068,11 @@ api_key = "op://zeroclaw/provider/openai-api-key"
         let load_task = tokio::spawn(Config::load_or_init());
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
+        // Threshold sized against the 3s fake-op sleep: a blocked worker pins
+        // elapsed at >=3s, while scheduler latency under full-suite CI load
+        // stays well under 1.5s.
         assert!(
-            started.elapsed() < std::time::Duration::from_millis(500),
+            started.elapsed() < std::time::Duration::from_millis(1500),
             "op:// config load should not block the async runtime worker"
         );
 


### PR DESCRIPTION
Closes #9763.

`onepassword_reference_load_does_not_block_runtime_worker` proves the blocking `op` shell-out doesn't stall the async worker by asserting a 50ms `tokio::time::sleep` completes within 500ms while the fake `op` sleeps 1s. That 450ms scheduler-latency budget is too tight for a loaded runner: under full-suite nextest the sleep can take longer than that to get scheduled with no real regression, and the fail-fast cancels the remaining ~10k tests (see the issue for a captured run).

Fix scales both sides of the margin instead of changing what's tested: the fake `op` now sleeps 3s and the threshold is 1500ms. A genuinely blocked worker still pins elapsed at >=3s — decisively over threshold — while benign scheduler latency now has ~30x headroom instead of ~10x. Costs the test +2s wall time.

Verified: the test passes isolated (`cargo test -p zeroclaw-config --lib onepassword_reference_load`, 3.02s); fmt and scoped clippy clean.