### PR TITLE
ci(scoop): rehearse bucket credential before the release is cut

### DIFF
--- a/.github/workflows/pub-scoop.yml
+++ b/.github/workflows/pub-scoop.yml
@@ -12,9 +12,15 @@ on:
         required: false
         default: false
         type: boolean
+      credential_canary:
+        description: "Require bucket credentials and exercise push authorization"
+        required: false
+        default: false
+        type: boolean
     secrets:
       SCOOP_BUCKET_TOKEN:
-        required: false
+        description: "Fine-grained token with Contents write on the Scoop bucket"
+        required: true
   workflow_dispatch:
     inputs:
       release_tag:
@@ -25,6 +31,11 @@ on:
         description: "Generate manifest only (no push)"
         required: false
         default: true
+        type: boolean
+      credential_canary:
+        description: "Require bucket credentials and exercise push authorization"
+        required: false
+        default: false
         type: boolean
 
 concurrency:
@@ -41,6 +52,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
       DRY_RUN: ${{ inputs.dry_run }}
+      CREDENTIAL_CANARY: ${{ inputs.credential_canary }}
       SCOOP_BUCKET_REPO: ${{ vars.SCOOP_BUCKET_REPO }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -55,23 +67,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # This probe runs for dry runs too, so a rehearsal exercises the same
-          # credential the publish path uses. A token that has expired or lost
-          # write on the bucket then surfaces between releases rather than after
-          # the release is already published and announced.
-          if [[ -z "${SCOOP_BUCKET_REPO:-}" || -z "${GH_TOKEN:-}" ]]; then
-            if [[ "$DRY_RUN" != "true" ]]; then
-              echo "::error::Repository variable SCOOP_BUCKET_REPO and secret SCOOP_BUCKET_TOKEN are both required when dry_run=false."
-              exit 1
-            fi
-            echo "::warning::Scoop bucket credentials are unavailable; skipping the push-access probe."
+          gate_result="$(bash scripts/release/scoop_credential_gate.sh)"
+          if [[ "$gate_result" == "skip" ]]; then
             exit 0
           fi
-          if [[ "$SCOOP_BUCKET_REPO" != */* ]]; then
-            echo "::error::SCOOP_BUCKET_REPO must be in owner/repo format."
+          if [[ "$gate_result" != "probe" ]]; then
+            echo "::error::Unexpected Scoop credential gate result."
             exit 1
           fi
 
+          # A credential canary and every configured publish or dry run exercise
+          # the same authorization path. The gate above only permits a missing
+          # credential for a generic standalone dry run.
           probe_dir="$(mktemp -d)"
           trap 'rm -rf "$probe_dir"' EXIT
           gh auth setup-git

--- a/.github/workflows/pub-scoop.yml
+++ b/.github/workflows/pub-scoop.yml
@@ -48,25 +48,45 @@ jobs:
           fetch-depth: 0
 
       - name: Validate Scoop publish configuration
-        if: inputs.dry_run == false
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          GIT_TERMINAL_PROMPT: "0"
         run: |
           set -euo pipefail
 
-          if [[ -z "${SCOOP_BUCKET_REPO:-}" ]]; then
-            echo "::error::Repository variable SCOOP_BUCKET_REPO is required when dry_run=false."
-            exit 1
-          fi
-          if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::error::Repository secret SCOOP_BUCKET_TOKEN is required when dry_run=false."
-            exit 1
+          # This probe runs for dry runs too, so a rehearsal exercises the same
+          # credential the publish path uses. A token that has expired or lost
+          # write on the bucket then surfaces between releases rather than after
+          # the release is already published and announced.
+          if [[ -z "${SCOOP_BUCKET_REPO:-}" || -z "${GH_TOKEN:-}" ]]; then
+            if [[ "$DRY_RUN" != "true" ]]; then
+              echo "::error::Repository variable SCOOP_BUCKET_REPO and secret SCOOP_BUCKET_TOKEN are both required when dry_run=false."
+              exit 1
+            fi
+            echo "::warning::Scoop bucket credentials are unavailable; skipping the push-access probe."
+            exit 0
           fi
           if [[ "$SCOOP_BUCKET_REPO" != */* ]]; then
             echo "::error::SCOOP_BUCKET_REPO must be in owner/repo format."
             exit 1
           fi
+
+          probe_dir="$(mktemp -d)"
+          trap 'rm -rf "$probe_dir"' EXIT
+          gh auth setup-git
+          git clone --depth=1 "https://github.com/${SCOOP_BUCKET_REPO}.git" "$probe_dir/bucket"
+
+          # Exercise GitHub's receive-pack authorization without changing the
+          # bucket. REST repository metadata is not an authoritative push test
+          # for every token type.
+          if ! git -C "$probe_dir/bucket" push --dry-run origin HEAD; then
+            echo "::error::SCOOP_BUCKET_TOKEN cannot push to ${SCOOP_BUCKET_REPO}."
+            echo "::error::Use a fine-grained token scoped to this repository with Contents: Read and write."
+            exit 1
+          fi
+
+          echo "SCOOP_BUCKET_TOKEN can push to ${SCOOP_BUCKET_REPO}."
 
       - name: Validate and compute metadata
         id: meta
@@ -166,19 +186,12 @@ jobs:
             exit 1
           fi
 
+          # Push access was already proven by the authoritative probe in
+          # "Validate Scoop publish configuration" earlier in this job.
           tmp_dir="$(mktemp -d)"
           trap 'rm -rf "$tmp_dir"' EXIT
           gh auth setup-git
           git clone --depth=1 "https://github.com/${SCOOP_BUCKET_REPO}.git" "$tmp_dir/bucket"
-
-          # Exercise GitHub's receive-pack authorization without changing the
-          # bucket. REST repository metadata is not an authoritative push test
-          # for every token type.
-          if ! git -C "$tmp_dir/bucket" push --dry-run origin HEAD; then
-            echo "::error::SCOOP_BUCKET_TOKEN cannot push to ${SCOOP_BUCKET_REPO}."
-            echo "::error::Use a fine-grained token scoped to this repository with Contents: Read and write."
-            exit 1
-          fi
 
           mkdir -p "$tmp_dir/bucket/bucket"
           cp "$MANIFEST_FILE" "$tmp_dir/bucket/bucket/zeroclaw.json"

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -1201,7 +1201,8 @@ jobs:
     with:
       release_tag: ${{ needs.validate.outputs.tag }}
       dry_run: false
-    secrets: inherit
+    secrets:
+      SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
   aur:
     name: Update AUR Package

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -1192,16 +1192,6 @@ jobs:
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
 
-  # ── Pre-publish: package manager credential rehearsal ────────────────
-  # Deliberately has no `needs`, so it starts immediately and reports within a
-  # minute instead of after the ~1.5h build matrix. Nothing depends on it: a
-  # dead bucket credential must never block shipping a release, it just has to
-  # be visible early enough to rotate before `scoop` runs post-publish.
-  scoop-preflight:
-    name: Scoop Credential Preflight
-    uses: ./.github/workflows/scoop-bucket-canary.yml
-    secrets: inherit
-
   # ── Post-publish: package manager auto-sync ─────────────────────────
   scoop:
     name: Update Scoop Manifest

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -1192,6 +1192,16 @@ jobs:
           cosign sign --yes \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
 
+  # ── Pre-publish: package manager credential rehearsal ────────────────
+  # Deliberately has no `needs`, so it starts immediately and reports within a
+  # minute instead of after the ~1.5h build matrix. Nothing depends on it: a
+  # dead bucket credential must never block shipping a release, it just has to
+  # be visible early enough to rotate before `scoop` runs post-publish.
+  scoop-preflight:
+    name: Scoop Credential Preflight
+    uses: ./.github/workflows/scoop-bucket-canary.yml
+    secrets: inherit
+
   # ── Post-publish: package manager auto-sync ─────────────────────────
   scoop:
     name: Update Scoop Manifest

--- a/.github/workflows/scoop-bucket-canary.yml
+++ b/.github/workflows/scoop-bucket-canary.yml
@@ -11,11 +11,11 @@ name: Scoop Bucket Canary
 # Running the rehearsal weekly surfaces a dead credential between releases,
 # while there is still time to rotate it.
 #
-# This detects credential rot; it is not what keeps the bucket correct. The
-# bucket's own excavator is the self-healing backstop: it reads the manifest's
-# checkver/autoupdate blocks and republishes from the bucket side using the
-# bucket's GITHUB_TOKEN, with no cross-repo credential involved. See
-# zeroclaw-labs/scoop-zeroclaw.
+# This detects credential rot; it is not what keeps the bucket correct. A
+# bucket-side Excavator backstop is proposed in zeroclaw-labs/scoop-zeroclaw#1,
+# but it is not operational until that workflow lands, receives write
+# permission, and passes a maintainer smoke test. Until then, recover a failed
+# publish by rotating the credential and rerunning the publisher.
 
 on:
   schedule:
@@ -63,4 +63,6 @@ jobs:
     with:
       release_tag: ${{ needs.latest-release.outputs.tag }}
       dry_run: true
-    secrets: inherit
+      credential_canary: true
+    secrets:
+      SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}

