### PR TITLE
feat(tools): tool-owned invocation triggers with send_via vocabulary (#7431, 1/2)

### DIFF
--- a/crates/zeroclaw-api/src/tool.rs
+++ b/crates/zeroclaw-api/src/tool.rs
@@ -315,6 +315,50 @@ impl OptionEntry {
     }
 }
 
+/// Reference implementation of the [`Tool::invocation_triggers`] matching
+/// contract: `true` when `trigger` occurs in `haystack` at a word boundary.
+/// Both are compared case-insensitively; the caller passes an
+/// already-lowercased `haystack` and a lowercased `trigger`. A boundary is
+/// the start/end of the string or any non-alphanumeric *character*
+/// (Unicode-aware), so a trigger matches only as a whole word or phrase
+/// (`dev` misses inside `device`, `send this to` hits inside `please send
+/// this to marta`). Boundaries and retry advancement are character-based, so
+/// multibyte trigger or haystack text is handled without panics or
+/// misclassification. Empty triggers never match.
+#[must_use]
+pub fn invocation_trigger_matches(haystack_lower: &str, trigger_lower: &str) -> bool {
+    if trigger_lower.is_empty() {
+        return false;
+    }
+    // `find` returns a byte offset of a valid substring, so `start` and
+    // `start + trigger.len()` are always char boundaries — the surrounding
+    // slices below are safe to index.
+    let mut search_start = 0;
+    while let Some(rel) = haystack_lower[search_start..].find(trigger_lower) {
+        let start = search_start + rel;
+        let end = start + trigger_lower.len();
+        let left_ok = haystack_lower[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric());
+        let right_ok = haystack_lower[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric());
+        if left_ok && right_ok {
+            return true;
+        }
+        // Advance one whole character past this occurrence's start so the next
+        // slice index stays on a boundary (byte + 1 could split a multibyte
+        // character and panic).
+        match haystack_lower[start..].chars().next() {
+            Some(c) => search_start = start + c.len_utf8(),
+            None => break,
+        }
+    }
+    false
+}
+
 #[async_trait]
 pub trait Tool: Send + Sync + crate::attribution::Attributable {
     /// Tool name (used in LLM function calling)
@@ -346,12 +390,20 @@ pub trait Tool: Send + Sync + crate::attribution::Attributable {
     /// e.g. routing wording or configured destination names for a delivery
     /// tool. A pre-turn prefilter may scan the message against these and
     /// nudge the model to consider the tool; the tool itself is never called
-    /// by the prefilter. Baseline matching contract: case-insensitive
-    /// substring search, so entries should be phrases distinctive enough not
-    /// to fire on ordinary prose. Entries derived from runtime config
-    /// (aliases, group names) must be computed live per call, never cached
-    /// across reloads. Default: no triggers; the tool does not participate
-    /// in prefilter hints.
+    /// by the prefilter.
+    ///
+    /// **Matching contract:** case-insensitive, **word-boundary** — a trigger
+    /// matches only where it is bounded by non-alphanumeric characters or the
+    /// message ends (see [`invocation_trigger_matches`]). So `dev` does not
+    /// fire inside `device` and `ops` does not fire inside `stops`; a trigger
+    /// only hits as a whole word or phrase. Entries should still be wording
+    /// that, taken whole, indicates this tool — avoid single common words.
+    /// A config-derived name that happens to equal a common word can still
+    /// over-fire; the hint is advisory (the model, not the prefilter, decides
+    /// to call), so the cost of a false positive is a wasted nudge, never an
+    /// action. Entries derived from runtime config (aliases, group names)
+    /// must be computed live per call, never cached across reloads. Default:
+    /// no triggers; the tool does not participate in prefilter hints.
     fn invocation_triggers(&self) -> Vec<String> {
         Vec::new()
     }
@@ -407,6 +459,50 @@ mod tests {
         let back: ToolSpec = serde_json::from_str(&arc_json).expect("spec deserializes");
         assert_eq!(back.name, spec.name);
         assert_eq!(*back.parameters, *spec.parameters);
+    }
+
+    #[test]
+    fn trigger_matches_are_word_bounded() {
+        // Whole-word / phrase hits.
+        assert!(invocation_trigger_matches(
+            "please send this to marta",
+            "send this to"
+        ));
+        assert!(invocation_trigger_matches(
+            "reply by voice please",
+            "by voice"
+        ));
+        assert!(invocation_trigger_matches("route to dev", "dev"));
+        assert!(invocation_trigger_matches("dev", "dev"));
+        // Substring-inside-word must NOT hit.
+        assert!(!invocation_trigger_matches(
+            "check the device status",
+            "dev"
+        ));
+        assert!(!invocation_trigger_matches("the bus stops here", "ops"));
+        assert!(!invocation_trigger_matches("recall everything", "all"));
+        // Bounded by punctuation counts as a word boundary.
+        assert!(invocation_trigger_matches("send to: dev.", "dev"));
+        // Empty trigger never matches.
+        assert!(!invocation_trigger_matches("anything", ""));
+    }
+
+    #[test]
+    fn trigger_matches_are_utf8_safe() {
+        // A multibyte trigger whose first occurrence is glued to another
+        // ideograph (rejected) and whose second occurrence is space-bounded
+        // (accepted). The byte-offset retry `start + 1` would land inside the
+        // leading multibyte character and panic; the char-based advance must
+        // reject the first, survive, and accept the second.
+        assert!(invocation_trigger_matches("料理番 送信 する", "送信"));
+        // Same trigger with only the glued occurrence must NOT match, and must
+        // not panic while scanning past it.
+        assert!(!invocation_trigger_matches("料理送信番", "送信"));
+        // A single ideograph is alphanumeric under Unicode, so an adjacent
+        // ideograph is not a boundary — no false positive inside CJK text.
+        assert!(!invocation_trigger_matches("東京都", "京"));
+        // But the same single-character trigger is bounded by ASCII spaces.
+        assert!(invocation_trigger_matches("go to 京 now", "京"));
     }
 
     #[test]

--- a/crates/zeroclaw-api/src/tool.rs
+++ b/crates/zeroclaw-api/src/tool.rs
@@ -342,6 +342,20 @@ pub trait Tool: Send + Sync + crate::attribution::Attributable {
         Vec::new()
     }
 
+    /// Lowercase phrases that suggest an inbound message wants this tool —
+    /// e.g. routing wording or configured destination names for a delivery
+    /// tool. A pre-turn prefilter may scan the message against these and
+    /// nudge the model to consider the tool; the tool itself is never called
+    /// by the prefilter. Baseline matching contract: case-insensitive
+    /// substring search, so entries should be phrases distinctive enough not
+    /// to fire on ordinary prose. Entries derived from runtime config
+    /// (aliases, group names) must be computed live per call, never cached
+    /// across reloads. Default: no triggers; the tool does not participate
+    /// in prefilter hints.
+    fn invocation_triggers(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Execute the tool with given arguments
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult>;
 
@@ -393,6 +407,35 @@ mod tests {
         let back: ToolSpec = serde_json::from_str(&arc_json).expect("spec deserializes");
         assert_eq!(back.name, spec.name);
         assert_eq!(*back.parameters, *spec.parameters);
+    }
+
+    #[test]
+    fn invocation_triggers_default_to_empty() {
+        struct Plain;
+        impl crate::attribution::Attributable for Plain {
+            fn role(&self) -> crate::attribution::Role {
+                crate::attribution::Role::Tool(crate::attribution::ToolKind::Plugin)
+            }
+            fn alias(&self) -> &str {
+                "plain"
+            }
+        }
+        #[async_trait]
+        impl Tool for Plain {
+            fn name(&self) -> &str {
+                "plain"
+            }
+            fn description(&self) -> &str {
+                "no triggers"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+                Ok(ToolResult::ok("ok"))
+            }
+        }
+        assert!(Plain.invocation_triggers().is_empty());
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -2778,6 +2778,10 @@ impl Tool for ToolArcRef {
         self.inner.spec()
     }
 
+    fn invocation_triggers(&self) -> Vec<String> {
+        self.inner.invocation_triggers()
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         self.inner.execute(args).await
     }
@@ -8318,6 +8322,71 @@ mod tool_arc_ref_spec_tests {
             Arc::ptr_eq(&wrapped.spec().parameters, &inner_params),
             "ToolArcRef must forward spec() so the inner Arc-shared schema \
              survives; the trait default deep-clones it every call"
+        );
+    }
+
+    /// Trigger-owning tool standing in for `send_via` behind bounded
+    /// delegation's `ToolArcRef` wrapper.
+    struct TriggerOwningTool;
+
+    impl ::zeroclaw_api::attribution::Attributable for TriggerOwningTool {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Tool(::zeroclaw_api::attribution::ToolKind::Plugin)
+        }
+        fn alias(&self) -> &str {
+            "trigger-owning-tool"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for TriggerOwningTool {
+        fn name(&self) -> &str {
+            "trigger_owning_tool"
+        }
+
+        fn description(&self) -> &str {
+            "test tool with invocation triggers"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object" })
+        }
+
+        fn invocation_triggers(&self) -> Vec<String> {
+            vec!["send this to".into(), "as a voice message".into()]
+        }
+
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: "ok".into(),
+                error: None,
+            })
+        }
+    }
+
+    #[test]
+    fn tool_arc_ref_forwards_invocation_triggers() {
+        // Regression: bounded delegation re-wraps every admitted parent tool
+        // in `ToolArcRef` (see the sub-tool assembly in `execute`). Without
+        // explicit forwarding the trait default returns an empty vocabulary,
+        // silently erasing a trigger-owning tool's metadata for any consumer
+        // scanning a delegate's assembled tools.
+        let inner: Arc<dyn Tool> = Arc::new(TriggerOwningTool);
+        let wrapped = ToolArcRef::new(Arc::clone(&inner));
+
+        assert_eq!(
+            wrapped.invocation_triggers(),
+            inner.invocation_triggers(),
+            "ToolArcRef must forward invocation_triggers(); the trait \
+             default erases the inner tool's vocabulary"
+        );
+        assert!(
+            wrapped
+                .invocation_triggers()
+                .iter()
+                .any(|t| t == "send this to"),
+            "wrapped trigger vocabulary must survive bounded delegation"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -209,6 +209,10 @@ impl Tool for ArcToolRef {
         self.0.spec()
     }
 
+    fn invocation_triggers(&self) -> Vec<String> {
+        self.0.invocation_triggers()
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         self.0.execute(args).await
     }
@@ -261,6 +265,10 @@ impl Tool for ArcDelegatingTool {
     // `parameters_schema()`, deep-cloning MCP schemas every loop iteration.
     fn spec(&self) -> zeroclaw_api::tool::ToolSpec {
         self.inner.spec()
+    }
+
+    fn invocation_triggers(&self) -> Vec<String> {
+        self.inner.invocation_triggers()
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
@@ -1808,6 +1816,66 @@ mod tests {
                 "SOP tool '{name}' must not be registered when engine is absent"
             );
         }
+    }
+
+    #[test]
+    fn send_via_triggers_survive_production_registry_boxing() {
+        // Regression: every arc in the registry is re-boxed as an
+        // `ArcDelegatingTool`, which must forward `invocation_triggers()` —
+        // otherwise the trait default erases send_via's vocabulary and the
+        // pre-turn prefilter can never match it. Build the real registry and
+        // assert the boxed send_via still carries its live triggers.
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+        let browser = BrowserConfig {
+            enabled: false,
+            allowed_domains: vec![],
+            session_name: None,
+            ..BrowserConfig::default()
+        };
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+        let cfg = test_config(&tmp);
+
+        let tools = all_tools_with_runtime(
+            Arc::new(Config::default()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            Arc::new(NativeRuntime::new()),
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .tools;
+
+        let send_via = tools
+            .iter()
+            .find(|t| t.name() == "send_via")
+            .expect("send_via is always registered");
+        let triggers = send_via.invocation_triggers();
+        assert!(
+            triggers.iter().any(|t| t == "send this to"),
+            "boxed send_via must keep its static triggers; got {triggers:?}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/send_via.rs
+++ b/crates/zeroclaw-tools/src/send_via.rs
@@ -43,9 +43,14 @@ pub struct TurnRoutingEntry {
 /// duration of the loop, and reads it back after the loop completes.
 pub type TurnRoutingHandle = Arc<Mutex<Vec<TurnRoutingEntry>>>;
 
-/// Static routing/modality wording that suggests a `send_via` call. Multiword
-/// phrases keep case-insensitive substring matching from firing on ordinary
-/// prose; live channel and peer-group names are added per call on top.
+/// Static routing/modality wording that suggests a `send_via` call. Each entry
+/// is a multiword phrase that, taken whole, requests a destination or delivery
+/// modality — chosen to survive the trait's word-boundary matching contract
+/// without firing on ordinary prose. Deliberately excluded: bare deadline /
+/// style wording like "reply by" ("reply by Friday"), "respond by", "reply in"
+/// ("reply in 5 minutes"), and "reply as" ("reply as soon as you can"), which
+/// carry no routing intent. Live channel and peer-group names are added per
+/// call on top.
 const STATIC_INVOCATION_TRIGGERS: &[&str] = &[
     "send this to",
     "send it to",
@@ -54,28 +59,25 @@ const STATIC_INVOCATION_TRIGGERS: &[&str] = &[
     "forward this to",
     "forward it to",
     "redirect to",
-    "deliver to",
-    "reply by",
-    "reply as",
-    "reply in",
-    "respond by",
+    "reply by voice",
+    "reply by text",
+    "reply via",
     "by voice",
     "via voice",
     "as voice",
     "voice message",
     "voice note",
-    "by text",
-    "as text",
     "text only",
-    "by email",
     "via email",
     "email this",
     "email it",
     "email me",
 ];
 
-/// Dynamic trigger entries shorter than this are dropped: single short
-/// tokens ("a", "io") match everywhere and poison substring scanning.
+/// Dynamic trigger entries shorter than this are dropped. Word-boundary
+/// matching already stops `dev` from firing inside `device`, but very short
+/// names (1–2 characters) collide with too many standalone words to be useful
+/// triggers. Compared by character count, not byte length.
 const MIN_DYNAMIC_TRIGGER_LEN: usize = 3;
 
 /// Agent-callable tool for per-turn output routing and channel fanout.
@@ -233,26 +235,31 @@ impl Tool for SendViaTool {
             .map(|t| (*t).to_string())
             .collect();
 
+        // Character count, not byte length: the rule excludes 1–2 *character*
+        // names, and a short multibyte name (e.g. a 1-char CJK alias) has a
+        // byte length >= 3 that a `.len()` check would wrongly admit.
+        let long_enough = |s: &str| s.chars().count() >= MIN_DYNAMIC_TRIGGER_LEN;
+
         // Live views, mirroring resolve_target: recomputed per call so config
         // reloads (channels, peer groups) take effect without a registry rebuild.
         for key in self.channel_map.read().keys() {
             let lower = key.to_lowercase();
             if let Some((channel_type, alias)) = lower.split_once('.') {
-                if channel_type.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+                if long_enough(channel_type) {
                     triggers.insert(channel_type.to_string());
                 }
                 // "default" is an implementation alias, not user wording.
-                if alias != "default" && alias.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+                if alias != "default" && long_enough(alias) {
                     triggers.insert(alias.to_string());
                 }
             }
-            if lower.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+            if long_enough(&lower) {
                 triggers.insert(lower);
             }
         }
         for group in (self.agent_peer_groups)().keys() {
             let lower = group.to_lowercase();
-            if lower.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+            if long_enough(&lower) {
                 triggers.insert(lower);
             }
         }
@@ -625,9 +632,28 @@ mod tests {
         assert!(has("family"));
         // The implementation alias never becomes a bare trigger word.
         assert!(!has("default"));
+        // Deadline / style wording that carries no routing intent must NOT be
+        // a trigger (would false-positive under the matching contract on
+        // "reply by Friday", "respond by noon", "reply as soon as you can").
+        for prose in [
+            "reply by",
+            "respond by",
+            "reply in",
+            "reply as",
+            "deliver to",
+        ] {
+            assert!(
+                !has(prose),
+                "ambiguous phrase must not be a trigger: {prose}"
+            );
+        }
         // Everything is lowercase: the scan contract is case-insensitive
         // matching against a lowercased message.
         assert!(triggers.iter().all(|t| t == &t.to_lowercase()));
+        // Under word-boundary matching (zeroclaw_api::tool::
+        // invocation_trigger_matches), a short channel type like "email" is a
+        // safe whole-word trigger and must not be dropped for length.
+        assert!(has("email"));
     }
 
     #[test]
@@ -661,6 +687,24 @@ mod tests {
         assert!(after.iter().any(|t| t == "discord"));
         assert!(after.iter().any(|t| t == "main"));
         assert!(after.iter().any(|t| t == "family"));
+    }
+
+    #[test]
+    fn short_multibyte_names_are_excluded_by_character_count() {
+        // A one-character CJK peer-group name is 3 bytes but 1 character; the
+        // min-length rule excludes 1–2 character names, so it must not become
+        // a trigger (a byte-length check would wrongly admit it). A
+        // three-character CJK name clears the rule.
+        let (tool, _routing) = make_tool(
+            vec![("telegram.default", Arc::new(StubChannel::new("telegram")))],
+            HashMap::from([
+                ("東".to_string(), pg("telegram", &["ana"])),
+                ("東京都".to_string(), pg("telegram", &["ana"])),
+            ]),
+        );
+        let triggers = tool.inner.invocation_triggers();
+        assert!(!triggers.iter().any(|t| t == "東"));
+        assert!(triggers.iter().any(|t| t == "東京都"));
     }
 
     fn pg_with_peers(channel: &str, agents: &[&str], peers: &[&str]) -> PeerGroupConfig {

--- a/crates/zeroclaw-tools/src/send_via.rs
+++ b/crates/zeroclaw-tools/src/send_via.rs
@@ -43,6 +43,41 @@ pub struct TurnRoutingEntry {
 /// duration of the loop, and reads it back after the loop completes.
 pub type TurnRoutingHandle = Arc<Mutex<Vec<TurnRoutingEntry>>>;
 
+/// Static routing/modality wording that suggests a `send_via` call. Multiword
+/// phrases keep case-insensitive substring matching from firing on ordinary
+/// prose; live channel and peer-group names are added per call on top.
+const STATIC_INVOCATION_TRIGGERS: &[&str] = &[
+    "send this to",
+    "send it to",
+    "send that to",
+    "send to my",
+    "forward this to",
+    "forward it to",
+    "redirect to",
+    "deliver to",
+    "reply by",
+    "reply as",
+    "reply in",
+    "respond by",
+    "by voice",
+    "via voice",
+    "as voice",
+    "voice message",
+    "voice note",
+    "by text",
+    "as text",
+    "text only",
+    "by email",
+    "via email",
+    "email this",
+    "email it",
+    "email me",
+];
+
+/// Dynamic trigger entries shorter than this are dropped: single short
+/// tokens ("a", "io") match everywhere and poison substring scanning.
+const MIN_DYNAMIC_TRIGGER_LEN: usize = 3;
+
 /// Agent-callable tool for per-turn output routing and channel fanout.
 pub struct SendViaTool {
     security: Arc<SecurityPolicy>,
@@ -190,6 +225,39 @@ impl Tool for SendViaTool {
          \n\
          `target` must be a channel alias (e.g. `telegram.default`) or a peer group name \
          the active agent belongs to. `modality` defaults to the peer group's output_modality."
+    }
+
+    fn invocation_triggers(&self) -> Vec<String> {
+        let mut triggers: std::collections::BTreeSet<String> = STATIC_INVOCATION_TRIGGERS
+            .iter()
+            .map(|t| (*t).to_string())
+            .collect();
+
+        // Live views, mirroring resolve_target: recomputed per call so config
+        // reloads (channels, peer groups) take effect without a registry rebuild.
+        for key in self.channel_map.read().keys() {
+            let lower = key.to_lowercase();
+            if let Some((channel_type, alias)) = lower.split_once('.') {
+                if channel_type.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+                    triggers.insert(channel_type.to_string());
+                }
+                // "default" is an implementation alias, not user wording.
+                if alias != "default" && alias.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+                    triggers.insert(alias.to_string());
+                }
+            }
+            if lower.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+                triggers.insert(lower);
+            }
+        }
+        for group in (self.agent_peer_groups)().keys() {
+            let lower = group.to_lowercase();
+            if lower.len() >= MIN_DYNAMIC_TRIGGER_LEN {
+                triggers.insert(lower);
+            }
+        }
+
+        triggers.into_iter().collect()
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -530,6 +598,69 @@ mod tests {
             output_modality: OutputModality::Text,
             ..PeerGroupConfig::default()
         }
+    }
+
+    #[test]
+    fn invocation_triggers_combine_static_and_live_names() {
+        let (tool, _routing) = make_tool(
+            vec![
+                ("telegram.default", Arc::new(StubChannel::new("telegram"))),
+                ("email.work", Arc::new(StubChannel::new("email"))),
+            ],
+            HashMap::from([("Family".to_string(), pg("telegram", &["ana"]))]),
+        );
+        let triggers = tool.inner.invocation_triggers();
+        let has = |t: &str| triggers.iter().any(|x| x == t);
+
+        // Static routing/modality wording.
+        assert!(has("send it to"));
+        assert!(has("via voice"));
+        // Channel types, full keys, and non-default aliases.
+        assert!(has("telegram"));
+        assert!(has("telegram.default"));
+        assert!(has("email"));
+        assert!(has("email.work"));
+        assert!(has("work"));
+        // Peer-group names, lowercased.
+        assert!(has("family"));
+        // The implementation alias never becomes a bare trigger word.
+        assert!(!has("default"));
+        // Everything is lowercase: the scan contract is case-insensitive
+        // matching against a lowercased message.
+        assert!(triggers.iter().all(|t| t == &t.to_lowercase()));
+    }
+
+    #[test]
+    fn invocation_triggers_follow_live_config_changes() {
+        let map: PerToolChannelHandle = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        let groups: Arc<parking_lot::RwLock<HashMap<String, PeerGroupConfig>>> =
+            Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        let resolver: AgentPeerGroupResolver = {
+            let groups = Arc::clone(&groups);
+            Arc::new(move || groups.read().clone())
+        };
+        let tool = SendViaTool::new(
+            Arc::new(SecurityPolicy::default()),
+            Arc::clone(&map),
+            resolver,
+        );
+
+        let before = tool.invocation_triggers();
+        assert!(!before.iter().any(|t| t == "family"));
+        assert!(!before.iter().any(|t| t == "discord"));
+
+        map.write().insert(
+            "discord.main".to_string(),
+            Arc::new(StubChannel::new("discord")) as Arc<dyn Channel>,
+        );
+        groups
+            .write()
+            .insert("family".to_string(), pg("discord", &["ana"]));
+
+        let after = tool.invocation_triggers();
+        assert!(after.iter().any(|t| t == "discord"));
+        assert!(after.iter().any(|t| t == "main"));
+        assert!(after.iter().any(|t| t == "family"));
     }
 
     fn pg_with_peers(channel: &str, agents: &[&str], peers: &[&str]) -> PeerGroupConfig {

--- a/crates/zeroclaw-tools/src/send_via.rs
+++ b/crates/zeroclaw-tools/src/send_via.rs
@@ -237,30 +237,32 @@ impl Tool for SendViaTool {
 
         // Character count, not byte length: the rule excludes 1–2 *character*
         // names, and a short multibyte name (e.g. a 1-char CJK alias) has a
-        // byte length >= 3 that a `.len()` check would wrongly admit.
+        // byte length >= 3 that a `.len()` check would wrongly admit. Counted
+        // on the ORIGINAL configured name, before lowercasing: Unicode
+        // lowercase can expand one scalar into several (e.g. 'İ' → "i̇"), and
+        // counting afterwards would let an excluded-length name through.
         let long_enough = |s: &str| s.chars().count() >= MIN_DYNAMIC_TRIGGER_LEN;
 
         // Live views, mirroring resolve_target: recomputed per call so config
         // reloads (channels, peer groups) take effect without a registry rebuild.
         for key in self.channel_map.read().keys() {
-            let lower = key.to_lowercase();
-            if let Some((channel_type, alias)) = lower.split_once('.') {
+            if let Some((channel_type, alias)) = key.split_once('.') {
                 if long_enough(channel_type) {
-                    triggers.insert(channel_type.to_string());
+                    triggers.insert(channel_type.to_lowercase());
                 }
+                let alias_lower = alias.to_lowercase();
                 // "default" is an implementation alias, not user wording.
-                if alias != "default" && long_enough(alias) {
-                    triggers.insert(alias.to_string());
+                if alias_lower != "default" && long_enough(alias) {
+                    triggers.insert(alias_lower);
                 }
             }
-            if long_enough(&lower) {
-                triggers.insert(lower);
+            if long_enough(key) {
+                triggers.insert(key.to_lowercase());
             }
         }
         for group in (self.agent_peer_groups)().keys() {
-            let lower = group.to_lowercase();
-            if long_enough(&lower) {
-                triggers.insert(lower);
+            if long_enough(group) {
+                triggers.insert(group.to_lowercase());
             }
         }
 
@@ -705,6 +707,40 @@ mod tests {
         let triggers = tool.inner.invocation_triggers();
         assert!(!triggers.iter().any(|t| t == "東"));
         assert!(triggers.iter().any(|t| t == "東京都"));
+    }
+
+    #[test]
+    fn name_length_is_counted_before_lowercase_expansion() {
+        // Unicode lowercase can expand a scalar: 'İ' (U+0130) lowercases to
+        // "i\u{307}" (two scalars). A two-character configured name like "İs"
+        // becomes three scalars after lowercasing, so a post-lowercase count
+        // would wrongly admit a name the 1–2 character rule excludes. The
+        // floor must be applied to the original configured name.
+        let name = "İs";
+        assert_eq!(name.chars().count(), 2);
+        assert!(name.to_lowercase().chars().count() >= MIN_DYNAMIC_TRIGGER_LEN);
+
+        let (tool, _routing) = make_tool(
+            vec![("telegram.default", Arc::new(StubChannel::new("telegram")))],
+            HashMap::from([(name.to_string(), pg("telegram", &["ana"]))]),
+        );
+        let triggers = tool.inner.invocation_triggers();
+        assert!(
+            !triggers.iter().any(|t| t == &name.to_lowercase()),
+            "case-expanding two-character name must stay excluded; got {triggers:?}"
+        );
+
+        // A three-character name containing the same expanding scalar still
+        // clears the rule and lands lowercased.
+        let (tool, _routing) = make_tool(
+            vec![("telegram.default", Arc::new(StubChannel::new("telegram")))],
+            HashMap::from([("İst".to_string(), pg("telegram", &["ana"]))]),
+        );
+        let triggers = tool.inner.invocation_triggers();
+        assert!(
+            triggers.iter().any(|t| t == &"İst".to_lowercase()),
+            "three-character name must remain a trigger after lowercasing"
+        );
     }
 
     fn pg_with_peers(channel: &str, agents: &[&str], peers: &[&str]) -> PeerGroupConfig {

--- a/crates/zeroclaw-tools/src/wrappers.rs
+++ b/crates/zeroclaw-tools/src/wrappers.rs
@@ -53,6 +53,10 @@ impl<T: Tool> Tool for RateLimitedTool<T> {
         self.inner.param_domains()
     }
 
+    fn invocation_triggers(&self) -> Vec<String> {
+        self.inner.invocation_triggers()
+    }
+
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         if self.security.is_rate_limited() {
             return Ok(ToolResult {
@@ -146,6 +150,10 @@ impl<T: Tool> Tool for PathGuardedTool<T> {
 
     fn param_domains(&self) -> Vec<(&'static str, zeroclaw_api::tool::OptionDomain)> {
         self.inner.param_domains()
+    }
+
+    fn invocation_triggers(&self) -> Vec<String> {
+        self.inner.invocation_triggers()
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** First of the two slices accepted in #7431. Adds a defaulted `Tool::invocation_triggers()` contract to `zeroclaw-api` (lowercase phrases suggesting an inbound message wants the tool) and implements it on `SendViaTool` (static routing/modality wording + live channel/peer-group names). This is the vocabulary the slice-2 prefilter will scan; nothing consumes it yet. The matching contract is **word-boundary** (case-insensitive), with a reference matcher `invocation_trigger_matches()` so the semantics are one enforceable definition shared by the tool authors and the future scanner. The four registry wrappers plus bounded delegation's `ToolArcRef` forward the new method so triggers survive production tool assembly.
- **Scope boundary:** No prefilter, no hint injection, no runtime flag, no telemetry, no behavior change on any turn — those are slice 2. `send_via`'s execution path and routing semantics are untouched. WIT interfaces unchanged.
- **Blast radius:** `Tool` trait (defaulted method — every implementor inherits it, source-compatible); the four registry wrapper adapters (`ArcToolRef`, `ArcDelegatingTool`, `RateLimitedTool`, `PathGuardedTool`); bounded delegation's `ToolArcRef`; `SendViaTool` metadata only.
- **Linked issue(s):** Related #7431 (first of two slices; does not close it).
- **Labels:** `enhancement`, `runtime`, `tool`, `experienced contributor`, `tool:delegate`, `domain:security`, `domain:architecture`, `risk:high`, `size:S`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — no runtime-observable behavior in this slice (the consumer lands in slice 2). Verified by unit tests, including production-registry and bounded-delegation regressions.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-api -p zeroclaw-tools -p zeroclaw-runtime --tests -- -D warnings
cargo test --locked -p zeroclaw-api --lib
cargo test --locked -p zeroclaw-tools --lib send_via
cargo test --locked -p zeroclaw-tools --lib invocation_triggers
cargo test --locked -p zeroclaw-runtime --lib tool_arc_ref_forwards_invocation_triggers
cargo test --locked -p zeroclaw-runtime --lib send_via_triggers_survive_production_registry_boxing
```

- **CI checks relied on and why they cover this change:** `Quality Gate` (`Format`, `Lint`, `Test`, the `Check` matrix) covers the trait change, wrapper forwarding, and new tests across the workspace, including `tool_arc_ref_forwards_invocation_triggers` and `name_length_is_counted_before_lowercase_expansion`. No WIT files are touched; the defaulted host-only `Tool` method leaves the WIT interface unchanged.
- **Known CI coverage gap, if any:** None specific to this diff. Earlier full-suite runs under heavy parallelism intermittently tripped three `git_operations` tests (`allows_readonly_ops_in_readonly_mode`, `non_repository_error_includes_path_context_and_recovery_hint`, `git_credential_op_fails_fast_without_terminal_prompt`). They were repository or credential-prompt setup failures outside this diff; the exact-head focused suites and hosted matrix are green, and the credential-prompt test also passed in the exact-head independent review.
- **Commands run and tail output:** Exact-head independent review at `b802d0f72bcc841e725e80470678d9fadcd8376c` recorded:
  ```
  cargo test --locked -p zeroclaw-api --lib
    test result: ok. 147 passed; 0 failed
  cargo test --locked -p zeroclaw-tools --lib send_via
    test result: ok. 21 passed; 0 failed
  cargo test --locked -p zeroclaw-tools --lib invocation_triggers
    test result: ok. 2 passed; 0 failed
  cargo test --locked -p zeroclaw-runtime --lib tool_arc_ref_forwards_invocation_triggers
    test result: ok. 1 passed; 0 failed
  cargo test --locked -p zeroclaw-runtime --lib send_via_triggers_survive_production_registry_boxing
    test result: ok. 1 passed; 0 failed
  cargo fmt --all -- --check   # exit 0
  cargo clippy … --tests -- -D warnings   # clean
  ```
- **Beyond CI, what did you manually verify?** The exact-head independent review mutation-tested both critical regressions: removing `ArcDelegatingTool::invocation_triggers()` made the production-registry test fail, and restoring the byte-oriented matcher retry made the UTF-8 regression panic. Restoring each fix made the focused test pass. No live scenario applies because nothing consumes the triggers in this slice.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` was not used as primary evidence; the change is confined to three crates and the focused suites plus cross-crate wrapper tests cover it. `zeroclaw-desktop` is excluded locally because it needs GTK development headers unavailable on this machine; CI covers it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No** in this slice — `invocation_triggers()` produces no model-visible text and is not yet read anywhere. It is worth flagging forward: in slice 2 a match will inject a hint that nudges the model toward `send_via`, which performs `ToolOperation::Act`. That is exactly why this slice makes the matching **word-boundary** and drops deadline/style phrases (`reply by`, `respond by`, `reply in`, `reply as`) that would false-positive on ordinary prose — so the slice-2 consumer inherits a contract that does not turn routine messages into outbound-side-effect candidates. Even then the hint is advisory; the model, not the prefilter, decides to call.

## Compatibility (required)

- Backward compatible? **Yes** — the trait method is defaulted (existing implementors, including wasm/plugin tools, compile unchanged and inherit the empty default).
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`. No consumer exists, so reverting is inert beyond removing the method and vocabulary.
- **Feature flags or config toggles:** None in this slice. The feature is gated by the default-off `tool_elicitation` flag introduced in slice 2.
- **Observable failure symptoms:** None expected — nothing reads the triggers yet. If wrapper forwarding regressed, `send_via_triggers_survive_production_registry_boxing` or `tool_arc_ref_forwards_invocation_triggers` fails; at runtime (slice 2) the symptom would be routing hints never firing despite configured vocabulary.

