### PR TITLE
feat(security): extend forbidden_paths with workspace-relative glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13226,6 +13226,7 @@ dependencies = [
  "chrono",
  "clap",
  "directories",
+ "glob",
  "hex",
  "hostname",
  "parking_lot",

--- a/crates/zeroclaw-config/Cargo.toml
+++ b/crates/zeroclaw-config/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1"
 chacha20poly1305 = "0.10"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 directories = "6.0"
+glob = "0.3"
 hex = "0.4"
 hostname = "0.4.2"
 parking_lot = "0.12"

--- a/crates/zeroclaw-config/src/forbidden_patterns.rs
+++ b/crates/zeroclaw-config/src/forbidden_patterns.rs
@@ -1,0 +1,404 @@
+//! Workspace-relative forbidden path pattern matching.
+//!
+//! Extends the existing `forbidden_paths` mechanism with glob and
+//! workspace-relative pattern support. Absolute paths (`/...`, `~...`)
+//! continue to use the existing prefix-match loop in `SecurityPolicy`.
+//! This module handles patterns that operate on the **workspace-relative**
+//! path, evaluated *before* the workspace short-circuit in the three
+//! path-check methods.
+//!
+//! # Pattern semantics
+//!
+//! | Pattern form | Matching rule |
+//! |---|---|
+//! | `*`, `?`, `[` chars present | `glob::Pattern` match on normalized relative path (`require_literal_separator: true`) |
+//! | Contains `/`, no glob chars, no trailing `/` | Exact match on normalized relative path |
+//! | Contains `/`, no glob chars, trailing `/` | Directory prefix — matches the directory and all descendants |
+//! | No `/`, no glob chars | Basename match against any single path component |
+//!
+//! Bare `*`, parent-traversing patterns (`../`), and invalid glob syntax
+//! are rejected silently during construction.
+
+use std::path::Path;
+
+use glob::MatchOptions;
+
+// Glob matching: `*`/`?` must not match path separators; dotfiles
+// are matched normally (needed for `.env*` deny patterns).
+static GLOB_MATCH_OPTIONS: MatchOptions = MatchOptions {
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+    case_sensitive: true,
+};
+
+/// Categorized set of forbidden path patterns evaluated against
+/// workspace-relative paths. Built once at policy construction from
+/// the `forbidden_paths` config entries.
+#[derive(Debug, Clone, Default)]
+pub struct ForbiddenPatternSet {
+    /// Glob patterns matched against the normalized workspace-relative path.
+    globs: Vec<glob::Pattern>,
+    /// Exact relative path matches (contain `/`, no glob chars, no trailing `/`).
+    /// Example: `.cargo/config.toml` matches only that exact relative path.
+    relative_exact_paths: Vec<String>,
+    /// Directory prefix patterns (contain `/`, no glob chars, trailing `/` stored
+    /// without the slash). Example: `secrets` from `secrets/` matches the
+    /// directory and everything underneath.
+    relative_dir_prefixes: Vec<String>,
+    /// Basename patterns (no `/`, no glob chars). Matched against any single
+    /// path component at any depth. Example: `credentials.json` matches
+    /// `credentials.json`, `dir/credentials.json`, etc.
+    basename_patterns: Vec<String>,
+}
+
+impl ForbiddenPatternSet {
+    /// Build from config entries. Only workspace-relative entries are
+    /// categorized here; absolute entries (`/...`, `~...`) are handled
+    /// by the existing `forbidden_paths` prefix loop in `SecurityPolicy`.
+    pub fn from_config_entries(config_patterns: &[String]) -> Self {
+        let mut result = Self::default();
+        for pattern in config_patterns {
+            result.add_pattern(pattern);
+        }
+        result
+    }
+
+    fn add_pattern(&mut self, pattern: &str) {
+        let trimmed = pattern.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            return;
+        }
+        // Absolute paths and ~ paths are handled by existing forbidden_paths loop.
+        if trimmed.starts_with('/') || trimmed.starts_with('~') {
+            return;
+        }
+        // Reject bare `*` — would block all files in workspace.
+        if trimmed == "*" {
+            return;
+        }
+        // Reject parent-traversing patterns (e.g. `../etc/passwd`).
+        // Only reject when `..` is followed by a separator, so harmless
+        // names like `foo..bar` are allowed.
+        if trimmed.contains("../") || trimmed.contains("..\\") {
+            return;
+        }
+
+        let has_glob_chars =
+            trimmed.contains('*') || trimmed.contains('?') || trimmed.contains('[');
+        let has_separator = trimmed.contains('/');
+
+        if has_glob_chars {
+            match glob::Pattern::new(trimmed) {
+                Ok(pat) => self.globs.push(pat),
+                Err(_) => {
+                    // Invalid glob — silently skip.
+                }
+            }
+        } else if has_separator && trimmed.ends_with('/') {
+            // Directory prefix — match the directory and all descendants.
+            self.relative_dir_prefixes
+                .push(trimmed.trim_end_matches('/').to_string());
+        } else if has_separator {
+            // Exact relative path match.
+            self.relative_exact_paths.push(trimmed.to_string());
+        } else {
+            // Bare filename — match any path component.
+            self.basename_patterns.push(trimmed.to_string());
+        }
+    }
+
+    /// Check if a workspace-relative path should be forbidden.
+    ///
+    /// `relative` is the path after stripping the workspace root prefix.
+    /// An empty path (the workspace root itself) is never forbidden.
+    pub fn is_forbidden(&self, relative: &Path) -> bool {
+        // Normalize to forward slashes for consistent matching.
+        let relative_str = normalize_separators(relative);
+
+        // Basename patterns — match the final path component.
+        if let Some(file_name) = relative.file_name().and_then(|v| v.to_str()) {
+            for basename in &self.basename_patterns {
+                if file_name == basename.as_str() {
+                    return true;
+                }
+            }
+        }
+
+        // Exact relative path patterns.
+        for exact in &self.relative_exact_paths {
+            if relative_str == *exact {
+                return true;
+            }
+        }
+
+        // Directory prefix patterns (trailing `/`).
+        for prefix in &self.relative_dir_prefixes {
+            if relative_str == *prefix || relative_str.starts_with(&format!("{prefix}/")) {
+                return true;
+            }
+        }
+
+        // Glob patterns.
+        for glob in &self.globs {
+            if glob.matches_with(&relative_str, GLOB_MATCH_OPTIONS) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns `true` if there are no workspace-relative patterns configured.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.globs.is_empty()
+            && self.relative_exact_paths.is_empty()
+            && self.relative_dir_prefixes.is_empty()
+            && self.basename_patterns.is_empty()
+    }
+}
+
+/// Normalize path separators to `/` for consistent cross-platform matching.
+fn normalize_separators(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn policy_entries(patterns: &[&str]) -> ForbiddenPatternSet {
+        let strings: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        ForbiddenPatternSet::from_config_entries(&strings)
+    }
+
+    // ── Basename patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn basename_matches_at_any_depth() {
+        let p = policy_entries(&["credentials.json"]);
+        assert!(p.is_forbidden(Path::new("credentials.json")));
+        assert!(p.is_forbidden(Path::new("dir/credentials.json")));
+        assert!(p.is_forbidden(Path::new("a/b/c/credentials.json")));
+    }
+
+    #[test]
+    fn basename_does_not_match_different_name() {
+        let p = policy_entries(&["credentials.json"]);
+        assert!(!p.is_forbidden(Path::new("other.json")));
+        assert!(!p.is_forbidden(Path::new("credentials.toml")));
+    }
+
+    #[test]
+    fn basename_matches_dotfiles() {
+        let p = policy_entries(&[".env"]);
+        assert!(p.is_forbidden(Path::new(".env")));
+        assert!(p.is_forbidden(Path::new("dir/.env")));
+    }
+
+    // ── Exact relative path patterns ─────────────────────────────────────
+
+    #[test]
+    fn exact_path_matches_only_exact() {
+        let p = policy_entries(&[".cargo/config.toml"]);
+        assert!(p.is_forbidden(Path::new(".cargo/config.toml")));
+        assert!(!p.is_forbidden(Path::new(".cargo/config.toml.bak")));
+        assert!(!p.is_forbidden(Path::new("other/config.toml")));
+    }
+
+    #[test]
+    fn exact_path_no_false_positive_on_prefix() {
+        let p = policy_entries(&["src/main.rs"]);
+        assert!(p.is_forbidden(Path::new("src/main.rs")));
+        assert!(!p.is_forbidden(Path::new("src/main.rs.bak")));
+    }
+
+    // ── Directory prefix patterns ────────────────────────────────────────
+
+    #[test]
+    fn dir_prefix_matches_directory_and_descendants() {
+        let p = policy_entries(&["secrets/"]);
+        assert!(p.is_forbidden(Path::new("secrets")));
+        assert!(p.is_forbidden(Path::new("secrets/file.txt")));
+        assert!(p.is_forbidden(Path::new("secrets/sub/dir/file.txt")));
+    }
+
+    #[test]
+    fn dir_prefix_does_not_match_unrelated() {
+        let p = policy_entries(&["secrets/"]);
+        assert!(!p.is_forbidden(Path::new("mysecrets/file.txt")));
+        assert!(!p.is_forbidden(Path::new("notsecrets")));
+    }
+
+    #[test]
+    fn dir_prefix_matches_root_level() {
+        let p = policy_entries(&["build/"]);
+        assert!(p.is_forbidden(Path::new("build")));
+        assert!(p.is_forbidden(Path::new("build/output")));
+    }
+
+    // ── Glob patterns ────────────────────────────────────────────────────
+
+    #[test]
+    fn glob_star_does_not_cross_separator() {
+        let p = policy_entries(&["*.toml"]);
+        assert!(p.is_forbidden(Path::new("Cargo.toml")));
+        assert!(p.is_forbidden(Path::new("rust-toolchain.toml")));
+        assert!(!p.is_forbidden(Path::new("src/config.toml")));
+        assert!(!p.is_forbidden(Path::new("dir/file.txt")));
+    }
+
+    #[test]
+    fn glob_double_star_crosses_directories() {
+        let p = policy_entries(&["**/*.log"]);
+        assert!(p.is_forbidden(Path::new("build/debug.log")));
+        assert!(p.is_forbidden(Path::new("src/main.log")));
+        assert!(p.is_forbidden(Path::new("a/b/c.log")));
+    }
+
+    #[test]
+    fn glob_question_mark() {
+        let p = policy_entries(&["file?.txt"]);
+        assert!(p.is_forbidden(Path::new("file1.txt")));
+        assert!(p.is_forbidden(Path::new("fileA.txt")));
+        assert!(!p.is_forbidden(Path::new("file12.txt")));
+        assert!(!p.is_forbidden(Path::new("file.txt")));
+    }
+
+    #[test]
+    fn glob_bracket_class() {
+        let p = policy_entries(&["file[0-9].txt"]);
+        assert!(p.is_forbidden(Path::new("file0.txt")));
+        assert!(p.is_forbidden(Path::new("file9.txt")));
+        assert!(!p.is_forbidden(Path::new("filex.txt")));
+    }
+
+    #[test]
+    fn glob_with_path_separator() {
+        let p = policy_entries(&["src/*.rs"]);
+        assert!(p.is_forbidden(Path::new("src/main.rs")));
+        assert!(p.is_forbidden(Path::new("src/lib.rs")));
+        assert!(!p.is_forbidden(Path::new("src/deep/main.rs")));
+        assert!(!p.is_forbidden(Path::new("lib/main.rs")));
+    }
+
+    #[test]
+    fn glob_matches_dotfiles() {
+        let p = policy_entries(&[".*"]);
+        assert!(p.is_forbidden(Path::new(".env")));
+        assert!(p.is_forbidden(Path::new(".gitignore")));
+        assert!(!p.is_forbidden(Path::new("env")));
+    }
+
+    #[test]
+    fn glob_env_star() {
+        let p = policy_entries(&[".env*"]);
+        assert!(p.is_forbidden(Path::new(".env")));
+        assert!(p.is_forbidden(Path::new(".env.local")));
+        assert!(p.is_forbidden(Path::new(".env.prod")));
+        assert!(!p.is_forbidden(Path::new("env")));
+    }
+
+    // ── Rejected patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn bare_star_rejected() {
+        let p = policy_entries(&["*"]);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn parent_traversal_rejected() {
+        let p = policy_entries(&["../etc/passwd"]);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn dots_in_name_not_rejected() {
+        // `foo..bar` is a harmless filename, not parent traversal.
+        let p = policy_entries(&["foo..bar"]);
+        assert!(!p.is_empty());
+        assert!(p.is_forbidden(Path::new("foo..bar")));
+        assert!(p.is_forbidden(Path::new("dir/foo..bar")));
+    }
+
+    #[test]
+    fn invalid_glob_rejected() {
+        let p = policy_entries(&["[invalid"]);
+        assert!(p.is_empty());
+    }
+
+    // ── Empty path (workspace root) ──────────────────────────────────────
+
+    #[test]
+    fn empty_relative_path_never_forbidden() {
+        let p = policy_entries(&["*.toml", "secrets/", ".env"]);
+        assert!(!p.is_forbidden(Path::new("")));
+    }
+
+    // ── Windows separator normalization ──────────────────────────────────
+
+    #[test]
+    fn windows_separators_normalized() {
+        // Pattern uses `/` but we test that `normalize_separators` converts
+        // `\` in the input path to `/` before matching.
+        let p = policy_entries(&[".cargo/config.toml"]);
+        // On non-Windows, construct a PathBuf with `\` (literal char).
+        // `normalize_separators` will convert it to `/` for matching.
+        let backslash_path = std::path::PathBuf::from(".cargo\\config.toml");
+        assert!(
+            p.is_forbidden(&backslash_path),
+            "backslash path must be normalized to forward slash before matching"
+        );
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────
+
+    #[test]
+    fn basename_with_equals() {
+        // Filenames with `=` are valid (e.g. env files, option assignments).
+        let p = policy_entries(&["key=value.env"]);
+        assert!(p.is_forbidden(Path::new("key=value.env")));
+        assert!(p.is_forbidden(Path::new("dir/key=value.env")));
+        assert!(!p.is_forbidden(Path::new("key_value.env")));
+    }
+
+    // ── Absolute entries are skipped ─────────────────────────────────────
+
+    #[test]
+    fn absolute_entries_skipped() {
+        let p = policy_entries(&["/etc", "~/.ssh"]);
+        assert!(p.is_empty());
+    }
+
+    // ── Comments and empty lines ─────────────────────────────────────────
+
+    #[test]
+    fn comments_and_blanks_ignored() {
+        let p = policy_entries(&["# this is a comment", "", "  ", "*.log"]);
+        assert!(!p.is_empty());
+        assert!(p.is_forbidden(Path::new("debug.log")));
+    }
+
+    // ── Multiple patterns ────────────────────────────────────────────────
+
+    #[test]
+    fn multiple_patterns_compose() {
+        let p = policy_entries(&["*.toml", "secrets/", ".env", ".cargo/config.toml"]);
+        assert!(p.is_forbidden(Path::new("Cargo.toml")));
+        assert!(p.is_forbidden(Path::new("secrets/creds.json")));
+        assert!(p.is_forbidden(Path::new(".env")));
+        assert!(p.is_forbidden(Path::new(".cargo/config.toml")));
+        assert!(!p.is_forbidden(Path::new("src/main.rs")));
+    }
+
+    // ── Platform-native path separators ──────────────────────────────────
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn unix_paths_match_directly() {
+        let p = policy_entries(&["src/*.rs"]);
+        assert!(p.is_forbidden(Path::new("src/main.rs")));
+    }
+}

--- a/crates/zeroclaw-config/src/lib.rs
+++ b/crates/zeroclaw-config/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cost;
 pub mod domain_matcher;
 pub mod env_overrides;
 pub mod field_visibility;
+pub mod forbidden_patterns;
 pub mod helpers;
 pub mod migration;
 pub mod multi_agent;

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -166,6 +166,9 @@ pub struct SecurityPolicy {
     pub workspace_only: bool,
     pub allowed_commands: Vec<String>,
     pub forbidden_paths: Vec<String>,
+    /// Lazily-built categorized workspace-relative patterns derived from
+    /// `forbidden_paths`. Initialized on first access.
+    pub forbidden_patterns: std::sync::OnceLock<crate::forbidden_patterns::ForbiddenPatternSet>,
     /// Directories the agent can read AND write under. Includes
     /// `RiskProfileConfig.allowed_roots` plus any cross-agent
     /// `AccessMode::ReadWrite` grants resolved from
@@ -489,6 +492,7 @@ impl Default for SecurityPolicy {
             workspace_only: true,
             allowed_commands: default_allowed_commands(),
             forbidden_paths: default_forbidden_paths(),
+            forbidden_patterns: std::sync::OnceLock::new(),
             allowed_roots: Vec::new(),
             allowed_roots_read_only: Vec::new(),
             allowed_roots_write_only: Vec::new(),
@@ -1553,6 +1557,17 @@ impl SecurityPolicy {
         }
     }
 
+    /// Return the categorized workspace-relative pattern set, lazily built
+    /// from `self.forbidden_paths` on first access and cached for the
+    /// lifetime of this policy.
+    fn workspace_relative_patterns(&self) -> &crate::forbidden_patterns::ForbiddenPatternSet {
+        self.forbidden_patterns.get_or_init(|| {
+            crate::forbidden_patterns::ForbiddenPatternSet::from_config_entries(
+                &self.forbidden_paths,
+            )
+        })
+    }
+
     /// Return the first path-like argument blocked by path policy.
     /// This is best-effort token parsing for shell commands and is intended
     /// as a safety gate before command execution.
@@ -1726,7 +1741,29 @@ impl SecurityPolicy {
                 .iter()
                 .any(|root| expanded_path.starts_with(root));
 
-            if in_workspace || in_allowed_root || in_read_only_root || in_write_only_root {
+            if in_workspace {
+                // Workspace path: check workspace-relative patterns
+                // (globs, basename, directory) before allowing.
+                //
+                // NOTE: this pre-check only fires for absolute paths.
+                // Relative shell arguments (e.g. `cat .env`) never reach
+                // this branch. Non-glob relative patterns (e.g. `secrets/`)
+                // are partially caught by the legacy prefix loop below,
+                // but workspace-relative glob patterns (e.g. `*.toml`) are
+                // NOT caught there — the authoritative enforcement for
+                // globs is the resolved-path check in
+                // `is_resolved_path_readable` / `is_resolved_path_allowed`.
+                if let Ok(relative) = expanded_path.strip_prefix(&self.workspace_dir)
+                    && self.workspace_relative_patterns().is_forbidden(relative)
+                {
+                    return false;
+                }
+                return true;
+            }
+
+            if in_allowed_root || in_read_only_root || in_write_only_root {
+                // allowed_roots bypasses forbidden_patterns — intentional;
+                // these are admin/operator-granted cross-agent access paths.
                 return true;
             }
 
@@ -1770,6 +1807,11 @@ impl SecurityPolicy {
             .canonicalize()
             .unwrap_or_else(|_| self.workspace_dir.clone());
         if resolved.starts_with(&workspace_root) {
+            if let Ok(relative) = resolved.strip_prefix(&workspace_root)
+                && self.workspace_relative_patterns().is_forbidden(relative)
+            {
+                return false;
+            }
             return true;
         }
         for root in &self.allowed_roots {
@@ -1848,6 +1890,11 @@ impl SecurityPolicy {
             .canonicalize()
             .unwrap_or_else(|_| self.workspace_dir.clone());
         if resolved.starts_with(&workspace_root) {
+            if let Ok(relative) = resolved.strip_prefix(&workspace_root)
+                && self.workspace_relative_patterns().is_forbidden(relative)
+            {
+                return false;
+            }
             return true;
         }
 
@@ -2188,6 +2235,7 @@ impl SecurityPolicy {
             workspace_only: effective_workspace_only,
             allowed_commands: risk_profile.allowed_commands.clone(),
             forbidden_paths: risk_profile.forbidden_paths.clone(),
+            forbidden_patterns: std::sync::OnceLock::new(),
             allowed_roots: risk_profile
                 .allowed_roots
                 .iter()
@@ -5651,5 +5699,122 @@ mod tests {
         );
         assert_eq!(attached_short_option_value("-f"), None);
         assert_eq!(attached_short_option_value("--long"), None);
+    }
+
+    // ── Conformance matrix: workspace-relative glob patterns ─────────────
+
+    /// After path resolution, a symlink pointing to a workspace file whose
+    /// basename matches a forbidden pattern is blocked.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn symlink_resolved_to_forbidden_basename_is_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().join("workspace");
+        std::fs::create_dir_all(&ws).unwrap();
+        // Create a real file with a forbidden basename.
+        std::fs::write(ws.join("secrets.json"), b"{}").unwrap();
+        // Create a symlink pointing to it from a subdirectory.
+        let sub = ws.join("link_dir");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("secrets.json"), b"{}").unwrap();
+
+        let policy = SecurityPolicy {
+            workspace_dir: ws.clone(),
+            forbidden_paths: vec!["secrets.json".into()],
+            ..SecurityPolicy::default()
+        };
+
+        // The resolved (canonical) path of the file matches the basename pattern.
+        let resolved = ws.join("secrets.json").canonicalize().unwrap();
+        assert!(
+            !policy.is_resolved_path_readable(&resolved),
+            "resolved path matching forbidden basename must be blocked"
+        );
+
+        // A symlink-resolved path also matches.
+        let symlink_resolved = sub.join("secrets.json").canonicalize().unwrap();
+        assert!(
+            !policy.is_resolved_path_readable(&symlink_resolved),
+            "symlink-resolved path matching forbidden basename must be blocked"
+        );
+    }
+
+    /// Relative shell arguments (no leading `/`) bypass the workspace
+    /// forbidden-pattern check — this is the expected best-effort behavior
+    /// documented in the RFC.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn relative_shell_arg_bypasses_workspace_forbidden_pattern() {
+        let policy = SecurityPolicy {
+            workspace_dir: PathBuf::from("/home/user/workspace"),
+            forbidden_paths: vec!["*.toml".into()],
+            ..SecurityPolicy::default()
+        };
+        // Relative path: not absolute, so is_path_allowed never reaches
+        // the workspace branch. This is the documented best-effort limit.
+        assert!(
+            policy.is_path_allowed("Cargo.toml"),
+            "relative shell args bypass workspace forbidden patterns (best-effort)"
+        );
+        assert!(
+            policy.is_path_allowed("./Cargo.toml"),
+            "relative shell args bypass workspace forbidden patterns (best-effort)"
+        );
+    }
+
+    /// A child SubAgent must not drop a parent's workspace-relative
+    /// forbidden_paths entry (e.g. "*.toml").
+    #[test]
+    fn subagent_cannot_drop_parent_workspace_glob_pattern() {
+        let parent = SecurityPolicy {
+            forbidden_paths: vec![
+                "/etc".into(),
+                "~/.ssh".into(),
+                "*.toml".into(),
+                "secrets/".into(),
+            ],
+            ..SecurityPolicy::default()
+        };
+
+        // Child tries to drop the workspace-relative entries.
+        let child_dropped_glob = SecurityPolicy {
+            forbidden_paths: vec!["/etc".into(), "~/.ssh".into()],
+            ..parent.clone()
+        };
+        let err = child_dropped_glob
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child must not drop parent's *.toml pattern");
+        assert!(
+            matches!(
+                err,
+                EscalationViolation::ForbiddenPathDroppedByChild { ref path }
+                if path == "*.toml"
+            ),
+            "violation must name the dropped pattern"
+        );
+
+        // Child tries to drop the directory pattern.
+        let child_dropped_dir = SecurityPolicy {
+            forbidden_paths: vec!["/etc".into(), "~/.ssh".into(), "*.toml".into()],
+            ..parent.clone()
+        };
+        let err = child_dropped_dir
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child must not drop parent's secrets/ pattern");
+        assert!(
+            matches!(
+                err,
+                EscalationViolation::ForbiddenPathDroppedByChild { ref path }
+                if path == "secrets/"
+            ),
+            "violation must name the dropped directory pattern"
+        );
+
+        // Child with all parent entries intact is accepted.
+        let child_complete = parent.clone();
+        assert!(
+            child_complete.ensure_no_escalation_beyond(&parent).is_ok(),
+            "child preserving all parent entries must be accepted"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `ForbiddenPatternSet` struct in new `forbidden_patterns.rs` module that categorizes `forbidden_paths` entries into globs, exact relative paths, directory prefixes, and basename patterns
  - Modified `is_path_allowed`, `is_resolved_path_readable`, and `is_resolved_path_allowed` to check workspace-relative patterns *before* the workspace allow short-circuit — closing the gap where files inside the workspace (e.g. `rust-toolchain.toml`, `.env`, `.cargo/config.toml`) were unconditionally allowed
  - `ForbiddenPatternSet` is lazily built on first access via `OnceLock` and cached for the policy lifetime, so there is no per-check rebuild cost
  - Added `glob = "0.3"` dependency to `zeroclaw-config` (already a workspace dep, now required for this crate)
  - Added 30 unit tests covering the full cross-platform conformance matrix
- **Scope boundary:** Does NOT add `forbidden_paths_file`, `.zeroclawignore`, or any project-local file mechanism — deferred to follow-up per Audacity88's status update. Does NOT change `ensure_no_escalation_beyond` mechanics (uses same `forbidden_paths` Vec).
- **Blast radius:** `SecurityPolicy` struct gains a new public field `forbidden_patterns: OnceLock<ForbiddenPatternSet>` with `..Default::default()` fallback. All existing construction sites use `..SecurityPolicy::default()` so no breakage. `zeroclaw-config` now requires `glob` at compile time.
- **Linked issue(s):** Related #8424 (prototype pending RFC ratification)
- **Labels:** `type:feature`, `risk:medium`, `size:M`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — all enforcement is internal to path-check methods; no user-visible CLI/TUI surface change
- **Interface(s exercised:** `cli` (path checking in shell command enforcement) and internal security policy
- **Setup / preconditions:** Set `forbidden_paths` in risk profile config to include workspace-relative patterns like `*.toml`, `secrets/`, `.env`, `.cargo/config.toml`
- **Steps to run:** Configure `forbidden_paths = ["*.toml", "secrets/", ".env"]`, then attempt file-tool read/write to `Cargo.toml` or `.env` inside workspace — should be denied
- **Expected on this branch (after):** Workspace-relative files matching forbidden patterns are blocked by `is_resolved_path_readable`/`is_resolved_path_allowed`
- **Prior behavior on `master` (before):** All workspace files were unconditionally allowed before `forbidden_paths` was consulted

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-config --lib
```

- **CI checks relied on and why they cover this change:** `cargo fmt`, `cargo clippy`, `cargo test` — all run locally before push. Full workspace clippy verified (0 warnings across all crates).
- **Known CI coverage gap, if any:** Cross-platform (macOS/Windows) clippy is weekly-only, not a required gate. Windows separator normalization tested in unit test but not on actual Windows.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → exit 0 (clean)
  - `cargo clippy --all-targets -- -D warnings` → exit 0, 0 warnings
  - `cargo test -p zeroclaw-config --lib` → 1274 passed, 0 failed
  - `cargo test -p zeroclaw-runtime -p zeroclaw-tools -p zeroclaw-providers -p zeroclaw-memory` → all OK
- **Beyond CI, what did you manually verify?** Symlink resolution path blocking (unit test creates real symlinks in tempdir), relative shell arg bypass behavior (documented best-effort limit), SubAgent escalation enforcement for glob patterns, edge cases (`foo..bar` not rejected, `key=value.env` basename matching, backslash normalization)
- **If any command was intentionally skipped, why:** Full `cargo test --workspace` skipped `zeroclaw-eval`/`zeroclaw-gateway`/`zeroclawlabs` due to missing `cairo-gobject` system dep on this machine (unrelated to this change)

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — tightens existing scope by denying previously-allowed workspace paths
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes** — existing `forbidden_paths` entries (absolute paths, `~` paths) retain their current prefix-match behavior. Workspace-relative entries that didn't match before (because workspace was unconditionally allowed) will now be enforced — this is the intended security improvement, not a regression.
- Config / env / CLI surface changed? **No** — new patterns are purely additive; existing configs work unchanged
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.
