### PR TITLE
chore(security): ignore RUSTSEC-2026-0247 (bitmaps unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,12 @@ ignore = [
     # proc-macro-error2 -- unmaintained derive/attribute macro helper; still in
     # the resolved graph via matrix-sdk dev-deps (aquamarine) in zeroclaw-channels
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive macro helper via matrix-sdk dev-deps; tracking #8519" },
+    # bitmaps -- repository archived 2026-05-03, all versions affected, no safe
+    # upgrade available. Reached only transitively:
+    # matrix-sdk -> eyeball-im -> imbl -> bitmaps. Upstream tracking issue
+    # matrix-org/matrix-rust-sdk#6859 asks matrix-sdk to move off the imbl stack;
+    # drop this entry once a matrix-sdk release no longer pulls bitmaps.
+    { id = "RUSTSEC-2026-0247", reason = "bitmaps unmaintained; transitive via matrix-sdk -> eyeball-im -> imbl; no safe upgrade; upstream matrix-org/matrix-rust-sdk#6859" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - RustSec published **RUSTSEC-2026-0247** for `bitmaps` (repository archived by its owner on 2026-05-03). All versions are affected and `cargo deny` reports **no safe upgrade is available**, so the `Security` job now fails on `master` and on every PR that triggers CI.
  - `bitmaps` is **not** a direct dependency. It is reached only transitively: `matrix-sdk -> eyeball-im -> imbl -> bitmaps`. Nothing in this repository can drop it without `matrix-sdk` moving off the `imbl` stack.
  - Added an ID-scoped ignore to `deny.toml` following the existing convention in that file, recording the dependency chain, the upstream tracking issue, and the removal condition inline.
- **Scope boundary:** Does **not** change any dependency, `Cargo.toml`, or `Cargo.lock`; does not touch application code, and does not relax any other `cargo deny` section (`bans`, `licenses`, `sources` are untouched). It suppresses exactly one advisory ID.
- **Blast radius:** The `Security` CI job only. The ignore is ID-scoped, so every other advisory — including any *future* advisory against `bitmaps` — still fails the build.
- **Linked issue(s):** Related matrix-org/matrix-rust-sdk#6859 (upstream request for `matrix-sdk` to move off the `imbl` stack)
- **Labels:** `dependencies`, `risk:low`, `size:XS`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes` — one command, and the A/B is visible.
- **Interface(s) exercised:** `cli` (CI tooling — `cargo deny`); no runtime surface.
- **Setup / preconditions:** `cargo-deny` 0.19.9 (the version CI installs).
- **Steps to run:** `cargo deny check advisories`
- **Expected on this branch (after):** `advisories ok`
- **Prior behavior on `master` (before):** `error[unmaintained]: bitmaps is unmaintained` / `advisories FAILED`

### How I tested

- **CI checks relied on and why they cover this change:** The `Security` job runs `cargo deny check`, which is the entire surface this PR touches.
- **Known CI coverage gap, if any:** None. The changed file is only consumed by `cargo deny`; no code path is affected.
- **Commands run and tail output:**

```sh
$ cargo deny check advisories       # on pristine upstream/master, before the fix
   ├ ID: RUSTSEC-2026-0247
advisories FAILED

$ cargo deny check advisories       # with the fix
advisories ok

$ cargo deny check                  # all sections, as CI runs it
advisories ok, bans ok, licenses ok, sources ok

$ cargo verify-project && cargo fetch --locked    # Lockfile integrity step
{"success":"true"}
```

- **Beyond CI, what did you manually verify?** Confirmed the failure reproduces on pristine `upstream/master` (`b718f1b1`) in a clean worktree, so this is not introduced by any in-flight branch. Verified the ignore list is strictly ID-scoped by temporarily removing an unrelated entry (`RUSTSEC-2025-0134`) and confirming that advisory then fails — so this entry cannot mask anything else. Confirmed the upstream chain `matrix-sdk -> eyeball-im -> imbl -> bitmaps` from the `cargo deny` output. I did **not** attempt a dependency upgrade: `cargo deny` reports no safe upgrade exists, and `imbl`/`eyeball-im` versions are chosen by `matrix-sdk`.
- **If any command was intentionally skipped, why:** Workspace `cargo test`/`clippy` skipped — no Rust source changed; `deny.toml` is not compiled.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

Worth stating plainly: this suppresses a security advisory, so it *reduces* signal by exactly one ID. The mitigation is that `bitmaps` is an **unmaintained** advisory, not a vulnerability — there is no known exploit, only an archived upstream. The entry is ID-scoped, documents its own removal condition, and the exposure is a transitive data-structure crate we do not call directly.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low-risk: `git revert 95bea8fd5b41f91cabd1f5cb7b34f4d9224d21f9`. Reverting restores the failing advisory check.