### PR TITLE
docs(wit): clarify enum case compatibility

### DIFF
--- a/.claude/skills/wit-breaking-change-check/SKILL.md
+++ b/.claude/skills/wit-breaking-change-check/SKILL.md
@@ -16,7 +16,7 @@ Classifies every modification in the current WIT diff against the breaking-chang
 ## Procedure
 
 1. Run `git diff origin/master -- wit/` to obtain the current diff.
-2. For each `wit/vN/` directory in the diff, check whether `wit/vN/.frozen` exists. If absent, report the version as experimental and skip it.
+2. For each `wit/vN/` directory in the diff, check whether `wit/vN/.frozen` exists. If absent, report the version as experimental and state that components must be rebuilt against the WIT shipped by the target host; do not claim the frozen-version compatibility window applies.
 3. For each frozen version with changes, classify every modification against the breaking-change taxonomy in `wit/VERSIONING.md`:
    - **Breaking**: removing/renaming any type, function, record field, enum case, or variant case; adding a case to an existing enum or variant; changing a function signature; changing a field type; reordering record fields; adding a required (non-optional) field to an existing record; adding a non-capability-gated required function to an existing interface.
    - **Non-breaking**: new `flags` bits, new capability-gated functions, new record/variant/enum types (but not cases added to an existing enum or variant), new interfaces, new worlds, `@since`/`@unstable` annotation additions.
@@ -28,4 +28,4 @@ Classifies every modification in the current WIT diff against the breaking-chang
 
 ## Notes
 
-The `.frozen` marker is a human-readable convention: its presence signals to reviewers and this skill that the version is stable and requires the breaking-change check before merge. Experimental (unfrozen) versions are skipped without a verdict.
+The `.frozen` marker is a human-readable convention: its presence signals to reviewers and this skill that the version is stable and requires the breaking-change check before merge. For experimental (unfrozen) versions, report the target-host rebuild requirement without assigning a frozen-version compatibility verdict.

--- a/.claude/skills/wit-breaking-change-check/SKILL.md
+++ b/.claude/skills/wit-breaking-change-check/SKILL.md
@@ -18,13 +18,13 @@ Classifies every modification in the current WIT diff against the breaking-chang
 1. Run `git diff origin/master -- wit/` to obtain the current diff.
 2. For each `wit/vN/` directory in the diff, check whether `wit/vN/.frozen` exists. If absent, report the version as experimental and skip it.
 3. For each frozen version with changes, classify every modification against the breaking-change taxonomy in `wit/VERSIONING.md`:
-   - **Breaking**: removing/renaming any type, function, record field, or variant case; changing a function signature; changing a field type; reordering record fields; adding a required (non-optional) field to an existing record; adding a non-capability-gated required function to an existing interface.
-   - **Non-breaking**: new `flags` bits, new capability-gated functions, new record/variant/enum types, new interfaces, new worlds, `@since`/`@unstable` annotation additions.
+   - **Breaking**: removing/renaming any type, function, record field, enum case, or variant case; adding a case to an existing enum or variant; changing a function signature; changing a field type; reordering record fields; adding a required (non-optional) field to an existing record; adding a non-capability-gated required function to an existing interface.
+   - **Non-breaking**: new `flags` bits, new capability-gated functions, new record/variant/enum types (but not cases added to an existing enum or variant), new interfaces, new worlds, `@since`/`@unstable` annotation additions.
 4. Report each finding with a verdict:
    - ✅ Non-breaking — with a brief reason citing the taxonomy
    - ❌ Breaking — with a brief reason citing the taxonomy
    - ⚠️ Uncertain — with the ambiguity explained
-5. If any breaking change is found, summarize the required migration path for plugin authors.
+5. If any breaking change is found, summarize the required migration path for plugin authors. For an unfrozen experimental version, state that components must be rebuilt against the target host's shipped WIT; the current-and-previous-major host compatibility window begins only after a version directory is frozen.
 
 ## Notes
 

