### PR TITLE
feat(agents): per-agent env vars and workspace-confined HOME for the shell tool

### DIFF
--- a/crates/zeroclaw-config/src/multi_agent.rs
+++ b/crates/zeroclaw-config/src/multi_agent.rs
@@ -3,7 +3,7 @@
 //! [`crate::schema::AliasedAgentConfig`] and [`crate::schema::Config`].
 
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use zeroclaw_macros::Configurable;
 
@@ -79,6 +79,61 @@ pub struct AgentMemoryConfig {
     /// The backend kind this agent uses. Defaults to `Sqlite` for new
     /// agents; once an agent has on-disk data the value is locked.
     pub backend: MemoryBackendKind,
+}
+
+/// How this agent's spawned-tool `HOME` is resolved. Default `Inherit`
+/// preserves today's behavior (the daemon's real `$HOME`, shared across
+/// every agent).
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, zeroclaw_macros::ConfigEnum,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum HomeMode {
+    /// Inherit the daemon's real `$HOME` (today's behavior).
+    #[default]
+    Inherit,
+    /// Use a directory inside the agent's own workspace
+    /// (`<agent_workspace>/home/`, created on demand) as `HOME`.
+    Workspace,
+    /// Use `AgentEnvConfig::home_path`, resolved and validated to stay
+    /// inside the agent's workspace boundary unless
+    /// `AgentWorkspaceConfig::unrestricted_filesystem` is set. See
+    /// `SecurityPolicy::for_agent`.
+    Custom,
+}
+
+/// Per-agent environment injection and HOME confinement
+/// (`[agents.<alias>.env]`). Distinct from
+/// `RiskProfileConfig::shell_env_passthrough` (a NAME allowlist of host env
+/// vars whose VALUES are copied from the daemon's own trusted ambient
+/// environment) — these are explicit `KEY=VALUE` pairs and an explicit
+/// `HOME` override, both fully operator-controlled config, never
+/// model-controlled at runtime. Same trust model as `McpServerConfig::env`.
+/// Applies to the `shell` tool today; other spawn-based tools can adopt
+/// the same `SecurityPolicy` fields later.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "agent_env"]
+#[serde(default)]
+pub struct AgentEnvConfig {
+    /// Explicit `KEY=VALUE` pairs injected into subprocesses this agent
+    /// spawns, on top of (and overriding) the safe-env snapshot and any
+    /// TUI-forwarded environment. Treated as secret, matching
+    /// `McpServerConfig::env`, since these commonly carry credentials
+    /// (e.g. `GITHUB_TOKEN`) for spawned tools.
+    #[secret]
+    #[cfg_attr(feature = "schema-export", schemars(extend("x-secret" = true)))]
+    pub vars: HashMap<String, String>,
+    /// How `HOME` is resolved for this agent's spawned subprocesses.
+    pub home_mode: HomeMode,
+    /// Custom `HOME` path, used only when `home_mode = "custom"`. Relative
+    /// paths resolve against the agent's workspace; absolute paths must
+    /// still resolve inside the workspace boundary unless
+    /// `workspace.unrestricted_filesystem = true`. Ignored for
+    /// `inherit`/`workspace` modes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub home_path: Option<PathBuf>,
 }
 
 /// Preferred output modality for a peer group.

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
 use parking_lot::Mutex;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -210,6 +210,21 @@ pub struct SecurityPolicy {
     /// Extra arguments forwarded to firejail when `sandbox_backend`
     /// resolves to `"firejail"`.
     pub firejail_args: Vec<String>,
+    /// Explicit `KEY=VALUE` env vars injected into subprocesses this
+    /// agent spawns, sourced from `agents.<alias>.env.vars`. Distinct
+    /// from `shell_env_passthrough` (a NAME allowlist of vars whose
+    /// VALUES are copied from the daemon's own ambient env) — these are
+    /// literal values from operator config, never model-controlled.
+    /// Empty (never populated) when constructed via `from_profiles`
+    /// alone; only `for_agent` has the agent context to fill this in.
+    pub env_vars: BTreeMap<String, String>,
+    /// Resolved, workspace-confined `HOME` override for this agent's
+    /// subprocesses. `None` means inherit the daemon's real `$HOME`
+    /// (today's default behavior). Populated by `SecurityPolicy::for_agent`
+    /// from `agents.<alias>.env.home_mode`/`home_path`; already validated
+    /// to sit inside `workspace_dir` unless
+    /// `workspace.unrestricted_filesystem` is set.
+    pub home_override: Option<PathBuf>,
     pub tracker: PerSenderTracker,
 }
 
