### PR TITLE
fix(cli): refuse to run when an agent's shell spawned the process

### DIFF
--- a/crates/zeroclaw-api/src/lib.rs
+++ b/crates/zeroclaw-api/src/lib.rs
@@ -22,6 +22,28 @@ pub mod session_keys;
 pub mod tool;
 pub mod vad;
 
+/// Marks a process spawned by an agent's shell.
+///
+/// Set on every command a tool spawns on a model's behalf; read by the
+/// `zeroclaw` CLI, which refuses to run when it sees it.
+///
+/// The CLI carries the *operator's* authority — it loads and rewrites
+/// `config.toml` with no agent policy anywhere in the process. So an agent that
+/// can execute it does not act with its own privileges, it acts with yours.
+/// `balanced`, the default preset, allows any command name (`allowed_commands =
+/// ["*"]`) and `zeroclaw` is classified low-risk, so nothing else in the policy
+/// stops the call.
+///
+/// Set unconditionally. [`TOOL_LOOP_SESSION_KEY`] looks like the same signal but
+/// is absent on unscoped turns, which would leave exactly the one-shot and
+/// webhook paths unmarked.
+///
+/// This binds the *caller*, not the command name, so copying or renaming the
+/// binary does not shake it off. An agent under a wildcard policy can still
+/// clear the variable deliberately (`env -u`); that is a bar to clear and a
+/// thing to alarm on, not a proof.
+pub const AGENT_SHELL_ENV_VAR: &str = "ZEROCLAW_AGENT_SHELL";
+
 tokio::task_local! {
     /// Current thread/sender ID for per-sender rate limiting.
     /// Set by the agent loop, read by SecurityPolicy.

--- a/crates/zeroclaw-config/src/presets.rs
+++ b/crates/zeroclaw-config/src/presets.rs
@@ -801,4 +801,46 @@ mod tests {
 
         assert!(channel.fields.is_empty());
     }
+
+    /// Why the CLI needs a guard of its own against agent callers.
+    ///
+    /// The risk profile does not stop an agent from invoking `zeroclaw`. On
+    /// `balanced` -- the *default* preset -- every check passes: the command
+    /// name matches the `["*"]` allowlist, `zeroclaw` is in neither the high-
+    /// nor the medium-risk table so the risk gate is inert, and a dotted config
+    /// path is not `looks_like_path`, so no forbidden path argument is found.
+    ///
+    /// The process it reaches carries operator authority with no agent policy
+    /// anywhere in it, so that one call escalates. `locked_down` blocks it only
+    /// incidentally, by having a real allowlist that happens to omit the name.
+    ///
+    /// If `balanced` ever starts refusing, the profile got stricter and this
+    /// test should be re-read rather than the guard deleted: the guard also
+    /// covers hand-rolled wildcard profiles, which no preset change reaches.
+    #[test]
+    fn the_risk_profile_alone_does_not_stop_an_agent_invoking_the_cli() {
+        let escalation = "zeroclaw config set agents.helper.risk_profile yolo";
+        let reaches_cli = |preset: &str| {
+            let profile = (risk_preset(preset).expect("preset in table").values)();
+            let policy = crate::policy::SecurityPolicy::from_risk_profile(
+                &profile,
+                std::path::Path::new("/tmp/zeroclaw-preset-probe"),
+            );
+            policy.validate_command_execution(escalation, false).is_ok()
+        };
+
+        assert!(
+            !reaches_cli("locked_down"),
+            "locked_down has a real allowlist that omits `zeroclaw`"
+        );
+        assert!(
+            reaches_cli("balanced"),
+            "balanced allows any command name, so policy alone cannot stop this \
+             -- the CLI-side guard is what does"
+        );
+        assert!(
+            reaches_cli("yolo"),
+            "yolo may configure things; it already holds that authority"
+        );
+    }
 }

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1168,6 +1168,7 @@ fn build_cron_shell_command(
     cmd.arg("-c")
         .arg(command)
         .current_dir(workspace_dir)
+        .env(zeroclaw_api::AGENT_SHELL_ENV_VAR, "1")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -338,6 +338,12 @@ impl Tool for ShellTool {
             cmd.env(SESSION_ID_ENV_VAR, session_id);
         }
 
+        // Unconditional, unlike the session key above: the `zeroclaw` CLI runs
+        // with the operator's authority and no agent policy anywhere in the
+        // process, so it has to be able to recognise a model caller on every
+        // path, scoped turn or not.
+        cmd.env(zeroclaw_api::AGENT_SHELL_ENV_VAR, "1");
+
         // Overlay TUI env on top of the safe-env snapshot. TUI vars win on
         // conflict — the user's real PATH etc. should take precedence over
         // whatever the daemon process inherited.
@@ -1104,6 +1110,29 @@ mod tests {
         assert!(
             env_output_contains_key(&result.output, "PATH"),
             "PATH should be available in shell environment"
+        );
+    }
+
+    /// The `zeroclaw` CLI refuses to run when it sees this marker, because the
+    /// CLI carries operator authority and an agent invoking it escalates. The
+    /// marker has to be unconditional: `ZEROCLAW_SESSION_ID` looks like the same
+    /// signal but is only set on scoped turns, which would leave one-shot and
+    /// webhook paths silently unmarked.
+    #[tokio::test]
+    async fn shell_marks_every_spawned_command_as_agent_invoked() {
+        let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
+
+        let result = tool
+            .execute(json!({"command": env_print_command()}))
+            .await
+            .expect("environment print command should succeed");
+
+        assert!(result.success);
+        assert!(
+            env_output_contains_key(&result.output, zeroclaw_api::AGENT_SHELL_ENV_VAR),
+            "{} must be set on every agent-spawned command, got: {}",
+            zeroclaw_api::AGENT_SHELL_ENV_VAR,
+            result.output
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/skill_tool.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_tool.rs
@@ -239,6 +239,10 @@ impl Tool for SkillShellTool {
             cmd.env(SESSION_ID_ENV_VAR, session_id);
         }
 
+        // A skill's command template is operator-authored, but the model fills
+        // in its arguments, so this spawns on a model's behalf like any other.
+        cmd.env(zeroclaw_api::AGENT_SHELL_ENV_VAR, "1");
+
         let result =
             tokio::time::timeout(Duration::from_secs(self.timeout_secs), cmd.output()).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,40 @@ fn parse_temperature(s: &str) -> std::result::Result<f64, String> {
     config::schema::validate_temperature(t)
 }
 
+/// Refusal message when this process was spawned by an agent's shell, or `None`
+/// when it was not.
+///
+/// The CLI holds the operator's authority: it loads, decrypts and rewrites
+/// `config.toml`, and no agent policy exists anywhere in the process. An agent
+/// that shells out to it therefore does not act with its own privileges, it
+/// acts with the operator's — `zeroclaw config set agents.x.risk_profile yolo`
+/// escalates in one call. Nothing in the risk profile prevents it: `balanced`,
+/// the default preset, sets `allowed_commands = ["*"]`, and `zeroclaw` is
+/// neither high- nor medium-risk, so the command validates cleanly.
+///
+/// Refuses *every* subcommand rather than the mutating ones. Reads leak too —
+/// `config get` on a secret field decrypts it — and an allowlist that has to
+/// stay correct as subcommands are added is the kind that silently stops being
+/// correct.
+///
+/// Only the value's presence is consulted; an empty value reads as absent so a
+/// stray `export ZEROCLAW_AGENT_SHELL=` does not lock an operator out of their
+/// own CLI. That is not a weakening: an agent that can set the variable empty
+/// can equally `env -u` it, which this never claimed to stop.
+fn agent_shell_refusal(marker: Option<std::ffi::OsString>) -> Option<String> {
+    let marker = marker?;
+    if marker.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "refusing to run: the `zeroclaw` CLI carries operator authority and was invoked from an \
+         agent's shell ({} is set).\n\nAn agent cannot reconfigure ZeroClaw through this command — \
+         doing so would run with your privileges, not the agent's. Run the command yourself in \
+         your own terminal.",
+        zeroclaw_api::AGENT_SHELL_ENV_VAR
+    ))
+}
+
 fn print_no_command_help(cmd: clap::Command) -> Result<()> {
     #[cfg(feature = "agent-runtime")]
     {
@@ -3415,6 +3449,13 @@ async fn async_main(command: clap::Command) -> Result<()> {
     }
 
     let cli = Cli::from_arg_matches(&cmd.get_matches()).map_err(|e| e.exit())?;
+
+    // Before anything reads config or touches disk: this process carries the
+    // operator's authority, so it must not run for an agent.
+    if let Some(refusal) = agent_shell_refusal(std::env::var_os(zeroclaw_api::AGENT_SHELL_ENV_VAR))
+    {
+        bail!(refusal);
+    }
 
     if let Some(config_dir) = &cli.config_dir
         && config_dir.trim().is_empty()

--- a/tests/component/agent_shell_cli_refusal.rs
+++ b/tests/component/agent_shell_cli_refusal.rs
@@ -1,0 +1,104 @@
+//! The `zeroclaw` CLI must refuse to run when an agent's shell spawned it.
+//!
+//! The CLI carries the operator's authority — it loads, decrypts and rewrites
+//! `config.toml`, and no agent policy exists anywhere in the process. So an
+//! agent that shells out to it escalates to the operator in one call:
+//! `zeroclaw config set agents.x.risk_profile yolo`.
+//!
+//! Nothing in the risk profile stops that call. `balanced` — the default preset
+//! — allows any command name, and `zeroclaw` is classified low-risk, so it
+//! passes the allowlist, the risk gate and the path check cleanly. See
+//! `zeroclaw_config::presets` for the matrix that pins this.
+//!
+//! These run the real binary rather than the guard function, because the value
+//! of the guard is entirely in *where* it sits: before config load, before
+//! logging, before any subcommand dispatch.
+
+use std::process::{Command, Output, Stdio};
+
+fn run_cli(args: &[&str], agent_marker: Option<&str>) -> Output {
+    let bin = env!("CARGO_BIN_EXE_zeroclaw");
+    let mut cmd = Command::new(bin);
+    cmd.args(args)
+        .env("RUST_LOG", "off")
+        .env_remove(zeroclaw_api::AGENT_SHELL_ENV_VAR)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(marker) = agent_marker {
+        cmd.env(zeroclaw_api::AGENT_SHELL_ENV_VAR, marker);
+    }
+    cmd.output().expect("zeroclaw binary should spawn")
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+#[test]
+fn config_set_is_refused_when_spawned_by_an_agent_shell() {
+    let output = run_cli(
+        &["config", "set", "agents.helper.risk_profile", "yolo"],
+        Some("1"),
+    );
+
+    assert!(
+        !output.status.success(),
+        "the escalating command must fail, got success"
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("operator authority"),
+        "refusal should say why, got: {stderr}"
+    );
+}
+
+#[test]
+fn every_subcommand_is_refused_not_just_the_mutating_ones() {
+    // `config get` on a secret decrypts it, so reads exfiltrate as surely as
+    // writes escalate. An allowlist of "safe" subcommands is one new subcommand
+    // away from being wrong.
+    for args in [
+        vec!["config", "get", "agents.helper.model_provider"],
+        vec!["config", "list"],
+        vec!["agent", "-a", "helper", "-m", "hello"],
+    ] {
+        let output = run_cli(&args, Some("1"));
+        assert!(
+            !output.status.success(),
+            "`{}` must be refused from an agent shell",
+            args.join(" ")
+        );
+        assert!(
+            stderr_of(&output).contains("operator authority"),
+            "`{}` should fail with the refusal, not something incidental",
+            args.join(" ")
+        );
+    }
+}
+
+#[test]
+fn an_operator_terminal_is_unaffected() {
+    // The same command without the marker must not hit the guard. It may still
+    // fail for its own reasons (no config in this environment), so assert on
+    // the absence of the refusal rather than on success.
+    let output = run_cli(&["config", "get", "agents.helper.model_provider"], None);
+
+    assert!(
+        !stderr_of(&output).contains("operator authority"),
+        "an operator's own terminal must never see the agent refusal: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn an_empty_marker_reads_as_absent() {
+    // A stray `export ZEROCLAW_AGENT_SHELL=` must not lock an operator out.
+    let output = run_cli(&["config", "get", "agents.helper.model_provider"], Some(""));
+
+    assert!(
+        !stderr_of(&output).contains("operator authority"),
+        "empty marker should not trip the guard: {}",
+        stderr_of(&output)
+    );
+}

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -1,3 +1,4 @@
+mod agent_shell_cli_refusal;
 #[cfg(feature = "agent-runtime")]
 mod config_dir_locale_regression;
 mod config_patch_cli;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `zeroclaw` CLI carries the operator's authority — it loads, decrypts and rewrites `config.toml`, and no agent policy exists anywhere in the process. An agent that shells out to it therefore acts with the operator's privileges, not its own, and `zeroclaw config set agents.x.risk_profile yolo` is a one-call escalation. Nothing in the risk profile prevents it: on `balanced` (the default preset) the call passes every gate — the command name matches the `["*"]` allowlist, `zeroclaw` is in neither the high- nor medium-risk table so the risk gate is inert, and a dotted config path is not `looks_like_path` so no forbidden-path argument is found. `locked_down` blocks it only incidentally, by having a real allowlist that omits the name.
- The shell tool, skill tools, and cron shell jobs now set `ZEROCLAW_AGENT_SHELL` on every command they spawn, and the CLI refuses to run when it sees it. Deliberately **not** keyed on the existing `ZEROCLAW_SESSION_ID`, which is only injected on scoped turns and would leave one-shot and webhook paths silently unmarked.
- The check binds the caller, not the command name, so copying or renaming the binary does not shake it off. It refuses **every** subcommand rather than a "safe" subset — `config get` on a secret decrypts it, so reads exfiltrate as surely as writes escalate.
- A new `presets` test pins the escalation matrix (`locked_down` refused, `balanced`/`yolo` allowed), so the justification for this guard is checkable rather than asserted.
- **Scope boundary:** Does not change the risk-profile model, the allowlist, or `balanced`'s `allowed_commands = ["*"]`. It adds one refusal at the CLI entry point plus the env marker on agent-spawned commands.
- **Blast radius:** The CLI's pre-dispatch path and the three command-spawning sites (shell tool, skill tools, cron). An operator's own terminal is unaffected (no marker present); an empty marker is treated as absent so a stray `export ZEROCLAW_AGENT_SHELL=` cannot lock the operator out.
- **Linked issue(s):** None.
- **Labels:** `bug`, `core`, `config`, `cron`, `runtime`, `tests`, `domain:security`, `tool:shell`, `risk:high`, `size:S`, `cli`, `distinguished contributor`, `needs-author-action`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `surface: cli`
- **Setup / preconditions:** A configured install with a `balanced` agent.
- **Steps to run:** From inside an agent turn, have the agent run a shell command that invokes `zeroclaw config set …` (or set `ZEROCLAW_AGENT_SHELL=1` in the environment and run any `zeroclaw` subcommand manually to simulate the spawned context).
- **Expected on this branch (after):** The CLI refuses with a message explaining it will not run when spawned by an agent shell; nothing is read or written.
- **Prior behavior on `master` (before):** The same `zeroclaw config set agents.x.risk_profile yolo` succeeds and escalates the agent to operator authority.

### How I tested

- **CI checks relied on and why they cover this change:** `cargo test` (the `presets` matrix test and the CLI refusal component tests), `clippy`, `fmt`.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```
cargo test -p zeroclaw-config -p zeroclaw-runtime
test result: ok. 1193 passed; 0 failed
test result: ok. 3483 passed; 0 failed; 2 ignored
cargo test --test component  →  214 passed
```

- **Beyond CI, what did you manually verify?** Mutation-proven both ways: removing the CLI guard fails the two refusal tests while leaving the two negative controls (operator terminal unaffected, empty marker treated as absent) green; dropping the env marker fails the shell-tool test.
- **Limits I did NOT verify away:** an agent under a wildcard policy can `env -u ZEROCLAW_AGENT_SHELL` and get through — this raises the bar and turns a silent success into a deliberate act, it is not a proof. The deeper issue is that `balanced` sets `allowed_commands = ["*"]`, which makes *no* command-name control fully reliable; the CLI is the instance found, not the whole class.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** (it removes an unintended one).
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: This PR closes a privilege-escalation path (agent → operator authority via the CLI). Mitigation is the env-marker refusal described above; the residual `env -u` bypass is documented, not hidden.
