### PR TITLE
docs(hardware): mark aardvark-sys and zeroclaw-robot-kit as retiring

### DIFF
--- a/crates/aardvark-sys/Cargo.toml
+++ b/crates/aardvark-sys/Cargo.toml
@@ -7,8 +7,14 @@ license = "MIT OR Apache-2.0"
 description = "Low-level bindings for the Total Phase Aardvark I2C/SPI/GPIO USB adapter"
 repository = "https://github.com/zeroclaw-labs/zeroclaw"
 
-# NOTE: This crate is the ONLY place in ZeroClaw where unsafe code is permitted.
-# The rest of the workspace remains #![forbid(unsafe_code)].
+# RETIRING: this crate is being deleted, not kept as a permanent unsafe carve-out.
+# See RFC #8043 for the plan and #7130 for the unsafe-policy decision. Do not add
+# call sites; new peripheral work belongs in zeroclaw-hardware. Any unsafe that
+# must outlive the deletion needs its own narrow, reviewed boundary there rather
+# than inheriting this crate's exemption.
+#
+# NOTE: While it exists, this crate is the ONLY place in ZeroClaw where unsafe
+# code is permitted. The rest of the workspace remains #![forbid(unsafe_code)].
 #
 # The Total Phase SDK is loaded at runtime via libloading (see src/lib.rs); the
 # vendored library lives in vendor/aardvark.so and FFI symbols are resolved

--- a/crates/aardvark-sys/Cargo.toml
+++ b/crates/aardvark-sys/Cargo.toml
@@ -7,16 +7,19 @@ license = "MIT OR Apache-2.0"
 description = "Low-level bindings for the Total Phase Aardvark I2C/SPI/GPIO USB adapter"
 repository = "https://github.com/zeroclaw-labs/zeroclaw"
 
-# RETIRING: this crate is being deleted, not kept as a permanent unsafe carve-out.
-# The retirement plan and the unsafe-policy decision are recorded at
-# https://github.com/zeroclaw-labs/zeroclaw/issues/8043 and
-# https://github.com/zeroclaw-labs/zeroclaw/issues/7130. Do not add
-# call sites; new peripheral work belongs in zeroclaw-hardware. Any unsafe that
-# must outlive the deletion needs its own narrow, reviewed boundary there rather
-# than inheriting this crate's exemption.
+# RETIREMENT PROPOSED, NOT DECIDED: an open proposal would delete this crate and
+# fold its FFI into zeroclaw-hardware. It is under discussion and has not been
+# ratified, so the current architecture contract still stands: FND-001 lists this
+# crate as an intentional independent exception. Follow the discussion at
+# https://github.com/zeroclaw-labs/zeroclaw/issues/8043, and the related
+# unsafe-code question at
+# https://github.com/zeroclaw-labs/zeroclaw/issues/7130, before adding call
+# sites. If the proposal is accepted, new peripheral work belongs in
+# zeroclaw-hardware instead, and the unsafe exemption below would need its own
+# narrow reviewed boundary there rather than transferring wholesale.
 #
-# NOTE: While it exists, this crate is the ONLY place in ZeroClaw where unsafe
-# code is permitted. The rest of the workspace remains #![forbid(unsafe_code)].
+# NOTE: This crate is the ONLY place in ZeroClaw where unsafe code is permitted.
+# The rest of the workspace remains #![forbid(unsafe_code)].
 #
 # The Total Phase SDK is loaded at runtime via libloading (see src/lib.rs); the
 # vendored library lives in vendor/aardvark.so and FFI symbols are resolved

--- a/crates/aardvark-sys/Cargo.toml
+++ b/crates/aardvark-sys/Cargo.toml
@@ -8,7 +8,9 @@ description = "Low-level bindings for the Total Phase Aardvark I2C/SPI/GPIO USB 
 repository = "https://github.com/zeroclaw-labs/zeroclaw"
 
 # RETIRING: this crate is being deleted, not kept as a permanent unsafe carve-out.
-# See RFC #8043 for the plan and #7130 for the unsafe-policy decision. Do not add
+# The retirement plan and the unsafe-policy decision are recorded at
+# https://github.com/zeroclaw-labs/zeroclaw/issues/8043 and
+# https://github.com/zeroclaw-labs/zeroclaw/issues/7130. Do not add
 # call sites; new peripheral work belongs in zeroclaw-hardware. Any unsafe that
 # must outlive the deletion needs its own narrow, reviewed boundary there rather
 # than inheriting this crate's exemption.

--- a/crates/robot-kit/README.md
+++ b/crates/robot-kit/README.md
@@ -1,11 +1,11 @@
 # ZeroClaw Robot Kit
 
