### PR TITLE
docs(channels): note that one-off git sends resolve the default alias

### DIFF
--- a/docs/book/src/channels/git.md
+++ b/docs/book/src/channels/git.md
@@ -40,7 +40,7 @@ The full field reference, straight from the schema:
 
 {{#config-fields channels.git}}
 
-The `default` alias is the common first instance. Leave `repos` empty to poll every repository visible to the credential, or set it to an explicit repository list for lower rate usage. Set `listen_to_bots` only if comments from other bot accounts should be processed. An unknown `provider` value is a clear startup error rather than a silent fallback.
+The `default` alias is the common first instance. It is also what one-off sends resolve: `zeroclaw channel send --channel-id git` looks up the `default` alias specifically, so name the instance `default` unless every send will come from an agent bound to a differently-named alias. Leave `repos` empty to poll every repository visible to the credential, or set it to an explicit repository list for lower rate usage. Set `listen_to_bots` only if comments from other bot accounts should be processed. An unknown `provider` value is a clear startup error rather than a silent fallback.
 
 Credential setup differs per provider and each has its own encrypted secret; both walkthroughs cover it end to end:
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** one sentence in the Git channel page: `zeroclaw channel send --channel-id git` resolves the `default` alias specifically, so an instance under another alias answers "Git channel is not configured" for one-off sends even while polling and agent-bound sends work. Found live; cost a debugging cycle.
- **Scope boundary:** docs wording only; does not change or document away the underlying behavior (arguably worth a code follow-up).
- **Blast radius:** docs book only.
- **Linked issue(s):** none.
- **Labels:** `docs`, `type:docs`, `risk:low`, `size:XS`, `distinguished contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; docs-only one-liner.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` gates cover the changed Markdown. Initial `CI Required Gate` failure came from `Detect Windows Clippy changes` on a docs-only diff — rerun requested.
- **Known CI coverage gap, if any:** None after the docs gates.
- **Commands run and tail output:** behavior verified live on 0.8.4: `channel send --channel-id git` with only `channels.git.main` configured → `Git channel is not configured`; after renaming the alias to `default` → `Message sent via git.`
- **Beyond CI, what did you manually verify?** the orchestrator lookup (`config.channels.git.get("default")`) matches the documented behavior.
- **If any command was intentionally skipped, why:** none.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.