--- a/.github/workflows/scoop-bucket-canary.yml
+++ b/.github/workflows/scoop-bucket-canary.yml
@@ -63,4 +63,5 @@ jobs:
     with:
       release_tag: ${{ needs.latest-release.outputs.tag }}
       dry_run: true
-    secrets: inherit
+    secrets:
+      SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}

--- a/.github/workflows/scoop-bucket-canary.yml
+++ b/.github/workflows/scoop-bucket-canary.yml
@@ -8,8 +8,14 @@ name: Scoop Bucket Canary
 # only thing that exercised it was the `scoop` job in Release Stable, which runs
 # after `publish`, so a dead credential was discovered once the release had
 # already been cut and announced and the bucket then had to be updated by hand.
-# Running the same rehearsal weekly, and again at the start of a release,
-# surfaces a dead credential while there is still time to rotate it.
+# Running the rehearsal weekly surfaces a dead credential between releases,
+# while there is still time to rotate it.
+#
+# This detects credential rot; it is not what keeps the bucket correct. The
+# bucket's own excavator is the self-healing backstop: it reads the manifest's
+# checkver/autoupdate blocks and republishes from the bucket side using the
+# bucket's GITHUB_TOKEN, with no cross-repo credential involved. See
+# zeroclaw-labs/scoop-zeroclaw.
 
 on:
   schedule:
@@ -17,10 +23,9 @@ on:
     # in the middle of a release.
     - cron: "23 7 * * 1"
   workflow_dispatch:
-  workflow_call:
 
 concurrency:
-  group: scoop-canary-${{ github.workflow }}-${{ github.ref }}
+  group: scoop-canary-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/scoop-bucket-canary.yml
+++ b/.github/workflows/scoop-bucket-canary.yml
@@ -1,0 +1,61 @@
+name: Scoop Bucket Canary
+
+# Rehearses the Scoop publish path against the current stable release without
+# touching the bucket.
+#
+# SCOOP_BUCKET_TOKEN is account-bound, so it expires and it silently loses
+# write when the owning identity's collaborator grant changes. Historically the
+# only thing that exercised it was the `scoop` job in Release Stable, which runs
+# after `publish`, so a dead credential was discovered once the release had
+# already been cut and announced and the bucket then had to be updated by hand.
+# Running the same rehearsal weekly, and again at the start of a release,
+# surfaces a dead credential while there is still time to rotate it.
+
+on:
+  schedule:
+    # Mondays, early UTC: a failure lands at the start of the week rather than
+    # in the middle of a release.
+    - cron: "23 7 * * 1"
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: scoop-canary-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  latest-release:
+    name: Resolve Current Release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve latest stable release tag
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
+
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::latest release is not a stable vX.Y.Z tag: ${tag}"
+            exit 1
+          fi
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Rehearsing the Scoop publish path against ${tag}." >> "$GITHUB_STEP_SUMMARY"
+
+  rehearse:
+    name: Rehearse Scoop Publish
+    needs: latest-release
+    uses: ./.github/workflows/pub-scoop.yml
+    with:
+      release_tag: ${{ needs.latest-release.outputs.tag }}
+      dry_run: true
+    secrets: inherit

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -45,7 +45,9 @@ Scans the published `dist` and `default-features` GHCR images every Saturday and
 
 ### Weekly Scoop Bucket Canary (`scoop-bucket-canary.yml`)
 
-Rehearses the Scoop publish path against the current stable release every Monday. It resolves the latest `vX.Y.Z` tag and calls `pub-scoop.yml` with `dry_run: true`, so it exercises the real `SCOOP_BUCKET_TOKEN` against the real bucket without writing anything.
+Rehearses the Scoop publish path against the current stable release every Monday. It resolves the latest `vX.Y.Z` tag and calls `pub-scoop.yml` with both `dry_run: true` and `credential_canary: true`, so it exercises the real `SCOOP_BUCKET_TOKEN` against the real bucket without writing anything.
+
+`credential_canary` is the fail-closed part of that contract: a missing `SCOOP_BUCKET_REPO` or `SCOOP_BUCKET_TOKEN` fails the run, and configured credentials must reach the `git push --dry-run` authorization probe. A generic manual `pub-scoop.yml` run with only `dry_run: true` remains permissive for manifest generation and may skip that probe when credentials are unavailable; do not use the generic mode as credential-verification evidence.
 
 This exists because `SCOOP_BUCKET_TOKEN` is account-bound: it expires, and it silently loses write when the owning identity's collaborator grant on the bucket changes. Both have happened. Before the canary, the only thing that exercised the credential was the post-publish `scoop` job, so a dead token was discovered after the release was already cut and announced, and the bucket had to be updated by hand.
 
@@ -56,7 +58,7 @@ The canary detects credential rot. It is deliberately not what keeps the bucket 
 Today the release publisher is the only automated writer:
 
 1. **`pub-scoop.yml` pushes on release.** Scoop users see the new version immediately when this succeeds. It needs the cross-repo `SCOOP_BUCKET_TOKEN`, which is the fragile part.
