### PR TITLE
fix(channels): accept Signal source UUID senders

### DIFF
--- a/crates/zeroclaw-channels/src/signal.rs
+++ b/crates/zeroclaw-channels/src/signal.rs
@@ -75,6 +75,8 @@ struct Envelope {
     source: Option<String>,
     #[serde(rename = "sourceNumber", default)]
     source_number: Option<String>,
+    #[serde(rename = "sourceUuid", default)]
+    source_uuid: Option<String>,
     #[serde(rename = "dataMessage", default)]
     data_message: Option<DataMessage>,
     #[serde(rename = "storyMessage", default)]
@@ -192,12 +194,20 @@ impl SignalChannel {
         builder.build().expect("Signal HTTP client should build")
     }
 
-    /// Effective sender: prefer `sourceNumber` (E.164), fall back to `source`.
+    /// Effective sender: prefer `sourceNumber` (E.164), then `source`, then `sourceUuid`.
     fn sender(envelope: &Envelope) -> Option<String> {
         envelope
             .source_number
             .as_deref()
-            .or(envelope.source.as_deref())
+            .filter(|sender| !sender.is_empty())
+            .or(envelope
+                .source
+                .as_deref()
+                .filter(|sender| !sender.is_empty()))
+            .or(envelope
+                .source_uuid
+                .as_deref()
+                .filter(|sender| !sender.is_empty()))
             .map(String::from)
     }
 
@@ -420,6 +430,11 @@ impl SignalChannel {
         }
 
         let Some(sender) = Self::sender(envelope) else {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                "dropping Signal envelope without a resolvable sender identity"
+            );
             return Vec::new();
         };
 
