### PR TITLE
fix(runtime/cron): validate delivery on update_job patches

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -490,6 +490,8 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
         job.enabled = enabled;
     }
     if let Some(delivery) = patch.delivery {
+        // Match add_*_job: announce delivery must include channel + to.
+        validate_delivery_config(Some(&delivery))?;
         job.delivery = delivery;
     }
     if let Some(model) = patch.model {
@@ -2075,6 +2077,45 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("delivery.to is required"));
+    }
+
+    #[test]
+    fn update_job_rejects_invalid_announce_delivery() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_shell_job(
+            &config,
+            "default",
+            Some("deliver-shell".into()),
+            Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "echo ok",
+            None,
+        )
+        .unwrap();
+
+        let err = update_job(
+            &config,
+            &job.id,
+            CronJobPatch {
+                delivery: Some(DeliveryConfig {
+                    mode: "announce".into(),
+                    channel: Some("discord".into()),
+                    to: None,
+                    thread_id: None,
+                    best_effort: true,
+                }),
+                ..CronJobPatch::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("delivery.to is required"));
+        let stored = get_job(&config, &job.id).unwrap();
+        assert_ne!(stored.delivery.mode, "announce");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - **Bug:** Updating a cron job's `delivery` to `announce` with a channel but no `to` succeeds and is persisted. Add paths already reject that shape; update deferred the failure until announce time with a half-configured job on disk.
  - **Cause:** `update_job` assigned `patch.delivery` without calling `validate_delivery_config` (unlike `add_*_job`).
  - **Fix:** Validate delivery before assign; invalid patches error and leave the stored job unchanged.
  - **Test:** Regression next to the existing add-path announce rejection test.
- **Scope boundary:** Does not change schedule/command/prompt patches, webhook delivery, or scheduler announce execution.
- **Blast radius:** Only updates that patch `delivery`. Valid patches and add paths unchanged.
- **Linked issue(s):** Closes #9890
- **Labels:** `bug`, `cron`, `runtime`, `priority:p1`, `risk:high`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** library store path (`zeroclaw-runtime` `cron::store::update_job` / unit tests)
- **Setup / preconditions:** Rust toolchain; workspace builds. Compare `master` vs this branch.
- **Steps to run:**
  1. On `master`: `add_shell_job(... delivery: None)` then `update_job` with announce delivery that has `channel` but `to: None`.
  2. On this branch: `cargo test -p zeroclaw-runtime --lib update_job_rejects_invalid_announce_delivery`
- **Expected on this branch (after):** focused test passes; update errors with `delivery.to is required` and stored mode stays non-announce.
- **Prior behavior on `master` (before):** same patch is accepted and persisted; failure is deferred until announce time.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib update_job_rejects_invalid_announce_delivery
```

- **CI checks relied on and why they cover this change:** Exact-head required CI is green, including format, lint, test, and the parallel runtime test covering the changed crate.
- **Known CI coverage gap, if any:** None for this validation path; regression is unit-tested.
- **Commands run and tail output:**

```text
GATE tip=ab4c11b base=master
- cargo fmt --all -- --check -> pass
- cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings -> pass
- cargo test -p zeroclaw-runtime --lib update_job_rejects_invalid_announce_delivery -> pass

test cron::store::tests::update_job_rejects_invalid_announce_delivery ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3600 filtered out; finished in 1.78s
```

- **Beyond CI, what did you manually verify?** Invalid announce patch returns `delivery.to is required` and stored `delivery.mode` stays non-announce. Did not exercise live Discord/Telegram announce.
- **If any command was intentionally skipped, why:** Full `./dev/ci.sh all` skipped; change is `update_job` delivery assign + unit test.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes` — previously accepted invalid delivery updates now correctly error; valid updates unchanged)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert ab4c11bfa9ab73e3265776a025c6d53ed8505932`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Valid cron delivery patches unexpectedly return validation errors, or cron updates stop persisting the requested delivery.
