### PR TITLE
feat(dist): ship channel-slack in the dist feature selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,7 @@ non_row_features = [
 dist_extra_features = [
     "channel-matrix",
     "channel-lark",
+    "channel-slack",
     "whatsapp-web",
 ]
 

--- a/Containerfile
+++ b/Containerfile
@@ -184,7 +184,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=locked \
 
     # Release build — zeroclawlabs (daemon)
     # >>> generated:container-standard by `cargo generate installers` - do not edit <<<
-    ZEROCLAW_FEATURES="acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+    ZEROCLAW_FEATURES="acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
 # >>> end generated:container-standard <<<
     CARGO_TARGET_DIR=/target \
     cargo build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ FROM --platform=$BUILDPLATFORM ${ZEROCLAW_BASE_RUST_SLIM} AS builder
 WORKDIR /app
 ARG TARGETARCH
 # >>> generated:docker-features-arg by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
 # >>> end generated:docker-features-arg <<<
 
 # Install build dependencies. g++ is required by inkjet (zerocode's syntax

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -36,7 +36,7 @@ WORKDIR /app
 ARG TARGETARCH
 ARG CARGO_ZIGBUILD_VERSION=0.23.0
 # >>> generated:docker-features-arg by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
 # >>> end generated:docker-features-arg <<<
 
 RUN apk add --no-cache build-base perl pkgconfig zig \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -53,7 +53,7 @@ FROM ${ZEROCLAW_BASE_RUST_BOOKWORM} AS builder
 
 WORKDIR /app
 # >>> generated:docker-features-arg by `cargo generate installers` - do not edit <<<
-ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+ARG ZEROCLAW_CARGO_FLAGS="--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
 # >>> end generated:docker-features-arg <<<
 
 # Install build dependencies

--- a/dev/ci/docker-tags.toml
+++ b/dev/ci/docker-tags.toml
@@ -27,8 +27,8 @@ pinned_tag = "dist-v0.8.4"
 floating_tag = "dist"
 dockerfile = "Dockerfile"
 platforms = "linux/amd64,linux/arm64"
-flags = "--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
-features = "acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+flags = "--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+features = "acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
 
 [[tags]]
 stem = "all-features"

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -33,7 +33,7 @@ build() {
   cargo web build
 
   # >>> generated:pkgbuild-build by `cargo generate installers` - do not edit <<<
-  cargo build --frozen --profile dist --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web
+  cargo build --frozen --profile dist --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web
 # >>> end generated:pkgbuild-build <<<
   cargo build --frozen --profile dist -p zerocode
 }

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
         # >>> generated:flake-packages by `cargo generate installers` - do not edit <<<
         # Default feature set: canonical lean Dist.
         # Override with `packages.zeroclaw.override { features = [ ... ]; }`.
-        zeroclawDefaultFeatures = [ "acp-bridge" "agent-runtime" "channel-acp-server" "channel-discord" "channel-email" "channel-filesystem" "channel-lark" "channel-matrix" "channel-telegram" "channel-webhook" "gateway" "observability-prometheus" "schema-export" "whatsapp-web" ];
+        zeroclawDefaultFeatures = [ "acp-bridge" "agent-runtime" "channel-acp-server" "channel-discord" "channel-email" "channel-filesystem" "channel-lark" "channel-matrix" "channel-slack" "channel-telegram" "channel-webhook" "gateway" "observability-prometheus" "schema-export" "whatsapp-web" ];
         buildZeroclaw = { pname, cargoPkg, features ? zeroclawDefaultFeatures }:
           (pkgs.makeRustPlatform {
             cargo = rustToolchain;

--- a/setup.bat
+++ b/setup.bat
@@ -218,7 +218,7 @@ set "BUILD_DESC=minimal (core only, no default features)"
 goto :do_build
 
 :build_dist
-set "FEATURES=--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
+set "FEATURES=--no-default-features --features acp-bridge,agent-runtime,channel-acp-server,channel-discord,channel-email,channel-filesystem,channel-lark,channel-matrix,channel-slack,channel-telegram,channel-webhook,gateway,observability-prometheus,schema-export,whatsapp-web"
 set "BUILD_DESC=dist (lean standard distribution (recommended))"
 goto :do_build
 

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -1429,7 +1429,17 @@ mod tests {
     fn dist_matches_lean_release_contract() {
         let features = resolve_feature_list(&root(), &Selection::Dist).unwrap();
         let mut expected = resolve_feature_list(&root(), &Selection::Full).unwrap();
-        expected.extend(["channel-matrix", "channel-lark", "whatsapp-web"].map(str::to_owned));
+        // Fork deviation: `channel-slack` is shipped in `dist` here. See the
+        // commit that added it for why this does not go upstream (#7952).
+        expected.extend(
+            [
+                "channel-matrix",
+                "channel-lark",
+                "channel-slack",
+                "whatsapp-web",
+            ]
+            .map(str::to_owned),
+        );
         expected.sort();
         expected.dedup();
         assert_eq!(features, expected);


### PR DESCRIPTION
Fork-local deviation. Do not send upstream.

`channel-slack` is only reachable through the `all-features` selection, which builds from Containerfile/StageX with natively-linked features (browser-native, hardware, plugins-wasm-cranelift) that pin it to amd64. Every arm64 tag actually published (`dist`, `dist-vX.Y.Z`, `vX.Y.Z`) comes from the `dist` selection, so an arm64 deployment configured with a Slack channel hits the runtime skip path:

    Slack channel is configured but this build was compiled without
    `channel-slack`; skipping Slack.

Add `channel-slack` to `dist_extra_features`, widen the policy tripwire in `dist_matches_lean_release_contract` to match, and regenerate the derived surfaces. The feature is a pure cfg gate (`channel-slack = []` in zeroclaw-channels) reaching Slack over websocket/HTTP through tungstenite and rustls, both already dependencies of agent-runtime, so it pulls no new crate into the graph and needs no system C library. It is absent from `container_excluded_features`, and `aarch64-unknown-linux-gnu` carries no entry in `dist_target_exclusions`, so nothing strips it back out on that target.

This widens the lean prebuilt contract restored in #9051, which deliberately kept `dist` to the Cargo defaults plus Matrix, Lark and WhatsApp Web. Upstream tracks the broad-channel case in #7952, whose non-goals rule out changing the default bundle, and whose accepted answer is a separate `channels-full` artifact. This commit is therefore a deliberate fork deviation, not a proposal against that decision, and must be rebased rather than upstreamed.

Verified by cross-compiling the arm64 image from the source Dockerfile on CI: the aarch64 binary carries the Socket Mode code path (`apps.connections.open`, `Socket Mode: websocket connected`) and no longer lists `channel-slack` among the channels compiled out.

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2 to 5 bullets; the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type:docs`, `risk:low`, `size:S`, `docs`. During label-spelling
  migration, copy the exact live label spelling from the GitHub UI.

## Testing (required)

### How you can test (when useful)

Include this subsection when reviewer-run manual verification adds useful signal, especially for user-visible behavior, a non-obvious test path, or a named CI coverage gap. For changes without useful manual verification, including docs-only, pure-refactor, or trivial changes, set the first field to `N/A` with a one-line reason and remove the remaining prompts.

When reviewer testing is requested, frame it A/B: the same steps should show the old behavior on `master` and the new behavior on this branch, so the reviewer can see the delta themselves.

- **Reviewer testing requested?** (`Yes` / `N/A`; if `N/A`, one line why)
- **Interface(s) exercised:** Name the surface(s) this touches using the same vocabulary the attribution span records: `surface` (`web` / `tui` / `cli`) and `channel` for messaging surfaces. Match the live attribution values; do not invent interface names.
- **Setup / preconditions:** (config, provider, channel, or state needed first)
- **Steps to run:** (the exact click-through or command sequence)
- **Expected on this branch (after):** (what the reviewer should observe if it works)
- **Prior behavior on `master` (before):** (run the same steps unpatched; what breaks or is missing, so the fix is visible)

### How I tested

Explain how the change was checked. Use the evidence that matches the changed surface: required CI, focused local tests, manual smoke, docs/link gates, or full workspace checks when they prove something narrower evidence would miss. Paste relevant output tails for commands you ran, not "all passed".

Fresh required CI is valid evidence when it covers the changed surface. Add extra validation only for a concrete coverage gap, such as platform-specific tests, cross-platform lint, desktop app coverage, release target builds, or stale/unavailable CI.

```sh
# Rust/code examples; choose the checks that match the changed surface:
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint (`scripts/ci/docs_quality_gate.sh`) and added-link integrity (`scripts/ci/docs_links_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **CI checks relied on and why they cover this change:** (for example, `Docs Style` covers the changed Markdown lines)
- **Known CI coverage gap, if any:** (for example, `None after the docs and links gates`)
- **Commands run and tail output:**
- **Beyond CI, what did you manually verify?** (functional scenarios, edge cases, and any security-relevant behavior; also what you did NOT verify)
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1-2 sentence risk-and-mitigation note. Manual verification of these scenarios goes under `### How I tested`, not here.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- Rust/MSRV/toolchain floor changed? (`Yes/No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users:

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
