### PR TITLE
fix(desktop): clean up temporary screenshots

### DIFF
--- a/apps/tauri/src/capabilities/screenshot.rs
+++ b/apps/tauri/src/capabilities/screenshot.rs
@@ -7,8 +7,31 @@
 #[cfg(target_os = "macos")]
 use base64::Engine;
 use serde::Serialize;
+#[cfg(any(target_os = "macos", test))]
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
+
+#[cfg(any(target_os = "macos", test))]
+struct TemporaryScreenshot {
+    path: PathBuf,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl Drop for TemporaryScreenshot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn with_temporary_screenshot<T>(
+    path: PathBuf,
+    operation: impl FnOnce(&Path) -> Result<T, String>,
+) -> Result<T, String> {
+    let temporary_screenshot = TemporaryScreenshot { path };
+    operation(&temporary_screenshot.path)
+}
 
 #[derive(Debug, Serialize)]
 pub struct ScreenshotResult {
@@ -33,25 +56,25 @@ pub fn take_screenshot() -> Result<ScreenshotResult, String> {
             chrono_ish_nanos()
         ));
 
-        // -x silences shutter sound. -t png writes a PNG. -C captures cursor.
-        let status = Command::new("/usr/sbin/screencapture")
-            .args(["-x", "-t", "png"])
-            .arg(&tmp)
-            .status()
-            .map_err(|e| format!("screencapture spawn failed: {e}"))?;
+        with_temporary_screenshot(tmp, |tmp| {
+            // -x silences shutter sound. -t png writes a PNG. -C captures cursor.
+            let status = Command::new("/usr/sbin/screencapture")
+                .args(["-x", "-t", "png"])
+                .arg(tmp)
+                .status()
+                .map_err(|e| format!("screencapture spawn failed: {e}"))?;
 
-        if !status.success() {
-            return Err(format!("screencapture exited with {status}"));
-        }
+            if !status.success() {
+                return Err(format!("screencapture exited with {status}"));
+            }
 
-        let bytes =
-            std::fs::read(&tmp).map_err(|e| format!("failed to read captured image: {e}"))?;
-        let _ = std::fs::remove_file(&tmp);
-
-        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-        Ok(ScreenshotResult {
-            format: "png".into(),
-            data: encoded,
+            let bytes =
+                std::fs::read(tmp).map_err(|e| format!("failed to read captured image: {e}"))?;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            Ok(ScreenshotResult {
+                format: "png".into(),
+                data: encoded,
+            })
         })
     }
 
@@ -68,4 +91,66 @@ fn chrono_ish_nanos() -> u128 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::with_temporary_screenshot;
+    use std::path::PathBuf;
+
+    fn test_path(case: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "zeroclaw-screenshot-test-{}-{}-{case}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after Unix epoch")
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn temporary_screenshot_is_removed_when_read_step_fails() {
+        let path = test_path("read-error");
+        std::fs::write(&path, b"captured png").expect("create screenshot fixture");
+
+        let error = with_temporary_screenshot(path.clone(), |candidate| {
+            assert!(candidate.exists(), "fixture should exist during read step");
+            Err::<(), _>("failed to read captured image: simulated".to_string())
+        })
+        .expect_err("simulated read failure should be returned");
+
+        assert_eq!(error, "failed to read captured image: simulated");
+        assert!(!path.exists(), "temporary screenshot should be removed");
+    }
+
+    #[test]
+    fn temporary_screenshot_is_removed_after_success() {
+        let path = test_path("success");
+        std::fs::write(&path, b"captured png").expect("create screenshot fixture");
+
+        with_temporary_screenshot(path.clone(), |candidate| {
+            std::fs::read(candidate)
+                .map(|_| ())
+                .map_err(|error| format!("failed to read captured image: {error}"))
+        })
+        .expect("read should succeed");
+
+        assert!(!path.exists(), "temporary screenshot should be removed");
+    }
+
+    #[test]
+    fn cleanup_failure_does_not_replace_primary_error() {
+        let path = test_path("cleanup-error");
+        std::fs::create_dir(&path).expect("create directory fixture");
+        std::fs::write(path.join("keep"), b"non-empty").expect("make cleanup fail");
+
+        let error = with_temporary_screenshot(path.clone(), |_| {
+            Err::<(), _>("screencapture failed".to_string())
+        })
+        .expect_err("primary failure should be returned");
+
+        assert_eq!(error, "screencapture failed");
+        std::fs::remove_dir_all(path).expect("remove directory fixture");
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Own the allocated macOS screenshot path with a small `TemporaryScreenshot` guard.
  - Attempt cleanup when capture spawning fails, capture exits unsuccessfully, reading fails, and after successful encoding.
  - Preserve the primary capture/read error if best-effort cleanup also fails.
  - Add focused lifecycle tests for success, read failure, and cleanup failure.
- **Scope boundary:** Does not change screenshot permissions, command arguments, output format, temporary-path naming, public APIs, or add a generic cleanup scheduler.
- **Blast radius:** Limited to the macOS desktop screenshot capability and its co-located tests.
- **Linked issue(s):** Closes #9710
- **Labels:** `bug`, `desktop`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the lifecycle behavior is exercised by focused unit tests; this Linux host cannot run macOS `screencapture` itself.

### How I tested

- **CI checks relied on and why they cover this change:** Required PR CI is green. The hosted desktop matrix runs Clippy with `--all-targets` on macOS, Linux, and Windows, so it compiles the platform-specific production branch and test targets.
- **Known CI coverage gap, if any:** Hosted CI does not execute the `zeroclaw-desktop` tests; the author-run command below is the execution evidence for the focused regressions. This Linux host also cannot execute the real macOS `screencapture` command, so no live capture smoke was run.
- **Commands run and tail output:**

```sh
$ cargo fmt --all -- --check
# exit 0

$ cargo test --locked -p zeroclaw-desktop
# 21 unit tests passed
# 1 integration test passed
# 0 failed

$ cargo clippy --locked -p zeroclaw-desktop --all-targets -- -D warnings
# Finished `dev` profile; exit 0

$ git diff --check
# exit 0
```

- **Beyond CI, what did you manually verify?** Temporarily replaced the guard cleanup with a no-op and confirmed the new success/read-failure tests failed while leaving their fixture paths behind; restored the guard and confirmed all tests pass. Also verified a simulated cleanup failure does not replace the primary screenshot error.
- **If any command was intentionally skipped, why:** A real macOS capture smoke test and Apple-target cross-check are unavailable on this Linux VM because it has no Apple SDK headers.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.** Cleanup remains limited to the process-generated screenshot path that the existing code already removed after success.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any Yes, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **Yes.**
- Config / env / CLI surface changed? **No.**
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is No or either surface/floor question is Yes: N/A.

## Rollback

- **Fast rollback command/path:** `git revert 4aed885f11995d4332177dee451f6558adbdb34c`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Screenshot capture errors, missing capture output, or unexpected handling of `zeroclaw-screenshot-*.png` temporary paths. Reverting restores the previous success-only cleanup behavior; no user configuration rollback is required.

## Supersede Attribution

N/A — this PR does not supersede another contribution.