@@ -958,6 +973,7 @@ mod tests {
         Envelope {
             source: source_number.map(String::from),
             source_number: source_number.map(String::from),
+            source_uuid: None,
             data_message: message.map(|m| DataMessage {
                 message: Some(m.to_string()),
                 timestamp: Some(1_700_000_000_000),
@@ -1342,6 +1358,7 @@ mod tests {
         let env = Envelope {
             source: Some("uuid-123".to_string()),
             source_number: Some("+1111111111".to_string()),
+            source_uuid: Some("uuid-456".to_string()),
             data_message: None,
             story_message: None,
             timestamp: Some(1000),
@@ -1354,6 +1371,7 @@ mod tests {
         let env = Envelope {
             source: Some("uuid-123".to_string()),
             source_number: None,
+            source_uuid: Some("uuid-456".to_string()),
             data_message: None,
             story_message: None,
             timestamp: Some(1000),
@@ -1380,6 +1398,7 @@ mod tests {
         let env = Envelope {
             source: Some(uuid.to_string()),
             source_number: None,
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: Some("Hello from privacy user".to_string()),
                 timestamp: Some(1_700_000_000_000),
@@ -1437,6 +1456,7 @@ mod tests {
         let env = Envelope {
             source: Some(uuid.to_string()),
             source_number: None,
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: Some("Group msg from privacy user".to_string()),
                 timestamp: Some(1_700_000_000_000),
@@ -1462,15 +1482,75 @@ mod tests {
     }
 
     #[test]
-    fn sender_none_when_both_missing() {
-        let env = Envelope {
-            source: None,
-            source_number: None,
-            data_message: None,
-            story_message: None,
-            timestamp: None,
-        };
+    fn sender_falls_back_to_source_uuid() {
+        let env: Envelope = serde_json::from_str(
+            r#"{
+                "source": "",
+                "sourceNumber": "",
+                "sourceUuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            SignalChannel::sender(&env),
+            Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890".to_string())
+        );
+    }
+
+    #[test]
+    fn sender_none_when_all_sources_missing() {
+        let env: Envelope = serde_json::from_str(
+            r#"{
+                "source": "",
+                "sourceNumber": null,
+                "sourceUuid": "",
+                "dataMessage": {
+                    "message": "unattributed",
+                    "timestamp": 1700000000000
+                }
+            }"#,
+        )
+        .unwrap();
+
         assert_eq!(SignalChannel::sender(&env), None);
+        assert!(make_channel().process_envelope(&env).is_empty());
+    }
+
+    #[test]
+    fn process_envelope_source_uuid_respects_allowlist() {
+        let uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let raw = format!(
+            r#"{{
+                "source": null,
+                "sourceNumber": null,
+                "sourceUuid": "{uuid}",
+                "timestamp": 1700000000000,
+                "dataMessage": {{
+                    "message": "Hello from sourceUuid",
+                    "timestamp": 1700000000000
+                }}
+            }}"#
+        );
+        let env: Envelope = serde_json::from_str(&raw).unwrap();
+
+        let allowed = SignalChannel::new(
+            "http://127.0.0.1:8686".to_string(),
+            "+1234567890".to_string(),
+            Vec::new(),
+            false,
+            "signal_test_alias",
+            Arc::new(move || vec![uuid.to_string()]),
+            false,
+            false,
+        );
+        let denied = make_channel();
+
+        let messages = allowed.process_envelope(&env);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].sender, uuid);
+        assert_eq!(messages[0].content, "Hello from sourceUuid");
+        assert!(denied.process_envelope(&env).is_empty());
     }
 
     #[test]
@@ -1607,6 +1687,7 @@ mod tests {
         let env = Envelope {
             source: Some("+1111111111".to_string()),
             source_number: Some("+1111111111".to_string()),
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: None,
                 timestamp: Some(1_700_000_000_000),
@@ -1639,6 +1720,7 @@ mod tests {
         let env = Envelope {
             source: Some("+1111111111".to_string()),
             source_number: Some("+1111111111".to_string()),
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: Some("group hello".to_string()),
                 timestamp: Some(1_700_000_000_000),
@@ -1695,6 +1777,7 @@ mod tests {
         let env = Envelope {
             source: Some("+1111111111".to_string()),
             source_number: Some("+1111111111".to_string()),
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: Some("group hello".to_string()),
                 timestamp: Some(1_700_000_000_000),
@@ -1927,6 +2010,7 @@ mod tests {
         let env = Envelope {
             source: Some(uuid.to_string()),
             source_number: None,
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: Some("hi".to_string()),
                 timestamp: Some(1_700_000_000_000),
@@ -2004,6 +2088,7 @@ mod tests {
         Envelope {
             source: sender.map(String::from),
             source_number: sender.map(String::from),
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: None,
                 timestamp: Some(1_700_000_000_000),
@@ -2025,6 +2110,7 @@ mod tests {
         Envelope {
             source: sender.map(String::from),
             source_number: sender.map(String::from),
+            source_uuid: None,
             data_message: Some(DataMessage {
                 message: None,
                 timestamp: Some(1_700_000_000_000),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Deserialize Signal's `sourceUuid` envelope field so phone-number-private senders retain a usable identity.
  - Resolve senders in `sourceNumber`, `source`, then `sourceUuid` order, ignoring empty values that would mask a valid fallback.
  - Route the resolved UUID through the existing sensitive allowlist and log a generic debug diagnostic when no sender identity is available.
- **Scope boundary:** No Signal configuration, outbound delivery, allowlist policy, or other channel behavior changes.
- **Blast radius:** Signal inbound envelope parsing and sender resolution only.
- **Linked issue(s):** Closes #9774
- **Labels:** `bug`, `channel`, `channel:signal`, `risk:medium`, `size:S`, `distinguished contributor`

### What this does, simply

- Signal users can hide their phone number, in which case signal-cli may identify them only by a UUID. ZeroClaw did not read that field, so otherwise valid messages from privacy-enabled senders were dropped before the allowlist could recognize them.

  This PR uses the UUID only when the existing phone-number and source fields are absent or empty, then checks it through the same sensitive allowlist as every other sender identity. Existing sender precedence and policy stay unchanged, and the new missing-sender diagnostic does not reveal identity data.

## Testing

### How you can test

- **Reviewer testing requested?** Yes; a live phone-number-privacy sender provides useful end-to-end confirmation beyond parser tests.
- **Interface(s) exercised:** Signal channel
- **Setup / preconditions:** Configure a Signal channel connected to signal-cli and allowlist a sender whose envelope exposes only `sourceUuid`.
- **Steps to run:** Start the Signal channel with debug logging, then send it a message from the privacy-enabled account.
- **Expected on this branch (after):** The allowed message is delivered using the UUID sender identity. Otherwise-processable data-message envelopes with no usable sender identity emit a generic debug diagnostic before being dropped.
- **Prior behavior on `master` (before):** The same inbound message is silently dropped before allowlist evaluation because `sourceUuid` is not deserialized.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on head `2ab63ba2fdcd4ed5c34387bf20d3b08152b59f71`, including all-features, platform, security, and test lanes. The focused local Signal suite directly covers the changed behavior.
- **Known CI coverage gap, if any:** No live signal-cli/device smoke was performed locally.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

bash scripts/ci/comment_hygiene_gate.sh
# Comment hygiene gate passed.

cargo test --locked -p zeroclaw-channels --features channel-signal signal::tests:: -- --nocapture
# test result: ok. 52 passed; 0 failed; 0 ignored

cargo clippy --locked -p zeroclaw-channels --all-targets --features channel-signal -- -D warnings
# Finished dev profile successfully with -D warnings
```

- **Beyond CI, what did you manually verify?** Raw-JSON regressions cover null and empty fallback, UUID allowlist acceptance and rejection, and the no-sender path. Constructed-envelope regressions cover sender precedence and downstream UUID routing. I did not run a live Signal device smoke.
- **If any command was intentionally skipped, why:** A live signal-cli/device smoke requires a configured Signal account and privacy-enabled sender; deterministic parser and channel tests cover the changed boundary locally.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A. Sender UUIDs follow the existing sensitive allowlist and are not included in the new diagnostic.

## Compatibility

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback

- **Fast rollback command/path:** `git revert <squash-merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Allowed `sourceUuid`-only Signal messages stop reaching the agent, or the no-sender debug diagnostic disappears from runtime logs.

## Supersede Attribution

N/A; this PR does not supersede another contribution.
