### PR TITLE
docs(rfcs): replace stale RFC snapshot with live link

### DIFF
--- a/docs/book/src/contributing/rfcs.md
+++ b/docs/book/src/contributing/rfcs.md
@@ -64,7 +64,7 @@ Large RFCs often ship across multiple PRs over several releases. The RFC's track
 
 ## Current open RFCs
 
-Open RFCs are the best primary source for "what's coming next" in ZeroClaw. Browse:
+Open RFCs are the best primary source for "what's coming next" in ZeroClaw. [Browse the current open RFCs on GitHub](https://github.com/zeroclaw-labs/zeroclaw/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22type%3Arfc%22) or run:
 
 <div class="os-tabs-src">
 
@@ -75,14 +75,6 @@ gh issue list --repo zeroclaw-labs/zeroclaw --label type:rfc --state open
 ```
 
 </div>
-
-The list above is the canonical source. A snapshot of notable open RFCs at time of writing (browse the live list for the current set):
-
-- **#6808**: Work Lanes, Board Automation, and Label Cleanup (governance, in progress)
-- **#6971**: Security UX, runtime credential boundaries, and isolation defaults
-- **#6996**: Granular sandbox policy: filesystem and network restrictions
-- **#7218**: A2A agent discovery (`.well-known/agent-card.json`) for multi-agent installs
-- **#7184**: Move translated `.ftl` and `.po` files into a git submodule
 
 ## Ratified foundational RFCs
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replaces the manually maintained open-RFC snapshot with a live GitHub query so the contributor guide no longer drifts as RFCs change.
- **Scope boundary:** Does not change any RFC proposal, implementation, decision status, or voting state.
- **Blast radius:** Documentation-only; no runtime, configuration, API, or user-data behavior changes.
- **Linked issue(s):** Related #6971
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a documentation-only source-of-truth cleanup covered by the documentation checks.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is currently pending; final green CI remains required before reviewer sign-off and merge. The local documentation checks directly cover the changed Markdown.
- **Known CI coverage gap, if any:** The optional `lychee` HTTP check was unavailable locally; direct HTTP verification returned 200 for the one added URL.
- **Commands run and tail output:**

```text
$ DOCS_FILES='docs/book/src/contributing/rfcs.md' scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Linting docs files: docs/book/src/contributing/rfcs.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: docs/book/src/contributing/rfcs.md !target/** !docs/book/src/SUMMARY.md
Linting: 1 file(s)
Summary: 0 error(s)

$ DOCS_FILES='docs/book/src/contributing/rfcs.md' scripts/ci/docs_links_gate.sh
Ran 6 tests in 0.274s
OK
Collected 1 added link(s) from 1 docs file(s).
Added HTTP(S) links detected, but lychee is not installed; skipping optional HTTP(S) validation.

$ curl -I -L 'https://github.com/zeroclaw-labs/zeroclaw/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22type%3Arfc%22'
HTTP/2 200
```

- **Beyond CI, what did you manually verify?** Confirmed the live GitHub query targets open issues with the `type:rfc` label and that the obsolete static snapshot is fully removed. No runtime behavior was exercised because the diff is documentation-only.
- **If any command was intentionally skipped, why:** Cargo validation was not run because the change does not touch Rust code, generated output, configuration, or runtime behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low risk. Revert the commit containing this documentation-only change.