-2. **Maintainers recover failed pushes.** Rotate or repair the token, dispatch the publisher with `dry_run: true` to verify it, rerun with `dry_run: false`, and confirm the bucket manifest landed the release version.
+2. **Maintainers recover failed pushes.** Rotate or repair the token, dispatch Scoop Bucket Canary to verify it through the fail-closed `credential_canary` path, rerun the publisher with `dry_run: false`, and confirm the bucket manifest landed the release version.
 
 A bucket-side Excavator is proposed in [scoop-zeroclaw#1](https://github.com/zeroclaw-labs/scoop-zeroclaw/pull/1). Once that workflow is merged, the bucket repository grants Actions read/write workflow permission, and a maintainer smoke test proves that it commits an update, it can become a credential-independent recovery layer. Until all three conditions are satisfied, do not assume a failed publisher will self-heal.
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -157,7 +157,7 @@ authoritative automation.
 | `AUR_SSH_KEY` | `pub-aur.yml` |
 | `DISCORD_WEBHOOK_URL` | `discord-release.yml` |
 | `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET`, `TWITTER_CONSUMER_API_KEY`, `TWITTER_CONSUMER_API_SECRET_KEY` | `tweet-release.yml` |
-| `SCOOP_BUCKET_TOKEN` | `pub-scoop.yml`; fine-grained PAT limited to `zeroclaw-labs/scoop-zeroclaw` with Contents read/write |
+| `SCOOP_BUCKET_TOKEN` | `pub-scoop.yml`, `release-stable-manual.yml`, `scoop-bucket-canary.yml`; fine-grained PAT limited to `zeroclaw-labs/scoop-zeroclaw` with Contents read/write |
 | `WEBSITE_REPO_PAT` | `release-stable-manual.yml` (triggers the website repo redeploy) |
 | `GITHUB_TOKEN` (automatic) | All workflows that push commits, open PRs, or push images to GHCR |
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -45,11 +45,22 @@ Scans the published `dist` and `default-features` GHCR images every Saturday and
 
 ### Weekly Scoop Bucket Canary (`scoop-bucket-canary.yml`)
 
-Rehearses the Scoop publish path against the current stable release every Monday, and again at the start of every Release Stable run as the `Scoop Credential Preflight` job. It resolves the latest `vX.Y.Z` tag and calls `pub-scoop.yml` with `dry_run: true`, so it exercises the real `SCOOP_BUCKET_TOKEN` against the real bucket without writing anything.
+Rehearses the Scoop publish path against the current stable release every Monday. It resolves the latest `vX.Y.Z` tag and calls `pub-scoop.yml` with `dry_run: true`, so it exercises the real `SCOOP_BUCKET_TOKEN` against the real bucket without writing anything.
 
 This exists because `SCOOP_BUCKET_TOKEN` is account-bound: it expires, and it silently loses write when the owning identity's collaborator grant on the bucket changes. Both have happened. Before the canary, the only thing that exercised the credential was the post-publish `scoop` job, so a dead token was discovered after the release was already cut and announced, and the bucket had to be updated by hand.
 
-The preflight is intentionally non-blocking: nothing in Release Stable depends on it. A dead package-manager credential must never stop a release from shipping; it only has to be visible early enough to rotate before the post-publish `scoop` job runs.
+The canary detects credential rot. It is deliberately not what keeps the bucket correct, and it is not wired into Release Stable: a dead package-manager credential must never gate or delay a release.
+
+#### How the Scoop bucket stays correct
+
+Two independent layers, in order of who acts first:
+
+1. **`pub-scoop.yml` pushes on release.** Atomic with the release, so Scoop users see the new version immediately. Needs the cross-repo `SCOOP_BUCKET_TOKEN`, which is the fragile part.
+2. **The bucket's own excavator self-heals.** `zeroclaw-labs/scoop-zeroclaw` runs the standard Scoop excavator, which reads the manifest's `checkver` and `autoupdate` blocks, recomputes `version`, `url`, and `hash` from the GitHub release, and commits from the bucket side using the bucket's own `GITHUB_TOKEN`. No cross-repo credential is involved, so it cannot fail the way layer 1 does.
+
+That ordering is why a failed `scoop` job is no longer urgent: if the push fails for any reason, excavator republishes within its schedule without a human. This mirrors the decision already made for Homebrew, where the project-owned publisher was retired in favor of Homebrew's official autobump service.
+
+The `checkver` and `autoupdate` blocks are therefore load-bearing in two places at once: excavator consumes them, and `scripts/release/scoop_metadata.sh` derives the release URL template from `autoupdate` so the push path and excavator cannot disagree about where the asset lives. Do not remove them, and do not hand-edit them out of `dist/scoop/zeroclaw.json`.
 
 ### PR Path Labeler (`pr-path-labeler.yml`)
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -53,14 +53,14 @@ The canary detects credential rot. It is deliberately not what keeps the bucket 
 
 #### How the Scoop bucket stays correct
 
-Two independent layers, in order of who acts first:
+Today the release publisher is the only automated writer:
 
-1. **`pub-scoop.yml` pushes on release.** Atomic with the release, so Scoop users see the new version immediately. Needs the cross-repo `SCOOP_BUCKET_TOKEN`, which is the fragile part.
-2. **The bucket's own excavator self-heals.** `zeroclaw-labs/scoop-zeroclaw` runs the standard Scoop excavator, which reads the manifest's `checkver` and `autoupdate` blocks, recomputes `version`, `url`, and `hash` from the GitHub release, and commits from the bucket side using the bucket's own `GITHUB_TOKEN`. No cross-repo credential is involved, so it cannot fail the way layer 1 does.
+1. **`pub-scoop.yml` pushes on release.** Scoop users see the new version immediately when this succeeds. It needs the cross-repo `SCOOP_BUCKET_TOKEN`, which is the fragile part.
+2. **Maintainers recover failed pushes.** Rotate or repair the token, dispatch the publisher with `dry_run: true` to verify it, rerun with `dry_run: false`, and confirm the bucket manifest landed the release version.
 
-That ordering is why a failed `scoop` job is no longer urgent: if the push fails for any reason, excavator republishes within its schedule without a human. This mirrors the decision already made for Homebrew, where the project-owned publisher was retired in favor of Homebrew's official autobump service.
+A bucket-side Excavator is proposed in [scoop-zeroclaw#1](https://github.com/zeroclaw-labs/scoop-zeroclaw/pull/1). Once that workflow is merged, the bucket repository grants Actions read/write workflow permission, and a maintainer smoke test proves that it commits an update, it can become a credential-independent recovery layer. Until all three conditions are satisfied, do not assume a failed publisher will self-heal.
 
-The `checkver` and `autoupdate` blocks are therefore load-bearing in two places at once: excavator consumes them, and `scripts/release/scoop_metadata.sh` derives the release URL template from `autoupdate` so the push path and excavator cannot disagree about where the asset lives. Do not remove them, and do not hand-edit them out of `dist/scoop/zeroclaw.json`.
+The `checkver` and `autoupdate` blocks are already load-bearing for the planned Excavator path. The current push path also uses `scripts/release/scoop_metadata.sh` to derive its release URL template from `autoupdate`, so both paths share one manifest contract. Do not remove those blocks, and do not hand-edit them out of `dist/scoop/zeroclaw.json`.
 
 ### PR Path Labeler (`pr-path-labeler.yml`)
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -43,6 +43,14 @@ Runs `npm audit --audit-level=high` daily at 09:23 UTC against `web/package-lock
 
 Scans the published `dist` and `default-features` GHCR images every Saturday and uploads HIGH/CRITICAL findings to the Security tab as SARIF. The scan is report-first (`exit-code: 0` for findings), but a missing expected image fails the job before Trivy setup with the absent tag and the owning publisher workflow named in the error.
 
+### Weekly Scoop Bucket Canary (`scoop-bucket-canary.yml`)
+
+Rehearses the Scoop publish path against the current stable release every Monday, and again at the start of every Release Stable run as the `Scoop Credential Preflight` job. It resolves the latest `vX.Y.Z` tag and calls `pub-scoop.yml` with `dry_run: true`, so it exercises the real `SCOOP_BUCKET_TOKEN` against the real bucket without writing anything.
+
+This exists because `SCOOP_BUCKET_TOKEN` is account-bound: it expires, and it silently loses write when the owning identity's collaborator grant on the bucket changes. Both have happened. Before the canary, the only thing that exercised the credential was the post-publish `scoop` job, so a dead token was discovered after the release was already cut and announced, and the bucket had to be updated by hand.
+
+The preflight is intentionally non-blocking: nothing in Release Stable depends on it. A dead package-manager credential must never stop a release from shipping; it only has to be visible early enough to rotate before the post-publish `scoop` job runs.
+
 ### PR Path Labeler (`pr-path-labeler.yml`)
 
 Auto-applies path and scope labels based on changed files. It runs on PR open, reopen, and every pushed update to the PR branch. Because `sync-labels: true` is enabled, labels defined in `.github/labeler.yml` are recalculated from the current PR file set.
@@ -147,6 +155,43 @@ automatic `GITHUB_TOKEN` cannot write another repository. Keep
 `SCOOP_BUCKET_TOKEN` narrowly scoped to the bucket; do not reuse a maintainer's
 broad CLI token. The publisher checks write access with `git push --dry-run`,
 then uses the same Git transport for the real update.
+
+### Rotating `SCOOP_BUCKET_TOKEN`
+
+Because deploy keys are unavailable, this credential is a personal access token
+and therefore has two independent failure modes, both of which have bitten a
+release:
+
+1. **The token expires.** Fine-grained PATs have a maximum lifetime, so this
+   recurs on a fixed schedule whether or not anything else changes.
+2. **The owning identity loses write on the bucket.** The token can still be
+   valid while the account behind it is only a `read` collaborator. This
+   produces `remote: Permission to zeroclaw-labs/scoop-zeroclaw.git denied to
+   <account>` and HTTP 403, not an auth error, so it reads as a code problem
+   when it is a permissions problem.
+
+Own the token with the `ZeroClaw-Bot` account, never a personal account, so the
+release path does not depend on one maintainer's credentials. To rotate:
+
+1. As `ZeroClaw-Bot`, create a fine-grained PAT with **Resource owner**
+   `zeroclaw-labs`, **Repository access** limited to the single repository
+   `zeroclaw-labs/scoop-zeroclaw`, and **Repository permissions → Contents:
+   Read and write**. Nothing else.
+2. Confirm the org approved the token. Fine-grained PATs against an org
+   resource owner stay pending until approved, and a pending token authenticates
+   but cannot push.
+3. Confirm `ZeroClaw-Bot` still has `write` on the bucket:
+   `gh api repos/zeroclaw-labs/scoop-zeroclaw/collaborators/ZeroClaw-Bot/permission --jq '.role_name'`.
+   Step 1 does not grant repository access; it only scopes what the token may
+   use. A token cannot exceed the permissions its owner already holds.
+4. Set the secret:
+   `gh secret set SCOOP_BUCKET_TOKEN --repo zeroclaw-labs/zeroclaw`.
+5. Verify without touching the bucket by dispatching
+   [Scoop Bucket Canary](#weekly-scoop-bucket-canary-scoop-bucket-canaryyml).
+   A green run proves the new token can push.
+
+Record the expiry date somewhere durable when you rotate. The canary will catch
+an expired token within a week regardless, but only after it has already broken.
 
 ### AUR package ownership
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -528,6 +528,16 @@ manually-triggerable sub-workflow. Re-run the specific one with `dry_run: true`
 first to confirm the fix, then `dry_run: false`. These are nice-to-have: a
 failed distribution job does not invalidate the release itself.
 
+**`Scoop Credential Preflight` failed early in the run:** The bucket token is
+dead or under-scoped. This job runs at the start of the release specifically so
+you can fix it while the build matrix is still running. Rotate the credential
+per [Rotating `SCOOP_BUCKET_TOKEN`](./ci-and-actions.md#rotating-scoop_bucket_token),
+then re-dispatch Scoop Bucket Canary to confirm. If you get to it before the
+post-publish `scoop` job starts, the release publishes to Scoop normally. If
+not, re-run `pub-scoop.yml` with `dry_run: false` at the release tag once the
+token is fixed. A `remote: Permission ... denied to <account>` 403 here is a
+permissions problem, not a manifest problem.
+
 **Homebrew Core is stale:** Homebrew is not a release-workflow job. Check the
 [Homebrew autobump status and documented manual bump
 path](https://docs.brew.sh/Autobump) instead of adding a repository fork token.

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -528,15 +528,18 @@ manually-triggerable sub-workflow. Re-run the specific one with `dry_run: true`
 first to confirm the fix, then `dry_run: false`. These are nice-to-have: a
 failed distribution job does not invalidate the release itself.
 
-**`Scoop Credential Preflight` failed early in the run:** The bucket token is
-dead or under-scoped. This job runs at the start of the release specifically so
-you can fix it while the build matrix is still running. Rotate the credential
+**The `scoop` job failed with `remote: Permission ... denied to <account>` (403):**
+A permissions problem, not a manifest problem: the bucket token is dead or
+under-scoped. This is not urgent, because the bucket's excavator republishes
+from the bucket side within its schedule without a credential. Rotate the token
 per [Rotating `SCOOP_BUCKET_TOKEN`](./ci-and-actions.md#rotating-scoop_bucket_token),
-then re-dispatch Scoop Bucket Canary to confirm. If you get to it before the
-post-publish `scoop` job starts, the release publishes to Scoop normally. If
-not, re-run `pub-scoop.yml` with `dry_run: false` at the release tag once the
-token is fixed. A `remote: Permission ... denied to <account>` 403 here is a
-permissions problem, not a manifest problem.
+then dispatch Scoop Bucket Canary to confirm the fix without writing to the
+bucket. Confirm the bucket landed the new version either way, since excavator
+covering for a dead token is easy to miss.
+
+**Weekly `Scoop Bucket Canary` went red:** The token has expired or lost write.
+Same rotation path. Fix it before the next release so layer 1 still works rather
+than leaning on excavator indefinitely.
 
 **Homebrew Core is stale:** Homebrew is not a release-workflow job. Check the
 [Homebrew autobump status and documented manual bump

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -530,16 +530,17 @@ failed distribution job does not invalidate the release itself.
 
 **The `scoop` job failed with `remote: Permission ... denied to <account>` (403):**
 A permissions problem, not a manifest problem: the bucket token is dead or
-under-scoped. This is not urgent, because the bucket's excavator republishes
-from the bucket side within its schedule without a credential. Rotate the token
-per [Rotating `SCOOP_BUCKET_TOKEN`](./ci-and-actions.md#rotating-scoop_bucket_token),
+under-scoped. Rotate the token per
+[Rotating `SCOOP_BUCKET_TOKEN`](./ci-and-actions.md#rotating-scoop_bucket_token),
 then dispatch Scoop Bucket Canary to confirm the fix without writing to the
-bucket. Confirm the bucket landed the new version either way, since excavator
-covering for a dead token is easy to miss.
+bucket. Rerun the Scoop publisher with `dry_run: false` and confirm the bucket
+landed the new version. Bucket-side Excavator recovery remains pending on
+`zeroclaw-labs/scoop-zeroclaw#1`, repository workflow write permission, and a
+maintainer smoke test; do not wait for it to repair a release until those steps
+are complete.
 
 **Weekly `Scoop Bucket Canary` went red:** The token has expired or lost write.
-Same rotation path. Fix it before the next release so layer 1 still works rather
-than leaning on excavator indefinitely.
+Same rotation path. Fix it before the next release.
 
 **Homebrew Core is stale:** Homebrew is not a release-workflow job. Check the
 [Homebrew autobump status and documented manual bump

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -526,7 +526,10 @@ restart the workflow.
 **A Scoop or AUR distribution job failed:** Each has a corresponding
 manually-triggerable sub-workflow. Re-run the specific one with `dry_run: true`
 first to confirm the fix, then `dry_run: false`. These are nice-to-have: a
-failed distribution job does not invalidate the release itself.
+failed distribution job does not invalidate the release itself. For Scoop
+credential failures, use Scoop Bucket Canary instead of treating a generic dry
+run as credential proof; the canary enables the fail-closed
+`credential_canary` path.
 
 **The `scoop` job failed with `remote: Permission ... denied to <account>` (403):**
 A permissions problem, not a manifest problem: the bucket token is dead or

--- a/scripts/release/scoop_credential_gate.sh
+++ b/scripts/release/scoop_credential_gate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-dry_run="${DRY_RUN:-false}"
-credential_canary="${CREDENTIAL_CANARY:-false}"
+dry_run="${DRY_RUN-false}"
+credential_canary="${CREDENTIAL_CANARY-false}"
 bucket_repo="${SCOOP_BUCKET_REPO:-}"
 bucket_token="${GH_TOKEN:-}"
 

--- a/scripts/release/scoop_credential_gate.sh
+++ b/scripts/release/scoop_credential_gate.sh
@@ -6,6 +6,22 @@ credential_canary="${CREDENTIAL_CANARY:-false}"
 bucket_repo="${SCOOP_BUCKET_REPO:-}"
 bucket_token="${GH_TOKEN:-}"
 
+case "$dry_run" in
+  true | false) ;;
+  *)
+    echo "::error::DRY_RUN must be true or false." >&2
+    exit 1
+    ;;
+esac
+
+case "$credential_canary" in
+  true | false) ;;
+  *)
+    echo "::error::CREDENTIAL_CANARY must be true or false." >&2
+    exit 1
+    ;;
+esac
+
 if [[ "$credential_canary" == "true" ]]; then
   if [[ -z "$bucket_repo" ]]; then
     echo "::error::Repository variable SCOOP_BUCKET_REPO is required for the credential canary." >&2

