### PR TITLE
test(xtask): derive generator dist assertions from the canonical registry

### DIFF
--- a/xtask/src/generate/container.rs
+++ b/xtask/src/generate/container.rs
@@ -91,10 +91,14 @@ mod tests {
     #[test]
     fn dist_renders_lean_release_channels() {
         let b = render_features(&root(), &Selection::Dist, "        ").unwrap();
-        assert!(b.contains("channel-matrix"));
-        assert!(b.contains("channel-lark"));
-        assert!(b.contains("whatsapp-web"));
-        assert!(!b.contains("channel-slack"));
+        for feature in
+            crate::generate::spec::resolve_feature_list(&root(), &Selection::Dist).unwrap()
+        {
+            assert!(b.contains(&feature), "dist feature {feature} not rendered");
+        }
+        for feature in crate::generate::spec::features_outside_dist(&root()).unwrap() {
+            assert!(!b.contains(&feature), "{feature} leaked into lean dist");
+        }
     }
 
     #[test]

--- a/xtask/src/generate/docker_tags.rs
+++ b/xtask/src/generate/docker_tags.rs
@@ -158,14 +158,21 @@ mod tests {
             .iter()
             .find(|t| t["stem"].as_str() == Some("all-features"))
             .unwrap();
-        assert!(
-            dist["features"]
-                .as_str()
-                .unwrap()
-                .contains("channel-matrix")
-        );
-        assert!(dist["features"].as_str().unwrap().contains("whatsapp-web"));
-        assert!(!dist["features"].as_str().unwrap().contains("channel-slack"));
+        let dist_features = dist["features"].as_str().unwrap();
+        for feature in
+            crate::generate::spec::resolve_feature_list(&root(), &Selection::Dist).unwrap()
+        {
+            assert!(
+                dist_features.contains(&feature),
+                "dist feature {feature} not rendered"
+            );
+        }
+        for feature in crate::generate::spec::features_outside_dist(&root()).unwrap() {
+            assert!(
+                !dist_features.contains(&feature),
+                "{feature} leaked into lean dist"
+            );
+        }
         assert!(all["features"].as_str().unwrap().contains("hardware"));
     }
 }

--- a/xtask/src/generate/flake.rs
+++ b/xtask/src/generate/flake.rs
@@ -117,9 +117,18 @@ mod tests {
     #[test]
     fn zone_default_is_lean_dist() {
         let z = render_zone(&root()).unwrap();
-        assert!(z.contains("\"channel-matrix\""));
-        assert!(z.contains("\"whatsapp-web\""));
-        assert!(!z.contains("\"channel-slack\""));
+        for feature in spec::resolve_feature_list(&root(), &Selection::Dist).unwrap() {
+            assert!(
+                z.contains(&format!("\"{feature}\"")),
+                "dist feature {feature} not rendered"
+            );
+        }
+        for feature in spec::features_outside_dist(&root()).unwrap() {
+            assert!(
+                !z.contains(&format!("\"{feature}\"")),
+                "{feature} leaked into lean dist"
+            );
+        }
     }
 
     #[test]

--- a/xtask/src/generate/packaging.rs
+++ b/xtask/src/generate/packaging.rs
@@ -198,8 +198,11 @@ mod tests {
         let f = spec::resolve_feature_list(&root(), &Selection::Dist)
             .unwrap()
             .join(",");
-        assert!(f.contains("channel-matrix"));
-        assert!(f.contains("whatsapp-web"));
-        assert!(!f.contains("channel-slack"));
+        for feature in spec::resolve_feature_list(&root(), &Selection::Dist).unwrap() {
+            assert!(f.contains(&feature), "dist feature {feature} not rendered");
+        }
+        for feature in spec::features_outside_dist(&root()).unwrap() {
+            assert!(!f.contains(&feature), "{feature} leaked into lean dist");
+        }
     }
 }

