### PR TITLE
feat(intake): narrow RFC routing across intake surfaces

### DIFF
--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -127,7 +127,7 @@ Process two groups:
    - Bug report (reproducible defect, something broken)
    - Feature request (new capability, enhancement)
    - Support question (how do I do X, why doesn't my config work)
-   - RFC (architectural proposal — do not triage; leave as-is)
+   - RFC (meets an RFC trigger below — do not triage; leave as-is)
    - Security issue (vulnerability — redirect immediately, see §2a)
    - Spam or noise — flag to user, do not close autonomously
 
@@ -379,15 +379,37 @@ Stale closures are especially sensitive — a reporter may have been waiting pat
 
 ## §7 Label Taxonomy
 
-Derived from RFC #5577 and current maintainer label policy. Apply these consistently:
+Derived from current maintainer label policy, with RFC scope set by [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496) (FND-003 Rev. 9). Apply these consistently:
 
 ### Type
 
 - `bug` — reproducible defect
 - `feature` — new capability or enhancement
-- `type:rfc` — architectural proposal issue
+- `type:rfc` — meets an RFC trigger; see below
 - `r:needs-repro` — bug report missing reproduction evidence
 - `r:support` — usage/configuration question, not a bug
+
+#### Applying `type:rfc`
+
+Never apply `type:rfc` because an issue merely sounds architectural, carries
+`domain:architecture`, or is labeled `risk:high`. Apply it only when the proposal requires a durable
+project-level decision before implementation, meaning it is at least one of:
+
+- a new security layer, or a material change to the project's security model;
+- a governance, contribution-process, or project-authority change;
+- a cross-cutting architectural refactor that changes ownership or contracts across established boundaries;
+- a new subsystem, or another project-wide capability boundary.
+
+An ordinary feature addition, a schema or data migration, a configuration field or default change, and
+a bounded implementation refactor are **not** RFCs, however large the diff or however sensitive the
+surrounding subsystem. A new channel, provider, or tool is ordinary work.
+
+The test is substantive project effect, not the issue title, the author, or an AI-assisted origin. An
+issue whose own body scopes itself with explicit non-goals and acceptance criteria is describing
+bounded work, not proposing a project-level decision.
+
+When in doubt, do not apply `type:rfc`; leave the type label as-is and flag the issue to the user.
+Adding it wrongly parks the work behind a Core vote it does not need.
 
 ### Priority (apply when determinable)
 

--- a/.claude/skills/github-issue-triage/references/triage-protocol.md
+++ b/.claude/skills/github-issue-triage/references/triage-protocol.md
@@ -379,7 +379,7 @@ Stale closures are especially sensitive — a reporter may have been waiting pat
 
 ## §7 Label Taxonomy
 
-Derived from current maintainer label policy, with RFC scope set by [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496) (FND-003 Rev. 9). Apply these consistently:
+Derived from current maintainer label policy, with RFC scope set by [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496) (FND-003 Rev. 15). Apply these consistently:
 
 ### Type
 
@@ -402,11 +402,12 @@ project-level decision before implementation, meaning it is at least one of:
 
 An ordinary feature addition, a schema or data migration, a configuration field or default change, and
 a bounded implementation refactor are **not** RFCs, however large the diff or however sensitive the
-surrounding subsystem. A new channel, provider, or tool is ordinary work.
+surrounding subsystem. A new channel, provider, or tool is ordinary work unless its substantive effect
+also crosses one of the triggers above.
 
-The test is substantive project effect, not the issue title, the author, or an AI-assisted origin. An
-issue whose own body scopes itself with explicit non-goals and acceptance criteria is describing
-bounded work, not proposing a project-level decision.
+The test is substantive project effect, not the issue title, the author, or an AI-assisted origin.
+Explicit non-goals and acceptance criteria help scope the work, but they do not determine the trigger
+by themselves.
 
 When in doubt, do not apply `type:rfc`; leave the type label as-is and flag the issue to the user.
 Adding it wrongly parks the work behind a Core vote it does not need.

--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -89,7 +89,7 @@ If the user requests changes, update the draft and re-present. Iterate until the
 Before final submission, analyze the collected content for scope creep:
 - Does the bug report describe multiple independent defects?
 - Does the feature request bundle unrelated changes?
-- Is an RFC/design proposal being filed as an ordinary feature request?
+- Is an RFC/design proposal being filed as an ordinary feature request? Check the reverse too, which is the more common error: ordinary features, schema or data migrations, configuration field and default changes, and bounded refactors are **not** RFCs. Route to the RFC form only when the proposal crosses one of the four triggers accepted in [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496); when unsure, file the feature request and note why it might cross one.
 - Is an active coordination surface being filed as one ordinary bug or feature instead of a roadmap/tracker?
 - Is a docs-only gap being mixed with a behavior change that should have its own bug or feature issue?
 

--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -23,7 +23,7 @@ Read `.github/ISSUE_TEMPLATE/config.yml` first. It is contact-link metadata, not
 
 Discover the issue forms from the current repository. Enumerate `.github/ISSUE_TEMPLATE/*.yml` excluding `config.yml`, then parse each form's `name`, `description`, `title`, `labels`, and `body`.
 
-Choose the best form from the parsed inventory. If the type is unclear, use AskUserQuestion with the parsed form names and descriptions. Do not collapse unclear issues to bug or feature by default.
+Choose the best form from the parsed inventory. First distinguish ordinary tracked work from an RFC: unless the request clearly crosses one of the four triggers accepted in [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496), keep it on the ordinary issue or PR path. Then choose the ordinary form by intent: bug, feature, docs, support, tracker, or contributor task. Do not collapse every non-RFC into a Feature Request. When the ordinary type is unclear, use AskUserQuestion with the parsed form names and descriptions. Do not ask the user to self-adjudicate an uncertain architecture boundary; record a possible trigger in the selected form so a maintainer can promote it.
 
 Then read the selected issue template to understand the required fields:
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,7 +14,7 @@ contact_links:
     about: Please read contribution and PR requirements before opening an issue.
   - name: RFC process
     url: https://github.com/zeroclaw-labs/zeroclaw/blob/master/docs/book/src/contributing/rfcs.md
-    about: Read this before filing significant architecture, default, governance, or process changes.
+    about: Most work starts as an ordinary issue or PR. Read this only when a durable project-level decision may be required.
   - name: PR workflow & reviewer expectations
     url: https://github.com/zeroclaw-labs/zeroclaw/blob/master/docs/book/src/maintainers/pr-workflow.md
     about: Read risk-based PR tracks, CI gates, and merge criteria before filing feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Propose an improvement or new capability
+description: Propose an improvement or new capability through the ordinary issue path
 title: "[Feature]: "
 labels:
   - enhancement
@@ -7,7 +7,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for sharing your idea.
+        **Use this form for new capabilities and improvements.** Most work does not need an RFC.
+        If you are unsure whether the proposal crosses an RFC trigger, use this form and describe
+        the architecture impact below. A maintainer can promote it if a durable project-level
+        decision is actually required.
+
         Please focus on user value, constraints, and rollout safety.
         Do not include personal/sensitive data; use neutral project-scoped placeholders.
 
@@ -90,10 +94,10 @@ body:
     id: routing
     attributes:
       label: Expected routing
-      description: Helps maintainers choose triage, design discussion, tracker routing, or contributor scoping.
+      description: Most feature requests use ordinary triage. Maintainers decide whether an RFC trigger is crossed.
       options:
         - Ordinary feature triage
-        - Needs design or RFC discussion first
+        - Needs maintainer design assessment
         - Should attach to an existing roadmap/tracker issue
         - Could become contributor-ready after maintainer scoping
         - Not sure

--- a/.github/ISSUE_TEMPLATE/rfc_design.yml
+++ b/.github/ISSUE_TEMPLATE/rfc_design.yml
@@ -17,8 +17,10 @@ body:
 
         **Do not use this form** for an ordinary feature addition, a schema or data migration, a
         configuration field or default change, or a bounded implementation refactor. A new channel,
-        provider, or tool is ordinary work however large the diff. Those go to the
-        [Feature Request](?template=feature_request.yml) form and proceed through an issue and PR.
+        provider, or tool is ordinary work however large the diff, unless its substantive effect
+        also crosses one of the triggers above. Those requests proceed through the ordinary issue
+        or PR path. Use the [Feature Request](?template=feature_request.yml) form when requesting a
+        new capability.
 
         The test is substantive project effect, not the size of the change. If you are unsure, file a
         feature request and say why it might cross a trigger; a maintainer can promote it. Maintainers
@@ -26,7 +28,7 @@ body:
         rejecting it.
 
         Scope and ratification rules: [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496)
-        (FND-003 Rev. 9). Security vulnerabilities must be reported privately, never as a public RFC.
+        (FND-003 Rev. 15). Security vulnerabilities must be reported privately, never as a public RFC.
 
   - type: dropdown
     id: trigger

--- a/.github/ISSUE_TEMPLATE/rfc_design.yml
+++ b/.github/ISSUE_TEMPLATE/rfc_design.yml
@@ -1,5 +1,5 @@
 name: RFC / Design Proposal
-description: Propose a significant architecture, governance, or user-facing direction change
+description: Propose a durable project-level decision that must be settled before implementation
 title: "RFC: "
 labels:
   - "type:rfc"
@@ -7,9 +7,39 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for significant changes to architecture, public interfaces, defaults, governance,
-        release process, contribution model, or project direction.
-        Smaller feature requests should use the feature template. Security vulnerabilities must be reported privately.
+        **Most work does not need an RFC.** Use this form only when the proposal requires a durable
+        project-level decision before implementation, meaning it is at least one of:
+
+        - a new security layer, or a material change to the project's security model;
+        - a governance, contribution-process, or project-authority change;
+        - a cross-cutting architectural refactor that changes ownership or contracts across established boundaries;
+        - a new subsystem, or another project-wide capability boundary.
+
+        **Do not use this form** for an ordinary feature addition, a schema or data migration, a
+        configuration field or default change, or a bounded implementation refactor. A new channel,
+        provider, or tool is ordinary work however large the diff. Those go to the
+        [Feature Request](?template=feature_request.yml) form and proceed through an issue and PR.
+
+        The test is substantive project effect, not the size of the change. If you are unsure, file a
+        feature request and say why it might cross a trigger; a maintainer can promote it. Maintainers
+        may reclassify an RFC that does not meet the trigger, which routes the work rather than
+        rejecting it.
+
+        Scope and ratification rules: [#9496](https://github.com/zeroclaw-labs/zeroclaw/issues/9496)
+        (FND-003 Rev. 9). Security vulnerabilities must be reported privately, never as a public RFC.
+
+  - type: dropdown
+    id: trigger
+    attributes:
+      label: Which RFC trigger does this meet?
+      description: Pick the one this proposal actually crosses. If none apply, use the Feature Request form instead.
+      options:
+        - "Security: a new security layer or material change to the security model"
+        - "Governance: a governance, contribution-process, or project-authority change"
+        - "Architecture: a cross-cutting refactor changing ownership or contracts across established boundaries"
+        - "Capability boundary: a new subsystem or project-wide capability boundary"
+    validations:
+      required: true
 
   - type: textarea
     id: problem


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - #9496 and merged PR #9499 narrowed RFC scope to four project-level triggers, but the issue picker, issue forms, and agent-assisted filing and triage guidance still routed ordinary work too readily into the RFC queue.
  - The RFC form now requires the filer to name one of those triggers and explicitly routes ordinary work to the best matching issue or direct PR path.
  - The Feature Request form now identifies itself as the ordinary form for a new capability without becoming the fallback for every non-RFC. Bugs, docs gaps, support records, trackers, and contributor tasks keep their own forms.
  - The filing and triage skills now reserve `type:rfc` for the four triggers, avoid asking contributors to self-adjudicate uncertain architecture boundaries, and let maintainers promote ordinary work when its substantive effect crosses a trigger.
- **Scope boundary:** Intake routing only. This does not change RFC ratification, discussion periods, voting, Core Team authority, labels, runtime behavior, or existing issue dispositions. It does not make Feature Request the universal non-RFC fallback.
- **Blast radius:** New issue selection and form submissions, plus agent-assisted issue filing and triage. Existing issues and open RFC votes are unchanged.
- **Linked issue(s):** Related #9496. Related #9499. Related #9817. Related #10167.
- **Labels:** `enhancement`, `docs`, `distinguished contributor`, `risk:medium`, `size:S`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` - issue-template and guidance-only changes with no runtime behavior. The rendered GitHub form can be inspected after merge, but local schema checks cover the changed contract.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh exact-head `Docs Style`, `Format`, `Repository Structure`, `Lint`, `Security`, full `Test`, and `CI Required Gate` all passed at `1ea629afe`. `Docs Style` covers the changed Markdown and link surfaces; the remaining required checks confirm the refreshed branch integrates cleanly with current `master`.
- **Known CI coverage gap, if any:** GitHub's rendered form was not exercised manually, and the two agent skills were not run end to end against a live issue. The YAML schema, field inventory, links, exact diff, and routing text were checked locally.
- **Commands run and tail output:**

```sh
$ git diff --name-status upstream/master...HEAD
M .claude/skills/github-issue-triage/references/triage-protocol.md
M .claude/skills/github-issue/SKILL.md
M .github/ISSUE_TEMPLATE/config.yml
M .github/ISSUE_TEMPLATE/feature_request.yml
M .github/ISSUE_TEMPLATE/rfc_design.yml

$ git diff --check upstream/master...HEAD
# no output

$ ruby -ryaml -e '<parse every issue form and config.yml>'
parsed form: .github/ISSUE_TEMPLATE/bug_report.yml
parsed form: .github/ISSUE_TEMPLATE/contributor_task.yml
parsed form: .github/ISSUE_TEMPLATE/docs_issue.yml
parsed form: .github/ISSUE_TEMPLATE/feature_request.yml
parsed form: .github/ISSUE_TEMPLATE/rfc_design.yml
parsed form: .github/ISSUE_TEMPLATE/roadmap_tracker.yml
parsed form: .github/ISSUE_TEMPLATE/support_config.yml
parsed config: .github/ISSUE_TEMPLATE/config.yml

$ ruby -ryaml -e '<audit RFC fields and Feature Request routing options>'
rfc ids: ["trigger", "problem", "proposal", "design", "alternatives", "non_goals", "risks", "breaking", "decision_surface", "hygiene"]
rfc required: ["trigger", "problem", "proposal", "risks", "breaking", "decision_surface"]
trigger options: 4
feature routing: ["Ordinary feature triage", "Needs maintainer design assessment", "Should attach to an existing roadmap/tracker issue", "Could become contributor-ready after maintainer scoping", "Not sure"]

$ BASE_SHA=a6464eb9ea2aa67492b799ad0b89528e9ec6659f bash scripts/ci/docs_quality_gate.sh
No docs files detected; skipping docs quality gate.

$ BASE_SHA=a6464eb9ea2aa67492b799ad0b89528e9ec6659f GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgSign GIT_CONFIG_VALUE_0=false bash scripts/ci/docs_links_gate.sh
Ran 6 tests in 0.372s
OK
Collected 1 added link(s) from 2 docs file(s).
Added HTTP(S) links detected, but lychee is not installed; skipping optional HTTP(S) validation.
```

- **Beyond CI, what did you manually verify?** Confirmed the four dropdown options match #9496 and FND-003 Rev. 15; the RFC field ids remain unchanged; the trigger remains required; Feature Request remains an ordinary issue form rather than the universal fallback; the added #9496 link resolves; and the refreshed PR delta contains only the five intended intake files.
- **If any command was intentionally skipped, why:** Rust checks were skipped because no Rust, build, dependency, runtime, config, environment, or CLI surface changed. Optional `lychee` validation was unavailable locally; the only added external link is the existing #9496 issue and was verified through GitHub.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`. The skills change classification guidance only; existing untrusted-input rules still govern fetched issue content.
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: `N/A`

The required RFC trigger applies only to new submissions. Existing issues, labels, votes, and accepted RFCs are unchanged.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After merge, `git revert <merged-PR-sha>`. On the open branch, revert `50b361959` and then `825233c18`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Contributors cannot submit the RFC form, the form offers a trigger outside FND-003 Rev. 15, ordinary work is routed to the wrong issue type, or agent-assisted filing and triage disagree with the visible forms.
