### PR TITLE
feat(cron/heartbeat): state the delivery contract to autonomous turns

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -60,6 +60,70 @@ pub fn is_no_reply_sentinel(output: &str) -> bool {
     false
 }
 
+/// The delivery contract stated to an autonomous cron turn.
+///
+/// A cron turn has no live reader: nothing the model writes is streamed to a
+/// person, and whether the final message reaches anyone at all is decided by
+/// `delivery`, which the model cannot see. Without this the agent cannot tell
+/// "I reported it" from "I wrote it where nobody looks", and the `NO_REPLY`
+/// sentinel honored below is unreachable on purpose — only by accident of
+/// phrasing.
+///
+/// Kept beside [`announce_delivery_decision`] deliberately: the text promises
+/// behavior that function implements, and a test pins the two together.
+///
+/// `destination` is the resolved answer to "where does the final message go":
+/// `None` when it reaches nobody, `Some(channel)` when it is sent there once
+/// the run ends. An empty name renders as "the configured channel" so a
+/// half-configured delivery still states the contract.
+#[must_use]
+pub(crate) fn delivery_contract(destination: Option<&str>) -> String {
+    let Some(channel) = destination else {
+        return "Delivery: no one reads this turn as you write it, and your final \
+message is not delivered to anyone — it is recorded in this run's history only. \
+To reach a person you must call a tool that sends a message. Do not state that you \
+have notified, alerted, messaged, or replied to anyone unless you actually called \
+such a tool in this turn."
+            .to_string();
+    };
+
+    let named = match channel.trim() {
+        "" => "the configured channel".to_string(),
+        channel => format!("the {channel} channel"),
+    };
+
+    format!(
+        "Delivery: no one reads this turn as you write it. When the run ends your \
+final message is sent to {named}, so write it as a standalone report rather \
+than a reply. If there is nothing worth reporting, answer with exactly NO_REPLY and \
+nothing is sent. To surface a problem an operator should see, answer \
+NO_REPLY[FAIL]: <reason> or NO_REPLY[REFUSE]: <reason> — those ARE delivered."
+    )
+}
+
+/// Where a cron job's final message goes. Announce mode sends to the
+/// configured channel; every other mode reaches nobody.
+#[must_use]
+fn cron_delivery_destination(delivery: &DeliveryConfig) -> Option<&str> {
+    delivery
+        .mode
+        .eq_ignore_ascii_case("announce")
+        .then(|| delivery.channel.as_deref().unwrap_or(""))
+}
+
+/// The full prompt an autonomous cron turn receives: the origin prefix, the
+/// operator's own prompt, then the delivery contract.
+#[must_use]
+fn cron_turn_prompt(job: &CronJob) -> String {
+    let name = job.name.clone().unwrap_or_else(|| "cron-job".to_string());
+    let prompt = job.prompt.clone().unwrap_or_default();
+    format!(
+        "[cron:{} {name}] {prompt}\n\n{}",
+        job.id,
+        delivery_contract(cron_delivery_destination(&job.delivery))
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnnounceDecision {
     /// Send the output to the configured channel.
@@ -760,10 +824,7 @@ async fn run_agent_job(
             "blocked by security policy: action budget exhausted".to_string(),
         );
     }
-    let name = job.name.clone().unwrap_or_else(|| "cron-job".to_string());
-    let prompt = job.prompt.clone().unwrap_or_default();
-
-    let prefixed_prompt = format!("[cron:{} {name}] {prompt}", job.id);
+    let prefixed_prompt = cron_turn_prompt(job);
     let model_override = job.model.clone();
 
     let mut cron_config = config.clone();
@@ -1219,6 +1280,162 @@ mod tests {
     use zeroclaw_config::schema::Config;
 
     const TEST_AGENT: &str = "test-agent";
+
+    fn announce_delivery() -> DeliveryConfig {
+        DeliveryConfig {
+            mode: "announce".to_string(),
+            channel: Some("telegram".to_string()),
+            to: Some("12345".to_string()),
+            ..DeliveryConfig::default()
+        }
+    }
+
+    #[test]
+    fn delivery_contract_for_announce_names_the_destination_and_the_sentinel() {
+        let contract = delivery_contract(cron_delivery_destination(&announce_delivery()));
+        assert!(
+            contract.contains("telegram"),
+            "names the destination channel"
+        );
+        assert!(
+            contract.contains("NO_REPLY"),
+            "names the suppression sentinel"
+        );
+    }
+
+    #[test]
+    fn delivery_contract_for_announce_marks_escalating_kinds_as_delivered() {
+        let contract = delivery_contract(cron_delivery_destination(&announce_delivery()));
+        assert!(contract.contains("NO_REPLY[FAIL]"));
+        assert!(contract.contains("NO_REPLY[REFUSE]"));
+    }
+
+    #[test]
+    fn delivery_contract_without_announce_says_the_reply_reaches_nobody() {
+        let contract = delivery_contract(cron_delivery_destination(&DeliveryConfig::default()));
+        assert!(
+            contract.contains("not delivered"),
+            "must state plainly that the final message reaches nobody, got: {contract}"
+        );
+        assert!(
+            contract.contains("history"),
+            "must say where the text does go, got: {contract}"
+        );
+        assert!(
+            contract.contains("call a tool that sends"),
+            "must name the only way to actually reach a person, got: {contract}"
+        );
+    }
+
+    #[test]
+    fn delivery_contract_defaults_to_the_non_delivering_form() {
+        // `DeliveryConfig::default()` is mode="none", so the undelivered
+        // contract is what an unconfigured cron job actually gets.
+        assert_eq!(DeliveryConfig::default().mode, "none");
+        assert_eq!(
+            delivery_contract(cron_delivery_destination(&DeliveryConfig::default())),
+            delivery_contract(cron_delivery_destination(&DeliveryConfig {
+                mode: "none".to_string(),
+                ..DeliveryConfig::default()
+            }))
+        );
+    }
+
+    #[test]
+    fn delivery_contract_for_announce_without_a_channel_still_states_the_sentinel() {
+        let contract = delivery_contract(cron_delivery_destination(&DeliveryConfig {
+            mode: "announce".to_string(),
+            channel: None,
+            to: None,
+            ..DeliveryConfig::default()
+        }));
+        assert!(contract.contains("NO_REPLY"));
+    }
+
+    /// The prompt and the delivery path must agree. If the sentinel the
+    /// contract instructs the model to use stopped being the one
+    /// `announce_delivery_decision` honors, the agent would be following
+    /// documented advice that silently no longer works.
+    #[test]
+    fn the_sentinel_the_contract_names_is_the_one_the_delivery_path_honors() {
+        let contract = delivery_contract(cron_delivery_destination(&announce_delivery()));
+
+        assert!(contract.contains("NO_REPLY"));
+        assert!(
+            !announce_delivery_decision("NO_REPLY").should_deliver(),
+            "the bare sentinel the contract names must suppress delivery"
+        );
+
+        assert!(contract.contains("NO_REPLY[FAIL]"));
+        assert!(
+            announce_delivery_decision("NO_REPLY[FAIL]: disk full").should_deliver(),
+            "the contract promises FAIL is delivered"
+        );
+        assert!(contract.contains("NO_REPLY[REFUSE]"));
+        assert!(
+            announce_delivery_decision("NO_REPLY[REFUSE]: not permitted").should_deliver(),
+            "the contract promises REFUSE is delivered"
+        );
+    }
+
+    #[test]
+    fn cron_delivery_destination_is_none_unless_announce() {
+        assert_eq!(cron_delivery_destination(&DeliveryConfig::default()), None);
+        assert_eq!(
+            cron_delivery_destination(&announce_delivery()),
+            Some("telegram")
+        );
+        // Announce with no channel still counts as delivering; the contract
+        // renders the unnamed destination rather than claiming nobody reads it.
+        assert_eq!(
+            cron_delivery_destination(&DeliveryConfig {
+                mode: "announce".to_string(),
+                channel: None,
+                ..DeliveryConfig::default()
+            }),
+            Some("")
+        );
+    }
+
+    /// Heartbeat resolves delivery as `Option<(channel, target)>` and
+    /// auto-detects a channel when unconfigured, so its default is the
+    /// opposite of cron's: it usually DOES deliver. The shared contract has
+    /// to render that shape correctly.
+    #[test]
+    fn delivery_contract_renders_the_heartbeat_destination_shape() {
+        let resolved: Option<(String, String)> = Some(("discord".into(), "99".into()));
+        let contract = delivery_contract(resolved.as_ref().map(|(channel, _)| channel.as_str()));
+        assert!(contract.contains("discord"));
+        assert!(contract.contains("NO_REPLY"));
+
+        let unresolved: Option<(String, String)> = None;
+        let contract = delivery_contract(unresolved.as_ref().map(|(channel, _)| channel.as_str()));
+        assert!(contract.contains("not delivered"));
+    }
+
+    #[test]
+    fn cron_turn_prompt_keeps_the_origin_prefix_and_appends_the_contract() {
+        let mut job = test_job("unused");
+        job.job_type = JobType::Agent;
+        job.name = Some("build-watch".to_string());
+        job.prompt = Some("check the build".to_string());
+        job.delivery = DeliveryConfig::default();
+
+        let prompt = cron_turn_prompt(&job);
+
+        assert!(
+            prompt.contains(&format!("[cron:{} build-watch]", job.id)),
+            "origin prefix is preserved, got: {prompt}"
+        );
+        assert!(
+            prompt.contains("check the build"),
+            "operator prompt survives"
+        );
+        assert!(
+            prompt.contains(&delivery_contract(cron_delivery_destination(&job.delivery))),
+            "the delivery contract is stated to the model"
+        );
+    }
 
     #[test]
     fn is_no_reply_sentinel_matches_bare_form_case_insensitively() {

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -60,6 +60,87 @@ pub fn is_no_reply_sentinel(output: &str) -> bool {
     false
 }
 
+/// The delivery contract stated to an autonomous cron turn.
+///
+/// A cron turn has no live reader: nothing the model writes is streamed to a
+/// person, and whether the final message reaches anyone at all is decided by
+/// `delivery`, which the model cannot see. Without this the agent cannot tell
+/// "I reported it" from "I wrote it where nobody looks", and the `NO_REPLY`
+/// sentinel honored below is unreachable on purpose — only by accident of
+/// phrasing.
+///
+/// Kept beside [`announce_delivery_decision`] deliberately: the text promises
+/// behavior that function implements, and a test pins the two together.
+///
+/// `destination` is the resolved answer to "where does the final message go":
+/// `None` when it reaches nobody, `Some(channel)` when it is sent there once
+/// the run ends. Callers must resolve `None` for any state in which delivery
+/// will fail, not merely for "delivery is switched off" — to the model those
+/// are the same situation. An empty name renders as "the configured channel":
+/// a job whose channel is set but unresolvable is delivery-attempted the same
+/// way a dangling channel reference is, which the scheduler tolerates by
+/// design.
+#[must_use]
+pub(crate) fn delivery_contract(destination: Option<&str>) -> String {
+    let Some(channel) = destination else {
+        return "Delivery: no one reads this turn as you write it, and your final \
+message is not delivered to anyone — it is recorded in this run's history only. \
+To reach a person you must call a tool that sends a message. Do not state that you \
+have notified, alerted, messaged, or replied to anyone unless you actually called \
+such a tool in this turn."
+            .to_string();
+    };
+
+    let named = match channel.trim() {
+        "" => "the configured channel".to_string(),
+        channel => format!("the {channel} channel"),
+    };
+
+    format!(
+        "Delivery: no one reads this turn as you write it. When the run ends your \
+final message is sent to {named}, so write it as a standalone report rather \
+than a reply. If there is nothing worth reporting, answer with exactly NO_REPLY and \
+nothing is sent. To surface a problem an operator should see, answer \
+NO_REPLY[FAIL]: <reason> or NO_REPLY[REFUSE]: <reason> — those ARE delivered."
+    )
+}
+
+/// Where a cron job's final message goes. Announce mode sends to the
+/// configured channel; every other mode reaches nobody.
+///
+/// Mirrors the validity conditions [`deliver_if_configured`] actually enforces:
+/// announce delivers only when **both** `channel` and `to` are set. With either
+/// missing the send is refused with an error and the message reaches nobody, so
+/// promising delivery would be a lie the model cannot check. Add-time
+/// validation rejects those jobs, but stored and hand-edited jobs still reach
+/// the scheduler in that state. `to` never appears in the prompt — only its
+/// presence matters, because its absence decides whether anyone is reached.
+///
+/// `delivery_contract_promises_delivery_only_when_delivery_happens` pins this
+/// against the real delivery path so the two cannot drift.
+#[must_use]
+fn cron_delivery_destination(delivery: &DeliveryConfig) -> Option<&str> {
+    if !delivery.mode.eq_ignore_ascii_case("announce") {
+        return None;
+    }
+    let channel = delivery.channel.as_deref()?;
+    delivery.to.as_deref()?;
+    Some(channel)
+}
+
+/// The full prompt an autonomous cron turn receives: the origin prefix, the
+/// operator's own prompt, then the delivery contract.
+#[must_use]
+fn cron_turn_prompt(job: &CronJob) -> String {
+    let name = job.name.clone().unwrap_or_else(|| "cron-job".to_string());
+    let prompt = job.prompt.clone().unwrap_or_default();
+    format!(
+        "[cron:{} {name}] {prompt}\n\n{}",
+        job.id,
+        delivery_contract(cron_delivery_destination(&job.delivery))
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnnounceDecision {
     /// Send the output to the configured channel.
@@ -818,10 +899,7 @@ async fn run_agent_job(
             "blocked by security policy: action budget exhausted".to_string(),
         );
     }
-    let name = job.name.clone().unwrap_or_else(|| "cron-job".to_string());
-    let prompt = job.prompt.clone().unwrap_or_default();
-
-    let prefixed_prompt = format!("[cron:{} {name}] {prompt}", job.id);
+    let prefixed_prompt = cron_turn_prompt(job);
     let model_override = job.model.clone();
 
     let mut cron_config = config.clone();
@@ -1316,6 +1394,225 @@ mod tests {
     ) -> anyhow::Result<tokio::process::Command> {
         let runtime = crate::platform::create_runtime(&config.runtime)?;
         runtime.build_shell_command(command, workspace_dir)
+    }
+
+    fn announce_delivery() -> DeliveryConfig {
+        DeliveryConfig {
+            mode: "announce".to_string(),
+            channel: Some("telegram".to_string()),
+            to: Some("12345".to_string()),
+            ..DeliveryConfig::default()
+        }
+    }
+
+    #[test]
+    fn delivery_contract_for_announce_names_the_destination_and_the_sentinel() {
+        let contract = delivery_contract(cron_delivery_destination(&announce_delivery()));
+        assert!(
+            contract.contains("telegram"),
+            "names the destination channel"
+        );
+        assert!(
+            contract.contains("NO_REPLY"),
+            "names the suppression sentinel"
+        );
+    }
+
+    #[test]
+    fn delivery_contract_for_announce_marks_escalating_kinds_as_delivered() {
+        let contract = delivery_contract(cron_delivery_destination(&announce_delivery()));
+        assert!(contract.contains("NO_REPLY[FAIL]"));
+        assert!(contract.contains("NO_REPLY[REFUSE]"));
+    }
+
+    #[test]
+    fn delivery_contract_without_announce_says_the_reply_reaches_nobody() {
+        let contract = delivery_contract(cron_delivery_destination(&DeliveryConfig::default()));
+        assert!(
+            contract.contains("not delivered"),
+            "must state plainly that the final message reaches nobody, got: {contract}"
+        );
+        assert!(
+            contract.contains("history"),
+            "must say where the text does go, got: {contract}"
+        );
+        assert!(
+            contract.contains("call a tool that sends"),
+            "must name the only way to actually reach a person, got: {contract}"
+        );
+    }
+
+    #[test]
+    fn delivery_contract_defaults_to_the_non_delivering_form() {
+        // `DeliveryConfig::default()` is mode="none", so the undelivered
+        // contract is what an unconfigured cron job actually gets.
+        assert_eq!(DeliveryConfig::default().mode, "none");
+        assert_eq!(
+            delivery_contract(cron_delivery_destination(&DeliveryConfig::default())),
+            delivery_contract(cron_delivery_destination(&DeliveryConfig {
+                mode: "none".to_string(),
+                ..DeliveryConfig::default()
+            }))
+        );
+    }
+
+    /// An announce job missing a required field is refused by
+    /// `deliver_if_configured`, so nobody receives the final message. The
+    /// model must be told that, not handed the delivering contract — and not
+    /// told to use `NO_REPLY`, which only means anything on a path that
+    /// delivers.
+    #[test]
+    fn delivery_contract_for_incomplete_announce_says_the_reply_reaches_nobody() {
+        for (label, delivery) in [
+            (
+                "no channel, no target",
+                DeliveryConfig {
+                    mode: "announce".to_string(),
+                    channel: None,
+                    to: None,
+                    ..DeliveryConfig::default()
+                },
+            ),
+            (
+                "no channel",
+                DeliveryConfig {
+                    mode: "announce".to_string(),
+                    channel: None,
+                    to: Some("12345".to_string()),
+                    ..DeliveryConfig::default()
+                },
+            ),
+            (
+                "no target",
+                DeliveryConfig {
+                    mode: "announce".to_string(),
+                    channel: Some("telegram".to_string()),
+                    to: None,
+                    ..DeliveryConfig::default()
+                },
+            ),
+        ] {
+            let contract = delivery_contract(cron_delivery_destination(&delivery));
+            assert!(
+                contract.contains("not delivered"),
+                "announce with {label} cannot promise delivery, got: {contract}"
+            );
+            assert!(
+                !contract.contains("NO_REPLY"),
+                "announce with {label} must not offer a sentinel that does nothing, got: {contract}"
+            );
+        }
+    }
+
+    /// The prompt and the delivery path must agree. If the sentinel the
+    /// contract instructs the model to use stopped being the one
+    /// `announce_delivery_decision` honors, the agent would be following
+    /// documented advice that silently no longer works.
+    #[test]
+    fn the_sentinel_the_contract_names_is_the_one_the_delivery_path_honors() {
+        let contract = delivery_contract(cron_delivery_destination(&announce_delivery()));
+
+        assert!(contract.contains("NO_REPLY"));
+        assert!(
+            !announce_delivery_decision("NO_REPLY").should_deliver(),
+            "the bare sentinel the contract names must suppress delivery"
+        );
+
+        assert!(contract.contains("NO_REPLY[FAIL]"));
+        assert!(
+            announce_delivery_decision("NO_REPLY[FAIL]: disk full").should_deliver(),
+            "the contract promises FAIL is delivered"
+        );
+        assert!(contract.contains("NO_REPLY[REFUSE]"));
+        assert!(
+            announce_delivery_decision("NO_REPLY[REFUSE]: not permitted").should_deliver(),
+            "the contract promises REFUSE is delivered"
+        );
+    }
+
+    #[test]
+    fn cron_delivery_destination_requires_announce_and_every_field_delivery_needs() {
+        assert_eq!(cron_delivery_destination(&DeliveryConfig::default()), None);
+        assert_eq!(
+            cron_delivery_destination(&announce_delivery()),
+            Some("telegram")
+        );
+
+        // Announce is necessary but not sufficient: `deliver_if_configured`
+        // refuses the send when either required field is absent, so a
+        // half-configured job reaches nobody.
+        assert_eq!(
+            cron_delivery_destination(&DeliveryConfig {
+                mode: "announce".to_string(),
+                channel: None,
+                to: Some("12345".to_string()),
+                ..DeliveryConfig::default()
+            }),
+            None,
+            "announce without a channel is refused at delivery"
+        );
+        assert_eq!(
+            cron_delivery_destination(&DeliveryConfig {
+                mode: "announce".to_string(),
+                channel: Some("telegram".to_string()),
+                to: None,
+                ..DeliveryConfig::default()
+            }),
+            None,
+            "announce without a target is refused at delivery"
+        );
+
+        // A set-but-unresolvable channel IS delivery-attempted (dangling refs
+        // are tolerated by design), so it keeps the delivering contract.
+        assert_eq!(
+            cron_delivery_destination(&DeliveryConfig {
+                mode: "announce".to_string(),
+                channel: Some(String::new()),
+                to: Some("12345".to_string()),
+                ..DeliveryConfig::default()
+            }),
+            Some("")
+        );
+    }
+
+    /// Heartbeat resolves delivery as `Option<(channel, target)>` and
+    /// auto-detects a channel when unconfigured, so its default is the
+    /// opposite of cron's: it usually DOES deliver. The shared contract has
+    /// to render that shape correctly.
+    #[test]
+    fn delivery_contract_renders_the_heartbeat_destination_shape() {
+        let resolved: Option<(String, String)> = Some(("discord".into(), "99".into()));
+        let contract = delivery_contract(resolved.as_ref().map(|(channel, _)| channel.as_str()));
+        assert!(contract.contains("discord"));
+        assert!(contract.contains("NO_REPLY"));
+
+        let unresolved: Option<(String, String)> = None;
+        let contract = delivery_contract(unresolved.as_ref().map(|(channel, _)| channel.as_str()));
+        assert!(contract.contains("not delivered"));
+    }
+
+    #[test]
+    fn cron_turn_prompt_keeps_the_origin_prefix_and_appends_the_contract() {
+        let mut job = test_job("unused");
+        job.job_type = JobType::Agent;
+        job.name = Some("build-watch".to_string());
+        job.prompt = Some("check the build".to_string());
+        job.delivery = DeliveryConfig::default();
+
+        let prompt = cron_turn_prompt(&job);
+
+        assert!(
+            prompt.contains(&format!("[cron:{} build-watch]", job.id)),
+            "origin prefix is preserved, got: {prompt}"
+        );
+        assert!(
+            prompt.contains("check the build"),
+            "operator prompt survives"
+        );
+        assert!(
+            prompt.contains(&delivery_contract(cron_delivery_destination(&job.delivery))),
+            "the delivery contract is stated to the model"
+        );
     }
 
     #[test]
@@ -2878,6 +3175,13 @@ mod tests {
     /// Channel name the recorder counts. Used only by the suppression test.
     const COUNT_CHANNEL: &str = "count-delivery";
 
+    static CONTRACT_DELIVERED: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    /// Separate channel and counter for the contract/delivery agreement test,
+    /// so its before/after deltas cannot race the suppression test's.
+    const CONTRACT_CHANNEL: &str = "contract-delivery";
+
     fn register_recording_delivery_fn() {
         // Idempotent: register_delivery_fn is a no-op once the OnceLock is set,
         // so repeated calls across tests are safe and the first writer wins. The
@@ -2890,6 +3194,9 @@ mod tests {
                 }
                 if channel == COUNT_CHANNEL {
                     DELIVERED.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
+                if channel == CONTRACT_CHANNEL {
+                    CONTRACT_DELIVERED.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 }
                 Ok(())
             })
@@ -2953,6 +3260,64 @@ mod tests {
                 DELIVERED.load(SeqCst),
                 before + 1,
                 "failure/refusal kind {visible:?} must be delivered, not suppressed"
+            );
+        }
+    }
+
+    /// The prompt must promise delivery exactly when delivery happens.
+    ///
+    /// Deliberately derives the expectation from running the real
+    /// `deliver_if_configured` rather than restating
+    /// `cron_delivery_destination`'s rules — a test that only re-encodes the
+    /// resolver would have agreed with the bug it is here to prevent, where
+    /// announce-without-a-required-field was told its report "is sent" while
+    /// the send was refused with an error.
+    #[tokio::test]
+    async fn delivery_contract_promises_delivery_only_when_delivery_happens() {
+        use std::sync::atomic::Ordering::SeqCst;
+        register_recording_delivery_fn();
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp).await;
+
+        let complete = || DeliveryConfig {
+            mode: "announce".to_string(),
+            channel: Some(CONTRACT_CHANNEL.to_string()),
+            to: Some("chat-id".to_string()),
+            thread_id: None,
+            best_effort: true,
+        };
+
+        for (label, delivery) in [
+            ("mode none", DeliveryConfig::default()),
+            ("announce, fully configured", complete()),
+            (
+                "announce, no target",
+                DeliveryConfig {
+                    to: None,
+                    ..complete()
+                },
+            ),
+            (
+                "announce, no channel",
+                DeliveryConfig {
+                    channel: None,
+                    ..complete()
+                },
+            ),
+        ] {
+            let promised = cron_delivery_destination(&delivery).is_some();
+
+            let mut job = test_job("echo ok");
+            job.delivery = delivery;
+
+            let before = CONTRACT_DELIVERED.load(SeqCst);
+            let sent = deliver_if_configured(&config, &job, "a real report").await;
+            let actually_delivered = sent.is_ok() && CONTRACT_DELIVERED.load(SeqCst) == before + 1;
+
+            assert_eq!(
+                promised, actually_delivered,
+                "{label}: prompt promises delivery={promised} but delivery \
+                 actually happened={actually_delivered}"
             );
         }
     }

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1846,6 +1846,16 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 Some(sc) => format!("{sc}\n\n{task_prompt}"),
                 None => task_prompt,
             };
+            // Appended, never prepended: heartbeat delivery is resolved from
+            // config (and auto-detects a channel when unset), so unlike cron
+            // this turn usually IS broadcast — the model has to know that
+            // before it writes an internal-sounding worklog.
+            let prompt = format!(
+                "{prompt}\n\n{}",
+                crate::cron::scheduler::delivery_contract(
+                    delivery.as_ref().map(|(channel, _)| channel.as_str())
+                )
+            );
             let temp: Option<f64> = config
                 .model_provider_for_agent(&agent_alias)
                 .and_then(|e| e.temperature);

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -2049,10 +2049,8 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
             // Daemon origin (agent::memory_inject): Conversation entries are
             // excluded for scheduled origins. `heartbeat_memory` stays for
             // the post-run auto-save consolidation below.
-            let prompt = match &session_context {
-                Some(sc) => format!("{sc}\n\n{task_prompt}"),
-                None => task_prompt,
-            };
+            let prompt =
+                heartbeat_turn_prompt(session_context.as_deref(), &task_prompt, delivery.as_ref());
             let temp: Option<f64> = config
                 .model_provider_for_agent(&agent_alias)
                 .and_then(|e| e.temperature);
@@ -2271,6 +2269,37 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
             sleep_mins = base_interval;
         }
     }
+}
+
+/// The full prompt an autonomous heartbeat turn receives: the optional session
+/// context, the origin-marked task, then the delivery contract.
+///
+/// The contract is **appended, never prepended**. Heartbeat delivery is
+/// resolved from config (auto-detecting a channel when unset), so unlike cron
+/// this turn usually IS broadcast, and the model has to know that before it
+/// writes an internal-sounding worklog. Prepending would also move the
+/// `[Heartbeat Task` marker off the front of the string, which
+/// `zeroclaw_memory::should_skip_autosave_content` tests position-dependently.
+///
+/// `delivery` is the *same* resolved `Option<(channel, target)>` that gates the
+/// real `deliver_announcement` call in the worker, so the contract cannot
+/// promise a send the worker will not perform. Passing it in rather than
+/// re-deriving it is what makes that impossible rather than merely true today;
+/// `heartbeat_contract_tracks_the_value_that_gates_the_real_send` pins it.
+#[must_use]
+fn heartbeat_turn_prompt(
+    session_context: Option<&str>,
+    task_prompt: &str,
+    delivery: Option<&(String, String)>,
+) -> String {
+    let prompt = match session_context {
+        Some(sc) => format!("{sc}\n\n{task_prompt}"),
+        None => task_prompt.to_string(),
+    };
+    format!(
+        "{prompt}\n\n{}",
+        crate::cron::scheduler::delivery_contract(delivery.map(|(channel, _)| channel.as_str()))
+    )
 }
 
 /// Resolve delivery target: explicit config > auto-detect first configured channel.
