### PR TITLE
fix(sop): honour the documented sops_dir default in the daemon

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1522,13 +1522,14 @@ impl Agent {
             None
         };
 
-        // SOP loading is gated on `[sop] sops_dir`: unset disables all SOP
-        // runtime behavior, matching the documented rollback path.
-        // If caller provided an engine (daemon path), use it; otherwise
-        // build our own (CLI/standalone path) only when the gate is set.
+        // SOP loading is gated on the resolved SOPs directory existing: `[sop]
+        // sops_dir` is an optional override, and omitting it resolves the
+        // documented `<workspace>/sops` default. Removing that directory is the
+        // rollback path. If the caller provided an engine (daemon path), use it;
+        // otherwise build our own (CLI/standalone path) when the gate passes.
         let (sop_engine, sop_audit) = match (sop_engine, sop_audit) {
             (Some(engine), Some(audit)) => (Some(engine), Some(audit)),
-            (None, None) if config.sop.sops_dir.is_some() => {
+            (None, None) if crate::sop::sops_enabled(&config.sop, &config.data_dir) => {
                 let mem: Arc<dyn zeroclaw_memory::Memory> =
                     zeroclaw_memory::create_memory_for_agent(config, agent_alias, None).await?;
                 // CLI / standalone path: no channel map is wired here, so the route

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1271,11 +1271,12 @@ pub async fn run(
             (None, None)
         };
 
-        // Build SOP engine when sops_dir is configured so SOP tools are
-        // available on this path (CLI agent run). No channel map is wired on this
-        // path, so the approval route adapter is the no-op (log-only); the daemon
-        // path injects a real channel-delivering adapter.
-        let (sop_engine, sop_audit) = if config.sop.sops_dir.is_some() {
+        // Build the SOP engine when the resolved SOPs directory exists — an
+        // omitted `sops_dir` resolves the documented `<workspace>/sops` default —
+        // so SOP tools are available on this path (CLI agent run). No channel map
+        // is wired on this path, so the approval route adapter is the no-op
+        // (log-only); the daemon path injects a real channel-delivering adapter.
+        let (sop_engine, sop_audit) = if crate::sop::sops_enabled(&config.sop, &config.data_dir) {
             let sop_mem: Arc<dyn zeroclaw_memory::Memory> =
                 zeroclaw_memory::create_memory_for_agent(&config, agent_alias, None).await?;
             let (engine, audit) = crate::sop::build_sop_engine(
@@ -2867,10 +2868,11 @@ pub async fn process_message(
         };
 
         // Build SOP engine when sops_dir is configured so SOP tools are
-        // available on this path (process_message CLI agent). No channel map is
-        // wired here, so the approval route adapter is the no-op (log-only); the
-        // daemon path injects a real channel-delivering adapter.
-        let (sop_engine, sop_audit) = if config.sop.sops_dir.is_some() {
+        // available on this path (process_message CLI agent), gated on the
+        // resolved SOPs directory existing rather than on the optional override.
+        // No channel map is wired here, so the approval route adapter is the no-op
+        // (log-only); the daemon path injects a real channel-delivering adapter.
+        let (sop_engine, sop_audit) = if crate::sop::sops_enabled(&config.sop, &config.data_dir) {
             let sop_mem: Arc<dyn zeroclaw_memory::Memory> =
                 zeroclaw_memory::create_memory_for_agent(&config, agent_alias, None).await?;
             let (engine, audit) = crate::sop::build_sop_engine(

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -1214,8 +1214,16 @@ type = "manual"
 
         // The gate and the loader must agree: enabling construction is only
         // meaningful if the engine then actually reads definitions from there.
-        let loaded = load_sops(tmp.path(), config.sops_dir.as_deref(), SopExecutionMode::Auto);
-        assert_eq!(loaded.len(), 1, "definitions must load from the default dir");
+        let loaded = load_sops(
+            tmp.path(),
+            config.sops_dir.as_deref(),
+            SopExecutionMode::Auto,
+        );
+        assert_eq!(
+            loaded.len(),
+            1,
+            "definitions must load from the default dir"
+        );
         assert_eq!(loaded[0].name, "default-dir-sop");
     }
 

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -201,6 +201,23 @@ pub fn resolve_sops_dir(workspace_dir: &Path, config_dir: Option<&str>) -> PathB
     }
 }
 
+/// Whether SOP runtime state should be constructed for this configuration.
+///
+/// Callers previously gated construction on `[sop] sops_dir` being *set*, which
+/// contradicted the documented contract — `sops_dir` is an optional override, and
+/// when omitted the runtime resolves the default `<workspace>/sops`. The engine
+/// itself already honours that default (see [`load_sops`]), so gating on the
+/// override meant a populated `<workspace>/sops` was never read by the daemon:
+/// SOPs loaded for `sop list` yet silently never ran.
+///
+/// The gate is therefore the resolved directory *existing*, which is the same
+/// question [`load_sops_from_directory`] asks. Removing (or never creating) the
+/// directory remains the rollback path, and an explicit `sops_dir` pointing
+/// somewhere absent still disables SOPs exactly as before.
+pub fn sops_enabled(config: &SopConfig, workspace_dir: &Path) -> bool {
+    resolve_sops_dir(workspace_dir, config.sops_dir.as_deref()).is_dir()
+}
+
 /// Resolve `<sops_dir>/<name>`, accepting only a single normal path
 /// component so caller-controlled names cannot escape the SOP root.
 fn resolve_sop_dir(sops_dir: &Path, name: &str) -> Result<PathBuf> {
@@ -1149,6 +1166,154 @@ mod tests {
         assert_eq!(
             resolve_sops_dir(workspace, Some("")),
             workspace.join("sops")
+        );
+    }
+
+    /// Write a minimal, valid SOP under `<dir>/<name>/SOP.toml`.
+    fn write_sop(dir: &Path, name: &str) {
+        let sop_dir = dir.join(name);
+        std::fs::create_dir_all(&sop_dir).expect("create SOP dir");
+        std::fs::write(
+            sop_dir.join("SOP.toml"),
+            format!(
+                r#"
+[sop]
+name = "{name}"
+description = "regression fixture"
+version = "1.0.0"
+
+[[triggers]]
+type = "manual"
+"#
+            ),
+        )
+        .expect("write SOP.toml");
+    }
+
+    /// Regression for #9779.
+    ///
+    /// `sops_dir` is an optional override; omitting it must resolve the
+    /// documented `<workspace>/sops` default. Before the fix every construction
+    /// site gated on the override being *set*, so a populated default directory
+    /// was visible to `sop list` yet the daemon never built an engine for it and
+    /// SOPs silently never ran.
+    #[test]
+    fn sops_enabled_when_sops_dir_is_omitted_and_default_dir_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_sop(&tmp.path().join("sops"), "default-dir-sop");
+
+        let config = SopConfig {
+            sops_dir: None,
+            ..Default::default()
+        };
+
+        assert!(
+            sops_enabled(&config, tmp.path()),
+            "an omitted sops_dir with a populated <workspace>/sops must enable SOPs"
+        );
+
+        // The gate and the loader must agree: enabling construction is only
+        // meaningful if the engine then actually reads definitions from there.
+        let loaded = load_sops(tmp.path(), config.sops_dir.as_deref(), SopExecutionMode::Auto);
+        assert_eq!(loaded.len(), 1, "definitions must load from the default dir");
+        assert_eq!(loaded[0].name, "default-dir-sop");
+    }
+
+    /// The rollback path survives: no directory, no SOP runtime.
+    #[test]
+    fn sops_disabled_when_default_dir_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = SopConfig {
+            sops_dir: None,
+            ..Default::default()
+        };
+        assert!(
+            !sops_enabled(&config, tmp.path()),
+            "absent <workspace>/sops must leave SOPs disabled"
+        );
+    }
+
+    /// An explicit override still wins, and still disables when it points nowhere.
+    #[test]
+    fn sops_enabled_follows_an_explicit_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_sop(&tmp.path().join("custom"), "override-sop");
+
+        let configured = SopConfig {
+            sops_dir: Some("custom".into()),
+            ..Default::default()
+        };
+        assert!(
+            sops_enabled(&configured, tmp.path()),
+            "an explicit sops_dir that exists must enable SOPs"
+        );
+
+        let missing = SopConfig {
+            sops_dir: Some("nope".into()),
+            ..Default::default()
+        };
+        assert!(
+            !sops_enabled(&missing, tmp.path()),
+            "an explicit sops_dir that does not exist must leave SOPs disabled"
+        );
+    }
+
+    /// The invariant the bug violated, stated directly: the gate must never
+    /// suppress a directory the loader would have read definitions from.
+    ///
+    /// The old `sops_dir.is_some()` gate broke exactly this — omitted override
+    /// plus a populated `<workspace>/sops` meant `load_sops` would return a SOP
+    /// while the gate said "no engine". Any future gate that is stricter than
+    /// the loader fails here.
+    #[test]
+    fn the_gate_never_suppresses_a_directory_the_loader_would_read() {
+        for override_dir in [None, Some(""), Some("custom"), Some("absent")] {
+            for create_default in [false, true] {
+                for create_custom in [false, true] {
+                    let tmp = tempfile::tempdir().unwrap();
+                    if create_default {
+                        write_sop(&tmp.path().join("sops"), "in-default");
+                    }
+                    if create_custom {
+                        write_sop(&tmp.path().join("custom"), "in-custom");
+                    }
+
+                    let config = SopConfig {
+                        sops_dir: override_dir.map(str::to_owned),
+                        ..Default::default()
+                    };
+                    let loaded = load_sops(
+                        tmp.path(),
+                        config.sops_dir.as_deref(),
+                        SopExecutionMode::Auto,
+                    );
+
+                    if !loaded.is_empty() {
+                        assert!(
+                            sops_enabled(&config, tmp.path()),
+                            "gate refused an engine while the loader would read {} SOP(s) \
+                             (override={override_dir:?}, default_dir={create_default}, \
+                             custom_dir={create_custom})",
+                            loaded.len()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// A file where the directory should be is not a SOPs root.
+    #[test]
+    fn sops_disabled_when_default_path_is_a_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("sops"), b"not a directory").unwrap();
+        let config = SopConfig {
+            sops_dir: None,
+            ..Default::default()
+        };
+        assert!(
+            !sops_enabled(&config, tmp.path()),
+            "a regular file at <workspace>/sops must not enable SOPs"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/sop/mod.rs
+++ b/crates/zeroclaw-runtime/src/sop/mod.rs
@@ -1190,12 +1190,10 @@ type = "manual"
         .expect("write SOP.toml");
     }
 
-    /// Regression for #9779.
-    ///
     /// `sops_dir` is an optional override; omitting it must resolve the
-    /// documented `<workspace>/sops` default. Before the fix every construction
-    /// site gated on the override being *set*, so a populated default directory
-    /// was visible to `sop list` yet the daemon never built an engine for it and
+    /// documented `<workspace>/sops` default. Every construction site used to
+    /// gate on the override being *set*, so a populated default directory was
+    /// visible to `sop list` yet the daemon never built an engine for it and
     /// SOPs silently never ran.
     #[test]
     fn sops_enabled_when_sops_dir_is_omitted_and_default_dir_exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5015,19 +5015,19 @@ async fn async_main(command: clap::Command) -> Result<()> {
                 // Same resolved-directory gate as the full daemon path above.
                 let (sop_engine, sop_audit) =
                     if zeroclaw_runtime::sop::sops_enabled(&config.sop, &config.data_dir) {
-                    let mem: Arc<dyn zeroclaw_memory::Memory> =
-                        Arc::from(zeroclaw_memory::create_memory_from_config(&config, None)?);
-                    let sop_adapters = build_sop_adapters(&config);
-                    let (engine, audit) = zeroclaw_runtime::sop::build_sop_engine(
-                        config.sop.clone(),
-                        &config.data_dir,
-                        mem,
-                        sop_adapters,
-                    );
-                    (Some(engine), Some(audit))
-                } else {
-                    (None, None)
-                };
+                        let mem: Arc<dyn zeroclaw_memory::Memory> =
+                            Arc::from(zeroclaw_memory::create_memory_from_config(&config, None)?);
+                        let sop_adapters = build_sop_adapters(&config);
+                        let (engine, audit) = zeroclaw_runtime::sop::build_sop_engine(
+                            config.sop.clone(),
+                            &config.data_dir,
+                            mem,
+                            sop_adapters,
+                        );
+                        (Some(engine), Some(audit))
+                    } else {
+                        (None, None)
+                    };
                 // EPIC A1 + SOP cron: same tick as the full daemon path.
                 let sop_maintenance = spawn_sop_maintenance(
                     sop_engine.as_ref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4230,9 +4230,14 @@ async fn async_main(command: clap::Command) -> Result<()> {
                 let canvas_store_for_channels = canvas_store_for_channels.clone();
                 let mut registry = daemon::DaemonRegistry::new();
 
-                // SOP loading is gated on `[sop] sops_dir`: unset disables all
-                // SOP runtime behavior, matching the documented rollback path.
-                let (sop_engine, sop_audit) = if current_config.sop.sops_dir.is_some() {
+                // SOP loading is gated on the *resolved* SOPs directory existing,
+                // not on `[sop] sops_dir` being set: the override is optional and
+                // omitting it resolves the documented `<workspace>/sops` default.
+                // Removing that directory remains the rollback path.
+                let (sop_engine, sop_audit) = if zeroclaw_runtime::sop::sops_enabled(
+                    &current_config.sop,
+                    &current_config.data_dir,
+                ) {
                     let mem: Arc<dyn zeroclaw_memory::Memory> = Arc::from(
                         zeroclaw_memory::create_memory_from_config(&current_config, None)?,
                     );
@@ -5007,7 +5012,9 @@ async fn async_main(command: clap::Command) -> Result<()> {
                 }));
 
                 let cancel = tokio_util::sync::CancellationToken::new();
-                let (sop_engine, sop_audit) = if config.sop.sops_dir.is_some() {
+                // Same resolved-directory gate as the full daemon path above.
+                let (sop_engine, sop_audit) =
+                    if zeroclaw_runtime::sop::sops_enabled(&config.sop, &config.data_dir) {
                     let mem: Arc<dyn zeroclaw_memory::Memory> =
                         Arc::from(zeroclaw_memory::create_memory_from_config(&config, None)?);
                     let sop_adapters = build_sop_adapters(&config);


### PR DESCRIPTION
Fixes #9779.

`[sop] sops_dir` is documented as an optional override:

> Optional override. When omitted, the runtime and CLI both resolve the default `<workspace>/sops`; SOPs load from there whenever it exists.

The runtime did not honour that. Every SOP construction site gated on the override being *set*, so omitting it meant no engine was built at all — and a populated `<workspace>/sops` was read by `sop list` yet never loaded by the daemon. Cron-driven SOPs silently never ran, with no error to explain why.

## Where the defect actually is

Not in the loader. `SopEngine::reload` → `load_sops` → `resolve_sops_dir` already resolves the documented default, and `load_sops_from_directory` already returns empty for an absent directory. The bug is purely the outer gate, duplicated across five sites:

| File | Path |
|---|---|
| `src/main.rs` | full daemon |
| `src/main.rs` | second daemon path |
| `crates/zeroclaw-runtime/src/agent/loop_.rs` | CLI agent run |
| `crates/zeroclaw-runtime/src/agent/loop_.rs` | `process_message` agent |
| `crates/zeroclaw-runtime/src/agent/agent.rs` | CLI / standalone |

Each tested `config.sop.sops_dir.is_some()`, so the correct resolution below was never reached.

## The change

One shared predicate in `sop::mod`, so the five sites cannot drift apart again:

```rust
pub fn sops_enabled(config: &SopConfig, workspace_dir: &Path) -> bool {
    resolve_sops_dir(workspace_dir, config.sops_dir.as_deref()).is_dir()
}
```

The gate is now the resolved directory *existing* — the same question `load_sops_from_directory` asks — which makes the gate and the loader agree by construction.

| `sops_dir` | `<workspace>/sops` | before | after |
|---|---|---|---|
| set, exists | — | enabled | enabled (unchanged) |
| set, absent | — | enabled, loads nothing | disabled |
| omitted | exists | **disabled — the bug** | **enabled** |
| omitted | absent | disabled | disabled (unchanged) |

## Semantic note

The rollback path moves from "unset `sops_dir`" to "no SOPs directory present". The in-code comments described the unset case as the documented rollback path, but the schema doc on the field says the opposite, and the schema doc is the contract users read — so this follows the schema doc and the comments are updated to match. If an explicit kill switch is wanted, an `[sop] enabled` flag would express that more honestly than an override doing double duty; happy to add it instead.

## Tests

Added to `sop::tests`:

- `sops_enabled_when_sops_dir_is_omitted_and_default_dir_exists` — the regression. Asserts the gate opens **and** that `load_sops` actually returns the definition, so gate and loader are pinned together rather than only the flag being checked.
- `sops_disabled_when_default_dir_is_absent` — rollback preserved.
- `sops_enabled_follows_an_explicit_override` — an explicit dir that exists enables; one that does not, disables.
- `sops_disabled_when_default_path_is_a_file` — a regular file at `<workspace>/sops` is not a SOPs root.

No behaviour change for anyone who sets `sops_dir` explicitly.
