### PR TITLE
fix(channels/git): make an empty peer allowlist loud instead of silent

### DIFF
--- a/crates/zeroclaw-channels/src/git/channel.rs
+++ b/crates/zeroclaw-channels/src/git/channel.rs
@@ -153,6 +153,9 @@ pub struct GitChannel {
     /// accessors. The provider remains the source of truth; this is a
     /// memo of the value it returned.
     identity: parking_lot::Mutex<Option<SelfIdentity>>,
+    /// Senders already warned about falling outside the peer allowlist, so the
+    /// WARN fires once per sender per process instead of once per event.
+    warned_unauthorized: parking_lot::Mutex<HashSet<String>>,
     /// Last draft-edit instant per comment id (throttle).
     draft_edits: parking_lot::Mutex<HashMap<String, Instant>>,
 }
@@ -171,6 +174,7 @@ impl GitChannel {
             provider,
             identity: parking_lot::Mutex::new(None),
             draft_edits: parking_lot::Mutex::new(HashMap::new()),
+            warned_unauthorized: parking_lot::Mutex::new(HashSet::new()),
         })
     }
 
@@ -188,6 +192,7 @@ impl GitChannel {
             provider,
             identity: parking_lot::Mutex::new(None),
             draft_edits: parking_lot::Mutex::new(HashMap::new()),
+            warned_unauthorized: parking_lot::Mutex::new(HashSet::new()),
         }
     }
 
@@ -375,12 +380,27 @@ impl GitChannel {
             return true;
         };
         if !self.is_user_allowed(&msg.sender) {
-            ::zeroclaw_log::record!(
-                DEBUG,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_attrs(::serde_json::json!({"sender": msg.sender})),
-                "ignoring git event from unauthorized user"
-            );
+            // First drop for a sender is a WARN: with an empty or misconfigured
+            // allowlist this branch eats every event (including `sop`-routed PR
+            // lifecycle events), and at DEBUG the operator sees "routed to SOP
+            // ingress" followed by nothing. Repeats stay DEBUG so a busy public
+            // repo cannot turn this into log spam.
+            if self.warned_unauthorized.lock().insert(msg.sender.clone()) {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({"sender": msg.sender})),
+                    "git channel dropping events from sender outside the peer \
+                     allowlist (repeats for this sender log at DEBUG)"
+                );
+            } else {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_attrs(::serde_json::json!({"sender": msg.sender})),
+                    "ignoring git event from unauthorized user"
+                );
+            }
             return true;
         }
         tx.send(msg).await.is_ok()
@@ -449,6 +469,22 @@ impl Channel for GitChannel {
             );
         }
         let plan = TransportPlan::from_routes(&self.cfg.events);
+
+        // Fail loudly on the one misconfiguration that silently disables the
+        // whole channel: an empty resolved peer allowlist drops EVERY inbound
+        // event — peer checks apply to `sop` routes too — and the only trace
+        // was a DEBUG line per event. Resolved once here for the diagnostic;
+        // per-event checks still resolve live.
+        if (self.peer_resolver)().is_empty() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"alias": self.alias})),
+                "git channel peer allowlist resolves to EMPTY: every inbound event \
+                 will be dropped; add a [peer_groups.<name>] with channel = \"git\" \
+                 (or \"git.<alias>\") and external_peers ([\"*\"] accepts any author)"
+            );
+        }
 
         ::zeroclaw_log::record!(
             INFO,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - An empty resolved peer allowlist drops every inbound git event — including `sop`-routed PR lifecycle events — with only a per-event DEBUG line. A fully configured review pipeline (App installed, polling healthy, SOP loaded and matched) produced no runs and no diagnostics at the default log level.
  - `listen()` now WARNs at startup when the peer set resolves empty, naming the `[peer_groups]` shape to fix (groups match on their `channel` field and read `external_peers`; the adjacent approval-group syntax uses `members`, an easy conflation that produces exactly this state).
  - The unauthorized drop WARNs once per sender (tracked per listener); repeats stay DEBUG so a busy public repo cannot turn it into log spam.
- **Scope boundary:** log-only; no change to admission behavior, matching, or the peer model.
- **Blast radius:** git channel logging only.
- **Linked issue(s):** Fixes #9792.
- **Labels:** `bug`, `channel`, `observability`, `tool:sop`, `risk:medium`, `size:XS`, `distinguished contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `channel` (git)
- **Setup / preconditions:** a `[channels.git.<alias>]` with a GitHub App credential, and NO `[peer_groups]` entry whose `channel` matches it.
- **Steps to run:** start the daemon; watch startup logs; open any PR on a watched repo.
- **Expected on this branch (after):** one startup WARN naming the empty allowlist and the config shape to fix; first dropped event per sender logs WARN.
- **Prior behavior on `master` (before):** silence at default level; per-event DEBUG only.

### How I tested

- **CI checks relied on and why they cover this change:** required gate at head (Build/Check/Clippy jobs cover the touched crate). `Web Permission Tests` failed on the initial run — unrelated surface for a log-only git-channel change — rerun requested; will reconcile if it stays red.
- **Known CI coverage gap, if any:** no unit test asserts the new log lines (log-only change; existing `zeroclaw-channels` tests unaffected).
- **Commands run and tail output:**
  - `cargo build --release --features channels-full --bin zeroclaw` → `Finished ... in 4m 25s`
  - `cargo check --release -p zeroclaw-channels --features channel-git` → `Finished ... in 58.74s`
- **Beyond CI, what did you manually verify?** Deployed on a live 0.8.4 daemon: with the misconfigured peer-group shape the startup WARN fires (`git channel peer allowlist resolves to EMPTY: ...`, alias attr); with the corrected shape it does not, and a real `pull_request.opened` flowed to SOP dispatch. Not verified: Gitea/Forgejo provider path (shared listener code; provider-agnostic).
- **If any command was intentionally skipped, why:** full workspace test suite — untouched crates; relying on required CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No — WARN logs the sender login already present in DEBUG.
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` of the single commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** none expected; the change emits at most one WARN per sender plus one at startup. If log volume were somehow wrong, grep `git channel dropping events from sender` / `peer allowlist resolves to EMPTY`.