@@ -3296,6 +3325,138 @@ mod tests {
             },
         );
         assert!(has_supervised_channels(&config));
+    }
+
+    /// The heartbeat prompt must carry three things at once: the origin marker
+    /// autosave filtering keys on, the operator's task, and the delivery
+    /// contract — with the marker still at the front of the string.
+    #[test]
+    fn heartbeat_turn_prompt_states_the_contract_without_displacing_the_origin_marker() {
+        let task_prompt = "[Heartbeat Task | high] check the build";
+        let delivery = ("discord".to_string(), "99".to_string());
+
+        let prompt = heartbeat_turn_prompt(None, task_prompt, Some(&delivery));
+
+        assert!(
+            prompt.starts_with("[Heartbeat Task |"),
+            "origin marker must stay at the front: should_skip_autosave_content \
+             is a position-dependent prefix test, got: {prompt}"
+        );
+        assert!(prompt.contains("check the build"), "the task survives");
+        assert!(
+            prompt.contains("discord"),
+            "names the resolved destination, got: {prompt}"
+        );
+        assert!(
+            prompt.contains("NO_REPLY"),
+            "names the suppression sentinel, got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn heartbeat_turn_prompt_without_delivery_says_the_reply_reaches_nobody() {
+        let prompt = heartbeat_turn_prompt(None, "[Heartbeat Task | low] tidy up", None);
+        assert!(
+            prompt.contains("not delivered"),
+            "must state plainly that nobody receives it, got: {prompt}"
+        );
+        assert!(
+            !prompt.contains("NO_REPLY"),
+            "must not offer a sentinel that does nothing on a non-delivering \
+             path, got: {prompt}"
+        );
+    }
+
+    /// Session context is prepended by the worker before the contract is
+    /// appended. Only the append is this function's contract; the context
+    /// displacing the `[Heartbeat Task` marker is pre-existing behavior of the
+    /// `load_session_context` path (and the reason autosave suppression misses
+    /// those turns) — deliberately not pinned here, so fixing it does not have
+    /// to fight a test asserting the broken shape is correct.
+    #[test]
+    fn heartbeat_turn_prompt_keeps_session_context_and_still_appends_the_contract() {
+        let delivery = ("slack".to_string(), "C123".to_string());
+        let prompt = heartbeat_turn_prompt(
+            Some("[Memory context] earlier messages"),
+            "[Heartbeat Task | high] check the build",
+            Some(&delivery),
+        );
+
+        assert!(prompt.contains("earlier messages"), "context survives");
+        assert!(prompt.contains("check the build"), "task survives");
+        assert!(
+            prompt
+                .trim_end()
+                .ends_with(&crate::cron::scheduler::delivery_contract(Some("slack"))),
+            "contract is appended last, got: {prompt}"
+        );
+    }
+
+    /// The contract the model reads must agree with the value that actually
+    /// gates the send.
+    ///
+    /// The worker calls `deliver_announcement` only under
+    /// `if let Some((channel, target)) = &delivery`, and hands that same
+    /// binding to `heartbeat_turn_prompt`. This pins the half that could still
+    /// drift — `Some`/`None` mapping to the delivering/non-delivering form —
+    /// which is precisely the defect that existed on the cron side, where the
+    /// prompt promised delivery for states the send refused. The config→
+    /// `Option` half is covered by the `resolve_delivery_*` tests above.
+    #[test]
+    fn heartbeat_contract_tracks_the_value_that_gates_the_real_send() {
+        let gating: Option<(String, String)> = Some(("discord".to_string(), "99".to_string()));
+        let prompt = heartbeat_turn_prompt(None, "[Heartbeat Task | high] t", gating.as_ref());
+        assert!(
+            prompt.contains("is sent to the discord channel"),
+            "a gating value that WILL deliver must promise delivery, got: {prompt}"
+        );
+        assert!(
+            !prompt.contains("not delivered to anyone"),
+            "must not also claim it reaches nobody, got: {prompt}"
+        );
+
+        let gating: Option<(String, String)> = None;
+        let prompt = heartbeat_turn_prompt(None, "[Heartbeat Task | high] t", gating.as_ref());
+        assert!(
+            prompt.contains("not delivered to anyone"),
+            "a gating value that will NOT deliver must not promise delivery, got: {prompt}"
+        );
+
+        // And the real config path yields that non-delivering value when
+        // heartbeat delivery is unconfigured.
+        assert_eq!(
+            resolve_heartbeat_delivery(&Config::default()).unwrap(),
+            None
+        );
+    }
+
+    /// Every sentinel the heartbeat prompt instructs the model to use must be
+    /// classified the way the prompt says by the function the worker actually
+    /// consults before delivering.
+    #[test]
+    fn the_sentinels_the_heartbeat_prompt_names_are_the_ones_the_worker_honors() {
+        use crate::cron::scheduler::announce_delivery_decision;
+
+        let delivery = ("discord".to_string(), "99".to_string());
+        let prompt = heartbeat_turn_prompt(None, "[Heartbeat Task | high] t", Some(&delivery));
+
+        assert!(prompt.contains("answer with exactly NO_REPLY and"));
+        assert!(
+            !announce_delivery_decision("NO_REPLY").should_deliver(),
+            "the bare sentinel the prompt names must suppress the send"
+        );
+
+        assert!(prompt.contains("NO_REPLY[FAIL]"));
+        assert!(
+            announce_delivery_decision("NO_REPLY[FAIL]: disk full").should_deliver(),
+            "the prompt promises FAIL reaches an operator"
+        );
+
+        assert!(prompt.contains("NO_REPLY[REFUSE]"));
+        assert!(
+            announce_delivery_decision("NO_REPLY[REFUSE]: not permitted").should_deliver(),
+            "the prompt promises REFUSE reaches an operator"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** A cron agent turn's entire model-visible framing was `format!("[cron:{} {name}] {prompt}", job.id)`. That names the origin and says nothing about what happens to the reply. Two consequences, both disclosure gaps rather than plumbing gaps — the delivery machinery is already correct.
- **The reply may reach nobody, and the model isn't told.** `DeliveryConfig::default()` is `mode = "none"`, and `deliver_if_configured` returns early for any non-announce mode. The final message is then recorded in the job's run history and delivered to no one. Since the model cannot see that config, it cannot tell "I reported it" from "I wrote it where nobody looks", and can end a run stating it notified someone when nothing was sent.
- **The `NO_REPLY` sentinel is unreachable on purpose.** `is_no_reply_sentinel` / `announce_delivery_decision` honor it, but it appears in no prompt text, no tool schema (`crates/zeroclaw-tools` has no match), and no model-facing docs. The only party able to emit it has never been told it exists, so any suppression today is an accident of phrasing.
- Adds `delivery_contract(&DeliveryConfig) -> String`, stating per job whether the final message is delivered and how to report nothing, and routes prompt construction through `cron_turn_prompt`.
- **Scope boundary:** cron agent jobs only. No change to delivery behavior, the sentinel's matching rules, scheduling, or the `[cron:` prefix. No new config. Heartbeat has the same defect but a different delivery shape and is left for a follow-up — see below.
- **Blast radius:** The prompt text of `JobType::Agent` cron runs. `zeroclaw-memory::should_skip_autosave_content` gates on `lowered.starts_with("[cron:")`; the prefix is deliberately unchanged and its suite is in the evidence below.
- **Linked issue(s):** N/A
- **Labels:** `type:feat`, `risk:low`, `size:S`

### What the model is now told

Announce mode names the destination channel, the exact `NO_REPLY` token, and that `NO_REPLY[FAIL]: <reason>` / `NO_REPLY[REFUSE]: <reason>` are **delivered** rather than suppressed — matching `is_no_reply_sentinel`, which treats only the bare and `[INFO]` forms as quiet.

Non-announce mode says the reply is not delivered, says where it does go, and instructs the agent not to claim it notified, alerted, messaged, or replied to anyone without calling a sending tool in that turn.

### Follow-up, not included

The heartbeat path has the identical defect (`daemon/mod.rs` honors the same sentinel at the delivery boundary) but resolves delivery as `Option<(channel, target)>` rather than a `DeliveryConfig`, and substitutes a completion notice when output is empty. Reusing `delivery_contract` there needs a small signature change and touches a 2957-line file, so it is better as its own PR than smuggled into this one.

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `surface` = `cli` (cron agent job dispatch)
- **Setup / preconditions:** Any `JobType::Agent` cron job with no `delivery` configured (the default).
- **Steps to run:** Run the job (`cron run <id>`) and inspect the prompt the agent receives, then ask it to "notify the team" as part of the job prompt.
- **Expected on this branch (after):** The prompt carries a delivery contract stating the reply is not delivered and that reaching a person requires a sending tool.
- **Prior behavior on `master` (before):** The prompt is only `[cron:<id> <name>] <prompt>`; the agent will typically answer as though someone is reading, and may report having notified people when nothing was sent.

### How I tested

Seven tests written before the implementation and confirmed failing on missing symbols. The one I would review first is `the_sentinel_the_contract_names_is_the_one_the_delivery_path_honors`, which pins the prompt text to the runtime behavior it promises — if the sentinel or its kind semantics ever drift, the agent would otherwise be following documented advice that silently stopped working.

- `delivery_contract_for_announce_names_the_destination_and_the_sentinel`
- `delivery_contract_for_announce_marks_escalating_kinds_as_delivered`
- `delivery_contract_without_announce_says_the_reply_reaches_nobody`
- `delivery_contract_defaults_to_the_non_delivering_form` — pins that `DeliveryConfig::default().mode == "none"`, i.e. the undelivered contract is what an unconfigured job actually gets
- `delivery_contract_for_announce_without_a_channel_still_states_the_sentinel`
- `the_sentinel_the_contract_names_is_the_one_the_delivery_path_honors`
- `cron_turn_prompt_keeps_the_origin_prefix_and_appends_the_contract`

```sh
cargo test -p zeroclaw-runtime
# test result: ok. 3603 passed; 0 failed; 2 ignored   (3596 before, +7)

cargo test -p zeroclaw-memory                 # 501 + 4 passed, 0 failed
cargo test -p zeroclaw-tools -p zeroclaw-gateway   # 403 + 9 + 1581 passed, 0 failed
cargo fmt --all -- --check                                      # clean
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings   # clean
bash scripts/ci/comment_hygiene_gate.sh                         # passed
```

- **CI checks relied on and why they cover this change:** Quality Gate over `zeroclaw-runtime`, which owns cron dispatch.
- **Known CI coverage gap, if any:** No test drives a live cron fire end-to-end through a real provider, so the assertion is on the constructed prompt rather than on model behavior given that prompt. The delivery decision itself was already covered and is unchanged.
- **Beyond CI, what did you manually verify?** I grepped every consumer of the prompt shape before changing it; the only one is `zeroclaw-memory::should_skip_autosave_content`, which matches on the `[cron:` prefix, so the prefix stays first and that crate's suite is included above. I also confirmed `NO_REPLY` appears in no tool schema, so the sentinel really was undisclosed rather than documented elsewhere.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — fixtures use `telegram` / `12345`
- Prompt injection or untrusted model-visible text introduced/changed? **Yes, narrowly** — this adds host-authored text to the prompt of autonomous turns. It is a constant plus the configured channel name; no untrusted input is interpolated, and the operator's own prompt keeps its existing position.
- If any `Yes`, describe the risk and mitigation: The only interpolated value is `delivery.channel`, which comes from operator config rather than any external party, and it is trimmed and emptiness-checked before use.
