### PR TITLE
fix(runtime/cron): infer shell when blank prompt key lacks job_type

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -366,7 +366,15 @@ impl Tool for CronAddTool {
                 });
             }
             None => {
-                if args.get("prompt").is_some() {
+                // Infer agent only when prompt has non-blank content. A present
+                // but null/empty/whitespace `prompt` key must not forge Agent
+                // (and then fail "Missing 'prompt'") when a shell command is
+                // supplied — match the content check used below for agent jobs.
+                if args
+                    .get("prompt")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|prompt| !prompt.trim().is_empty())
+                {
                     JobType::Agent
                 } else {
                     JobType::Shell
@@ -1084,6 +1092,33 @@ mod tests {
                 .unwrap_or_default()
                 .contains("Missing 'prompt'")
         );
+    }
+
+    #[tokio::test]
+    async fn blank_or_null_prompt_without_job_type_infers_shell_when_command_present() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg), TEST_AGENT);
+
+        for prompt in [json!(null), json!(""), json!("   ")] {
+            let result = tool
+                .execute(json!({
+                    "schedule": { "kind": "cron", "expr": "*/5 * * * *" },
+                    "command": "echo ok",
+                    "prompt": prompt,
+                }))
+                .await
+                .unwrap();
+            assert!(
+                result.success,
+                "prompt={prompt:?} should infer shell, got error={:?}",
+                result.error
+            );
+        }
+
+        let jobs = cron::list_jobs(&cfg).unwrap();
+        assert_eq!(jobs.len(), 3);
+        assert!(jobs.iter().all(|job| job.command == "echo ok"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - **Bug:** Omitting `job_type` while sending a shell `command` plus a present-but-blank `prompt` (`null` / `""` / whitespace) makes `cron_add` treat the request as an agent job, then reject it with `Missing 'prompt'` — so a valid shell cron never gets created.
  - **Cause:** Inference used key presence (`args.get("prompt").is_some()`) instead of non-blank prompt content.
  - **Fix:** Infer `JobType::Agent` only when `prompt` is a non-empty string after trim (same rule as the agent-path prompt check); otherwise keep shell inference when a command is supplied.
  - **Test:** Regression covers `null` / `""` / `"   "` with `command: "echo ok"`.
- **Scope boundary:** Does not change explicit `job_type: "agent"` / `"shell"`, schedule parsing, or delivery validation.
- **Blast radius:** Only job-type inference when `job_type` is omitted. Explicit job types and non-blank prompts unchanged.
- **Linked issue(s):** Closes #9889
- **Labels:** Current PR labels: `bug`, `cron`, `runtime`, `tool`, `priority:p1`, `tool:cron`, `risk:high`, `size:XS`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** library tool path (`zeroclaw-runtime` `CronAddTool` / unit tests)
- **Setup / preconditions:** Rust toolchain; workspace builds. Compare `master` vs this branch.
- **Steps to run:**
  1. On `master`: call `cron_add` with `command: "echo ok"`, omit `job_type`, set `prompt` to `null` / `""` / `"   "` (same matrix as the new unit test).
  2. On this branch: `cargo test -p zeroclaw-runtime --lib blank_or_null_prompt_without_job_type_infers_shell_when_command_present`
- **Expected on this branch (after):** focused test passes; blank/null/whitespace `prompt` + `command` creates shell jobs.
- **Prior behavior on `master` (before):** same payload fails with `Missing 'prompt'` because key presence forged `JobType::Agent`.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib blank_or_null_prompt_without_job_type_infers_shell_when_command_present
```

- **CI checks relied on and why they cover this change:** PR Checks (fmt/clippy/test) exercise the same crate surface once they finish.
- **Known CI coverage gap, if any:** None for this inference path; regression is unit-tested.
- **Commands run and tail output:**

```text
GATE tip=9fa79ef base=master
- cargo fmt --all -- --check → pass
- cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings → pass
- cargo test -p zeroclaw-runtime --lib blank_or_null_prompt_without_job_type_infers_shell_when_command_present → pass

test tools::cron_add::tests::blank_or_null_prompt_without_job_type_infers_shell_when_command_present ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3600 filtered out; finished in 0.17s
```

- **Beyond CI, what did you manually verify?** Confirmed the three blank-prompt cases create shell jobs with `command == "echo ok"`. Did not run a live daemon announce path (out of scope).
- **If any command was intentionally skipped, why:** Full `./dev/ci.sh all` skipped; change is one inference branch + unit test.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

Rollback command: `git revert 9fa79ef`.
