### PR TITLE
fix(zerocode): correct config editor navigation dispatch

### DIFF
--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -52,6 +52,14 @@ fn retain_direct_children(fields: &mut Vec<ConfigFieldEntry>, prefix: &str) {
     fields.retain(|field| is_direct_child_path(&field.path, prefix));
 }
 
+fn append_uncontrolled_char(buf: &mut String, key: &KeyEvent) {
+    if let KeyCode::Char(c) = key.code
+        && !key.modifiers.contains(KeyModifiers::CONTROL)
+    {
+        buf.push(c);
+    }
+}
+
 pub(crate) fn init_terminal() -> Result<Term> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -2260,14 +2268,7 @@ impl App {
             Some(ConfigEditorAction::Backspace) => {
                 self.edit_buf.pop();
             }
-            None => {
-                if let KeyCode::Char(c) = key.code
-                    && !key.modifiers.contains(KeyModifiers::CONTROL)
-                {
-                    self.edit_buf.push(c);
-                }
-            }
-            _ => {}
+            _ => append_uncontrolled_char(&mut self.edit_buf, &key),
         }
         Ok(())
     }
@@ -2691,14 +2692,7 @@ impl App {
             Some(ConfigEditorAction::Backspace) => {
                 self.personality_content.pop();
             }
-            None => {
-                if let KeyCode::Char(c) = key.code
-                    && !key.modifiers.contains(KeyModifiers::CONTROL)
-                {
-                    self.personality_content.push(c);
-                }
-            }
-            _ => {}
+            _ => append_uncontrolled_char(&mut self.personality_content, &key),
         }
         Ok(())
     }
@@ -2898,14 +2892,7 @@ impl App {
             Some(ConfigEditorAction::Backspace) => {
                 self.skills_body.pop();
             }
-            None => {
-                if let KeyCode::Char(c) = key.code
-                    && !key.modifiers.contains(KeyModifiers::CONTROL)
-                {
-                    self.skills_body.push(c);
-                }
-            }
-            _ => {}
+            _ => append_uncontrolled_char(&mut self.skills_body, &key),
         }
         Ok(())
     }
