### PR TITLE
fix(runtime): harden verifiable intent boundaries

### DIFF
--- a/crates/zeroclaw-runtime/src/verifiable_intent/types.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/types.rs
@@ -1,11 +1,12 @@
 //! Core data models for the Verifiable Intent credential chain.
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 // ── JWK / Key material ───────────────────────────────────────────────
 
 /// A JSON Web Key (EC P-256) used for signing and key confirmation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Jwk {
     pub kty: String,
     pub crv: String,
@@ -14,8 +15,21 @@ pub struct Jwk {
     /// Base64url-encoded y coordinate.
     pub y: String,
     /// Base64url-encoded private key (only present for signing keys, never serialized to verifiers).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing)]
     pub d: Option<String>,
+}
+
+impl fmt::Debug for Jwk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let private_scalar = self.d.as_ref().map(|_| "[REDACTED]");
+        f.debug_struct("Jwk")
+            .field("kty", &self.kty)
+            .field("crv", &self.crv)
+            .field("x", &self.x)
+            .field("y", &self.y)
+            .field("d", &private_scalar)
+            .finish()
+    }
 }
 
 /// Confirmation claim (`cnf`) binding a credential to a public key.
@@ -285,6 +299,29 @@ pub struct CredentialChain {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn jwk_private_scalar_is_not_serialized_or_debugged() {
+        let secret = "private-scalar-sentinel";
+        let jwk: Jwk = serde_json::from_value(serde_json::json!({
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-coordinate",
+            "y": "y-coordinate",
+            "d": secret,
+        }))
+        .unwrap();
+
+        assert_eq!(jwk.d.as_deref(), Some(secret));
+
+        let serialized = serde_json::to_string(&jwk).unwrap();
+        assert!(!serialized.contains(secret));
+        assert!(!serialized.contains("\"d\""));
+
+        let debug = format!("{jwk:?}");
+        assert!(!debug.contains(secret));
+        assert!(debug.contains("[REDACTED]"));
+    }
 
     #[test]
     fn entity_matches_by_id() {

--- a/crates/zeroclaw-runtime/src/verifiable_intent/verification.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/verification.rs
@@ -307,16 +307,8 @@ fn check_payment_amount(
             ),
         );
     };
-    if let Some(actual_currency) = &fulfillment.currency
-        && actual_currency != currency
-    {
-        return ConstraintCheckResult::violation(
-            ct,
-            ViError::new(
-                ViErrorKind::CurrencyMismatch,
-                format!("expected {currency}, got {actual_currency}"),
-            ),
-        );
+    if let Err(err) = verify_fulfillment_currency(currency, fulfillment.currency.as_deref()) {
+        return ConstraintCheckResult::violation(ct, err);
     }
     if let Some(max_val) = max
         && actual_amount > max_val
@@ -358,16 +350,8 @@ fn check_payment_budget(
             ),
         );
     };
-    if let Some(actual_currency) = &fulfillment.currency
-        && actual_currency != currency
-    {
-        return ConstraintCheckResult::violation(
-            ct,
-            ViError::new(
-                ViErrorKind::CurrencyMismatch,
-                format!("expected {currency}, got {actual_currency}"),
-            ),
-        );
+    if let Err(err) = verify_fulfillment_currency(currency, fulfillment.currency.as_deref()) {
+        return ConstraintCheckResult::violation(ct, err);
     }
     // Single-transaction check: amount must not exceed budget.
     // Cumulative tracking is the payment network's responsibility.
@@ -381,6 +365,30 @@ fn check_payment_budget(
         );
     }
     ConstraintCheckResult::ok(ct)
