### PR TITLE
feat(whatsapp-web): implement add_reaction and remove_reaction (rebase of #7535)

### DIFF
--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2736,10 +2736,8 @@ impl Channel for WhatsAppWebChannel {
                     // that requires plumbing message metadata
                     // through the trait.
                     participant: None,
-                    ..Default::default()
                 }),
-                text: Some(emoji.to_string()),
-                ..Default::default()
+                text: Some(emoji.to_string())
             }),
             ..Default::default()
         };
@@ -2785,12 +2783,10 @@ impl Channel for WhatsAppWebChannel {
                     id: Some(message_id.to_string()),
                     // `participant` is not needed for 1:1 chats.
                     participant: None,
-                    ..Default::default()
                 }),
                 // Empty text removes the reaction per WhatsApp
                 // protocol.
-                text: Some(String::new()),
-                ..Default::default()
+                text: Some(String::new())
             }),
             ..Default::default()
         };

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -426,6 +426,21 @@ impl WhatsAppWebChannel {
         let sender = sender_jid.user().to_string();
         let chat = info.source.chat.to_string();
 
+        // Use the native WhatsApp message id so that ack_reactions
+        // (add_reaction/remove_reaction) can build a correct MessageKey
+        // targeting the inbound message. Fall back to a UUID when the
+        // id is missing (should be rare).
+        let native_msg_id = if info.id.is_empty() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                "WhatsApp message missing native id, falling back to UUID"
+            );
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            info.id.clone()
+        };
+
         let allowed_peers = (context.peer_resolver)();
         let sender_resolution = Self::resolve_sender_allowlist(
             client,
@@ -646,6 +661,7 @@ impl WhatsAppWebChannel {
                 Vec::new(),
                 true,
                 conversation_scope,
+                native_msg_id,
             )
             .await;
             return;
@@ -732,6 +748,7 @@ impl WhatsAppWebChannel {
             attachments,
             false,
             conversation_scope,
+            native_msg_id,
         )
         .await;
     }
