### PR TITLE
fix(skills): keep blank lines inside SkillDocument block scalars

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/document.rs
+++ b/crates/zeroclaw-runtime/src/skills/document.rs
@@ -104,7 +104,13 @@ fn parse_frontmatter(src: &str) -> Result<SkillFrontmatter, DocumentParseError> 
             continue;
         }
         if let Some((ref key, ref mut parts)) = multiline {
-            if line.starts_with(' ') || line.starts_with('\t') {
+            // A blank/whitespace-only line is a paragraph break *inside* the
+            // block scalar, not a terminator — keep collecting. Only a
+            // non-indented, non-empty line (a real next key) ends the scalar.
+            // Mirrors `parse_simple_frontmatter` in skills/mod.rs so service
+            // read/write cannot truncate multi-paragraph descriptions the
+            // agent loader still sees.
+            if line.starts_with(' ') || line.starts_with('\t') || line.trim().is_empty() {
                 parts.push(line.trim().to_string());
                 continue;
             }
@@ -492,6 +498,41 @@ mod tests {
         let content = "---\nname: x\ndescription: >-\n  multi-line\n  description text\n---\n";
         let doc = SkillDocument::parse(content).unwrap();
         assert_eq!(doc.frontmatter.description, "multi-line description text");
+    }
+
+    #[test]
+    fn parses_block_scalar_description_keeps_blank_line_paragraph_break() {
+        // A blank line is a paragraph break *inside* a YAML block scalar, not a
+        // terminator. SkillDocument must match the runtime loader here so
+        // service edits cannot shrink multi-paragraph descriptions.
+        let content = "---\nname: x\ndescription: >-\n  para one\n\n  para two\n---\n# Body\n";
+        let doc = SkillDocument::parse(content).unwrap();
+        assert!(
+            doc.frontmatter.description.contains("para one"),
+            "first paragraph missing: {:?}",
+            doc.frontmatter.description
+        );
+        assert!(
+            doc.frontmatter.description.contains("para two"),
+            "second paragraph after blank line was truncated: {:?}",
+            doc.frontmatter.description
+        );
+        assert_eq!(doc.frontmatter.name, "x");
+        assert_eq!(doc.body.trim(), "# Body");
+    }
+
+    #[test]
+    fn block_scalar_description_round_trips_across_blank_paragraph() {
+        let content = "---\nname: x\ndescription: >-\n  para one\n\n  para two\n---\nbody\n";
+        let doc = SkillDocument::parse(content).unwrap();
+        let serialized = doc.serialize();
+        let again = SkillDocument::parse(&serialized).unwrap();
+        assert!(
+            again.frontmatter.description.contains("para one")
+                && again.frontmatter.description.contains("para two"),
+            "round-trip lost paragraph: {:?}",
+            again.frontmatter.description
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - **Bug:** `SkillDocument::parse` / skills-service read-write truncates YAML block-scalar `description` values at the first blank line, so multi-paragraph skill descriptions are silently shortened even though the agent loader still sees the full text.
  - **Cause:** The document frontmatter loop treated blank lines as block-scalar terminators; `parse_simple_frontmatter` already keeps them as in-scalar paragraph breaks.
  - **Fix:** Keep collecting on blank/whitespace-only lines inside block scalars (loader parity); only a non-indented non-empty next key ends the scalar.
  - **Test:** Regression covers blank-line paragraph retention and parse→serialize→parse round-trip.
- **Scope boundary:** Does not change loader parsing, tag lists, or non-block-scalar fields.
- **Blast radius:** Only `SkillDocument` block-scalar continuation. Agent loader path unchanged.
- **Linked issue(s):** Closes #9908
- **Labels:** `bug`, `runtime`, `skills`, `priority:p2`, `risk:high`, `size:XS`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** library path (`zeroclaw-runtime` `SkillDocument` / unit tests)
- **Setup / preconditions:** Rust toolchain; workspace builds. Compare `master` vs this branch.
- **Steps to run:**
  1. On `master`: parse a `SKILL.md` whose `description: >-` contains a blank line between two paragraphs via `SkillDocument::parse` — second paragraph is dropped.
  2. On this branch: `cargo test -p zeroclaw-runtime --lib block_scalar_description`
- **Expected on this branch (after):** focused tests pass; both paragraphs retained through parse and round-trip.
- **Prior behavior on `master` (before):** description truncated at the blank line inside the block scalar.

### How I tested

```sh
cargo fmt -p zeroclaw-runtime -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib block_scalar_description
```

- **CI checks relied on and why they cover this change:** PR Checks (fmt/clippy/test) exercise the same crate surface once they finish.
- **Known CI coverage gap, if any:** None for this parser path; regression is unit-tested.
- **Commands run and tail output:**

```text
GATE tip=f212eb7b4732 base=master
- cargo fmt -p zeroclaw-runtime -- --check → pass
- cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings → pass
- cargo test -p zeroclaw-runtime --lib block_scalar_description → pass

test skills::document::tests::parses_block_scalar_description_keeps_blank_line_paragraph_break ... ok
test skills::document::tests::parses_block_scalar_description ... ok
test skills::document::tests::block_scalar_description_round_trips_across_blank_paragraph ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 3599 filtered out; finished in 0.10s
```

- **Beyond CI, what did you manually verify?** Confirmed blank-line paragraph retention and serialize round-trip keep both paragraphs. Did not run a live skills UI edit session (out of scope).
- **If any command was intentionally skipped, why:** Full workspace `cargo fmt --all` / `./dev/ci.sh all` skipped; change is one parser branch + unit tests in `zeroclaw-runtime`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert f212eb7b4732`.