--- a/xtask/src/generate/setup_bat.rs
+++ b/xtask/src/generate/setup_bat.rs
@@ -269,9 +269,15 @@ mod tests {
         let presets = render_presets(&root()).unwrap();
         let (_, dist_and_rest) = presets.split_once(":build_dist").unwrap();
         let (dist, _) = dist_and_rest.split_once("goto :do_build").unwrap();
-        assert!(dist.contains("channel-matrix"));
-        assert!(dist.contains("whatsapp-web"));
-        assert!(!dist.contains("channel-slack"));
+        for feature in spec::resolve_feature_list(&root(), &Selection::Dist).unwrap() {
+            assert!(
+                dist.contains(&feature),
+                "dist feature {feature} not rendered"
+            );
+        }
+        for feature in spec::features_outside_dist(&root()).unwrap() {
+            assert!(!dist.contains(&feature), "{feature} leaked into lean dist");
+        }
     }
 
     #[test]

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -805,6 +805,21 @@ pub fn resolve_feature_list(
     resolve_feature_list_from_package(&meta, root, selection)
 }
 
+/// Concrete feature leaves the canonical registry keeps out of
+/// `Selection::Dist`.
+///
+/// Leanness tests assert against this derived set instead of naming a sentinel
+/// feature, so promoting a channel into `dist_extra_features` stays a
+/// one-line registry edit and never requires touching a test.
+#[cfg(test)]
+pub(crate) fn features_outside_dist(manifest_dir: &Path) -> anyhow::Result<Vec<String>> {
+    let dist = resolve_feature_list(manifest_dir, &Selection::Dist)?;
+    Ok(resolve_feature_list(manifest_dir, &Selection::All)?
+        .into_iter()
+        .filter(|feature| !dist.contains(feature))
+        .collect())
+}
+
 fn workspace_root_package(
     meta: &cargo_metadata::Metadata,
 ) -> anyhow::Result<&cargo_metadata::Package> {
@@ -1406,6 +1421,10 @@ mod tests {
         );
     }
 
