### PR TITLE
docs(sop): document which agent executes SOP steps

### DIFF
--- a/docs/book/src/sop/how-it-works.md
+++ b/docs/book/src/sop/how-it-works.md
@@ -6,6 +6,7 @@
 - CLI `zeroclaw sop` currently manages definitions only: `list`, `validate`, `show`.
 - SOP runs are started by a live event fan-in (MQTT, filesystem, or AMQP), by the daemon's periodic SOP maintenance tick for `cron` triggers, or by the in-agent tool `sop_execute`. The remaining trigger types (webhook, peripheral, calendar) are defined and matched but not yet wired to a live event source (see [SOP Fan-In](./fan-in/overview.md)).
 - Run progression uses tools: `sop_status`, `sop_approve`, `sop_advance`.
+- Steps execute under the SOP's bound agent when the manifest sets `agent = "<alias>"` (a step-level `- agent:` bullet overrides it per step); without a binding, daemon-dispatched runs fall back to the daemon's default agent, whose risk profile may not expose the tools the steps assume. Bind the agent explicitly for any SOP whose steps run shell or file tools.
 - Run state is process-local by default. With `sop.persist_runs = true`, successful initialization of the default SQLite backend stores it under `<data_dir>/sop/runs.db` and restores active runs after restart. Initialization failure logs a warning and falls back to process-local memory.
 - SOP audit records are persisted in the configured Memory backend under category `sop`.
 

--- a/docs/book/src/sop/how-it-works.md
+++ b/docs/book/src/sop/how-it-works.md
@@ -3,10 +3,10 @@
 ## Runtime contract
 
 - SOP definitions are loaded from `<workspace>/sops/<sop_name>/SOP.toml` plus optional `SOP.md`.
-- CLI `zeroclaw sop` currently manages definitions only: `list`, `validate`, `show`.
+- CLI `zeroclaw sop` manages definitions with `list`, `validate`, `show`, `graph`, and `delete`, and manages approval gates with `pending`, `approve`, and `deny`.
 - SOP runs are started by a live event fan-in (MQTT, filesystem, or AMQP), by the daemon's periodic SOP maintenance tick for `cron` triggers, or by the in-agent tool `sop_execute`. The remaining trigger types (webhook, peripheral, calendar) are defined and matched but not yet wired to a live event source (see [SOP Fan-In](./fan-in/overview.md)).
 - Run progression uses tools: `sop_status`, `sop_approve`, `sop_advance`.
-- Steps execute under the SOP's bound agent when the manifest sets `agent = "<alias>"` (a step-level `- agent:` bullet overrides it per step); without a binding, daemon-dispatched runs fall back to the daemon's default agent, whose risk profile may not expose the tools the steps assume. Bind the agent explicitly for any SOP whose steps run shell or file tools.
+- Agent steps execute under the SOP's bound agent when the manifest sets `agent = "<alias>"` (a step-level `- agent:` bullet overrides it per step). Unbound steps driven inside an agent turn by `sop_execute`, `sop_approve`, or `sop_advance` inherit the calling agent; a step bound to another agent is reassembled under that agent or refused when reassembly is unavailable. Where an unbound agent step reaches the headless run driver (an approval surface resuming a gate or the gateway manual-run endpoint starting a run), the current fallback is the `[agents]` key that sorts first by string byte order, including disabled entries; with no configured key, the fallback is an empty alias. Cron-, fan-in-, RPC `sops/run`-, and approval-timeout auto-approval-dispatched agent steps do not currently have an agent loop and remain parked. Bind the agent explicitly for any SOP whose steps run shell or file tools.
 - Run state is process-local by default. With `sop.persist_runs = true`, successful initialization of the default SQLite backend stores it under `<data_dir>/sop/runs.db` and restores active runs after restart. Initialization failure logs a warning and falls back to process-local memory.
 - SOP audit records are persisted in the configured Memory backend under category `sop`.
 


### PR DESCRIPTION
> **Superseded by #9841.** This docs-only patch captured temporary current-master behavior that the runtime fix removes.

## Summary

- **Base branch:** `master`
- **What changed and why:** one paragraph in the SOP runtime contract documenting which agent executes steps: the SOP-level `agent = "<alias>"` binding (with per-step `- agent:` override), and the fallback — daemon-dispatched runs otherwise execute under the daemon's default agent, whose risk profile may not expose the tools steps assume. The failure mode is hard to diagnose: steps "complete" as prose refusals while the run records success.
- **Scope boundary:** documents existing behavior; no schema or engine change. Deliberately placed in `how-it-works.md` (runtime contract), not `syntax.md`, which intentionally does not enumerate manifest fields.
- **Blast radius:** docs book only.
- **Linked issue(s):** Related #9784 (observed while diagnosing it).
- **Labels:** `docs`, `distinguished contributor`, `risk:low`, `size:XS`, `needs-author-action`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; docs-only paragraph.

### How I tested

- **CI checks relied on and why they cover this change:** all checks green at head including `CI Required Gate` and the docs gates.
- **Known CI coverage gap, if any:** None after the docs gates.
- **Commands run and tail output:** behavior verified live on 0.8.4, both directions: an unbound SOP dispatched from a channel executed under the daemon default agent (an advisor profile without shell tools; every step failed as prose yet recorded completed); after `agent = "pr_reviewer"`, the same SOP executed correctly under the bound agent.
- **Beyond CI, what did you manually verify?** the field exists in `SopTrigger`-adjacent types (`sop/types.rs`: SOP-level `agent`, step-level override via `effective_agent`).
- **If any command was intentionally skipped, why:** none.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.
