### PR TITLE
docs(rfc): route by what the author knows and gate RFC intake on an explicit trigger

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc_design.yml
+++ b/.github/ISSUE_TEMPLATE/rfc_design.yml
@@ -7,9 +7,31 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for significant changes to architecture, public interfaces, defaults, governance,
-        release process, contribution model, or project direction.
-        Smaller feature requests should use the feature template. Security vulnerabilities must be reported privately.
+        An RFC is for decisions the project must make **before** anyone can implement.
+        It is not a heavier feature request, and filing one for work that does not need a
+        project-level decision adds review latency without adding review.
+
+        Ordinary features, configuration fields and defaults, schema or data migrations, and
+        bounded refactors go straight to an issue and a PR — use the **Feature Request**
+        template instead. Security vulnerabilities must be reported privately; see `SECURITY.md`.
+
+  - type: dropdown
+    id: trigger
+    attributes:
+      label: Which project-level trigger applies?
+      description: >
+        Pick the trigger this proposal actually meets. If none of them fit, this is ordinary
+        work — close this form and use the Feature Request template. Maintainers may close an
+        RFC as an ordinary issue when it does not meet a trigger; the underlying work stays
+        valid and continues on the redirected issue or PR.
+      options:
+        - A new security layer, or a material change to the security model
+        - A governance, contribution-process, or project-authority change
+        - A cross-cutting refactor that changes ownership or contracts across established boundaries
+        - A new subsystem, or another project-wide capability boundary
+        - None of these — I will use the Feature Request template instead
+    validations:
+      required: true
 
   - type: textarea
     id: problem
@@ -45,9 +67,12 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: What other paths did you consider, including doing nothing?
+      description: >
+        What other paths did you consider, including doing nothing? If the only real
+        alternative is "do not build it", the proposal is probably an ordinary feature
+        rather than a decision the project has to settle first.
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: non_goals

--- a/.github/ISSUE_TEMPLATE/rfc_design.yml
+++ b/.github/ISSUE_TEMPLATE/rfc_design.yml
@@ -12,7 +12,7 @@ body:
         project-level decision adds review latency without adding review.
 
         Ordinary features, configuration fields and defaults, schema or data migrations, and
-        bounded refactors go straight to an issue and a PR — use the **Feature Request**
+        bounded refactors go straight to an issue and a PR. Use the **Feature Request**
         template instead. Security vulnerabilities must be reported privately; see `SECURITY.md`.
 
   - type: dropdown
@@ -21,7 +21,7 @@ body:
       label: Which project-level trigger applies?
       description: >
         Pick the trigger this proposal actually meets. If none of them fit, this is ordinary
-        work — close this form and use the Feature Request template. Maintainers may close an
+        work. Close this form and use the Feature Request template. Maintainers may close an
         RFC as an ordinary issue when it does not meet a trigger; the underlying work stays
         valid and continues on the redirected issue or PR.
       options:
@@ -29,7 +29,7 @@ body:
         - A governance, contribution-process, or project-authority change
         - A cross-cutting refactor that changes ownership or contracts across established boundaries
         - A new subsystem, or another project-wide capability boundary
-        - None of these — I will use the Feature Request template instead
+        - None of these: I will use the Feature Request template instead
     validations:
       required: true
 

--- a/docs/book/src/contributing/rfcs.md
+++ b/docs/book/src/contributing/rfcs.md
@@ -4,7 +4,7 @@ Substantial changes to ZeroClaw's architecture, user-facing surface, or core pol
 
 Governance, RFC ratification rules, and voting thresholds are defined in RFC #5577.
 
-## When to file an RFC vs. just a PR
+## When to file an RFC, an issue, or a PR
 
 | Change | RFC first? |
 |---|---|
@@ -12,14 +12,20 @@ Governance, RFC ratification rules, and voting thresholds are defined in RFC #55
 | New provider implementation | No: open a PR |
 | New tool | No: open a PR |
 | Bug fix | No: open a PR |
-| New config key | Depends: if it fits within existing schema shape, PR. If it introduces a new subsystem or paradigm, RFC |
+| New config key | No: open a PR. RFC only if the key introduces a new subsystem or changes a core policy |
 | Changing an established default | Yes: RFC |
 | Schema migration that breaks existing configs | Yes: RFC |
 | Cross-cutting refactor affecting multiple crates | Yes: RFC |
 | New subsystem (e.g. a new security layer, a new protocol) | Yes: RFC |
 | Changes to governance, release process, or contribution model | Yes: RFC |
 
