### PR TITLE
fix(cli): stop telling operators to reload with a signal that kills the daemon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4169,10 +4169,12 @@ async fn async_main(command: clap::Command) -> Result<()> {
             zeroclaw_runtime::restart::record_launch();
 
             // Reload loop. `daemon::run` returns DaemonExit::Shutdown on
-            // SIGINT/SIGTERM (loop ends) or DaemonExit::Reload on SIGUSR1
-            // (loop re-reads config from disk and re-runs). The PID stays
-            // the same across reloads — only the in-process subsystems
-            // tear down + re-instantiate.
+            // SIGINT/SIGTERM (loop ends) or DaemonExit::Reload when the
+            // in-process reload channel fires, which the gateway reload
+            // endpoint and the RPC config/reload method both write (loop
+            // re-reads config from disk and re-runs). The PID stays the same
+            // across reloads — only the in-process subsystems tear down +
+            // re-instantiate.
             let mut current_config = config;
             // Nag task for the degraded-security warning, scoped to the
             // current config. Re-evaluated each reload iteration so a repaired
@@ -7675,6 +7677,22 @@ fn warn_verifiable_intent_withheld(config: &Config) {
     );
 }
 
+/// Operator-facing text for the repeating degraded-security warning.
+///
+/// Split out so a regression can assert it names only signals the daemon
+/// registers. `daemon::run` handles SIGINT, SIGTERM and SIGHUP; reload arrives
+/// on the in-process channel the gateway reload endpoint writes. Naming any
+/// other signal here would tell an operator to send one whose default
+/// disposition terminates the process.
+fn degraded_security_nag_message(sections: &str, config_path: &str) -> String {
+    format!(
+        "Running with DEGRADED security: sections ({sections}) were reset to \
+         defaults and `--allow-degraded-security` was set. The posture may be \
+         weaker than intended — repair {config_path}, then restart or POST \
+         /admin/reload, as soon as possible."
+    )
+}
+
 fn gate_security_posture(
     config: &zeroclaw::config::Config,
     allow_degraded: bool,
@@ -7705,12 +7723,7 @@ fn gate_security_posture(
                 ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                     .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                     .with_attrs(::serde_json::json!({ "degraded_security": sections })),
-                &format!(
-                    "Running with DEGRADED security: sections ({sections}) were reset to \
-                     defaults and `--allow-degraded-security` was set. The posture may be \
-                     weaker than intended — repair {config_path} and reload \
-                     (SIGUSR1 / `zeroclaw admin reload`) as soon as possible."
-                )
+                &degraded_security_nag_message(&sections, &config_path)
             );
         }
     });