+    /// Pins the lean contract by name on purpose: widening `dist` must be a
+    /// deliberate, reviewed edit here, not a silent consequence of a registry
+    /// change. The generator suites derive their expectations from the
+    /// registry; this one stays the policy tripwire.
     #[test]
     fn dist_matches_lean_release_contract() {
         let features = resolve_feature_list(&root(), &Selection::Dist).unwrap();
@@ -1556,7 +1575,9 @@ mod tests {
         .unwrap();
         assert_eq!(host, dist);
 
-        assert!(exclude_features(host, &["channel-slack".to_owned()]).is_err());
+        let outside_dist = features_outside_dist(&root()).unwrap();
+        let not_in_dist = outside_dist.first().expect("dist is not the kitchen sink");
+        assert!(exclude_features(host, std::slice::from_ref(not_in_dist)).is_err());
         let (target, excluded) = exclusions.iter().next().unwrap();
         let resolved =
             resolve_feature_list_for_target(&root(), &Selection::Dist, Some(target)).unwrap();


### PR DESCRIPTION
The five generator suites (container, flake, packaging, setup_bat, docker_tags) each named features on both sides of the lean-dist contract:  `channel-matrix`/`whatsapp-web` as members, `channel-slack` as the exclusion sentinel. That duplicates `dist_extra_features` six ways, so a registry change means editing seven assertions across five files before the suite describes the contract again — and the sentinel quietly stops meaning anything if that particular feature is ever promoted.

Resolve the generator expectations from the registry instead: assert every feature in `Selection::Dist` renders, and assert every feature in `Selection::All` outside `Selection::Dist` stays out. The new `features_outside_dist` helper derives the exclusion set, so each generator checks that it agrees with the resolver, which is the property it actually owns.

`dist_matches_lean_release_contract` deliberately keeps naming the three features. Widening the lean prebuilt contract restored in #9051 should stay a reviewed, explicit edit rather than a silent consequence of a registry change, so the policy tripwire remains — now as the single place that encodes it.

No behavior change: this asserts the contract the resolver already implements.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The five generator suites (`container`, `flake`, `packaging`, `setup_bat`, `docker_tags`) each named features on both sides of the lean-dist contract: `channel-matrix`/`whatsapp-web` as members, `channel-slack` as the exclusion sentinel. That duplicates `dist_extra_features` six ways over.
  - Because the expectations are hand-written, a registry change breaks seven assertions across five files, and the suite stops describing the contract until every one is edited by hand.
  - The sentinel is also self-invalidating: it silently stops testing anything the day `channel-slack` is promoted into `dist`, because the assertion is about that one name rather than about leanness.
  - Generator expectations now resolve from the registry: every feature in `Selection::Dist` must render, and every feature in `Selection::All` outside `Selection::Dist` must stay out. A new `features_outside_dist` helper derives the exclusion set. Each generator asserts that it agrees with the resolver, which is the property that generator actually owns.
  - `dist_matches_lean_release_contract` deliberately keeps naming the three features, so the policy tripwire survives as the single place that encodes it.
- **Scope boundary:** No change to `dist_extra_features`, `container_excluded_features`, `dist_target_exclusions`, or any resolver logic. No generated surface changes — `cargo generate installers --check` is in sync before and after. This does not widen, narrow, or re-open the lean prebuilt contract, and it does not touch `channels-full`, `Selection::DistBroad`, or any channel implementation.
- **Blast radius:** `xtask` test code only. No production code path, no generated artifact, no release surface. A wrong assertion here can only fail CI, never ship.
- **Linked issue(s):** Related #9051, which restored the lean prebuilt contract these tests guard.
- **Labels:** `type:test`, `risk:low`, `size:S`, `dev`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — test-only refactor with no user-visible surface; the suites below are the whole signal.

### How I tested

The interesting question for a test refactor is not whether the suite is green, but whether the assertions still fail when they should. I checked both directions.

**1. Green on an unmodified registry**

```sh
cargo test --locked -p xtask --lib generate:: --no-fail-fast
```

```text
test result: ok. 85 passed; 0 failed; 0 ignored; 0 measured; 99 filtered out; finished in 0.62s
```

**2. The tripwire still trips, and is now the only thing that trips**

Temporarily adding `channel-slack` to `dist_extra_features` — that is, widening the lean contract — on `master` fails seven tests spread across five files:

```text
test generate::container::tests::dist_renders_lean_release_channels ... FAILED
test generate::flake::tests::zone_default_is_lean_dist ... FAILED
test generate::packaging::tests::pkgbuild_features_are_lean_dist_channels ... FAILED
test generate::setup_bat::tests::dist_preset_ships_lean_release_channels ... FAILED
test generate::spec::tests::dist_matches_lean_release_contract ... FAILED
test generate::docker_tags::tests::dist_tag_is_lean_while_all_tag_is_kitchen_sink ... FAILED
test generate::spec::tests::release_exclusions_remove_only_named_features ... FAILED
test result: FAILED. 78 passed; 7 failed
```

The same edit on this branch fails exactly one — the deliberate policy gate:

```text
test generate::spec::tests::dist_matches_lean_release_contract ... FAILED
test result: FAILED. 84 passed; 1 failed
```

Widening the contract still requires an explicit, reviewed test edit. It just no longer requires six mechanical ones that carry no additional signal.

**3. Lint, format, and generated-surface drift**

```sh
cargo fmt --all -- --check
cargo clippy --locked -p xtask --all-targets --no-deps -- -D warnings
cargo run --locked -p xtask --bin generate -- installers --check
```

```text
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.32s
ok: scoop in sync
ok: flake in sync
ok: docker-tags in sync
```

- **CI checks relied on and why they cover this change:** `Quality Gate` runs the `xtask` suite, clippy and fmt, which is the entire changed surface. The generated-surface drift check covers the claim that no rendered artifact moved.
- **Known CI coverage gap, if any:** None. The change is confined to `#[cfg(test)]` code in one crate.
- **Beyond CI, what did you manually verify?** The mutation test in point 2, in both directions, which is the substantive claim of this PR. I also confirmed that no `absent` feature is a substring of any `dist` feature, so the `!contains` loop cannot pass or fail spuriously on the current graph. I did **not** verify behaviour on any release target or container build, because no generated output changes.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` was not run; the diff is confined to `xtask` test modules and nothing outside that crate can observe it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>` is the plan. Reverting restores the hand-written assertions with no effect on any shipped artifact.