--- a/wit/VERSIONING.md
+++ b/wit/VERSIONING.md
@@ -22,7 +22,10 @@ Each `vN/` directory maps to one WIT package major version. Minor bumps (0.2,
 
 **Breaking — requires a new `vN+1/` directory:**
 
-- Removing or renaming any type, function, record field, or variant case
+- Removing or renaming any type, function, record field, enum case, or variant case
+- Adding a case to an existing enum or variant: these are closed types, so an
+  old component and a new host (or a new component and an old host) can fail to
+  link
 - Changing the type of any function parameter or return value
 - Changing the type of any record field
 - Reordering fields in a record
@@ -31,7 +34,8 @@ Each `vN/` directory maps to one WIT package major version. Minor bumps (0.2,
 
 - Adding new `flags` bits to `*-capabilities`
 - Adding new capability-gated functions to an interface
-- Adding new record types, variant types, or enums
+- Adding new record types, variant types, or enums (but not cases to an
+  existing enum or variant)
 - Adding new WIT `interface` definitions to the package
 - Adding new `world` definitions
 
@@ -45,12 +49,15 @@ Each `vN/` directory maps to one WIT package major version. Minor bumps (0.2,
 
 All current content in `wit/v0/` is gated behind
 `@unstable(feature = plugins-wit-v0)`. It graduates when the first
-stable Component Model release ships.
+stable Component Model release ships. Until a version directory is frozen,
+`v0` is experimental: components must be rebuilt against the WIT shipped by
+the target host, including after additions to existing enums or variants.
 
 #### Host compatibility window
 
-The host maintains adapters for **the current major version and one previous
-(N-1)**:
+After a version directory is frozen, the host maintains adapters for **the
+current major version and one previous (N-1)**. This compatibility window does
+not apply to unfrozen experimental versions:
 
 | When ships   | Supported | Dropped |
 | ------------ | --------- | ------- |

--- a/wit/VERSIONING.md
+++ b/wit/VERSIONING.md
@@ -20,7 +20,7 @@ Each `vN/` directory maps to one WIT package major version. Minor bumps (0.2,
 
 #### Breaking vs non-breaking changes
 
-**Breaking — requires a new `vN+1/` directory:**
+**Breaking for a frozen `vN/` directory — requires a new `vN+1/` directory:**
 
 - Removing or renaming any type, function, record field, enum case, or variant case
 - Adding a case to an existing enum or variant: these are closed types, so an
@@ -49,9 +49,9 @@ Each `vN/` directory maps to one WIT package major version. Minor bumps (0.2,
 
 All current content in `wit/v0/` is gated behind
 `@unstable(feature = plugins-wit-v0)`. It graduates when the first
-stable Component Model release ships. Until a version directory is frozen,
-`v0` is experimental: components must be rebuilt against the WIT shipped by
-the target host, including after additions to existing enums or variants.
+stable Component Model release ships. Until a version directory is frozen, it
+is experimental: components must be rebuilt against the WIT shipped by the
+target host, including after additions to existing enums or variants.
 
 #### Host compatibility window
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Classifies adding a case to an existing WIT enum or variant as breaking for frozen WIT versions.
  - Distinguishes that from adding a wholly new enum or variant type, which remains additive.
  - Documents the experimental, unfrozen-version rebuild requirement.
  - Aligns the WIT breaking-change review skill with the versioning guide.
- **Scope boundary:** Documentation and reviewer guidance only; no WIT interface, host runtime, plugin ABI, or compatibility behavior changes.
- **Blast radius:** Plugin authors and reviewers using the WIT compatibility policy.
- **Linked issue(s):** Fixes #9643
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing

### How you can test

- **Reviewer testing requested?** N/A — documentation and skill guidance only.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` validates the changed Markdown.
- **Known CI coverage gap, if any:** No repository-local lint directly targets `wit/VERSIONING.md` or `.claude` skill Markdown.
- **Commands run and tail output:**
  ```sh
  git diff --check
  scripts/ci/docs_quality_gate.sh
  scripts/ci/docs_links_gate.sh
  ```
  `git diff --check` passed. The docs quality gate found no `docs/book` files and skipped; the links gate’s helper tests passed and found no added links.
- **Beyond CI, what did you manually verify?** Compared the wording with #9643, the `memory-audit` enum-case addition in #9258, and the runtime WIT-drift hint that tells authors to rebuild against the WIT shipped with the host version.
- **If any command was intentionally skipped, why:** No Rust tests were run because this PR changes no runtime code or WIT definitions.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low-risk PR: `git revert <sha>` is the plan.