@@ -9746,6 +9759,27 @@ mod tests {
         });
 
         assert!((final_temperature - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn degraded_security_nag_names_only_handled_signals() {
+        // The daemon registers exactly these three, in
+        // crates/zeroclaw-runtime/src/daemon/mod.rs. Reload arrives on the
+        // in-process channel the gateway reload endpoint writes, not on a
+        // signal. Any other SIG* in operator guidance names something whose
+        // default disposition terminates the daemon.
+        const HANDLED: [&str; 3] = ["SIGINT", "SIGTERM", "SIGHUP"];
+
+        let message = degraded_security_nag_message("security", "/tmp/config.toml");
+        for token in message.split(|c: char| !c.is_ascii_alphanumeric()) {
+            let Some(suffix) = token.strip_prefix("SIG") else {
+                continue;
+            };
+            assert!(
+                !suffix.is_empty() && HANDLED.contains(&token),
+                "operator guidance names the unhandled signal {token}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The repeating degraded-security warning told operators to reload with `SIGUSR1`. **Nothing registers that signal**, so its default disposition terminates the daemon. The operator most likely to follow the advice is the one already running with a weakened security posture, and the warning repeats every 30 seconds telling them to act "as soon as possible".
  - The same sentence also named `zeroclaw admin reload`. **There is no `admin` command.** Both halves of the instruction were wrong, so the sentence is rewritten rather than trimmed. It now names `restart` and `POST /admin/reload`, which matches the `bail!` path in the same function that already tells the operator to repair and restart.
  - The reload-loop comment made the same claim about `DaemonExit::Reload`. It now attributes the exit to the in-process reload channel that the gateway reload endpoint and the RPC `config/reload` method write.
  - The message moved into `degraded_security_nag_message` so a regression can reach it. It was previously built with `format!` inside the spawned task, where no test could see it.
  - **Option 2 from the issue, per your direction:** no `SignalKind::user_defined1` handler is added, and the admin-reload behaviour is untouched.
- **Scope boundary:** does not add a signal handler, does not change reload behaviour, does not touch `daemon/mod.rs`, and adds no config or CLI surface. Text, one extracted function, and one test.
- **Blast radius:** one operator-facing log line and one code comment. `gate_security_posture` keeps its signature and all four of its existing paths; its sibling test still passes unchanged.
- **Linked issue(s):** Closes #9768.
- **Labels:** maintainer-set. #9768 carries `bug`, `runtime`, `priority:p1`, `status:accepted`, `follow-up`, `risk:medium`, `cli`.

### Provenance, since it changes how the bug reads

`git log -S` across all history returns **zero** commits for `user_defined1`, `libc::SIGUSR1` and `signal_hook`. The handler never existed, so this is not guidance left behind by a removed feature.

What did exist was the intent. #8104 removed a comment describing the watch channel as the "cross-platform replacement for the SIGUSR1 hack". The mechanism was replaced before it shipped; the operator-facing text kept describing the plan. The wording entered with #6179 (the reload-loop comment) and #7160 (the nag), which is why two files say the same untrue thing.

### One thing I left alone, for you to decide

`web/src/components/sections/ReloadDaemonButton.tsx:7` says `POST /admin/reload (raises SIGUSR1 inside the daemon)`. Same claim, third site, but TypeScript rather than Rust and a code comment with no operator-facing impact. You scoped this to the two Rust sites when that third site was not yet known, so I have not widened the diff. Say the word and it is a one-line follow-up here or separately.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A`. The defect is a string; the daemon's signal behaviour is unchanged by design, and the terminating behaviour is already demonstrated in #9768.
- **Interface(s) exercised:** `cli`
- **Prior behavior on `master` (before):** boot a daemon and send `kill -USR1 <pid>`. It exits **138** (128 + 10) and `/health` stops answering, while the warning tells the operator to do exactly that.
- **Expected on this branch (after):** the warning names `restart` and `POST /admin/reload`. Signal handling is untouched, so SIGUSR1 still terminates the process; the difference is that nothing tells an operator to send it.

### How I tested

The regression was written first and shown **failing against the unmodified message**. To make that possible the extraction was done first with the old wording byte-for-byte intact, so the red proves the wording rather than the refactor:

```
test tests::degraded_security_nag_names_only_handled_signals ... FAILED
panicked at src/main.rs:9776:13:
operator guidance names the unhandled signal SIGUSR1
test result: FAILED. 0 passed; 1 failed
```

After correcting the message:

```
test tests::degraded_security_nag_names_only_handled_signals ... ok
test result: ok. 353 passed; 0 failed   (whole src/main.rs test module)
```

**The test asserts the invariant, not the string.** It collects every `SIG*` token in the message and requires each to be one the daemon actually registers, so it fails on `SIGUSR1` today and would fail on a future `SIGQUIT` that a substring ban would miss.

- **CI checks relied on and why they cover this change:** the workspace test run covers the new unit test and the existing `gate_security_posture_fails_closed_unless_allowed`, which exercises all four posture paths through the unchanged function signature. `Format` and `Lint` cover the extraction.
- **Known CI coverage gap, if any:** none. The changed surface is a pure function and a comment, both reachable from the unit level, which is the lowest level that proves this.
- **Commands run and tail output:**

```
cargo fmt --all -- --check                                  -> exit 0
cargo test -p zeroclaw --bin zeroclaw degraded_security_nag -> ok, 1 passed
cargo test -p zeroclaw --bin zeroclaw gate_security_posture -> ok, 1 passed
cargo test -p zeroclaw --bin zeroclaw                       -> ok, 353 passed; 0 failed
cargo clippy -p zeroclaw --all-targets -- -D warnings       -> exit 0
bash scripts/ci/comment_hygiene_gate.sh src/main.rs         -> Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** That the daemon registers only SIGINT, SIGTERM and SIGHUP, by reading the handler set rather than the comment above it, and that no `user_defined1` handler has existed at any point in the repository's history. Also that `admin` is absent from the `Commands` enum, from `zeroclaw --help`, and from the generated CLI reference, and that `gateway` and `service` each offer `restart` rather than any reload.

  Not verified, deliberately: nothing at the process boundary. The change cannot alter signal behaviour, and a binary run would only re-demonstrate the defect already recorded in the issue.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- **Additional note:** the operator this text reaches is by definition running with security-critical config sections reset to defaults. Advice that terminates their daemon is worst in exactly that state, which is why the issue was raised at `p1` rather than as a typo.

## Compatibility (required)

- Backward compatible? **Yes.** Log text and a comment.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- Upgrade steps: none. Anything scraping the old string for `SIGUSR1` was scraping advice that never worked.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` the single commit on this branch. One file.
- **Feature flags or config toggles:** None. Text-only.
- **Observable failure symptoms:** the degraded-security warning naming any signal at all, or naming a command absent from `zeroclaw --help`. The new unit test fails on the first of those.
