### PR TITLE
chore(deps): clear remaining npm audit findings

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1659,9 +1659,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3347,9 +3347,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Update the resolved `brace-expansion` package from 2.1.2 to 2.1.4 and `nanoid` from 3.3.16 to 3.3.17, clearing the remaining advisories reported by the current web lockfile audit.
- **Scope boundary:** This changes only `web/package-lock.json`. It does not add dependency overrides, change direct manifest constraints, downgrade `openapi-typescript`, upgrade Vite, or alter application code.
- **Blast radius:** Web development and build dependency resolution only.
- **Linked issue(s):** Closes #9383
- **Labels:** `dependencies`, `distinguished contributor`, `domain:security`, `risk:medium`, `web`, `size:XS`, `type:dependencies`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A - this is a lockfile-only transitive dependency repair with no useful manual UI delta.

### How I tested

- **CI checks relied on and why they cover this change:** `Check npm advisories` verifies that this lockfile delta introduces no high-severity dependency advisory. Required CI must also remain green on this head.
- **Known CI coverage gap, if any:** Required pull-request CI does not generate the OpenAPI client or run the production web build. Those paths were covered locally with Node 24.19.0.
- **Commands run and tail output:**

  ```text
  (cd web && npm audit --package-lock-only --audit-level=high)
  found 0 vulnerabilities

  node -e 'JSON.parse(require("fs").readFileSync("web/package-lock.json", "utf8")); console.log("package-lock JSON: valid")'
  package-lock JSON: valid

  node --version
  v24.19.0

  npm --prefix web ci --no-audit --no-fund
  added 216 packages

  cargo web gen-api
  openapi-typescript 7.13.0
  target/openapi.json -> src/lib/api-generated.ts

  npm --prefix web test
  tests 8
  pass 8
  fail 0

  npm --prefix web run test:permissions
  # permission, catalog, warning, validation, and navigation suites passed

  npm --prefix web run test:contexts
  tests 12
  pass 12
  fail 0

  npm --prefix web run build
  2174 modules transformed
  built successfully

  git diff --check
  # no output
  ```

- **Beyond CI, what did you manually verify?** Confirmed the lockfile resolves `brace-expansion` 2.1.4 and `nanoid` 3.3.17 with registry integrity metadata, generated the TypeScript client from the gateway OpenAPI specification, and verified that generation and the production build leave the tracked tree clean.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The web dependency audit reports either advisory again, or the clean install, web tests, permission tests, or production build fail.

