### PR TITLE
fix(daemon): remove unsupported SIGUSR1 reload guidance

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4169,10 +4169,10 @@ async fn async_main(command: clap::Command) -> Result<()> {
             zeroclaw_runtime::restart::record_launch();
 
             // Reload loop. `daemon::run` returns DaemonExit::Shutdown on
-            // SIGINT/SIGTERM (loop ends) or DaemonExit::Reload on SIGUSR1
-            // (loop re-reads config from disk and re-runs). The PID stays
-            // the same across reloads — only the in-process subsystems
-            // tear down + re-instantiate.
+            // SIGINT/SIGTERM (loop ends) or DaemonExit::Reload after a
+            // `POST /admin/reload` request (loop re-reads config from disk and
+            // re-runs). The PID stays the same across reloads — only the
+            // in-process subsystems tear down + re-instantiate.
             let mut current_config = config;
             // Nag task for the degraded-security warning, scoped to the
             // current config. Re-evaluated each reload iteration so a repaired
@@ -7708,8 +7708,8 @@ fn gate_security_posture(
                 &format!(
                     "Running with DEGRADED security: sections ({sections}) were reset to \
                      defaults and `--allow-degraded-security` was set. The posture may be \
-                     weaker than intended — repair {config_path} and reload \
-                     (SIGUSR1 / `zeroclaw admin reload`) as soon as possible."
+                     weaker than intended — repair {config_path} and restart \
+                     the process as soon as possible."
                 )
             );
         }

--- a/tests/component/daemon_startup_feedback.rs
+++ b/tests/component/daemon_startup_feedback.rs
@@ -56,6 +56,16 @@ sys.exit(0 if b'\"result\"' in s.recv(4096) else 1)"#;
 }
 
 #[test]
+fn daemon_guidance_does_not_advertise_unhandled_sigusr1() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let main_source = std::fs::read_to_string(root.join("src/main.rs")).unwrap();
+    assert!(
+        !main_source.contains("SIGUSR1"),
+        "daemon guidance must not advertise the unsupported SIGUSR1 reload path"
+    );
+}
+
+#[test]
 fn daemon_feedback_follows_foreground_job_control_transitions() {
     let (_foreground_config, foreground_obstruction, foreground_port, foreground_command) =
         daemon_fixture();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Remove SIGUSR1 from the degraded-security warning because the daemon does not register that signal and its default action terminates the process.
  - Correct the daemon-only reload-loop comment to name `POST /admin/reload`, while the shared warning tells both daemon and standalone gateway callers to restart after repair.
  - Add a source-contract regression that rejects unsupported SIGUSR1 guidance in `src/main.rs`.
- **Scope boundary:** No signal handler, reload behavior, gateway route, scheduler, persistence, or configuration behavior changes.
- **Blast radius:** The shared degraded-security warning, one daemon reload-loop comment, and component regression coverage.
- **Linked issue(s):** Fixes #9768
- **Labels:** `bug`, `core`, `daemon`, `runtime`, `tests`, `priority:p1`, `follow-up`, `risk:low`, `size:XS`, `cli`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the regression checks the source contract directly, while triggering the warning manually requires a deliberately malformed security-critical configuration.

### How I tested

- **CI checks relied on and why they cover this change:** None at submission; required PR CI will run independently. The local component test exercises the new invariant, and workspace Clippy covers the changed Rust targets.
- **Known CI coverage gap, if any:** The environment lacks the external `expect` executable needed by one unchanged PTY component test. Untouched base b718f1b reproduces that same dependency failure.
- **Commands run and tail output:**

```text
# RED on the original guidance
CARGO_BUILD_JOBS=1 cargo test --locked --test component daemon_guidance_does_not_advertise_unhandled_sigusr1 -- --nocapture
result: FAILED. 0 passed; 1 failed; 214 filtered out

# GREEN after removing SIGUSR1 guidance
CARGO_BUILD_JOBS=1 cargo test --locked --test component daemon_guidance_does_not_advertise_unhandled_sigusr1 -- --nocapture
result: ok. 1 passed; 0 failed; 214 filtered out

CARGO_BUILD_JOBS=1 cargo test --locked --test component -- --skip daemon_feedback_follows_foreground_job_control_transitions
result: ok. 214 passed; 0 failed; 1 filtered out

CARGO_BUILD_JOBS=1 cargo test --locked --bin zeroclaw gate_security_posture_fails_closed_unless_allowed -- --nocapture
result: ok. 1 passed; 0 failed; 351 filtered out

cargo fmt --all -- --check
result: passed

CARGO_BUILD_JOBS=1 cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets -- -D clippy::correctness
result: passed (four pre-existing dead-code warnings in zeroclaw-gateway test helpers)

git diff --check
result: passed
```

- **Beyond CI, what did you manually verify?** `gate_security_posture` is shared by daemon and standalone gateway start/restart paths, so the warning now gives the universally valid repair-and-restart instruction. The daemon-only loop comment names the registered `.route("/admin/reload", post(handle_admin_reload))` path. `SIGUSR1` is absent from `src/main.rs` after the change.
- **If any command was intentionally skipped, why:** The unchanged `daemon_feedback_follows_foreground_job_control_transitions` test was filtered because its external `expect` dependency is unavailable locally; untouched base reproduces the same failure.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes — operator-facing warning text only; accepted commands and runtime behavior are unchanged.**
- Rust/MSRV/toolchain floor changed? **No**
- Exact upgrade steps for existing users: None.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 6dc9746807720256e4964f83508aa9e6603117ad`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The degraded-security warning again recommends SIGUSR1, or the reload-loop comment again claims SIGUSR1 is handled.