-> **Being retired.** `zeroclaw-robot-kit` is being folded into
-> `zeroclaw-hardware`. It still works, but it is closed to new work: add new
-> peripheral or robot support to `zeroclaw-hardware` instead of extending this
-> crate. Tracked in
-> [RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803), alongside
-> the `aardvark-sys` deletion in
+> **Retirement proposed.** An open proposal would fold `zeroclaw-robot-kit` into
+> `zeroclaw-hardware`. It has not been decided, so this crate remains supported
+> as it is today. If you are planning new peripheral or robot support, weigh in
+> on [RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803) first,
+> and consider whether `zeroclaw-hardware` is the better home. The related
+> `aardvark-sys` proposal is
 > [RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043).
 
 A complete toolkit for building AI-powered robots with ZeroClaw. Designed for Raspberry Pi deployment with offline Ollama inference.

--- a/crates/robot-kit/README.md
+++ b/crates/robot-kit/README.md
@@ -1,5 +1,13 @@
 # ZeroClaw Robot Kit
 
+> **Being retired.** `zeroclaw-robot-kit` is being folded into
+> `zeroclaw-hardware`. It still works, but it is closed to new work: add new
+> peripheral or robot support to `zeroclaw-hardware` instead of extending this
+> crate. Tracked in
+> [RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803), alongside
+> the `aardvark-sys` deletion in
+> [RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043).
+
 A complete toolkit for building AI-powered robots with ZeroClaw. Designed for Raspberry Pi deployment with offline Ollama inference.
 
 ## Features

--- a/docs/book/src/architecture/crates.md
+++ b/docs/book/src/architecture/crates.md
@@ -150,15 +150,20 @@ Terminal UI, built as a separate app under `apps/zerocode/`. It is its own works
 
 Specialised hardware support used by the `hardware` submodule. Out-of-scope unless you're bringing up specific peripherals.
 
-Both are being retired, so treat them as closed to new work. `aardvark-sys` is
-being deleted ([RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043)),
-and `zeroclaw-robot-kit` is being folded into `zeroclaw-hardware`
-([RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803)). New
-peripheral work belongs in `zeroclaw-hardware` directly.
+Retiring both has been proposed and is still under discussion. Neither proposal
+is accepted, so the contract in [FND-001](../foundations/fnd-001-intentional-architecture.md)
+still holds: both remain intentional independent crates with their own versioning
+cadence. The open proposals are
+[RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043), which would
+delete `aardvark-sys`, and
+[RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803), which would
+fold `zeroclaw-robot-kit` into `zeroclaw-hardware`. If you are starting new
+peripheral work, read those first and consider whether `zeroclaw-hardware` is
+the better home.
 
