### PR TITLE
docs(agents): name runtime Fluent helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ Subagents must set their working directory to the repository root before shell o
 
 ## User-Facing Text
 
-- User-facing runtime CLI, tool, and onboarding text uses Fluent `fl!()` keys rather than bare literals.
-- Zerocode uses its independent Fluent catalogue through its documented `crate::i18n` helpers. Web dashboard text follows the TypeScript `web/src/lib/i18n.ts` contract, not Rust `fl!()`.
+- User-facing runtime CLI, tool, and onboarding text uses Fluent keys through `zeroclaw_runtime::i18n::{get_required_cli_string, get_required_cli_string_with_args}` rather than bare literals; see `crates/zeroclaw-runtime/src/i18n.rs`.
+- Zerocode uses its independent Fluent catalogue through its documented `crate::i18n` helpers. Web dashboard text follows the TypeScript `web/src/lib/i18n.ts` contract, not the Rust runtime i18n helpers.
 - Logs, tracing fields, and panic text remain English and use stable error keys where the logging contract requires them.
 - English Markdown is the documentation source of truth. Follow the documented localization workflow instead of editing generated translations by hand.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replace the nonexistent Rust `fl!()` guidance with the runtime i18n helper pair contributors actually use.
  - Point contributors to `crates/zeroclaw-runtime/src/i18n.rs`, the helper implementation.
  - Clarify that the web dashboard follows its TypeScript i18n contract rather than Rust runtime helpers.
- **Scope boundary:** Repository-root `AGENTS.md` only; no runtime i18n behavior or Fluent catalogues change.
- **Blast radius:** Contributor guidance only; no production consumers.
- **Linked issue(s):** Fixes #9924
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — documentation-only correction with no manual runtime path.

### How I tested

- **CI checks relied on and why they cover this change:** No local gate directly covers repository-root `AGENTS.md`. `git diff --check` passed; docs/link gates were run but did not include this file.
- **Known CI coverage gap, if any:** `AGENTS.md` is outside the docs-quality and link-gate paths. The replacement API names were manually verified against `crates/zeroclaw-runtime/src/i18n.rs` and existing channel call sites.
- **Commands run and tail output:**
  - `scripts/ci/docs_quality_gate.sh` → `No docs files detected; skipping docs quality gate.`
  - `scripts/ci/docs_links_gate.sh` → `Ran 6 tests ... OK`; `No added links detected in changed docs lines.`
  - `git diff --check` → no output.
  - Verified both helpers are public in `crates/zeroclaw-runtime/src/i18n.rs` and used by `crates/zeroclaw-channels/src/util.rs`.
- **Beyond CI, what did you manually verify?** Confirmed `fl!()` has no Rust usage in the repository and the replacement names match the runtime implementation. Did not run Rust build/test because no Rust source changed.
- **If any command was intentionally skipped, why:** Rust build, formatting, clippy, and test suites were skipped because this PR only changes contributor guidance.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback

Low-risk documentation-only PR: `git revert 8accf0f4e`.