@@ -4368,6 +4355,7 @@ impl App {
         self.section == ConfigSection::Zeroclaw
             && self.zeroclaw_pane == ZeroclawPane::Detail
             && self.is_scalar_field_edit()
+            && !self.edit_buf.is_empty()
             && matches!(
                 crate::keymap::ConfigEditorAction::from_chord(key),
                 Some(
@@ -4897,31 +4885,75 @@ mod tests {
             field_idx: 0,
         };
         manager.zeroclaw_pane = ZeroclawPane::Detail;
-        let word_left = KeyEvent::new(KeyCode::Left, KeyModifiers::ALT);
+        let word_chords = [
+            KeyEvent::new(KeyCode::Left, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Right, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char('f'), KeyModifiers::ALT),
+        ];
 
-        assert!(manager.claims_pane_navigation(&word_left));
+        assert!(
+            word_chords
+                .iter()
+                .all(|key| !manager.claims_pane_navigation(key))
+        );
+
+        manager.edit_buf = "alpha beta".into();
+        assert!(
+            word_chords
+                .iter()
+                .all(|key| manager.claims_pane_navigation(key))
+        );
 
         manager.section = ConfigSection::Zerocode;
-        assert!(!manager.claims_pane_navigation(&word_left));
+        assert!(!manager.claims_pane_navigation(&word_chords[0]));
 
         manager.section = ConfigSection::Zeroclaw;
         manager.zeroclaw_pane = ZeroclawPane::Sections;
-        assert!(!manager.claims_pane_navigation(&word_left));
+        assert!(!manager.claims_pane_navigation(&word_chords[0]));
 
         manager.zeroclaw_pane = ZeroclawPane::Detail;
         manager.select_items = vec!["first".into(), "second".into()];
-        assert!(!manager.claims_pane_navigation(&word_left));
+        assert!(!manager.claims_pane_navigation(&word_chords[0]));
 
         manager.select_items.clear();
         manager.fields[0].kind = PropKind::StringArray;
-        assert!(!manager.claims_pane_navigation(&word_left));
+        assert!(!manager.claims_pane_navigation(&word_chords[0]));
 
         manager.screen = Screen::FieldList {
             section_idx: 0,
             prefix: "example".into(),
             breadcrumb: vec!["example".into()],
         };
-        assert!(!manager.claims_pane_navigation(&word_left));
+        assert!(!manager.claims_pane_navigation(&word_chords[0]));
+    }
+
+    #[tokio::test]
+    async fn append_only_config_editors_preserve_alt_word_characters() {
+        let alt_b = KeyEvent::new(KeyCode::Char('b'), KeyModifiers::ALT);
+        let alt_f = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::ALT);
+
+        let mut alias = test_manager();
+        alias.handle_alias_create(alt_b).await.unwrap();
+        alias.handle_alias_create(alt_f).await.unwrap();
+        assert_eq!(alias.edit_buf, "bf");
+
+        let mut personality = test_manager();
+        let mut term = test_term();
+        personality
+            .handle_personality_editor(alt_b, &mut term)
+            .await
+            .unwrap();
+        personality
+            .handle_personality_editor(alt_f, &mut term)
+            .await
+            .unwrap();
+        assert_eq!(personality.personality_content, "bf");
+
+        let mut skills = test_manager();
+        skills.handle_skills_editor(alt_b, &mut term).await.unwrap();
+        skills.handle_skills_editor(alt_f, &mut term).await.unwrap();
+        assert_eq!(skills.skills_body, "bf");
     }
 
     #[test]
@@ -4978,6 +5010,17 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<String>(16);
         let rpc = Arc::new(RpcClient::with_rpc(Arc::new(RpcOutbound::new(tx))));
         App::new(rpc, std::path::Path::new("/tmp"))
+    }
+
+    fn test_term() -> Term {
+        let backend = WideCellCleanupBackend::new(io::stdout());
+        Terminal::with_options(
+            backend,
+            ratatui::TerminalOptions {
+                viewport: ratatui::Viewport::Fixed(Rect::new(0, 0, 80, 24)),
+            },
+        )
+        .expect("test terminal")
     }
 
     fn entry_with_cost(key: &str, cost_category: &str) -> ConfigSectionEntry {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Empty scalar fields in ZeroCode Config now leave overlapping word-navigation chords available for pane navigation because local cursor movement cannot do anything without text. Nonempty scalar fields still claim those chords for local word movement. Alias, personality, and skills editors now preserve printable Alt+B and Alt+F input when global pane bindings do not consume those chords.
- **Scope boundary:** This PR does not change global keymap defaults, persisted keymap/config state, cursor support in append-only editors, or Chat/Code/ACP behavior.
- **Blast radius:** ZeroCode Config keyboard dispatch only. The global app dispatcher continues to rely on Config's existing ownership predicate.
- **Linked issue(s):** Related #7467 and #9277. Corrective follow-up to #9287.
- **Labels:** `bug`, `config`, `distinguished contributor`, `risk:medium`, `zerocode`, `size:S`, `needs-author-action`

### What this does, simply

ZeroCode Config uses some of the same keys to move through text and to move between parts of the screen. An empty field was keeping those keys even though there was no text to move through, so the keys appeared to do nothing. Some fields could also swallow typed shortcuts.

This PR lets a field keep a key only when that field can actually use it. Empty fields pass movement keys to the surrounding screen, while fields containing text keep normal word movement. It does not change saved keybindings or navigation outside ZeroCode Config.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; terminal behavior is the user-visible boundary.
- **Interface(s) exercised:** `surface: tui`
- **Setup / preconditions:** Open ZeroCode Config with global pane bindings that overlap the Config editor word-navigation chords. To exercise the append-only fallback, rebind global pane navigation away from Alt+B and Alt+F.
- **Steps to run:** Open an empty scalar field and press Alt+Left, Alt+B, Alt+Right, and Alt+F. Then type a multiword value and repeat those chords. Finally, open the alias-name, personality, and skills inline editors and press Alt+B and Alt+F.
- **Expected on this branch (after):** Empty scalar fields allow the overlapping chords to switch panes; nonempty scalar fields move the local cursor by words; append-only editors insert `b` and `f` when those chords are not consumed globally.
- **Prior behavior on `master` (before):** Empty scalar fields claim the chords without moving the cursor or switching panes, while append-only editors silently drop Alt+B and Alt+F after action resolution.

### How I tested

Focused tests cover all four empty/nonempty scalar ownership chords and exercise Alt+B/F through the alias, personality, and skills handlers.

```sh
cargo fmt --all -- --check
cargo test -p zerocode --bin zerocode 'config_manager::tests::' -- --nocapture
```

Both commands passed. `git diff --check` and `scripts/ci/comment_hygiene_gate.sh` also passed.

- **CI checks relied on and why they cover this change:** Hosted CI passed on head `11c4b685086ce54b2d57aa3212571b596b3e426e`, including the required gate, formatting, lint, cross-platform checks, and tests.
- **Known CI coverage gap, if any:** The rebound global-pane-binding fallback was not exercised manually; focused tests cover Alt+B/F through the alias, personality, and skills handlers.
- **Commands run and tail output:**

```text
running 15 tests
test config_manager::tests::pane_navigation_claims_only_scalar_field_edits ... ok
test config_manager::tests::append_only_config_editors_preserve_alt_word_characters ... ok
test config_manager::tests::scalar_field_edit_supports_cursor_insertion_and_word_navigation ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 657 filtered out; finished in 0.04s
```

`cargo fmt --all -- --check` completed without output.
- **Beyond CI, what did you manually verify?** In the ZeroCode Config TUI, I verified that empty scalar fields release the overlapping chords for pane navigation and nonempty scalar fields retain local word navigation.
- **If any command was intentionally skipped, why:** Broader local workspace validation was deferred to hosted CI because the production change is confined to Config keyboard dispatch and focused tests cover the corrected paths.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Empty Config scalar fields swallow pane-navigation chords, or Alt+B/F input disappears in alias, personality, or skills editors.