+}
+
+fn verify_fulfillment_currency(expected: &str, actual: Option<&str>) -> Result<(), ViError> {
+    if expected.trim().is_empty() {
+        return Err(ViError::new(
+            ViErrorKind::CurrencyMismatch,
+            "payment constraint currency is empty",
+        ));
+    }
+    match actual {
+        Some(actual) if actual.trim().is_empty() => Err(ViError::new(
+            ViErrorKind::CurrencyMismatch,
+            format!("missing payment currency; expected {expected}"),
+        )),
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(ViError::new(
+            ViErrorKind::CurrencyMismatch,
+            format!("expected {expected}, got {actual}"),
+        )),
+        None => Err(ViError::new(
+            ViErrorKind::CurrencyMismatch,
+            format!("missing payment currency; expected {expected}"),
+        )),
+    }
 }
 
 fn check_line_items(
@@ -417,8 +425,14 @@ fn check_line_items(
     }
 
     // Total quantity check
-    let total_allowed: u32 = constraint_items.iter().map(|l| l.quantity).sum();
-    let total_actual: u32 = fulfillment_items.iter().map(|f| f.quantity).sum();
+    let total_allowed: u128 = constraint_items
+        .iter()
+        .map(|item| u128::from(item.quantity))
+        .sum();
+    let total_actual: u128 = fulfillment_items
+        .iter()
+        .map(|item| u128::from(item.quantity))
+        .sum();
     if total_actual > total_allowed {
         return ConstraintCheckResult::violation(
             ct,
@@ -655,6 +669,57 @@ mod tests {
     }
 
     #[test]
+    fn allowed_line_item_quantity_total_does_not_wrap() {
+        let constraint_items = vec![
+            LineItemEntry {
+                id: "line-1".into(),
+                acceptable_items: vec![],
+                quantity: u32::MAX,
+            },
+            LineItemEntry {
+                id: "line-2".into(),
+                acceptable_items: vec![],
+                quantity: 1,
+            },
+        ];
+        let f = Fulfillment {
+            line_items: Some(vec![FulfillmentLineItem {
+                item_id: "SKU001".into(),
+                quantity: u32::MAX,
+            }]),
+            ..Default::default()
+        };
+
+        assert!(check_line_items(&constraint_items, &f).satisfied);
+    }
+
+    #[test]
+    fn fulfillment_line_item_quantity_total_does_not_wrap() {
+        let constraint_items = vec![LineItemEntry {
+            id: "line-1".into(),
+            acceptable_items: vec![],
+            quantity: u32::MAX,
+        }];
+        let f = Fulfillment {
+            line_items: Some(vec![
+                FulfillmentLineItem {
+                    item_id: "SKU001".into(),
+                    quantity: u32::MAX,
+                },
+                FulfillmentLineItem {
+                    item_id: "SKU002".into(),
+                    quantity: 1,
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let result = check_line_items(&constraint_items, &f);
+        assert!(!result.satisfied);
+        assert_eq!(result.violations[0].kind, ViErrorKind::LineItemViolation);
+    }
+
+    #[test]
     fn budget_within_limit_passes() {
         let f = Fulfillment {
             amount: Some(30000),
@@ -775,5 +840,43 @@ mod tests {
         let results = check_constraints(&constraints, &f, StrictnessMode::Strict);
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|r| r.satisfied));
+    }
+
+    #[test]
+    fn missing_or_empty_currency_fails_currency_bound_constraints() {
+        for (expected, currency) in [
+            ("USD", None),
+            ("USD", Some(String::new())),
+            ("USD", Some(" ".into())),
+            ("", Some(String::new())),
+            (" ", Some(" ".into())),
+        ] {
+            let constraints = vec![
+                Constraint::PaymentAmount {
+                    currency: expected.into(),
+                    min: None,
+                    max: Some(40000),
+                },
+                Constraint::PaymentBudget {
+                    currency: expected.into(),
+                    max: 50000,
+                },
+            ];
+            let fulfillment = Fulfillment {
+                amount: Some(20000),
+                currency,
+                ..Default::default()
+            };
+            let results = check_constraints(&constraints, &fulfillment, StrictnessMode::Strict);
+
+            assert_eq!(results.len(), 2);
+            assert_eq!(results[0].constraint_type, "payment.amount");
+            assert_eq!(results[1].constraint_type, "payment.budget");
+            for result in results {
+                assert!(!result.satisfied);
+                assert_eq!(result.violations.len(), 1);
+                assert_eq!(result.violations[0].kind, ViErrorKind::CurrencyMismatch);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Stop serializing JWK private scalars and redact them from debug output.
  - Accumulate checkout quantities without `u32` wraparound.
  - Reject absent, empty, or whitespace-only currencies in currency-bound payment constraints.
- **Scope boundary:** Limited to the existing Verifiable Intent data-representation and constraint-validation owners in `types.rs` and `verification.rs`.
- **Blast radius:** Verifiable Intent callers that serialize or debug JWK values, plus checkout line-item and payment constraint evaluation.
- **Linked issue(s):** None.
- **Labels:** `bug`, `runtime`, `security`, `security:secrets`, `domain:security`, `risk:high`, `size:S`

## Testing

### How you can test

- **Reviewer testing requested?** N/A. These are internal credential and constraint invariants with deterministic unit coverage and no stable live service boundary.

### How I tested

- **CI checks relied on and why they cover this change:** All visible checks passed on the current head, including the required CI gate, workspace tests, parallel runtime tests, cross-platform checks, MSRV, and security analysis. These complement the focused runtime tests below with broader repository and platform coverage.
- **Known CI coverage gap, if any:** None known for this two-file runtime change.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
# exit 0

cargo test --locked -p zeroclaw-runtime --lib verifiable_intent -- --nocapture
test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 3549 filtered out

cargo clippy --locked -p zeroclaw-runtime --lib --tests -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

- **Beyond CI, what did you manually verify?** Confirmed the aggregate diff remains confined to the two recorded owners and that private `d` still deserializes.
- **If any command was intentionally skipped, why:** Full workspace tests and Clippy were left to required CI because the focused runtime suite directly exercises all changed behavior and touched-crate Clippy is clean.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes.** A populated JWK `d` field is no longer emitted by Serde or exposed through `Debug`; deserialization remains supported.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- **Additional security note:** Payment checks now fail closed when a currency-bound constraint cannot compare a nonempty expected currency with a nonempty fulfillment currency.

## Compatibility

- Backward compatible? **Not for callers that depended on serializing private JWK material.** Deserialization remains compatible. Callers that intentionally export private JWK material must construct that private-key output explicitly instead of serializing the shared `Jwk` value. ZeroClaw's production key-generation and signing paths are unaffected: they construct public-only JWKs with `d: None` and keep private PKCS#8 key bytes separate.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback

- **Fast rollback command/path:** `git revert <commit-that-landed-this-change>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Private `d` appears in serialized or debug-formatted JWKs, large quantity totals wrap, or a currency-bound payment constraint succeeds without a nonempty matching currency.
