### PR TITLE
fix(providers/openai-codex): do not retry the default endpoint without streaming

### DIFF
--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1416,6 +1416,29 @@ impl OpenAiCodexModelProvider {
                     return Err(stream_err);
                 }
 
+                // The ChatGPT Codex backend REQUIRES streaming: a `stream: false`
+                // body is rejected with `400 {"detail":"Stream must be set to
+                // true"}`. Retrying without streaming there cannot succeed, and
+                // it destroys the diagnosis: the caller sees a non-retryable 400
+                // instead of the transient decode error that actually happened,
+                // so a recoverable blip is reported as a hard provider failure.
+                // Custom endpoints keep the fallback; many accept both modes.
+                if !self.custom_endpoint {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "error": format!("{}", stream_err),
+                                "endpoint": "default",
+                            })),
+                        "OpenAI Codex streaming response decode failed; the default endpoint \
+                         requires streaming, so the original error is surfaced rather than \
+                         retried without it"
+                    );
+                    return Err(stream_err);
+                }
+
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -2031,6 +2054,43 @@ mod tests {
         let provider = OpenAiCodexModelProvider::new("test", &options, Some("test-key")).unwrap();
         assert!(provider.custom_endpoint);
         assert_eq!(provider.gateway_api_key.as_deref(), Some("test-key"));
+    }
+
+    /// The ChatGPT Codex backend rejects `stream: false` with
+    /// `400 {"detail":"Stream must be set to true"}`, so retrying a failed
+    /// stream without streaming cannot succeed there. It only replaces a
+    /// transient, retryable decode error with a non-retryable 400, which the
+    /// reliability layer then refuses to retry, so a recoverable blip ends the
+    /// turn. The default endpoint must surface the original error instead.
+    ///
+    /// `mock_codex_provider` binds a local port, so every mock-backed test is a
+    /// CUSTOM endpoint and keeps the fallback. This pins the flag those two
+    /// paths actually branch on.
+    #[test]
+    fn default_endpoint_is_not_marked_custom() {
+        let provider =
+            OpenAiCodexModelProvider::new("test", &ModelProviderRuntimeOptions::default(), None)
+                .expect("default provider constructs");
+        assert!(
+            !provider.custom_endpoint,
+            "the default Codex endpoint must not be treated as custom: the \
+             non-streaming fallback is skipped on exactly that flag"
+        );
+
+        let custom = OpenAiCodexModelProvider::new(
+            "test",
+            &ModelProviderRuntimeOptions {
+                provider_api_url: Some("https://api.tonsof.blue/v1".to_string()),
+                ..ModelProviderRuntimeOptions::default()
+            },
+            Some("test-key"),
+        )
+        .expect("custom provider constructs");
+        assert!(
+            custom.custom_endpoint,
+            "a configured provider_api_url must keep the fallback: many \
+             OpenAI-compatible endpoints accept both modes"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1418,6 +1418,29 @@ impl OpenAiCodexModelProvider {
                     return Err(stream_err);
                 }
 
+                // The ChatGPT Codex backend REQUIRES streaming: a `stream: false`
+                // body is rejected with `400 {"detail":"Stream must be set to
+                // true"}`. Retrying without streaming there cannot succeed, and
+                // it destroys the diagnosis: the caller sees a non-retryable 400
+                // instead of the transient decode error that actually happened,
+                // so a recoverable blip is reported as a hard provider failure.
+                // Custom endpoints keep the fallback; many accept both modes.
+                if !self.custom_endpoint {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({
+                                "error": format!("{}", stream_err),
+                                "endpoint": "default",
+                            })),
+                        "OpenAI Codex streaming response decode failed; the default endpoint \
+                         requires streaming, so the original error is surfaced rather than \
+                         retried without it"
+                    );
+                    return Err(stream_err);
+                }
+
                 ::zeroclaw_log::record!(
                     WARN,
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -2155,6 +2178,43 @@ mod tests {
         let provider = OpenAiCodexModelProvider::new("test", &options, Some("test-key")).unwrap();
         assert!(provider.custom_endpoint);
         assert_eq!(provider.gateway_api_key.as_deref(), Some("test-key"));
+    }
+
+    /// The ChatGPT Codex backend rejects `stream: false` with
+    /// `400 {"detail":"Stream must be set to true"}`, so retrying a failed
+    /// stream without streaming cannot succeed there. It only replaces a
+    /// transient, retryable decode error with a non-retryable 400, which the
+    /// reliability layer then refuses to retry, so a recoverable blip ends the
+    /// turn. The default endpoint must surface the original error instead.
+    ///
+    /// `mock_codex_provider` binds a local port, so every mock-backed test is a
+    /// CUSTOM endpoint and keeps the fallback. This pins the flag those two
+    /// paths actually branch on.
+    #[test]
+    fn default_endpoint_is_not_marked_custom() {
+        let provider =
+            OpenAiCodexModelProvider::new("test", &ModelProviderRuntimeOptions::default(), None)
+                .expect("default provider constructs");
+        assert!(
+            !provider.custom_endpoint,
+            "the default Codex endpoint must not be treated as custom: the \
+             non-streaming fallback is skipped on exactly that flag"
+        );
+
+        let custom = OpenAiCodexModelProvider::new(
+            "test",
+            &ModelProviderRuntimeOptions {
+                provider_api_url: Some("https://api.tonsof.blue/v1".to_string()),
+                ..ModelProviderRuntimeOptions::default()
+            },
+            Some("test-key"),
+        )
+        .expect("custom provider constructs");
+        assert!(
+            custom.custom_endpoint,
+            "a configured provider_api_url must keep the fallback: many \
+             OpenAI-compatible endpoints accept both modes"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** when a Codex responses stream fails to decode, the provider retried the same request with `stream = false`. The ChatGPT Codex backend requires streaming and rejects that body with `400 {"detail":"Stream must be set to true"}`, so the retry cannot succeed there. Worse, the 400 replaces the original error: a transient, retryable decode failure is reported to the caller as a non-retryable provider error, and the reliability layer then refuses to retry it, ending the turn.
- The fallback is preserved for custom endpoints, which commonly accept both modes. It is skipped only for the default endpoint, keyed on the `custom_endpoint` flag the provider already computes from `is_default_responses_url`. The original decode error is surfaced instead, so the failure the caller sees is the failure that happened.
- **Scope boundary:** one branch in `chat()`'s decode-failure path. No change to request construction, streaming behavior, or the custom-endpoint fallback.
- **Blast radius:** `openai_codex` provider error handling.
- **Linked issue(s):** none filed; found in production, evidence below.
- **Labels:** `bug`, `provider`, `provider:openai`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `No` — the failure needs a real stream decode error against the live Codex endpoint, which is not reproducible on demand.

### How I tested

- **CI checks relied on and why they cover this change:** the required gate builds and tests `zeroclaw-providers`, which owns the changed file.
- **Known CI coverage gap, if any:** no test drives a real decode failure against the default endpoint; `mock_codex_provider` binds a local port and is therefore a custom endpoint by construction, so the mock-backed tests exercise the retained fallback rather than the skipped one. The added test pins the flag both paths branch on.
- **Commands run and tail output:**
  - `cargo test -p zeroclaw-providers --lib openai_codex` -> `test result: ok. 52 passed; 0 failed; 0 ignored`
  - the two pre-existing fallback regressions (`codex_retries_non_streaming_when_stream_decode_fails`, `codex_retries_non_streaming_when_stream_contains_malformed_frame_after_text`) are **unmodified and still pass**, which is the intended outcome: they document the custom-endpoint behavior this change deliberately keeps.
  - `cargo clippy -p zeroclaw-providers --lib` -> clean; `cargo fmt --all` applied.
- **Beyond CI, what did you manually verify?** Deployed on a live 0.8.4 daemon running an unattended PR-review pipeline on this repo.
  - Before: 10 runs hit `{"detail":"Stream must be set to true"}` in one working window; 6 were rescued by a step-level retry, 4 died. Sample: `attempt 1/3: non_retryable; error=OpenAI Codex API error (400 Bad Request): {"detail":"Stream must be set to true"}; kind=provider_error`.
  - After (binary installed 02:54Z): **0 occurrences** in the ~18 hours since, across ~90 review runs.
  - Honest limit on that evidence: neither the new gate's WARN nor the old fallback's WARN has fired since install, so no stream decode failure has occurred in the measurement window. The symptom is absent and the change is deployed, but the skipped branch has not itself been observed firing in production.
- **If any command was intentionally skipped, why:** full workspace tests — untouched crates; relying on required CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No — strictly one fewer request on the failure path.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes. Custom endpoints keep the existing fallback; only the default endpoint changes, and only on a path that could not previously succeed.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert` of the single commit restores the previous behavior.