@@ -1276,10 +1293,11 @@ impl WhatsAppWebChannel {
         attachments: Vec<MediaAttachment>,
         passive_context: bool,
         conversation_scope: ChannelConversationScope,
+        id: String,
     ) {
         if let Err(e) = tx
             .send(ChannelMessage {
-                id: uuid::Uuid::new_v4().to_string(),
+                id,
                 channel: "whatsapp".to_string(),
                 channel_alias: Some(alias.to_string()),
                 sender: sender.to_string(),

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2690,6 +2690,22 @@ impl Channel for WhatsAppWebChannel {
         Ok(())
     }
 
+    /// Add an emoji reaction to a message.
+    ///
+    /// ## Current scope (honest documentation)
+    ///
+    /// The `Channel::add_reaction` trait does not provide the target
+    /// message's `is_from_me` flag or the sender's participant JID,
+    /// both of which are needed to construct a fully correct
+    /// [`waproto::whatsapp::MessageKey`] for group chats and for
+    /// reacting to the bot's own messages.  The implementation below
+    /// therefore targets **1:1 chats reacting to inbound messages**
+    /// (`from_me: false`, no `participant`).  Group chats and
+    /// own-message reactions are not yet supported; the protocol
+    /// library's `BotMessage::message_key()` builder (which derives
+    /// `from_me` and `participant` from the stored message `Info`) is
+    /// the intended resolution path when those fields are plumbed
+    /// through the trait.
     async fn add_reaction(
         &self,
         channel_id: &str,
@@ -2709,8 +2725,17 @@ impl Channel for WhatsAppWebChannel {
             reaction_message: Some(waproto::whatsapp::message::ReactionMessage {
                 key: Some(waproto::whatsapp::MessageKey {
                     remote_jid: Some(to.to_string()),
+                    // `from_me: false` is correct for inbound 1:1
+                    // messages.  Own-message reactions and group
+                    // chats need `BotMessage::message_key()` — see
+                    // method doc above.
                     from_me: Some(false),
                     id: Some(message_id.to_string()),
+                    // `participant` is not needed for 1:1 chats.
+                    // For group chats the sender JID must be set;
+                    // that requires plumbing message metadata
+                    // through the trait.
+                    participant: None,
                     ..Default::default()
                 }),
                 text: Some(emoji.to_string()),
@@ -2727,6 +2752,12 @@ impl Channel for WhatsAppWebChannel {
         Ok(())
     }
 
+    /// Remove an emoji reaction from a message.
+    ///
+    /// Scope is the same as [`Self::add_reaction`]: 1:1 chats,
+    /// inbound messages.  See that method's doc comment for the
+    /// group / own-message limitation and the intended resolution
+    /// path via `BotMessage::message_key()`.
     async fn remove_reaction(
         &self,
         channel_id: &str,
@@ -2746,10 +2777,18 @@ impl Channel for WhatsAppWebChannel {
             reaction_message: Some(waproto::whatsapp::message::ReactionMessage {
                 key: Some(waproto::whatsapp::MessageKey {
                     remote_jid: Some(to.to_string()),
+                    // `from_me: false` is correct for inbound 1:1
+                    // messages.  Own-message reactions and group
+                    // chats need `BotMessage::message_key()` — see
+                    // `add_reaction` doc above.
                     from_me: Some(false),
                     id: Some(message_id.to_string()),
+                    // `participant` is not needed for 1:1 chats.
+                    participant: None,
                     ..Default::default()
                 }),
+                // Empty text removes the reaction per WhatsApp
+                // protocol.
                 text: Some(String::new()),
                 ..Default::default()
             }),

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2738,6 +2738,7 @@ impl Channel for WhatsAppWebChannel {
                     participant: None,
                 }),
                 text: Some(emoji.to_string()),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -2787,6 +2788,7 @@ impl Channel for WhatsAppWebChannel {
                 // Empty text removes the reaction per WhatsApp
                 // protocol.
                 text: Some(String::new()),
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2706,18 +2706,16 @@ impl Channel for WhatsAppWebChannel {
         let deliverable = Self::resolve_outbound_recipient(channel_id);
         let to = self.recipient_to_jid(&deliverable)?;
         let outgoing = waproto::whatsapp::Message {
-            reaction_message: Some(
-                waproto::whatsapp::message::ReactionMessage {
-                    key: Some(waproto::whatsapp::MessageKey {
-                        remote_jid: Some(to.to_string()),
-                        from_me: Some(false),
-                        id: Some(message_id.to_string()),
-                        ..Default::default()
-                    }),
-                    text: Some(emoji.to_string()),
+            reaction_message: Some(waproto::whatsapp::message::ReactionMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    remote_jid: Some(to.to_string()),
+                    from_me: Some(false),
+                    id: Some(message_id.to_string()),
                     ..Default::default()
-                },
-            ),
+                }),
+                text: Some(emoji.to_string()),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         Box::pin(client.send_message(to, outgoing)).await?;
@@ -2745,18 +2743,16 @@ impl Channel for WhatsAppWebChannel {
         let deliverable = Self::resolve_outbound_recipient(channel_id);
         let to = self.recipient_to_jid(&deliverable)?;
         let outgoing = waproto::whatsapp::Message {
-            reaction_message: Some(
-                waproto::whatsapp::message::ReactionMessage {
-                    key: Some(waproto::whatsapp::MessageKey {
-                        remote_jid: Some(to.to_string()),
-                        from_me: Some(false),
-                        id: Some(message_id.to_string()),
-                        ..Default::default()
-                    }),
-                    text: Some(String::new()),
+            reaction_message: Some(waproto::whatsapp::message::ReactionMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    remote_jid: Some(to.to_string()),
+                    from_me: Some(false),
+                    id: Some(message_id.to_string()),
                     ..Default::default()
-                },
-            ),
+                }),
+                text: Some(String::new()),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         Box::pin(client.send_message(to, outgoing)).await?;
@@ -2849,12 +2845,7 @@ impl Channel for WhatsAppWebChannel {
         ));
     }
 
-    async fn add_reaction(
-        &self,
-        _channel_id: &str,
-        _message_id: &str,
-        _emoji: &str,
-    ) -> Result<()> {
+    async fn add_reaction(&self, _channel_id: &str, _message_id: &str, _emoji: &str) -> Result<()> {
         anyhow::bail!(i18n::get_required_cli_string(
             "channel-whatsapp-web-feature-missing-error"
         ));

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2737,7 +2737,7 @@ impl Channel for WhatsAppWebChannel {
                     // through the trait.
                     participant: None,
                 }),
-                text: Some(emoji.to_string())
+                text: Some(emoji.to_string()),
             }),
             ..Default::default()
         };
@@ -2786,7 +2786,7 @@ impl Channel for WhatsAppWebChannel {
                 }),
                 // Empty text removes the reaction per WhatsApp
                 // protocol.
-                text: Some(String::new())
+                text: Some(String::new()),
             }),
             ..Default::default()
         };

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2689,6 +2689,84 @@ impl Channel for WhatsAppWebChannel {
         );
         Ok(())
     }
+
+    async fn add_reaction(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> anyhow::Result<()> {
+        if message_id.is_empty() || emoji.is_empty() {
+            return Ok(());
+        }
+        let client = self.client.lock().clone();
+        let Some(client) = client else {
+            anyhow::bail!("WhatsApp Web client not connected. Initialize the bot first.");
+        };
+        let deliverable = Self::resolve_outbound_recipient(channel_id);
+        let to = self.recipient_to_jid(&deliverable)?;
+        let outgoing = waproto::whatsapp::Message {
+            reaction_message: Some(
+                waproto::whatsapp::message::ReactionMessage {
+                    key: Some(waproto::whatsapp::MessageKey {
+                        remote_jid: Some(to.to_string()),
+                        from_me: Some(false),
+                        id: Some(message_id.to_string()),
+                        ..Default::default()
+                    }),
+                    text: Some(emoji.to_string()),
+                    ..Default::default()
+                },
+            ),
+            ..Default::default()
+        };
+        Box::pin(client.send_message(to, outgoing)).await?;
+        ::zeroclaw_log::record!(
+            DEBUG,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+            &format!("reaction {emoji} added to {message_id}")
+        );
+        Ok(())
+    }
+
+    async fn remove_reaction(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        emoji: &str,
+    ) -> anyhow::Result<()> {
+        if message_id.is_empty() {
+            return Ok(());
+        }
+        let client = self.client.lock().clone();
+        let Some(client) = client else {
+            anyhow::bail!("WhatsApp Web client not connected. Initialize the bot first.");
+        };
+        let deliverable = Self::resolve_outbound_recipient(channel_id);
+        let to = self.recipient_to_jid(&deliverable)?;
+        let outgoing = waproto::whatsapp::Message {
+            reaction_message: Some(
+                waproto::whatsapp::message::ReactionMessage {
+                    key: Some(waproto::whatsapp::MessageKey {
+                        remote_jid: Some(to.to_string()),
+                        from_me: Some(false),
+                        id: Some(message_id.to_string()),
+                        ..Default::default()
+                    }),
+                    text: Some(String::new()),
+                    ..Default::default()
+                },
+            ),
+            ..Default::default()
+        };
+        Box::pin(client.send_message(to, outgoing)).await?;
+        ::zeroclaw_log::record!(
+            DEBUG,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+            &format!("reaction {emoji} removed from {message_id}")
+        );
+        Ok(())
+    }
 }
 
 // Stub implementation when feature is not enabled
@@ -2766,6 +2844,28 @@ impl Channel for WhatsAppWebChannel {
     }
 
     async fn stop_typing(&self, _recipient: &str) -> Result<()> {
+        anyhow::bail!(i18n::get_required_cli_string(
+            "channel-whatsapp-web-feature-missing-error"
+        ));
+    }
+
+    async fn add_reaction(
+        &self,
+        _channel_id: &str,
+        _message_id: &str,
+        _emoji: &str,
+    ) -> Result<()> {
+        anyhow::bail!(i18n::get_required_cli_string(
+            "channel-whatsapp-web-feature-missing-error"
+        ));
+    }
+
+    async fn remove_reaction(
+        &self,
+        _channel_id: &str,
+        _message_id: &str,
+        _emoji: &str,
+    ) -> Result<()> {
         anyhow::bail!(i18n::get_required_cli_string(
             "channel-whatsapp-web-feature-missing-error"
         ));


### PR DESCRIPTION
## Summary

Rebase of #7535 (by @chengzhichao-xydt, closed due to merge conflicts with `master`) onto current `master`.

Implements `add_reaction` and `remove_reaction` for WhatsApp Web, closing the `ack_reactions` parity gap with Telegram/Discord/Matrix.

## Changes (from the original PR)

- **add_reaction**: Sends a WhatsApp `ReactionMessage` with the target message key and emoji text
- **remove_reaction**: Removes the reaction by sending an empty-text `ReactionMessage` (the documented WhatsApp mechanism)
- **Stub arms**: Both methods bail with the standard feature-missing error when compiled without `whatsapp-web`

### Current scope (honest documentation)

The `Channel::add_reaction` trait does not provide the target message's `is_from_me` flag or sender participant JID. The `MessageKey` therefore targets **1:1 chats reacting to inbound messages** (`from_me: false`, `participant: None`). Group chats and own-message reactions need `BotMessage::message_key()` — the canonical builder in the whatsapp-rust library — when those fields are plumbed through the trait. The method docs and explicit field comments state this limitation.

## What changed in this rebase

`master` had refactored the WhatsApp Web inbound-message event handling into `handle_inbound_message_event` / `send_inbound_channel_message` since #7535 was opened, which conflicted with the original PR's last commit (plumbing the native WhatsApp message id into `ChannelMessage.id`, which `add_reaction`/`remove_reaction` need to build a correct `MessageKey`).

This PR keeps master's refactored structure and reapplies that same fix against it: `handle_inbound_message_event` now computes `native_msg_id` from `info.id` (falling back to a UUID only if empty, with a warning) and threads it through both `send_inbound_channel_message` call sites via a new `id` parameter. No other behavioral changes from the original PR.

## Validation

```bash
cargo fmt --all -- --check
# (no output — formatting is clean)

cargo check -p zeroclaw-channels --features whatsapp-web
# Finished, no errors

cargo test -p zeroclaw-channels --features whatsapp-web whatsapp_web
# 78 passed; 0 failed
```

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No** — uses existing WhatsApp Web connection
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility

- Backward compatible? **Yes** — adds new trait method implementations; existing behavior is unchanged
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk PR: `git revert <sha>` is the plan.