-This also settles where `unsafe` lives. `aardvark-sys` is currently the only
-crate permitted to use it, but that exemption disappears with the crate rather
-than transferring to `zeroclaw-hardware` wholesale; see
+Where `unsafe` should live is part of that open question, not a settled one.
+`aardvark-sys` is currently the only crate permitted to use it. Whether that
+exemption ends with the crate or moves elsewhere is being decided in
 [#7130](https://github.com/zeroclaw-labs/zeroclaw/issues/7130).
 
 ## Feature flags

--- a/docs/book/src/architecture/crates.md
+++ b/docs/book/src/architecture/crates.md
@@ -146,9 +146,20 @@ Derive macros for config schema, tool registration, and channel registration. Sa
 
 Terminal UI, built as a separate app under `apps/zerocode/`. It is its own workspace member with no `zeroclaw-*` crate dependency (see [Docs & Translations → zerocode strings](../maintainers/docs-and-translations.md) for its independent i18n catalogue).
 
-### `aardvark-sys`, `robot-kit`
+### `aardvark-sys`, `zeroclaw-robot-kit`
 
 Specialised hardware support used by the `hardware` submodule. Out-of-scope unless you're bringing up specific peripherals.
+
+Both are being retired, so treat them as closed to new work. `aardvark-sys` is
+being deleted ([RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043)),
+and `zeroclaw-robot-kit` is being folded into `zeroclaw-hardware`
+([RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803)). New
+peripheral work belongs in `zeroclaw-hardware` directly.
+
+This also settles where `unsafe` lives. `aardvark-sys` is currently the only
+crate permitted to use it, but that exemption disappears with the crate rather
+than transferring to `zeroclaw-hardware` wholesale; see
+[#7130](https://github.com/zeroclaw-labs/zeroclaw/issues/7130).
 
 ## Feature flags
 

--- a/docs/book/src/contributing/agent-guidelines.md
+++ b/docs/book/src/contributing/agent-guidelines.md
@@ -73,23 +73,27 @@ The stability-tier definitions and versioning policy live in [FND-001](../founda
 | `zeroclaw-macros` | Beta | Tightly coupled to the config schema |
 | `zeroclaw-eval` | Experimental | Agent evaluation harness with deterministic replay of LLM trace fixtures |
 | `zeroclaw-spawn` | Beta | Attribution-propagating `tokio::spawn` wrapper layered on `zeroclaw-log` |
-| `zeroclaw-robot-kit` | Experimental | Robot control toolkit: drive, vision, speech, sensors, and safety. **Being retired** into `zeroclaw-hardware` |
-| `aardvark-sys` | Experimental | Low-level FFI bindings for the Total Phase Aardvark adapter. **Being deleted**; carries the workspace's only `unsafe` |
+| `zeroclaw-robot-kit` | Experimental | Robot control toolkit: drive, vision, speech, sensors, and safety. **Retirement proposed** (RFC #9803) |
+| `aardvark-sys` | Experimental | Low-level FFI bindings for the Total Phase Aardvark adapter; carries the workspace's only `unsafe`. **Retirement proposed** (RFC #8043) |
 
 Stable components follow the breaking-change policy. Beta components may make breaking changes in a MINOR release with changelog notes. Experimental components carry no stability guarantee. Tiers are promoted, never demoted, through deliberate team decision.
 
-Two crates are on the way out and should not be built on. `aardvark-sys` is
-being deleted outright, and `zeroclaw-robot-kit` is being folded into
-`zeroclaw-hardware`. Do not add call sites to either, and do not treat
-`aardvark-sys` as a permanent home for `unsafe` code: the decision on
-[#7130](https://github.com/zeroclaw-labs/zeroclaw/issues/7130) is to delete the
-crate rather than make it a standing carve-out from a workspace-wide
-`forbid(unsafe_code)`. Any `unsafe` that must survive the deletion needs its own
-narrow, reviewed boundary inside `zeroclaw-hardware`, not an inherited exemption.
-See [RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043) for the
-`aardvark-sys` plan and
-[RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803) for
-`zeroclaw-robot-kit`.
+Retiring two crates has been proposed and neither proposal is decided.
+[RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043) would delete
+`aardvark-sys`; [RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803)
+would fold `zeroclaw-robot-kit` into `zeroclaw-hardware`. Until they are
+ratified, both crates remain supported and
+[FND-001](../foundations/fnd-001-intentional-architecture.md) continues to list
+them as intentional independent exceptions.
+
+Treat that as a reason to check before investing, not as a prohibition: if you
+are about to add call sites to either, read the open proposals first and
+consider whether `zeroclaw-hardware` is the better home.
+
+Whether `aardvark-sys` stays the permanent home for `unsafe` is part of the same
+open question. [#7130](https://github.com/zeroclaw-labs/zeroclaw/issues/7130)
+proposes a workspace-wide `forbid(unsafe_code)` with `aardvark-sys` as the sole
+carve-out; whether that carve-out survives depends on how RFC #8043 resolves.
 
 Change-risk routing is:
 

--- a/docs/book/src/contributing/agent-guidelines.md
+++ b/docs/book/src/contributing/agent-guidelines.md
@@ -73,10 +73,23 @@ The stability-tier definitions and versioning policy live in [FND-001](../founda
 | `zeroclaw-macros` | Beta | Tightly coupled to the config schema |
 | `zeroclaw-eval` | Experimental | Agent evaluation harness with deterministic replay of LLM trace fixtures |
 | `zeroclaw-spawn` | Beta | Attribution-propagating `tokio::spawn` wrapper layered on `zeroclaw-log` |
-| `robot-kit` | Experimental | Robot control toolkit: drive, vision, speech, sensors, and safety |
-| `aardvark-sys` | Experimental | Low-level FFI bindings for the Total Phase Aardvark adapter; the only crate where `unsafe` is permitted |
+| `zeroclaw-robot-kit` | Experimental | Robot control toolkit: drive, vision, speech, sensors, and safety. **Being retired** into `zeroclaw-hardware` |
+| `aardvark-sys` | Experimental | Low-level FFI bindings for the Total Phase Aardvark adapter. **Being deleted**; carries the workspace's only `unsafe` |
 
 Stable components follow the breaking-change policy. Beta components may make breaking changes in a MINOR release with changelog notes. Experimental components carry no stability guarantee. Tiers are promoted, never demoted, through deliberate team decision.
+
+Two crates are on the way out and should not be built on. `aardvark-sys` is
+being deleted outright, and `zeroclaw-robot-kit` is being folded into
+`zeroclaw-hardware`. Do not add call sites to either, and do not treat
+`aardvark-sys` as a permanent home for `unsafe` code: the decision on
+[#7130](https://github.com/zeroclaw-labs/zeroclaw/issues/7130) is to delete the
+crate rather than make it a standing carve-out from a workspace-wide
+`forbid(unsafe_code)`. Any `unsafe` that must survive the deletion needs its own
+narrow, reviewed boundary inside `zeroclaw-hardware`, not an inherited exemption.
+See [RFC #8043](https://github.com/zeroclaw-labs/zeroclaw/issues/8043) for the
+`aardvark-sys` plan and
+[RFC #9803](https://github.com/zeroclaw-labs/zeroclaw/issues/9803) for
+`zeroclaw-robot-kit`.
 
 Change-risk routing is:
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Two open proposals would retire `aardvark-sys` and `zeroclaw-robot-kit`, but nothing in the tree pointed at them. Contributors kept accreting work against both crates without knowing a retirement was on the table, and the crates.io publishing work in #9381 had to keep re-deriving which crates are permanent surface area.
  - Adds a pointer to the open proposals in the four places a developer actually lands: the stability-tier table, the architecture crate list, the `aardvark-sys` manifest header, and the robot-kit README.
  - **These notices describe pending proposals, not decisions.** RFC #8043's Core vote closed REVISE and the RFC is not accepted; RFC #9803 has no vote. Each notice says so explicitly and names FND-001 as the contract still in force, so the public record carries one contract rather than two.
  - Corrects the crate name while here: the package is `zeroclaw-robot-kit`; `robot-kit` is only the directory. The tier table and architecture list both had the directory name.
- **Scope boundary:** Documentation and comments only. Does **not** perform either retirement, move any module, change `members`, alter feature gating, or add `forbid(unsafe_code)` anywhere. Does not amend FND-001, and does not assert any outcome for #8043, #9803, or #7130. The one manifest edit is a comment block; `cargo metadata` output is unchanged.
- **Blast radius:** None at runtime or build time. If either proposal is rejected, these notices become stale pointers to a closed discussion rather than false statements of policy, so the failure mode is mild.
- **Linked issue(s):** Related #9803, Related #8043, Related #7130, Related #9381
- **Labels:** `docs`, `hardware`, `domain:architecture`, `type:docs`, `risk:low`, `size:XS`

## Revision history

The first version of this PR stated that both crates **are being retired** and that #7130's `unsafe` question was settled. @Audacity88 blocked it on exactly that: RFC #8043 is not accepted, RFC #9803 has no vote, and FND-001 still lists both crates as intentional independent exceptions, so the tree would have carried two contradictory architecture contracts at once.

That was a fair call and the current revision takes the second path he offered: describe a pending proposal rather than settled policy. Concretely:

- `RETIRING: this crate is being deleted` becomes `RETIREMENT PROPOSED, NOT DECIDED`, and the manifest note now says FND-001 remains the contract in force.
- `Both are being retired, so treat them as closed to new work` becomes a statement that retirement is proposed and under discussion, with FND-001 cited as still holding.
- `This also settles where unsafe lives` is removed. The text now says the question is open in #7130 and that whether the carve-out survives depends on how #8043 resolves.
- The tier table reads **Retirement proposed** rather than **Being retired** / **Being deleted**.
- `Do not add call sites` becomes a prompt to read the open proposals before investing, which is guidance a reader can act on without presuming an outcome.

The `zeroclaw-robot-kit` package-name correction is unchanged.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — documentation and comments only; there is no behavior to exercise. The substantive review question is whether the notices now read as pending rather than decided, which is a judgement call rather than something a command can verify.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` covers the changed Markdown lines in both docs files. `Lint` runs the comment hygiene gate, which covers the manifest comment. There is no code change for the Rust gates to cover.
- **Known CI coverage gap, if any:** `docs_links_gate.sh` strips the `#fragment` before validating (`collect_changed_links.py:96`), so it cannot catch a heading rename that orphans an inbound anchor link. Checked manually below.
- **Commands run and tail output:**

```sh
$ bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Summary: 0 error(s)

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

# Manifest still parses after the comment-block edit:
$ cargo metadata --no-deps --format-version 1 >/dev/null && echo OK
OK

# Confirm no assertive phrasing survived the reword:
$ grep -rniE "being retired|being deleted|is being folded|closed to new work|this also settles" <the four files>
(no matches)

# The heading rename `### aardvark-sys, robot-kit` -> `### aardvark-sys, zeroclaw-robot-kit`
# changes its anchor. Confirmed nothing links to the old one:
$ grep -rn "aardvark-sys-robot-kit\|#aardvark-sys" docs/ *.md
(no matches)
```

## Security (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

The earlier revision asserted that the `unsafe` exemption does not transfer to `zeroclaw-hardware`. That claim is withdrawn: it is a position in the #7130 and #8043 discussions, not a decision, and this PR no longer states it as one. No lint changes either way.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>` is the plan. Nothing depends on this text, so a revert cannot break a build or a release.