--- a/scripts/release/scoop_credential_gate.sh
+++ b/scripts/release/scoop_credential_gate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dry_run="${DRY_RUN:-false}"
+credential_canary="${CREDENTIAL_CANARY:-false}"
+bucket_repo="${SCOOP_BUCKET_REPO:-}"
+bucket_token="${GH_TOKEN:-}"
+
+if [[ "$credential_canary" == "true" ]]; then
+  if [[ -z "$bucket_repo" ]]; then
+    echo "::error::Repository variable SCOOP_BUCKET_REPO is required for the credential canary." >&2
+    exit 1
+  fi
+  if [[ -z "$bucket_token" ]]; then
+    echo "::error::Secret SCOOP_BUCKET_TOKEN is required for the credential canary." >&2
+    exit 1
+  fi
+elif [[ -z "$bucket_repo" || -z "$bucket_token" ]]; then
+  if [[ "$dry_run" != "true" ]]; then
+    echo "::error::Repository variable SCOOP_BUCKET_REPO and secret SCOOP_BUCKET_TOKEN are both required when dry_run=false." >&2
+    exit 1
+  fi
+
+  echo "::warning::Scoop bucket credentials are unavailable; skipping the push-access probe." >&2
+  printf 'skip\n'
+  exit 0
+fi
+
+if [[ "$bucket_repo" != */* ]]; then
+  echo "::error::SCOOP_BUCKET_REPO must be in owner/repo format." >&2
+  exit 1
+fi
+
+printf 'probe\n'

--- a/tests/architecture/release_workflow.rs
+++ b/tests/architecture/release_workflow.rs
@@ -224,7 +224,9 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
 
     for (dry_run, credential_canary, variable) in [
         ("yes", "false", "DRY_RUN"),
+        ("", "false", "DRY_RUN"),
         ("true", "yes", "CREDENTIAL_CANARY"),
+        ("true", "", "CREDENTIAL_CANARY"),
     ] {
         let invalid = run_gate(
             dry_run,
@@ -239,7 +241,29 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
     }
 
     let canary_workflow = workflow("scoop-bucket-canary.yml");
+    let canary_triggers = yaml_block(&canary_workflow, "on:\n");
+    assert!(
+        canary_triggers.contains("- cron: \"23 7 * * 1\""),
+        "the Scoop canary must keep its weekly schedule trigger"
+    );
+    assert!(
+        canary_triggers.contains("  workflow_dispatch:"),
+        "the Scoop canary must stay manually dispatchable for credential rotation proof"
+    );
+    let canary_resolve_job = yaml_block(&canary_workflow, "  latest-release:\n");
+    assert!(
+        !canary_resolve_job.lines().any(|line| {
+            line.starts_with("    if:") || line.starts_with("    continue-on-error:")
+        }),
+        "the Scoop canary tag resolver must run and fail closed on every scheduled invocation"
+    );
     let canary_job = yaml_block(&canary_workflow, "  rehearse:\n");
+    assert!(
+        !canary_job.lines().any(|line| {
+            line.starts_with("    if:") || line.starts_with("    continue-on-error:")
+        }),
+        "the Scoop canary rehearsal must run and fail closed on every scheduled invocation"
+    );
     for required in [
         "uses: ./.github/workflows/pub-scoop.yml",
         "dry_run: true",
@@ -294,8 +318,29 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
         ["SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}"],
         "real Scoop caller must map exactly the one secret its callee declares"
     );
+    assert!(
+        !release_scoop_job
+            .lines()
+            .any(|line| line.starts_with("    continue-on-error:")),
+        "real Scoop publisher failures must stay fatal"
+    );
+    let release_scoop_conditions = release_scoop_job
+        .lines()
+        .filter(|line| line.starts_with("    if:"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        release_scoop_conditions,
+        ["    if: ${{ !cancelled() && needs.publish.result == 'success' }}"],
+        "real Scoop publisher must stay gated only on a successful publish"
+    );
 
     let publisher_workflow = workflow("pub-scoop.yml");
+    let publisher_triggers = yaml_block(&publisher_workflow, "on:\n");
+    let publisher_dispatch = yaml_block(publisher_triggers, "  workflow_dispatch:\n");
+    assert!(
+        yaml_block(publisher_dispatch, "      dry_run:\n").contains("default: true"),
+        "manual Scoop publisher dispatch must stay non-destructive by default"
+    );
     let workflow_call = yaml_block(&publisher_workflow, "  workflow_call:\n");
     let workflow_call_secrets = yaml_block(workflow_call, "    secrets:\n");
     let scoop_token = yaml_block(workflow_call_secrets, "      SCOOP_BUCKET_TOKEN:\n");
@@ -314,6 +359,27 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
     );
 
     let publisher_job = yaml_block(&publisher_workflow, "  publish-scoop:\n");
+    assert!(
+        !publisher_job.lines().any(|line| {
+            line.starts_with("    if:") || line.starts_with("    continue-on-error:")
+        }),
+        "the Scoop publisher job must run and fail closed on every invocation, including canary dry runs"
+    );
+    let push_step = yaml_block(publisher_job, "      - name: Push to Scoop bucket\n");
+    assert_eq!(
+        push_step
+            .lines()
+            .filter(|line| line.starts_with("        if:"))
+            .collect::<Vec<_>>(),
+        ["        if: inputs.dry_run == false"],
+        "the bucket write must stay gated on a non-dry-run so canary rehearsals never push"
+    );
+    assert!(
+        !push_step
+            .lines()
+            .any(|line| line.starts_with("        continue-on-error:")),
+        "real bucket write failures must stay fatal"
+    );
     let publisher_env = yaml_block(publisher_job, "    env:\n");
     let canary_env = "CREDENTIAL_CANARY: ${{ inputs.credential_canary }}";
     assert_eq!(
@@ -322,9 +388,20 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
         "publisher job-level env must map credential_canary into the tested gate exactly once"
     );
     assert_eq!(
-        publisher_workflow.matches(canary_env).count(),
+        publisher_workflow.matches("CREDENTIAL_CANARY").count(),
         1,
-        "credential_canary env mapping must not drift outside the publisher job"
+        "credential_canary must have exactly one uppercase env binding, at publisher job scope"
+    );
+    let dry_run_env = "DRY_RUN: ${{ inputs.dry_run }}";
+    assert_eq!(
+        publisher_env.matches(dry_run_env).count(),
+        1,
+        "publisher job-level env must map dry_run into the tested gate exactly once"
+    );
+    assert_eq!(
+        publisher_workflow.matches("DRY_RUN").count(),
+        1,
+        "dry_run must have exactly one uppercase env binding, at publisher job scope"
     );
 
     let validate_step = yaml_block(
@@ -332,10 +409,10 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
         "      - name: Validate Scoop publish configuration\n",
     );
     assert!(
-        !validate_step
-            .lines()
-            .any(|line| line.trim_start().starts_with("if:")),
-        "the Scoop credential gate step must run on every invocation, including canary dry runs"
+        !validate_step.lines().any(|line| {
+            line.starts_with("        if:") || line.starts_with("        continue-on-error:")
+        }),
+        "the Scoop credential gate step must run and fail closed on every invocation, including canary dry runs"
     );
     assert!(
         validate_step.contains("gate_result=\"$(bash scripts/release/scoop_credential_gate.sh)\""),

--- a/tests/architecture/release_workflow.rs
+++ b/tests/architecture/release_workflow.rs
@@ -16,6 +16,28 @@ fn workflow(name: &str) -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", workflow_path.display()))
 }
 
+fn yaml_block<'a>(document: &'a str, header: &str) -> &'a str {
+    let header_indent = header.len() - header.trim_start().len();
+    let start = document
+        .find(header)
+        .unwrap_or_else(|| panic!("workflow is missing YAML block: {header}"));
+    let remainder = &document[start + header.len()..];
+    let end = remainder
+        .split_inclusive('\n')
+        .scan(0, |offset, line| {
+            let line_start = *offset;
+            *offset += line.len();
+            Some((line_start, line))
+        })
+        .find_map(|(offset, line)| {
+            let trimmed = line.trim();
+            let indent = line.len() - line.trim_start().len();
+            (!trimmed.is_empty() && indent <= header_indent).then_some(offset)
+        })
+        .unwrap_or(remainder.len());
+    &remainder[..end]
+}
+
 #[test]
 fn macos_desktop_release_notarizes_published_dmg() {
     let workflow_path =
@@ -134,15 +156,15 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let gate = root.join("scripts/release/scoop_credential_gate.sh");
 
-    let run_gate = |dry_run: bool,
-                    credential_canary: bool,
+    let run_gate = |dry_run: &str,
+                    credential_canary: &str,
                     bucket_repo: Option<&str>,
                     bucket_token: Option<&str>| {
         let mut command = Command::new("bash");
         command
             .arg(&gate)
-            .env("DRY_RUN", dry_run.to_string())
-            .env("CREDENTIAL_CANARY", credential_canary.to_string())
+            .env("DRY_RUN", dry_run)
+            .env("CREDENTIAL_CANARY", credential_canary)
             .env_remove("SCOOP_BUCKET_REPO")
             .env_remove("GH_TOKEN");
         if let Some(repo) = bucket_repo {
@@ -154,7 +176,7 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
         command.output().expect("run Scoop credential gate")
     };
 
-    let generic_dry_run = run_gate(true, false, None, None);
+    let generic_dry_run = run_gate("true", "false", None, None);
     assert!(
         generic_dry_run.status.success(),
         "a generic dry run may omit bucket credentials: {}",
@@ -166,14 +188,19 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
         (None, Some("test-token"), "repository"),
         (Some("example/scoop-bucket"), None, "token"),
     ] {
-        let canary = run_gate(true, true, repo, token);
+        let canary = run_gate("true", "true", repo, token);
         assert!(
             !canary.status.success(),
             "credential canary must fail when the {missing} is missing"
         );
     }
 
-    let configured_canary = run_gate(true, true, Some("example/scoop-bucket"), Some("test-token"));
+    let configured_canary = run_gate(
+        "true",
+        "true",
+        Some("example/scoop-bucket"),
+        Some("test-token"),
+    );
     assert!(
         configured_canary.status.success(),
         "configured credential canary must reach the authorization probe: {}",
@@ -181,29 +208,122 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
     );
     assert_eq!(configured_canary.stdout, b"probe\n");
 
+    for (repo, token, missing) in [
+        (None, Some("test-token"), "repository"),
+        (Some("example/scoop-bucket"), None, "token"),
+    ] {
+        let publish = run_gate("false", "false", repo, token);
+        assert!(
+            !publish.status.success(),
+            "real publish must fail when the {missing} is missing"
+        );
+    }
+
+    for (dry_run, credential_canary, variable) in [
+        ("yes", "false", "DRY_RUN"),
+        ("true", "yes", "CREDENTIAL_CANARY"),
+    ] {
+        let invalid = run_gate(
+            dry_run,
+            credential_canary,
+            Some("example/scoop-bucket"),
+            Some("test-token"),
+        );
+        assert!(
+            !invalid.status.success(),
+            "invalid {variable} value must fail closed"
+        );
+    }
+
     let canary_workflow = workflow("scoop-bucket-canary.yml");
+    let canary_job = yaml_block(&canary_workflow, "  rehearse:\n");
     for required in [
+        "uses: ./.github/workflows/pub-scoop.yml",
+        "dry_run: true",
         "credential_canary: true",
         "SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}",
     ] {
         assert!(
-            canary_workflow.contains(required),
+            canary_job.contains(required),
             "Scoop canary is missing fail-closed invariant: {required}"
         );
     }
     assert!(
-        !canary_workflow.contains("secrets: inherit"),
+        !canary_job.contains("secrets: inherit"),
         "Scoop canary must receive only the named bucket token"
+    );
+    let canary_secrets = yaml_block(canary_job, "    secrets:\n");
+    let canary_secret_names = canary_secrets
+        .lines()
+        .filter(|line| line.starts_with("      ") && !line.starts_with("       "))
+        .map(str::trim)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        canary_secret_names,
+        ["SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}"],
+        "Scoop canary must map exactly the one secret its callee declares"
+    );
+
+    let release_workflow = workflow("release-stable-manual.yml");
+    let release_scoop_job = yaml_block(&release_workflow, "  scoop:\n");
+    for required in [
+        "uses: ./.github/workflows/pub-scoop.yml",
+        "dry_run: false",
+        "SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}",
+    ] {
+        assert!(
+            release_scoop_job.contains(required),
+            "real Scoop publisher caller is missing invariant: {required}"
+        );
+    }
+    assert!(
+        !release_scoop_job.contains("secrets: inherit"),
+        "real Scoop publisher must receive only the named bucket token"
+    );
+    let release_scoop_secrets = yaml_block(release_scoop_job, "    secrets:\n");
+    let release_scoop_secret_names = release_scoop_secrets
+        .lines()
+        .filter(|line| line.starts_with("      ") && !line.starts_with("       "))
+        .map(str::trim)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        release_scoop_secret_names,
+        ["SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}"],
+        "real Scoop caller must map exactly the one secret its callee declares"
     );
 
     let publisher_workflow = workflow("pub-scoop.yml");
+    let workflow_call = yaml_block(&publisher_workflow, "  workflow_call:\n");
+    let workflow_call_secrets = yaml_block(workflow_call, "    secrets:\n");
+    let scoop_token = yaml_block(workflow_call_secrets, "      SCOOP_BUCKET_TOKEN:\n");
     assert!(
-        publisher_workflow.contains("required: true\n  workflow_dispatch:"),
+        scoop_token.contains("required: true"),
         "reusable Scoop publisher must require its declared bucket token"
     );
+    let declared_secrets = workflow_call_secrets
+        .lines()
+        .filter(|line| line.starts_with("      ") && !line.starts_with("       "))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        declared_secrets,
+        ["      SCOOP_BUCKET_TOKEN:"],
+        "reusable Scoop publisher must declare exactly one secret"
+    );
+
+    let publisher_job = yaml_block(&publisher_workflow, "  publish-scoop:\n");
+    let canary_env = "CREDENTIAL_CANARY: ${{ inputs.credential_canary }}";
+    assert_eq!(
+        publisher_job.matches(canary_env).count(),
+        1,
+        "publisher job must map credential_canary into the tested gate exactly once"
+    );
+    assert_eq!(
+        publisher_workflow.matches(canary_env).count(),
+        1,
+        "credential_canary env mapping must not drift outside the publisher job"
+    );
     assert!(
-        publisher_workflow
-            .contains("gate_result=\"$(bash scripts/release/scoop_credential_gate.sh)\""),
+        publisher_job.contains("gate_result=\"$(bash scripts/release/scoop_credential_gate.sh)\""),
         "Scoop publisher must enforce the tested credential gate"
     );
 }

--- a/tests/architecture/release_workflow.rs
+++ b/tests/architecture/release_workflow.rs
@@ -130,6 +130,85 @@ fn package_publishers_use_canonical_sources_and_scoped_credentials() {
 }
 
 #[test]
+fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let gate = root.join("scripts/release/scoop_credential_gate.sh");
+
+    let run_gate = |dry_run: bool,
+                    credential_canary: bool,
+                    bucket_repo: Option<&str>,
+                    bucket_token: Option<&str>| {
+        let mut command = Command::new("bash");
+        command
+            .arg(&gate)
+            .env("DRY_RUN", dry_run.to_string())
+            .env("CREDENTIAL_CANARY", credential_canary.to_string())
+            .env_remove("SCOOP_BUCKET_REPO")
+            .env_remove("GH_TOKEN");
+        if let Some(repo) = bucket_repo {
+            command.env("SCOOP_BUCKET_REPO", repo);
+        }
+        if let Some(token) = bucket_token {
+            command.env("GH_TOKEN", token);
+        }
+        command.output().expect("run Scoop credential gate")
+    };
+
+    let generic_dry_run = run_gate(true, false, None, None);
+    assert!(
+        generic_dry_run.status.success(),
+        "a generic dry run may omit bucket credentials: {}",
+        String::from_utf8_lossy(&generic_dry_run.stderr)
+    );
+    assert_eq!(generic_dry_run.stdout, b"skip\n");
+
+    for (repo, token, missing) in [
+        (None, Some("test-token"), "repository"),
+        (Some("example/scoop-bucket"), None, "token"),
+    ] {
+        let canary = run_gate(true, true, repo, token);
+        assert!(
+            !canary.status.success(),
+            "credential canary must fail when the {missing} is missing"
+        );
+    }
+
+    let configured_canary = run_gate(true, true, Some("example/scoop-bucket"), Some("test-token"));
+    assert!(
+        configured_canary.status.success(),
+        "configured credential canary must reach the authorization probe: {}",
+        String::from_utf8_lossy(&configured_canary.stderr)
+    );
+    assert_eq!(configured_canary.stdout, b"probe\n");
+
+    let canary_workflow = workflow("scoop-bucket-canary.yml");
+    for required in [
+        "credential_canary: true",
+        "SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}",
+    ] {
+        assert!(
+            canary_workflow.contains(required),
+            "Scoop canary is missing fail-closed invariant: {required}"
+        );
+    }
+    assert!(
+        !canary_workflow.contains("secrets: inherit"),
+        "Scoop canary must receive only the named bucket token"
+    );
+
+    let publisher_workflow = workflow("pub-scoop.yml");
+    assert!(
+        publisher_workflow.contains("required: true\n  workflow_dispatch:"),
+        "reusable Scoop publisher must require its declared bucket token"
+    );
+    assert!(
+        publisher_workflow
+            .contains("gate_result=\"$(bash scripts/release/scoop_credential_gate.sh)\""),
+        "Scoop publisher must enforce the tested credential gate"
+    );
+}
+
+#[test]
 fn scoop_publisher_metadata_follows_canonical_url_template() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let metadata_script = root.join("scripts/release/scoop_metadata.sh");

--- a/tests/architecture/release_workflow.rs
+++ b/tests/architecture/release_workflow.rs
@@ -19,7 +19,10 @@ fn workflow(name: &str) -> String {
 fn yaml_block<'a>(document: &'a str, header: &str) -> &'a str {
     let header_indent = header.len() - header.trim_start().len();
     let start = document
-        .find(header)
+        .match_indices(header)
+        .find_map(|(offset, _)| {
+            (offset == 0 || document.as_bytes().get(offset - 1) == Some(&b'\n')).then_some(offset)
+        })
         .unwrap_or_else(|| panic!("workflow is missing YAML block: {header}"));
     let remainder = &document[start + header.len()..];
     let end = remainder
@@ -311,11 +314,12 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
     );
 
     let publisher_job = yaml_block(&publisher_workflow, "  publish-scoop:\n");
+    let publisher_env = yaml_block(publisher_job, "    env:\n");
     let canary_env = "CREDENTIAL_CANARY: ${{ inputs.credential_canary }}";
     assert_eq!(
-        publisher_job.matches(canary_env).count(),
+        publisher_env.matches(canary_env).count(),
         1,
-        "publisher job must map credential_canary into the tested gate exactly once"
+        "publisher job-level env must map credential_canary into the tested gate exactly once"
     );
     assert_eq!(
         publisher_workflow.matches(canary_env).count(),

--- a/tests/architecture/release_workflow.rs
+++ b/tests/architecture/release_workflow.rs
@@ -326,9 +326,31 @@ fn scoop_credential_canary_fails_closed_without_weakening_generic_dry_runs() {
         1,
         "credential_canary env mapping must not drift outside the publisher job"
     );
+
+    let validate_step = yaml_block(
+        publisher_job,
+        "      - name: Validate Scoop publish configuration\n",
+    );
     assert!(
-        publisher_job.contains("gate_result=\"$(bash scripts/release/scoop_credential_gate.sh)\""),
+        !validate_step
+            .lines()
+            .any(|line| line.trim_start().starts_with("if:")),
+        "the Scoop credential gate step must run on every invocation, including canary dry runs"
+    );
+    assert!(
+        validate_step.contains("gate_result=\"$(bash scripts/release/scoop_credential_gate.sh)\""),
         "Scoop publisher must enforce the tested credential gate"
+    );
+    assert!(
+        validate_step.contains("push --dry-run origin HEAD"),
+        "the authorization probe must live in the unconditional credential gate step"
+    );
+    assert_eq!(
+        publisher_workflow
+            .matches("push --dry-run origin HEAD")
+            .count(),
+        1,
+        "Scoop publisher must keep exactly one authoritative authorization probe"
     );
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `SCOOP_BUCKET_TOKEN` is account-bound, so it expires and it silently loses write when the owning identity's collaborator grant on the bucket changes. Both have happened, and the only thing that ever exercised the credential was the post-publish `scoop` job, so the failure always landed *after* the release was cut and announced.
  - v0.8.1 failed with `denied to theonlyhennygod` (403, a read-only collaborator). v0.8.3 never ran the publisher at all and the bucket was updated by hand a week later. v0.8.4 failed with `denied to ZeroClaw-Bot` (403) and was fixed by a manual re-dispatch two hours after the release went out.
  - Makes `dry_run: true` a real rehearsal: the authoritative `git push --dry-run` probe moves into `Validate Scoop publish configuration` and now runs for both dry-run modes. Previously a dry run skipped the push step entirely, so nothing exercised the credential between releases, which is why the token stayed dead across two of them.
  - Adds `scoop-bucket-canary.yml`, which resolves the current stable tag and calls `pub-scoop.yml` with `dry_run: true`. It runs weekly so expiry surfaces between releases; Release Stable remains the real publish path and passes only the named Scoop token.
  - Documents the two failure modes and a step-by-step rotation procedure. Deploy keys are disabled on the bucket by org policy, so a bot-owned fine-grained PAT stays the only mechanism.
- **Scope boundary:** Does not change how the manifest is derived. That pipeline was never at fault and is untouched: metadata still comes from `dist/scoop/zeroclaw.json` via `scripts/release/scoop_metadata.sh`. Does not rotate the credential (that is an out-of-band operator action, now documented). Does not touch AUR, which failed in the same v0.8.4 run for an unrelated reason (an AUR-side maintenance window) and is handled separately.
- **Blast radius:** `.github/workflows/**` plus maintainer documentation. The canary is weekly and outside the release critical path. It reuses the publisher in an explicit fail-closed rehearsal mode; the normal standalone dry-run remains permissive, and the real publish path keeps its existing `dry_run == false` mutation gate.
- **Linked issue(s):** Related #9322
- **Labels:** `ci`, `docs`, `tests`, `scripts`, `distinguished contributor`, `risk:high`, `size:S`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `cli` (GitHub Actions workflows; no runtime surface)
- **Setup / preconditions:** Maintainer access to dispatch workflows on `zeroclaw-labs/zeroclaw`. `SCOOP_BUCKET_TOKEN` and the `SCOOP_BUCKET_REPO` variable must be present.
- **Steps to run:** Dispatch `Pub Scoop Manifest` at ref `fix/scoop-credential-preflight` with `release_tag=v0.8.4`, `dry_run=true`, and `credential_canary=true`. After merge, `Scoop Bucket Canary` exercises the same path.
- **Expected on this branch (after):** the run enters `credential_canary: true`, reaches `git push --dry-run`, confirms push authorization, skips the real push, and leaves the bucket unchanged. A generic standalone dry run without credentials may still skip permissively.
- **Prior behavior on `master` (before):** no scheduled credential canary exists, and a manual dry run skips the authorization check because the validation step runs only when `dry_run == false`.

### How I tested

- **CI checks relied on and why they cover this change:** `CI Required Gate` runs the architecture suite, which contains `release_workflow::package_publishers_use_canonical_sources_and_scoped_credentials`. That test pins the exact invariants this PR moves around: it requires `push --dry-run origin HEAD` and `Contents: Read and write` to still be present in `pub-scoop.yml`, and forbids reintroducing the heuristic `.permissions.push` check or the inline manifest heredoc. `Docs Style` covers the two changed Markdown files.
- **Known CI coverage gap, if any:** No CI job lints workflow YAML, so I ran `actionlint` with `shellcheck` locally. Separately, `docs_links_gate.sh` strips the `#fragment` before validating (`collect_changed_links.py:96`), so it never checks anchors; I verified the two new anchors against real mdbook output instead.
- **Commands run and tail output:**

```sh
$ actionlint -shellcheck=shellcheck .github/workflows/pub-scoop.yml .github/workflows/scoop-bucket-canary.yml
$ echo $?
0
# The 4 shellcheck infos actionlint reports on release-stable-manual.yml are
# pre-existing: the same 4 appear on an unmodified master checkout.

$ cargo test --locked --test architecture
running 13 tests
test release_workflow::package_publishers_use_canonical_sources_and_scoped_credentials ... ok
test release_workflow::scoop_publisher_metadata_follows_canonical_url_template ... ok
test release_workflow::macos_desktop_release_notarizes_published_dmg ... ok
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
No blocking markdown issues on changed lines.

$ bash scripts/ci/docs_links_gate.sh
Collected 133 added link(s) from 113 docs file(s).
Checked 77 local docs link target(s).
```

- **Beyond CI, what did you manually verify?**
  - Unit-tested all six branches of the new credential guard as a standalone script: dry-run with no credentials warns and exits 0; publish with no credentials, with a token but no repo variable, and with a malformed `owner/repo` each error and exit 1; both dry-run and publish with full credentials reach the probe. This mattered because the guard runs under `set -euo pipefail` and an early `exit 0` path.
  - Confirmed the two new doc anchors match real mdbook output (`id="weekly-scoop-bucket-canary-scoop-bucket-canaryyml"`, `id="rotating-scoop_bucket_token"`) by building a minimal book, since the book's own build needs a repo-built preprocessor and the links gate does not check fragments.
  - Confirmed the diagnosis end-to-end before writing the fix: the live bucket manifest is correct at 0.8.4, its hash matches `SHA256SUMS`, and the release zip contains `zeroclaw.exe` and `zerocode.exe` at the archive root, so `bin` resolves. The manifest pipeline is genuinely not the problem.
  - Confirmed `ZeroClaw-Bot` currently holds `write` on the bucket, so the preflight should pass today rather than immediately going red.
  - **Operational boundary:** the bucket Excavator companion remains pending and must not be treated as a live recovery path until its workflow, write permission, and smoke test are complete. Until then, use the documented manual recovery path.
- **If any command was intentionally skipped, why:** `cargo fmt`/`clippy` are not meaningful here; no Rust source changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes` — the new weekly and manual canary receives the existing write-capable `SCOOP_BUCKET_TOKEN`; its repository `GITHUB_TOKEN` remains read-only, and the reusable publisher receives only the named Scoop token.
- New external network calls? `Yes` — the weekly and manual canary adds recurring calls to the existing GitHub release and Scoop bucket endpoints; it introduces no new destination.
- Secrets / tokens / credentials handling changed? `Yes` — the credential is deliberately exercised by the weekly canary, but callers pass only `SCOOP_BUCKET_TOKEN`; `secrets: inherit` is forbidden by regression tests. The probe is a receive-pack dry run and cannot mutate the bucket.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — the docs name the `ZeroClaw-Bot` service account only. The GitHub handle that appeared in the v0.8.1 failure log is deliberately not reproduced in the diff.
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — reuses the existing `SCOOP_BUCKET_TOKEN` secret and `SCOOP_BUCKET_REPO` variable.
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

`.github/workflows/**` is High risk per `AGENTS.md`.

- **Fast rollback command/path:** revert the canary/publisher commits. The weekly workflow has no release-path dependents, so disabling or reverting it cannot strand a release.
- **Feature flags or config toggles:** disable `Scoop Bucket Canary` from the Actions UI to stop the schedule without changing release publication.
- **Observable failure symptoms:** a red weekly canary with a missing-repository, missing-token, or authorization-probe error. Generic `Pub Scoop Manifest` dry runs remain separately identifiable and permissive when credentials are intentionally unavailable.
