### PR TITLE
fix(providers): preserve OpenRouter streaming extras

### DIFF
--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -864,10 +864,14 @@ impl ModelProvider for OpenRouterModelProvider {
             stream: Some(true),
         };
 
-        let payload = match serde_json::to_value(&native_request) {
+        let payload = match self.merge_extra_body(&native_request) {
             Ok(v) => v,
             Err(e) => {
-                return stream::once(async move { Err(StreamError::Json(e)) }).boxed();
+                let error = match e.downcast::<serde_json::Error>() {
+                    Ok(e) => StreamError::Json(e),
+                    Err(e) => StreamError::ModelProvider(e.to_string()),
+                };
+                return stream::once(async move { Err(error) }).boxed();
             }
         };
 
@@ -2180,7 +2184,7 @@ mod tests {
     }
 
     #[test]
-    fn extra_body_with_nested_provider_routing() {
+    fn streaming_extra_body_with_nested_provider_routing() {
         let model_provider = OpenRouterModelProvider::builder("test").credential(Some("key")).extra_body(
             serde_json::json!({"model_provider": {"only": ["Anthropic"], "allow_fallbacks": false}}),
         ).build();
@@ -2191,7 +2195,7 @@ mod tests {
             tools: None,
             tool_choice: None,
             max_tokens: None,
-            stream: None,
+            stream: Some(true),
         };
 
         let merged = model_provider.merge_extra_body(&request).unwrap();
@@ -2199,6 +2203,48 @@ mod tests {
         let prov = obj.get("model_provider").unwrap();
         assert_eq!(prov["only"], serde_json::json!(["Anthropic"]));
         assert_eq!(prov["allow_fallbacks"], false);
+        assert_eq!(obj.get("stream"), Some(&serde_json::json!(true)));
+    }
+
+    #[tokio::test]
+    async fn stream_chat_rejects_non_object_extra_body_before_request() {
+        use crate::traits::{ChatRequest, StreamOptions};
+        use futures_util::StreamExt as _;
+
+        let model_provider = OpenRouterModelProvider::builder("test")
+            .credential(Some("key"))
+            .extra_body(serde_json::json!(["invalid"]))
+            .build();
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hello".into(),
+        }];
+
+        let mut stream = model_provider.stream_chat(
+            ChatRequest {
+                messages: &messages,
+                tools: None,
+                thinking: None,
+            },
+            "anthropic/claude-haiku-4-5",
+            Some(0.0),
+            StreamOptions {
+                enabled: true,
+                count_tokens: false,
+            },
+        );
+
+        let error = stream
+            .next()
+            .await
+            .expect("stream should yield the request-body error")
+            .expect_err("non-object provider_extra should fail before the request");
+        assert!(
+            error
+                .to_string()
+                .contains("provider_extra must be a JSON object"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** OpenRouter streaming requests now pass their native request through the same `provider_extra` merge used by non-streaming requests, so configured routing and sampling overrides are not silently dropped. Request serialization errors retain their existing `StreamError::Json` classification, while invalid non-object extras fail before network I/O with the same validation message as non-streaming calls.
- **Scope boundary:** This does not change non-streaming OpenRouter requests, other providers, configuration parsing, or the documented top-level override semantics.
- **Blast radius:** OpenRouter's native streaming request construction and its immediate preflight error path.
- **Linked issue(s):** Fixes #9775
- **Labels:** `bug`, `provider`, `provider:openrouter`, `priority:p1`, `risk:medium`, `size:XS`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — request construction is deterministic: the focused test inspects the merged streaming-shaped value passed directly to reqwest, while the invalid-extra test exercises `stream_chat` through its pre-network validation path.

### How I tested

- **CI checks relied on and why they cover this change:** Required PR CI is green on head `2509f949`, including the workspace Test and Lint jobs. The focused provider tests cover the payload merge seam used by `stream_chat` and its pre-network validation path.
- **Known CI coverage gap, if any:** No live OpenRouter request was sent. The body handed to the HTTP client is built synchronously and covered by the merge test; invalid extras are covered through `stream_chat` itself.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# no output; exit 0

cargo test -p zeroclaw-providers openrouter::tests::stream
# running 4 tests
# test openrouter::tests::streaming_extra_body_with_nested_provider_routing ... ok
# test openrouter::tests::stream_chat_disabled_options_returns_final ... ok
# test openrouter::tests::stream_chat_rejects_non_object_extra_body_before_request ... ok
# test openrouter::tests::stream_chat_without_key_returns_error_event ... ok
# test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1178 filtered out
```

- **Beyond CI, what did you manually verify?** Confirmed the merged streaming payload retains `stream: true`, includes nested OpenRouter routing extras, and rejects a non-object `provider_extra` before spawning the HTTP request. No real API key or external provider call was used.
- **If any command was intentionally skipped, why:** Full-workspace tests and clippy were skipped because this is a single provider request-construction fix with focused behavior coverage; required CI can provide the broader repository gates.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit for this PR.
- **Feature flags or config toggles:** None. As an operator workaround, remove `provider_extra` from the affected OpenRouter alias.
- **Observable failure symptoms:** OpenRouter streaming calls again omit configured top-level overrides, or logs/stream consumers report `provider_extra must be a JSON object` for an invalid configuration.