@@ -397,6 +412,18 @@ pub enum EscalationViolation {
     /// Child raises `shell_env_passthrough` to leak env vars the
     /// parent declined to forward.
     ShellEnvPassthroughExpanded { variable: String },
+    /// Child `env_vars` sets a key not present (or present with a
+    /// different value) on the parent — either a new leak surface or a
+    /// tamper on a variable the parent already pinned.
+    EnvVarNotInParent { variable: String },
+    /// Child `home_override` resolves outside the parent's own HOME
+    /// (or workspace, if the parent has no HOME override) boundary.
+    HomeOverrideNotInParent { path: PathBuf },
+    /// Parent confined HOME but the child leaves `home_override` unset,
+    /// which falls back to the daemon's real `$HOME`. Runs the same
+    /// direction as `ForbiddenPathDroppedByChild`: dropping a parent's
+    /// restriction is an escalation, not a narrowing.
+    HomeOverrideDroppedByChild { parent_path: PathBuf },
     /// Child override raises `max_actions_per_hour` above the
     /// parent's ceiling.
     MaxActionsExceeded { child: u32, parent: u32 },
@@ -450,6 +477,18 @@ impl std::fmt::Display for EscalationViolation {
             Self::ShellEnvPassthroughExpanded { variable } => write!(
                 f,
                 "subagent shell_env_passthrough entry {variable:?} is not present on the parent's list"
+            ),
+            Self::EnvVarNotInParent { variable } => write!(
+                f,
+                "subagent env_vars entry {variable:?} is not present with the same value on the parent's env_vars"
+            ),
+            Self::HomeOverrideNotInParent { path } => write!(
+                f,
+                "subagent home_override {path:?} is not contained within the parent's HOME/workspace boundary"
+            ),
+            Self::HomeOverrideDroppedByChild { parent_path } => write!(
+                f,
+                "subagent leaves home_override unset (inheriting the daemon's real $HOME) while the parent confines HOME to {parent_path:?}"
             ),
             Self::MaxActionsExceeded { child, parent } => write!(
                 f,
@@ -505,6 +544,8 @@ impl Default for SecurityPolicy {
             sandbox_enabled: None,
             sandbox_backend: None,
             firejail_args: vec![],
+            env_vars: BTreeMap::new(),
+            home_override: None,
             tracker: PerSenderTracker::new(),
         }
     }
@@ -2323,6 +2364,53 @@ impl SecurityPolicy {
             }
         }
 
+        // env_vars is a leak/tamper surface like shell_env_passthrough, but
+        // keyed AND valued: a delegated child must not inject a var (by
+        // name) the parent didn't already grant, nor override the
+        // parent's value for a shared name.
+        for (key, value) in &self.env_vars {
+            match parent.env_vars.get(key) {
+                Some(parent_value) if parent_value == value => {}
+                _ => {
+                    return Err(EscalationViolation::EnvVarNotInParent {
+                        variable: key.clone(),
+                    });
+                }
+            }
+        }
+
+        // home_override is checked in BOTH directions, because `None` is
+        // not a neutral value here — it means "inherit the daemon's real
+        // $HOME", the least confined option, not "no opinion".
+        //
+        //   - Child sets a HOME: it must stay within whatever the parent
+        //     already permits (the parent's own resolved HOME, or its
+        //     workspace when the parent has no override). A child HOME
+        //     outside that boundary would let a delegate write config and
+        //     state files (.bashrc, .gitconfig, .npmrc) the parent never
+        //     sanctioned.
+        //   - Child leaves HOME unset while the parent confined it: that
+        //     escapes the confinement outright, landing back on the real
+        //     $HOME. Same shape as `ForbiddenPathDroppedByChild` and
+        //     `WorkspaceOnlyDisabledByChild` — a child may narrow the
+        //     parent's restrictions, never drop them.
+        match (&self.home_override, &parent.home_override) {
+            (Some(child_home), parent_home) => {
+                let parent_boundary = parent_home.as_ref().unwrap_or(&parent.workspace_dir);
+                if !path_contains(parent_boundary, child_home) {
+                    return Err(EscalationViolation::HomeOverrideNotInParent {
+                        path: child_home.clone(),
+                    });
+                }
+            }
+            (None, Some(parent_home)) => {
+                return Err(EscalationViolation::HomeOverrideDroppedByChild {
+                    parent_path: parent_home.clone(),
+                });
+            }
+            (None, None) => {}
+        }
+
         if self.max_actions_per_hour > parent.max_actions_per_hour {
             return Err(EscalationViolation::MaxActionsExceeded {
                 child: self.max_actions_per_hour,
@@ -2428,6 +2516,12 @@ impl SecurityPolicy {
             sandbox_enabled: risk_profile.sandbox_enabled,
             sandbox_backend: risk_profile.sandbox_backend.clone(),
             firejail_args: risk_profile.firejail_args.clone(),
+            // `agents.<alias>.env` has no risk/runtime-profile source —
+            // it's agent-private state. `from_profiles` has no agent
+            // context, so these stay at their no-op defaults; `for_agent`
+            // overwrites them once it has `agent_cfg` in hand.
+            env_vars: BTreeMap::new(),
+            home_override: None,
             tracker: PerSenderTracker::new(),
         }
     }
@@ -2497,9 +2591,95 @@ impl SecurityPolicy {
             if agent_cfg.workspace.unrestricted_filesystem {
                 policy.workspace_only = false;
             }
+
+            policy.env_vars = agent_cfg
+                .env
+                .vars
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            policy.home_override = match agent_cfg.env.home_mode {
+                crate::multi_agent::HomeMode::Inherit => None,
+                crate::multi_agent::HomeMode::Workspace => {
+                    // Parity with the `memory/` subdirectory convention:
+                    // keep HOME's dotfiles/caches out of the workspace root.
+                    let home = agent_workspace.join("home");
+                    std::fs::create_dir_all(&home).with_context(|| {
+                        format!(
+                            "SecurityPolicy::for_agent: failed to create agent HOME dir {}",
+                            home.display()
+                        )
+                    })?;
+                    Some(home)
+                }
+                crate::multi_agent::HomeMode::Custom => {
+                    let Some(raw) = agent_cfg.env.home_path.as_ref() else {
+                        anyhow::bail!(
+                            "agents.{agent_alias}.env.home_mode = \"custom\" requires env.home_path"
+                        );
+                    };
+                    let expanded = expand_user_path(&raw.to_string_lossy());
+                    let candidate = if expanded.is_absolute() {
+                        expanded
+                    } else {
+                        agent_workspace.join(expanded)
+                    };
+                    if !agent_cfg.workspace.unrestricted_filesystem
+                        && workspace_prefixed_relative_suffix(&candidate, &agent_workspace)
+                            .is_none()
+                    {
+                        anyhow::bail!(
+                            "agents.{agent_alias}.env.home_path ({}) resolves outside the agent's \
+                             workspace ({}); set workspace.unrestricted_filesystem = true to allow \
+                             this, or use a path inside the workspace",
+                            candidate.display(),
+                            agent_workspace.display()
+                        );
+                    }
+                    std::fs::create_dir_all(&candidate).with_context(|| {
+                        format!(
+                            "SecurityPolicy::for_agent: failed to create agent HOME dir {}",
+                            candidate.display()
+                        )
+                    })?;
+                    Some(candidate)
+                }
+            };
         }
 
         Ok(policy)
+    }
+
+    /// Move this policy onto a new workspace root, carrying workspace-relative
+    /// derived paths with it.
+    ///
+    /// `workspace_dir` is not a plain field: other fields are resolved against
+    /// it at construction time, so assigning it directly leaves those derived
+    /// paths pointing at the old root. Bounded delegation
+    /// (`DelegateTool::policy_for_target`) retargets a delegate onto the
+    /// caller's workspace and must go through here.
+    ///
+    /// Today that means `home_override`. A HOME that resolved inside the old
+    /// workspace is re-rooted onto the new one, preserving its suffix, so the
+    /// confinement moves with the workspace instead of going stale. A HOME
+    /// that was never workspace-relative (only reachable via
+    /// `workspace.unrestricted_filesystem`) is left untouched — re-rooting an
+    /// absolute path the operator chose deliberately would be wrong.
+    ///
+    /// Note `allowed_roots` is derived the same way (`from_profiles` joins
+    /// relative profile entries onto `workspace_dir`) but is deliberately NOT
+    /// re-rooted here: that would widen what a bounded delegate may reach in
+    /// the caller's workspace, a trust-boundary change that needs its own
+    /// justification rather than riding along with the HOME fix.
+    pub fn rebind_workspace(&mut self, new_workspace: &Path) {
+        // Resolve against the OLD root before overwriting it.
+        if let Some(home) = &self.home_override
+            && let Some(suffix) = workspace_prefixed_relative_suffix(home, &self.workspace_dir)
+        {
+            self.home_override = Some(new_workspace.join(suffix));
+        }
+        self.workspace_dir = new_workspace.to_path_buf();
     }
 
     pub fn prompt_summary(&self) -> String {
@@ -4641,6 +4821,295 @@ mod tests {
         );
     }
 
+    // ── agents.<alias>.env: env_vars + home_override resolution ─────
+
+    fn cfg_for_env_tests(root: &Path) -> crate::schema::Config {
+        let mut cfg = crate::schema::Config {
+            data_dir: root.join("data"),
+            config_path: root.join("config.toml"),
+            ..crate::schema::Config::default()
+        };
+        cfg.risk_profiles.insert(
+            "default".into(),
+            crate::schema::RiskProfileConfig::default(),
+        );
+        cfg
+    }
+
+    #[test]
+    fn for_agent_home_mode_inherit_leaves_home_override_none() {
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-inherit-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        cfg.agents.insert(
+            "agent_a".into(),
+            AliasedAgentConfig {
+                risk_profile: "default".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+
+        let policy = SecurityPolicy::for_agent(&cfg, "agent_a").unwrap();
+        assert!(policy.home_override.is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn for_agent_home_mode_workspace_resolves_under_agent_workspace_and_creates_dir() {
+        use crate::multi_agent::HomeMode;
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-workspace-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        let mut agent = AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..AliasedAgentConfig::default()
+        };
+        agent.env.home_mode = HomeMode::Workspace;
+        cfg.agents.insert("agent_a".into(), agent);
+
+        let expected = cfg.agent_workspace_dir("agent_a").join("home");
+        let policy = SecurityPolicy::for_agent(&cfg, "agent_a").unwrap();
+
+        assert_eq!(policy.home_override, Some(expected.clone()));
+        assert!(expected.is_dir(), "HomeMode::Workspace must create the dir");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn for_agent_home_mode_custom_relative_path_resolves_inside_workspace() {
+        use crate::multi_agent::HomeMode;
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-custom-rel-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        let mut agent = AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..AliasedAgentConfig::default()
+        };
+        agent.env.home_mode = HomeMode::Custom;
+        agent.env.home_path = Some(PathBuf::from("myhome"));
+        cfg.agents.insert("agent_a".into(), agent);
+
+        let expected = cfg.agent_workspace_dir("agent_a").join("myhome");
+        let policy = SecurityPolicy::for_agent(&cfg, "agent_a").unwrap();
+
+        assert_eq!(policy.home_override, Some(expected.clone()));
+        assert!(expected.is_dir());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn for_agent_home_mode_custom_absolute_path_outside_workspace_errors_without_unrestricted() {
+        use crate::multi_agent::HomeMode;
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-custom-abs-reject-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let outside = std::env::temp_dir().join(format!(
+            "zeroclaw-env-outside-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        let mut agent = AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..AliasedAgentConfig::default()
+        };
+        agent.env.home_mode = HomeMode::Custom;
+        agent.env.home_path = Some(outside.clone());
+        cfg.agents.insert("agent_a".into(), agent);
+
+        let err = SecurityPolicy::for_agent(&cfg, "agent_a")
+            .expect_err("a HOME path outside the workspace must be rejected by default");
+        assert!(err.to_string().contains("home_path"));
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
+    }
+
+    #[test]
+    fn for_agent_home_mode_custom_absolute_path_outside_workspace_allowed_with_unrestricted() {
+        use crate::multi_agent::HomeMode;
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-custom-abs-allow-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let outside = std::env::temp_dir().join(format!(
+            "zeroclaw-env-outside-allow-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        let mut agent = AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..AliasedAgentConfig::default()
+        };
+        agent.env.home_mode = HomeMode::Custom;
+        agent.env.home_path = Some(outside.clone());
+        agent.workspace.unrestricted_filesystem = true;
+        cfg.agents.insert("agent_a".into(), agent);
+
+        let policy = SecurityPolicy::for_agent(&cfg, "agent_a").unwrap();
+        assert_eq!(policy.home_override, Some(outside.clone()));
+        assert!(outside.is_dir());
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
+    }
+
+    #[test]
+    fn for_agent_home_mode_custom_without_home_path_errors() {
+        use crate::multi_agent::HomeMode;
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-custom-missing-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        let mut agent = AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..AliasedAgentConfig::default()
+        };
+        agent.env.home_mode = HomeMode::Custom;
+        cfg.agents.insert("agent_a".into(), agent);
+
+        let err = SecurityPolicy::for_agent(&cfg, "agent_a")
+            .expect_err("HomeMode::Custom without home_path must error");
+        assert!(err.to_string().contains("home_path"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn for_agent_env_vars_propagate_from_agent_config() {
+        use crate::schema::AliasedAgentConfig;
+
+        let root = std::env::temp_dir().join(format!(
+            "zeroclaw-env-vars-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let mut cfg = cfg_for_env_tests(&root);
+        let mut agent = AliasedAgentConfig {
+            risk_profile: "default".into(),
+            ..AliasedAgentConfig::default()
+        };
+        agent.env.vars.insert("FOO".to_string(), "bar".to_string());
+        cfg.agents.insert("agent_a".into(), agent);
+
+        let policy = SecurityPolicy::for_agent(&cfg, "agent_a").unwrap();
+        assert_eq!(policy.env_vars.get("FOO"), Some(&"bar".to_string()));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn from_profiles_leaves_env_vars_and_home_override_at_defaults() {
+        // agents.<alias>.env has no risk/runtime-profile source — only
+        // `for_agent` has the agent context to populate it.
+        let risk = crate::schema::RiskProfileConfig::default();
+        let policy = SecurityPolicy::from_profiles(&risk, None, Path::new("/ws"));
+        assert!(policy.env_vars.is_empty());
+        assert!(policy.home_override.is_none());
+    }
+
+    // ── rebind_workspace: bounded delegation retargeting ────────────
+
+    #[test]
+    fn rebind_workspace_re_roots_a_workspace_confined_home() {
+        // Bounded delegation onto the caller's workspace: the confinement
+        // moves with the workspace instead of pointing at the old root.
+        let mut policy = SecurityPolicy {
+            workspace_dir: PathBuf::from("/agents/worker/workspace"),
+            home_override: Some(PathBuf::from("/agents/worker/workspace/home")),
+            ..SecurityPolicy::default()
+        };
+        policy.rebind_workspace(Path::new("/agents/caller/workspace"));
+
+        assert_eq!(
+            policy.workspace_dir,
+            PathBuf::from("/agents/caller/workspace")
+        );
+        assert_eq!(
+            policy.home_override,
+            Some(PathBuf::from("/agents/caller/workspace/home")),
+            "a workspace-relative HOME must follow the workspace it is confined to"
+        );
+    }
+
+    #[test]
+    fn rebind_workspace_preserves_a_nested_home_suffix() {
+        let mut policy = SecurityPolicy {
+            workspace_dir: PathBuf::from("/agents/worker/workspace"),
+            home_override: Some(PathBuf::from("/agents/worker/workspace/nested/home")),
+            ..SecurityPolicy::default()
+        };
+        policy.rebind_workspace(Path::new("/agents/caller/workspace"));
+        assert_eq!(
+            policy.home_override,
+            Some(PathBuf::from("/agents/caller/workspace/nested/home"))
+        );
+    }
+
+    #[test]
+    fn rebind_workspace_leaves_a_non_workspace_relative_home_untouched() {
+        // Only reachable with workspace.unrestricted_filesystem: the
+        // operator picked an absolute path that was never derived from the
+        // workspace, so re-rooting it would override a deliberate choice.
+        let mut policy = SecurityPolicy {
+            workspace_dir: PathBuf::from("/agents/worker/workspace"),
+            home_override: Some(PathBuf::from("/srv/shared-home")),
+            ..SecurityPolicy::default()
+        };
+        policy.rebind_workspace(Path::new("/agents/caller/workspace"));
+
+        assert_eq!(
+            policy.workspace_dir,
+            PathBuf::from("/agents/caller/workspace")
+        );
+        assert_eq!(
+            policy.home_override,
+            Some(PathBuf::from("/srv/shared-home")),
+            "an absolute, non-workspace-relative HOME must not be re-rooted"
+        );
+    }
+
+    #[test]
+    fn rebind_workspace_without_a_home_override_only_moves_the_workspace() {
+        // Regression guard: rebinding must not invent a confinement where
+        // the agent had none (that would be a silent behavior change).
+        let mut policy = SecurityPolicy {
+            workspace_dir: PathBuf::from("/agents/worker/workspace"),
+            home_override: None,
+            ..SecurityPolicy::default()
+        };
+        policy.rebind_workspace(Path::new("/agents/caller/workspace"));
+
+        assert_eq!(
+            policy.workspace_dir,
+            PathBuf::from("/agents/caller/workspace")
+        );
+        assert!(policy.home_override.is_none());
+    }
+
     // ── Edge cases: from_config preserves tracker ────────────
 
     #[test]
@@ -5534,6 +6003,126 @@ mod tests {
             err,
             EscalationViolation::ShellEnvPassthroughExpanded { ref variable }
             if variable == "AWS_SECRET_ACCESS_KEY"
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_accepts_env_var_matching_parent_value() {
+        let parent = SecurityPolicy {
+            env_vars: BTreeMap::from([("NODE_ENV".to_string(), "production".to_string())]),
+            ..parent_policy_for_escalation_tests()
+        };
+        let child = SecurityPolicy {
+            env_vars: BTreeMap::from([("NODE_ENV".to_string(), "production".to_string())]),
+            ..parent.clone()
+        };
+        assert!(child.ensure_no_escalation_beyond(&parent).is_ok());
+    }
+
+    #[test]
+    fn ensure_no_escalation_rejects_new_env_var_not_in_parent() {
+        let parent = parent_policy_for_escalation_tests();
+        let child = SecurityPolicy {
+            env_vars: BTreeMap::from([("GITHUB_TOKEN".to_string(), "leaked".to_string())]),
+            ..parent.clone()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child adding an env_vars entry the parent never set must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::EnvVarNotInParent { ref variable }
+            if variable == "GITHUB_TOKEN"
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_rejects_env_var_value_override() {
+        let parent = SecurityPolicy {
+            env_vars: BTreeMap::from([("NODE_ENV".to_string(), "production".to_string())]),
+            ..parent_policy_for_escalation_tests()
+        };
+        let child = SecurityPolicy {
+            env_vars: BTreeMap::from([("NODE_ENV".to_string(), "development".to_string())]),
+            ..parent.clone()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child overriding a parent-set env var value must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::EnvVarNotInParent { ref variable }
+            if variable == "NODE_ENV"
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_accepts_home_override_none_when_parent_none() {
+        let parent = parent_policy_for_escalation_tests();
+        let child = parent.clone();
+        assert!(child.ensure_no_escalation_beyond(&parent).is_ok());
+    }
+
+    #[test]
+    fn ensure_no_escalation_accepts_home_override_inside_parent_home() {
+        let parent = SecurityPolicy {
+            home_override: Some(PathBuf::from("/workspace/home")),
+            ..parent_policy_for_escalation_tests()
+        };
+        let child = SecurityPolicy {
+            home_override: Some(PathBuf::from("/workspace/home/nested")),
+            ..parent.clone()
+        };
+        assert!(child.ensure_no_escalation_beyond(&parent).is_ok());
+    }
+
+    #[test]
+    fn ensure_no_escalation_accepts_home_override_inside_parent_workspace_when_parent_home_none() {
+        let parent = parent_policy_for_escalation_tests();
+        let child = SecurityPolicy {
+            home_override: Some(PathBuf::from("/workspace/home")),
+            ..parent.clone()
+        };
+        assert!(child.ensure_no_escalation_beyond(&parent).is_ok());
+    }
+
+    #[test]
+    fn ensure_no_escalation_rejects_home_override_outside_parent_boundary() {
+        let parent = parent_policy_for_escalation_tests();
+        let child = SecurityPolicy {
+            home_override: Some(PathBuf::from("/etc/somewhere-else")),
+            ..parent.clone()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child home_override outside the parent's boundary must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::HomeOverrideNotInParent { ref path }
+            if path == std::path::Path::new("/etc/somewhere-else")
+        ));
+    }
+
+    #[test]
+    fn ensure_no_escalation_rejects_child_dropping_parent_home_override() {
+        // `None` is the LEAST confined value (it inherits the daemon's
+        // real $HOME), so a child may narrow the parent's confinement but
+        // never drop it — same direction as forbidden_paths.
+        let parent = SecurityPolicy {
+            home_override: Some(PathBuf::from("/workspace/home")),
+            ..parent_policy_for_escalation_tests()
+        };
+        let child = SecurityPolicy {
+            home_override: None,
+            ..parent.clone()
+        };
+        let err = child
+            .ensure_no_escalation_beyond(&parent)
+            .expect_err("child dropping the parent's HOME confinement must be rejected");
+        assert!(matches!(
+            err,
+            EscalationViolation::HomeOverrideDroppedByChild { ref parent_path }
+            if parent_path == std::path::Path::new("/workspace/home")
         ));
     }
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -3762,6 +3762,17 @@ pub struct AliasedAgentConfig {
     #[serde(default)]
     #[nested]
     pub a2a: crate::multi_agent::AgentA2aConfig,
+
+    /// Per-agent environment injection and HOME confinement
+    /// (`[agents.<alias>.env]`). Explicit `KEY=VALUE` env vars and an
+    /// optional workspace-confined `HOME` override for subprocesses this
+    /// agent spawns (the `shell` tool today). Default is a no-op: no
+    /// extra vars, `HOME` inherited from the daemon. See
+    /// `crate::multi_agent::AgentEnvConfig`.
+    #[tab(Workspace)]
+    #[serde(default)]
+    #[nested]
+    pub env: crate::multi_agent::AgentEnvConfig,
 }
 
 impl Default for AliasedAgentConfig {
@@ -3789,6 +3800,7 @@ impl Default for AliasedAgentConfig {
             memory: crate::multi_agent::AgentMemoryConfig::default(),
             identity: IdentityConfig::default(),
             a2a: crate::multi_agent::AgentA2aConfig::default(),
+            env: crate::multi_agent::AgentEnvConfig::default(),
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -497,7 +497,12 @@ impl DelegateTool {
             target_policy.tracker = self.security.tracker.clone();
 
             if self.security.risk_profile_name == target_policy.risk_profile_name {
-                target_policy.workspace_dir = self.security.workspace_dir.clone();
+                // Not a plain field assignment: a workspace-confined HOME
+                // (agents.<alias>.env.home_mode) is resolved against the
+                // target's own workspace, so it has to be re-rooted onto the
+                // caller's alongside it or the bounded run writes its
+                // dotfiles outside the workspace it is actually using.
+                target_policy.rebind_workspace(&self.security.workspace_dir);
             }
         }
 
@@ -6917,6 +6922,56 @@ mod tests {
         assert!(
             chain.contains("[risk_profiles.narrow].delegation_policy mode = \"allow\""),
             "expected exact remediation path in forbidden-policy diagnostic, got: {chain}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_delegate_re_roots_workspace_confined_home_onto_caller_workspace() {
+        // Bounded delegation retargets the delegate onto the caller's
+        // workspace. A HOME confined to the target's own workspace has to
+        // move with it, or the bounded run writes its dotfiles/caches into a
+        // workspace it is not otherwise using.
+        use zeroclaw_config::multi_agent::HomeMode;
+
+        // Equal max_actions puts both agents on the `narrow` profile, which
+        // is what gates the workspace rebind.
+        let mut config = (*config_with_two_agents("caller", 5, "target", 5)).clone();
+        config
+            .agents
+            .get_mut("caller")
+            .unwrap()
+            .delegates
+            .push(DelegateTargetConfig::bounded("target"));
+        config.agents.get_mut("target").unwrap().env.home_mode = HomeMode::Workspace;
+        let config = Arc::new(config);
+
+        let caller_workspace = config.agent_workspace_dir("caller");
+        let target_workspace = config.agent_workspace_dir("target");
+
+        let caller_policy =
+            Arc::new(SecurityPolicy::for_agent(&config, "caller").expect("caller policy resolves"));
+        let mut delegate_agents = HashMap::new();
+        for (name, agent) in &config.agents {
+            delegate_agents.insert(name.clone(), agent.clone());
+        }
+        let tool = DelegateTool::new(delegate_agents, None, caller_policy)
+            .with_root_config(config.clone())
+            .with_caller_alias("caller");
+
+        let resolved = tool
+            .policy_for_target("target")
+            .expect("bounded same-profile delegate resolves");
+
+        assert_eq!(resolved.workspace_dir, caller_workspace);
+        assert_eq!(
+            resolved.home_override,
+            Some(caller_workspace.join("home")),
+            "bounded delegation must carry the HOME confinement onto the caller's workspace"
+        );
+        assert_ne!(
+            resolved.home_override,
+            Some(target_workspace.join("home")),
+            "HOME must not stay pinned to the target's own workspace after the rebind"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -349,18 +349,41 @@ impl Tool for ShellTool {
             }
         }
 
+        // Per-agent explicit env vars (agents.<alias>.env.vars) are
+        // deliberate operator config, not ambient/inherited env — they win
+        // over both the safe-env snapshot AND the TUI overlay. An operator
+        // who pins a value for this agent should get that value even when
+        // a connected TUI's shell happens to export something else.
+        for (k, v) in &self.security.env_vars {
+            cmd.env(k, v);
+        }
+
+        // Per-agent HOME override (agents.<alias>.env.home_mode), resolved
+        // and workspace-confined by SecurityPolicy::for_agent. Applied
+        // after the blanket env_vars loop so it always wins even if
+        // `env_vars` also happens to contain a HOME key.
+        if let Some(ref home) = self.security.home_override {
+            cmd.env("HOME", home);
+            #[cfg(target_os = "windows")]
+            {
+                cmd.env("USERPROFILE", home);
+            }
+        }
+
         // Android: platform tools (sh, getprop, am, dumpsys, content, pm, ...)
         // live in /system/bin and /system/xbin. The cleared+rebuilt PATH above
         // may omit them, leaving the shell unable to resolve any platform tool.
         // Detect Android at runtime (works for bionic and musl builds).
         if is_android() {
             let ambient = std::env::var("PATH").unwrap_or_default();
-            let tui_path = self
-                .tui_env
-                .as_ref()
-                .and_then(|env| env.get("PATH"))
-                .map(String::as_str);
-            cmd.env("PATH", android_child_path(tui_path, &ambient));
+            // Same precedence as the overlays above: a PATH pinned in
+            // `agents.<alias>.env.vars` outranks the TUI's, which outranks
+            // the daemon's ambient one. The platform dirs are still
+            // prepended in every case — without them the Android shell
+            // cannot resolve `sh` itself, so a pinned PATH extends the
+            // lookup rather than replacing it outright.
+            let path_override = resolved_path_override(&self.security.env_vars, &self.tui_env);
+            cmd.env("PATH", android_child_path(path_override, &ambient));
         }
 
         let timeout_secs = self.timeout_secs;
@@ -548,8 +571,26 @@ fn append_truncation_marker(output: &mut String, marker: &str) {
 /// (`/system/bin:/system/xbin`) are prefixed onto the curated PATH, with a
 /// TUI-provided PATH winning over the daemon's ambient PATH. Yields the bare
 /// platform dirs when the resolved base is empty.
-fn android_child_path(tui_path: Option<&str>, ambient_path: &str) -> String {
-    let base = tui_path.unwrap_or(ambient_path);
+/// Highest-precedence `PATH` among the env overlays applied to a spawned
+/// subprocess: a value pinned in `agents.<alias>.env.vars` outranks the
+/// TUI's forwarded one, matching the order those overlays are applied in
+/// `ShellTool::execute`. `None` means neither overlay set `PATH`, so the
+/// daemon's ambient value stands.
+fn resolved_path_override<'a>(
+    env_vars: &'a std::collections::BTreeMap<String, String>,
+    tui_env: &'a Option<HashMap<String, String>>,
+) -> Option<&'a str> {
+    env_vars
+        .get("PATH")
+        .or_else(|| tui_env.as_ref().and_then(|env| env.get("PATH")))
+        .map(String::as_str)
+}
+
+/// Build the Android child PATH: platform dirs always first, then the
+/// highest-precedence PATH the caller resolved (per-agent `env.vars`, else
+/// the TUI's, else the daemon's ambient one).
+fn android_child_path(override_path: Option<&str>, ambient_path: &str) -> String {
+    let base = override_path.unwrap_or(ambient_path);
     if base.is_empty() {
         "/system/bin:/system/xbin".to_string()
     } else {
@@ -573,6 +614,43 @@ mod tests {
         assert_eq!(
             super::android_child_path(None, ""),
             "/system/bin:/system/xbin"
+        );
+    }
+
+    #[test]
+    fn resolved_path_override_prefers_agent_env_over_tui_env() {
+        let mut env_vars = std::collections::BTreeMap::new();
+        env_vars.insert("PATH".to_string(), "/opt/pinned/bin".to_string());
+        let mut tui = std::collections::HashMap::new();
+        tui.insert("PATH".to_string(), "/tui/bin".to_string());
+
+        // Agent config wins over the TUI overlay.
+        assert_eq!(
+            super::resolved_path_override(&env_vars, &Some(tui.clone())),
+            Some("/opt/pinned/bin")
+        );
+        // TUI still wins over ambient when the agent pins nothing.
+        assert_eq!(
+            super::resolved_path_override(&std::collections::BTreeMap::new(), &Some(tui)),
+            Some("/tui/bin")
+        );
+        // Neither set: caller falls back to the daemon's ambient PATH.
+        assert_eq!(
+            super::resolved_path_override(&std::collections::BTreeMap::new(), &None),
+            None
+        );
+    }
+
+    #[test]
+    fn android_child_path_keeps_platform_dirs_ahead_of_pinned_agent_path() {
+        // A per-agent PATH extends the Android lookup; it must not drop
+        // the platform dirs, or the child shell cannot resolve `sh`.
+        let mut env_vars = std::collections::BTreeMap::new();
+        env_vars.insert("PATH".to_string(), "/opt/pinned/bin".to_string());
+        let resolved = super::resolved_path_override(&env_vars, &None);
+        assert_eq!(
+            super::android_child_path(resolved, "/daemon"),
+            "/system/bin:/system/xbin:/opt/pinned/bin"
         );
     }
 
@@ -1068,6 +1146,23 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             allowed_commands: vec![env_print_command().into()],
             shell_env_passthrough: vars.iter().map(|v| (*v).to_string()).collect(),
+            ..SecurityPolicy::default()
+        })
+    }
+
+    fn test_security_with_agent_env(
+        vars: &[(&str, &str)],
+        home_override: Option<std::path::PathBuf>,
+    ) -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: std::env::temp_dir(),
+            allowed_commands: vec![env_print_command().into()],
+            env_vars: vars
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            home_override,
             ..SecurityPolicy::default()
         })
     }
@@ -1729,5 +1824,154 @@ mod tests {
             env_output_contains_assignment(&result.output, "SSH_AUTH_SOCK", "/tmp/fake.sock"),
             "SSH_AUTH_SOCK from tui_env must reach subprocess"
         );
+    }
+
+    // ── Per-agent env / HOME overlay tests ──────────────────────────
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_agent_env_vars_are_passed_to_subprocess() {
+        let tool = ShellTool::new(
+            test_security_with_agent_env(&[("ZC_AGENT_TEST_VAR", "agent_injected")], None),
+            test_runtime(),
+        );
+
+        let result = tool
+            .execute(json!({"command": env_print_command()}))
+            .await
+            .expect("environment print command should succeed");
+
+        assert!(result.success);
+        assert!(
+            env_output_contains_assignment(&result.output, "ZC_AGENT_TEST_VAR", "agent_injected"),
+            "agent-configured env var should appear in subprocess env, got:\n{}",
+            result.output
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_agent_env_vars_override_tui_env_on_conflict() {
+        // Explicit per-agent config (agents.<alias>.env.vars) is deliberate
+        // operator intent and must win over ambient TUI-forwarded env.
+        let tool = ShellTool::new(
+            test_security_with_agent_env(&[("ZC_CONFLICT_VAR", "agent_wins")], None),
+            test_runtime(),
+        )
+        .with_tui_env(Some({
+            let mut m = std::collections::HashMap::new();
+            m.insert("ZC_CONFLICT_VAR".to_string(), "tui_loses".to_string());
+            m
+        }));
+
+        let result = tool
+            .execute(json!({"command": env_print_command()}))
+            .await
+            .expect("environment print command should succeed");
+
+        assert!(result.success);
+        assert!(
+            env_output_contains_assignment(&result.output, "ZC_CONFLICT_VAR", "agent_wins"),
+            "per-agent env var should win over tui_env on conflict, got:\n{}",
+            result.output
+        );
+        assert!(
+            !env_output_contains_assignment(&result.output, "ZC_CONFLICT_VAR", "tui_loses"),
+            "tui_env value must not leak through when the agent config overrides it, got:\n{}",
+            result.output
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_home_override_sets_home_in_subprocess() {
+        let home_dir = std::env::temp_dir().join(format!(
+            "zeroclaw-shell-home-override-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&home_dir).unwrap();
+
+        let tool = ShellTool::new(
+            test_security_with_agent_env(&[], Some(home_dir.clone())),
+            test_runtime(),
+        );
+
+        let result = tool
+            .execute(json!({"command": env_print_command()}))
+            .await
+            .expect("environment print command should succeed");
+
+        assert!(result.success);
+        assert!(
+            env_output_contains_assignment(
+                &result.output,
+                home_env_key(),
+                &home_dir.display().to_string()
+            ),
+            "home_override should set {} in subprocess env, got:\n{}",
+            home_env_key(),
+            result.output
+        );
+
+        let _ = std::fs::remove_dir_all(&home_dir);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_home_override_none_inherits_daemon_home() {
+        // No agent-configured home_override: HOME must come from the
+        // existing SAFE_ENV_VARS-sourced daemon env, unchanged.
+        let tool = ShellTool::new(test_security_with_agent_env(&[], None), test_runtime());
+
+        let result = tool
+            .execute(json!({"command": env_print_command()}))
+            .await
+            .expect("environment print command should succeed");
+
+        assert!(result.success);
+        assert!(
+            env_output_contains_key(&result.output, home_env_key()),
+            "{} should still be available without an agent home_override",
+            home_env_key()
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_home_override_wins_over_tui_env_home() {
+        let home_dir = std::env::temp_dir().join(format!(
+            "zeroclaw-shell-home-vs-tui-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&home_dir).unwrap();
+        let home_key = home_env_key();
+
+        let tool = ShellTool::new(
+            test_security_with_agent_env(&[], Some(home_dir.clone())),
+            test_runtime(),
+        )
+        .with_tui_env(Some({
+            let mut m = std::collections::HashMap::new();
+            m.insert(home_key.to_string(), "tui-home".to_string());
+            m
+        }));
+
+        let result = tool
+            .execute(json!({"command": env_print_command()}))
+            .await
+            .expect("environment print command should succeed");
+
+        assert!(result.success);
+        assert!(
+            env_output_contains_assignment(
+                &result.output,
+                home_key,
+                &home_dir.display().to_string()
+            ),
+            "home_override should win over a tui_env-forwarded {home_key}, got:\n{}",
+            result.output
+        );
+        assert!(
+            !env_output_contains_assignment(&result.output, home_key, "tui-home"),
+            "tui_env {home_key} must not leak through when home_override is set, got:\n{}",
+            result.output
+        );
+
+        let _ = std::fs::remove_dir_all(&home_dir);
     }
 }

--- a/docs/book/src/agents/filesystem.md
+++ b/docs/book/src/agents/filesystem.md
@@ -91,17 +91,14 @@ env vars and a confined `HOME`, scoped to that one agent:
 
 - **`vars`** are explicit `KEY=VALUE` pairs injected into every subprocess
   this agent spawns, on top of (and overriding) the safe-env snapshot and any
-  TUI-forwarded environment. This is distinct from
-  `risk_profiles.<name>.shell-env-passthrough`, which only allowlists env var
-  *names* whose *values* are copied from the daemon's own trusted ambient
-  environment — `agents.<alias>.env.vars` sets literal values, fully
-  operator-controlled, the same trust model as an MCP server's `env` block.
+  TUI-forwarded environment. This allows setting literal values, fully
+  user-controlled, the same trust model as an MCP server's `env` block.
   One exception to "overriding": on Android, `/system/bin` and
   `/system/xbin` are always prepended to `PATH`, so a `PATH` pinned here
-  extends the platform lookup rather than replacing it — without those
+  extends the platform lookup rather than replacing it, without those
   directories the child shell cannot resolve `sh` itself.
 - **`home_mode`** controls what `HOME` resolves to for this agent's
-  subprocesses: `inherit` (default) keeps today's behavior — the daemon's
+  subprocesses: `inherit` (default) keeps normal behavior, the daemon's
   real `$HOME`, shared across every agent. `workspace` points `HOME` at
   `agents/<alias>/workspace/home/`, created on demand. `custom` uses
   `home_path`, which is validated to stay inside the agent's workspace

--- a/docs/book/src/agents/filesystem.md
+++ b/docs/book/src/agents/filesystem.md
@@ -81,3 +81,28 @@ An agent's identity (its personality) is sourced per agent:
 The `format` selects how the identity is loaded. The default reads the
 project's personality files; the alternative loads an AIEOS JSON definition,
 either from a path relative to the workspace or inline.
+
+## Environment
+
+Subprocesses an agent spawns (the `shell` tool today) can be given explicit
+env vars and a confined `HOME`, scoped to that one agent:
+
+{{#config-fields agents.env}}
+
+- **`vars`** are explicit `KEY=VALUE` pairs injected into every subprocess
+  this agent spawns, on top of (and overriding) the safe-env snapshot and any
+  TUI-forwarded environment. This is distinct from
+  `risk_profiles.<name>.shell-env-passthrough`, which only allowlists env var
+  *names* whose *values* are copied from the daemon's own trusted ambient
+  environment — `agents.<alias>.env.vars` sets literal values, fully
+  operator-controlled, the same trust model as an MCP server's `env` block.
+  One exception to "overriding": on Android, `/system/bin` and
+  `/system/xbin` are always prepended to `PATH`, so a `PATH` pinned here
+  extends the platform lookup rather than replacing it — without those
+  directories the child shell cannot resolve `sh` itself.
+- **`home_mode`** controls what `HOME` resolves to for this agent's
+  subprocesses: `inherit` (default) keeps today's behavior — the daemon's
+  real `$HOME`, shared across every agent. `workspace` points `HOME` at
+  `agents/<alias>/workspace/home/`, created on demand. `custom` uses
+  `home_path`, which is validated to stay inside the agent's workspace
+  boundary unless `workspace.unrestricted-filesystem = true`.

--- a/docs/book/src/security/autonomy.md
+++ b/docs/book/src/security/autonomy.md
@@ -81,7 +81,7 @@ OS-level sandboxing fields live on the same risk profile. See [Sandboxing](./san
 
 The shell tool runs in a minimal environment by default; expose specific env vars via the risk profile. Secrets (`API_KEY`, `_TOKEN`, `_SECRET`, `_PASSWORD` patterns) are *never* passed through automatically; list them explicitly or fetch from the secrets store inside the command.
 
-This is a NAME allowlist: `risk_profiles.<name>.shell-env-passthrough` only says which var *names* may be copied, and the *values* always come from the daemon's own trusted ambient environment. It is distinct from `agents.<alias>.env.vars` (see [Filesystem components → Environment](../agents/filesystem.md#environment)), which sets explicit `KEY=VALUE` pairs and, optionally, a workspace-confined `HOME`, per agent. Both are fully operator-authored config — a delegated subagent cannot expand either beyond what its parent already grants (see the escalation checks in `SecurityPolicy::ensure_no_escalation_beyond`).
+This is a NAME allowlist: `risk_profiles.<name>.shell-env-passthrough` only says which var *names* may be copied, and the *values* always come from the daemon's own trusted ambient environment. It is distinct from `agents.<alias>.env.vars` (see [Filesystem components → Environment](../agents/filesystem.md#environment)), which sets explicit `KEY=VALUE` pairs and, optionally, a workspace-confined `HOME`, per agent. Both are fully operator-authored config: a delegated subagent cannot expand either beyond what its parent already grants (see the escalation checks in `SecurityPolicy::ensure_no_escalation_beyond`).
 
 ## Per-channel stricter autonomy
 

--- a/docs/book/src/security/autonomy.md
+++ b/docs/book/src/security/autonomy.md
@@ -81,6 +81,8 @@ OS-level sandboxing fields live on the same risk profile. See [Sandboxing](./san
 
 The shell tool runs in a minimal environment by default; expose specific env vars via the risk profile. Secrets (`API_KEY`, `_TOKEN`, `_SECRET`, `_PASSWORD` patterns) are *never* passed through automatically; list them explicitly or fetch from the secrets store inside the command.
 
+This is a NAME allowlist: `risk_profiles.<name>.shell-env-passthrough` only says which var *names* may be copied, and the *values* always come from the daemon's own trusted ambient environment. It is distinct from `agents.<alias>.env.vars` (see [Filesystem components → Environment](../agents/filesystem.md#environment)), which sets explicit `KEY=VALUE` pairs and, optionally, a workspace-confined `HOME`, per agent. Both are fully operator-authored config — a delegated subagent cannot expand either beyond what its parent already grants (see the escalation checks in `SecurityPolicy::ensure_no_escalation_beyond`).
+
 ## Per-channel stricter autonomy
 
 Autonomy is per-agent, not per-channel. To run a public-facing channel at a stricter level than your main agent, define a second agent bound to a stricter risk profile and route that channel to it. Per-channel `excluded_tools` (`channels.<type>.<alias>.excluded_tools`) is the cheaper knob when you only need to hide individual tools, no second agent required.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `[agents.<alias>.env]` so we can inject explicit `KEY=VALUE` pairs into an agent's subprocesses. Today the only option is `risk_profiles.<name>.shell-env-passthrough`, but the values always come from the daemon's env, so there is no way to give an agent a different value from the daemon.
  - Adds `env.home_mode` so an agent's `HOME` can be confined to its own workspace. Previously every agent's spawned tools shared the daemon's real `HOME`, so `git`, `npm`, etc. used dotfiles and caches in the user's home directory, and were subject to all of the filesystem access restrictions there.
  - Adds both onto `SecurityPolicy` (`env_vars`, `home_override`) rather than into `ShellTool` directly, so the other spawn-based tools can adopt them later without reworking config.
  - Extends `ensure_no_escalation_beyond` in both directions: a delegated subagent cannot add or retarget an env var its parent didn't grant, and cannot _drop_ a HOME confinement its parent set (dropping it falls back to the real `$HOME`, so `None` is the least-confined value, not a neutral one).
  - Adds `SecurityPolicy::rebind_workspace` and routes bounded delegation through it, so a workspace-confined HOME follows the workspace when a bounded delegate is retargeted onto the caller's.
- **Scope boundary:** the `shell` tool only. `skill_tool`, `codex/claude/gemini/opencode_cli`, `google_workspace`, and `content_search` still use the daemon's environment; they can adopt the two new `SecurityPolicy` fields in follow-ups. `rebind_workspace` deliberately does not re-root `allowed_roots`, which is derived from `workspace_dir` the same way - that would widen what a bounded delegate can reach in the caller's workspace and needs its own justification. No changes to `shell-env-passthrough`, `SAFE_ENV_VARS`, or the `env_clear()` baseline.
- **Blast radius:** `SecurityPolicy` gains two fields and is constructed on every per-agent path (agent loop, gateway, channels, cron, RPC, delegate). Both default to inert (`BTreeMap::new()` / `None`) and only `SecurityPolicy::for_agent` populates them, so an install with no `[agents.<alias>.env]` block behaves exactly as before. `EscalationViolation` gains two variants; no crate matches on it exhaustively.
- **Linked issue(s):** none
- **Labels:** `type:feature`, `risk:medium`, `size:M`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `surface: cli`
- **Setup / preconditions:** an install with at least one configured agent and the `shell` tool enabled.
- **Steps to run:** add to `zeroclaw.toml`, then have the agent run `echo "$ZC_DEMO"; echo "$HOME"` through the `shell` tool:

  ```toml
  [agents.default.env]
  home-mode = "workspace"

  [agents.default.env.vars]
  ZC_DEMO = "injected"
  ```

- **Expected on this branch (after):** prints `injected`, then a `HOME` of `<install>/agents/default/workspace/home`, and that directory now exists.
- **Prior behavior on `master` (before):** the config keys are rejected as unknown; unset, `$ZC_DEMO` is empty and `$HOME` is the daemon's real home.

### How I tested

Focused local tests on the two changed crates plus a compile check of every crate that constructs a `SecurityPolicy` or an `AliasedAgentConfig`.

```sh
$ cargo test -p zeroclaw-config --lib
test result: ok. 1274 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p zeroclaw-runtime --lib tools::shell::
test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 3541 filtered out

$ cargo test -p zeroclaw-runtime --lib tools::delegate::
test result: ok. 120 passed; 0 failed; 0 ignored; 0 measured; 3488 filtered out

$ cargo clippy -p zeroclaw-config -p zeroclaw-runtime --lib --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo fmt -p zeroclaw-config -p zeroclaw-runtime -- --check

$ cargo check -p zeroclaw-gateway -p zeroclaw-channels -p zeroclaw-tools
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.80s

$ cargo check -p zeroclaw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 35s

$ cargo test -p zeroclaw --lib
test result: ok. 271 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- **CI checks relied on and why they cover this change:** the standard Rust workflow (`cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test`) covers every changed line - the diff is Rust plus two hand-written mdBook pages. `Docs Style` covers the changed Markdown.
- **Known CI coverage gap, if any:** the generated config reference (`docs/book/src/reference/config.md`, `env-vars.md`) has not been regenerated in this branch; it derives from the schema, so it needs the repo's normal doc-build step before merge.
- **Commands run and tail output:** above.
- **Beyond CI, what did you manually verify?** 28 new tests, covering each `HomeMode` through `SecurityPolicy::for_agent` (including custom paths rejected outside the workspace and permitted under `unrestricted_filesystem`), the env/HOME overlay precedence against `tui_env` in a real spawned subprocess, both escalation directions, and the bounded-delegation workspace rebind end-to-end through `DelegateTool::policy_for_target`. `cargo check -p zeroclaw` and `cargo test -p zeroclaw --lib` pass clean, confirming this diff compiles and the top-level binary crate's own test suite is unaffected. I have not run the feature end-to-end against a live daemon (the manual smoke test in "How you can test" above, which exercises the gateway/channel/agent-loop wiring rather than unit-level `SecurityPolicy` construction), so that's worth a reviewer pass. I plan to run this later and verify it works as expected.
- **If any command was intentionally skipped, why:** none skipped at this point.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation:
  - **Filesystem scope.** `home_mode = "custom"` can name a `HOME` outside the agent's workspace, but only when `workspace.unrestricted_filesystem = true` is already set; otherwise `for_agent` rejects it at policy construction with the offending path in the message. Containment is checked with the existing `workspace_prefixed_relative_suffix` helper, which refuses any path containing `..`. The default (`inherit`) changes nothing, and the common case (`workspace`) strictly narrows today's behavior.
  - **Credentials.** `env.vars` commonly carries tokens for spawned tools, so it is marked `#[secret]` - the same treatment as `McpServerConfig::env`, which means encryption at rest via the existing secret-store walk and masking in `config show`. Values are operator-authored config and are never model-controlled at runtime; the model can neither read nor set them. They are injected only into subprocesses the agent already had authority to spawn.
  - **Delegation.** Both fields are gated in `ensure_no_escalation_beyond`, so a subagent cannot use them to widen its parent's envelope in either direction (add/retarget a var, or drop a HOME confinement).

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes** - new optional `[agents.<alias>.env]` block: `vars` (map, default empty), `home-mode` (`inherit` | `workspace` | `custom`, default `inherit`), `home-path` (optional, `custom` only).
- Rust/MSRV/toolchain floor changed? **No**
- Upgrade steps: none. Every field defaults to today's behavior, so existing configs load and run unchanged without edits.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`. No migration, no persisted state beyond the `<workspace>/home/` directories created on demand, which are inert once the config block is gone.
- **Feature flags or config toggles:** the feature is inert unless `[agents.<alias>.env]` is set. To disable per agent without reverting, drop the block or set `home-mode = "inherit"` and empty `vars`.
- **Observable failure symptoms:**
  - Policy construction failing at startup: grep for `SecurityPolicy::for_agent: failed to create agent HOME dir` (unwritable workspace) or `resolves outside the agent's workspace` (misconfigured `home-path`). Both fail closed - the agent does not start.
  - Delegation refusals: grep for `subagent env_vars entry`, `subagent home_override`, or the existing `subagent build refused: policy override escalates beyond parent` warning.
  - Tools misbehaving under a confined HOME: symptoms are tool-specific (`git` losing global config, `npm` re-downloading its cache) and resolve by setting `home-mode = "inherit"`.

---

If this is too wide of a scope, we could change to just the `env` config overrides and let `HOME` be managed manually there. There will be more limitations to only supporting an env var, but it'd be a much smaller change.

This new home override felt like the best way to allow sandboxing to both be an effective isolation tool, and still flexible enough to be useful for real use cases. Without this change, the vast majority of things I've tried to do only work without the sandbox, since so many CLI tools expect to be able to do arbitrary things in their HOME.

If this seems like a good direction to go, we should probably do follow-up PRs to add env var support to other tools that would make sense to have it, though the practicality and side effects of them will vary heavily.