-Rule of thumb: if you'd want a second opinion before writing the code, it's an RFC. If it's obvious what to build, it's a PR.
+Which one you file depends on how much you already know:
+
+- You know **what** to build and **how** to build it: open a PR.
+- You know **what** to build but not **how**: open an issue and settle the approach there.
+- You are proposing a substantial change to architecture, the user-facing surface, or a core policy: file an RFC.
+
+Needing a second opinion is not by itself a reason to file an RFC. Most proposals that need review need it on the approach, which an issue or a draft PR carries faster than a discussion period and a ballot.
 
 ## Filing an RFC
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **`rfcs.md` routing rule.** The rule of thumb said *"if you'd want a second opinion before writing the code, it's an RFC."* Wanting a second opinion is the normal state of anyone working in an unfamiliar area, so the guidance converted ordinary uncertainty into RFCs. Replaced with a three-way rule keyed on what the author already knows: knows what and how opens a PR, knows what but not how opens an issue, and only a substantial change to architecture, the user-facing surface, or a core policy is an RFC. That restates the sentence this page already opens with, so the guidance is now self-consistent.
  - **The config-key row.** It read `Depends: if it fits within existing schema shape, PR. If it introduces a new subsystem or paradigm, RFC`, asking the filer to self-adjudicate a distinction they are the least placed in the room to make. Now defaults to a PR, with the RFC reserved for a new subsystem or a core-policy change.
  - **Section heading** updated from "When to file an RFC vs. just a PR" to cover the issue path the new rule introduces.
  - **RFC issue template.** The only scope gate was a prose paragraph nothing enforced, and three of six content fields were optional, so a proposal needing no project-level decision validated cleanly. Adds a required trigger dropdown as the first field, naming the four project-level triggers plus an explicit "none of these" option that routes to the Feature Request template, and flips **Alternatives considered** to required since a proposal whose only alternative is not building it is ordinary feature work.
- **Scope boundary:** Intake and routing only. No ratification rule, threshold, discussion period, electorate, or label change. No existing RFC is reclassified by this PR.
- **Blast radius:** New filings and the contributor-facing routing guidance. Open RFCs and in-flight votes are unaffected.
- **Linked issue(s):** refs #9496

## Coordination with #9499

#9499 also edits `docs/book/src/contributing/rfcs.md`. The edits are in different places and do not overlap:

- #9499 rewrites the ratification and outcomes material: the governance-authority line near the top, the discussion-window paragraph, the threshold paragraph, and the Rejected/Deferred bullets.
- This PR touches only the routing section: the heading, the config-key table row, and the rule-of-thumb paragraph.

The one place they come close is the governance-authority line and the section heading two lines below it, so a trivial conflict is possible depending on merge order. **Happy to rebase onto #9499 whenever it lands** rather than have that PR absorb the conflict.

Two defects deliberately left to #9499 because that PR owns those surfaces:

1. The threshold text in #9499 currently documents unanimity for architecture changes. If #9496 is ratified, that will re-enshrine the rule it narrows, so #9499 likely needs a pass before merge.
2. FND-003 §8.1 instructs maintainers to apply `rfc:rejected` and `rfc:revision-requested`. Neither label exists in the repository.

## Why the template needed changing too

#9496 defines the narrowed trigger and #9499 corrects the contributor guide, but neither touches the issue template, which is the only surface a filer interacts with *before* the issue exists. Tightening the prose without tightening the form leaves the intake path unchanged. The dropdown wording is taken from #9496 so the form and the protocol agree; if #9496 lands materially different wording, this dropdown should follow it rather than diverge.

## What this does not do

It does not close or reclassify any existing RFC. Closing filed RFCs on trigger grounds depends on #9496 conferring that authority; this PR only changes what gets filed next.

## Testing

- `bash scripts/ci/docs_quality_gate.sh` — passes. "No prose em-dashes in changed docs files"; "No blocking markdown issues on changed lines." The four pre-existing issues it reports are outside changed lines and untouched here.
- `ruby -ryaml` parse of `rfc_design.yml` — parses clean; `trigger` is the first input field, `type: dropdown`, `required: true`, 5 options.
- Required-field audit after the change: `trigger`, `problem`, `proposal`, `alternatives`, `risks`, `breaking`, `decision_surface`, and the hygiene checkbox required; `design` and `non_goals` remain optional.
- Redirect target cross-checked against `.github/ISSUE_TEMPLATE/feature_request.yml`, whose `name:` is exactly `Feature Request`.
- `grep` for U+2014 across both changed files returns nothing; the template prose was rewritten to match the docs house style even though the gate does not cover `.github/`.
- Docs and template only; no Rust surface touched, so no `cargo` gate applies.
