### PR TITLE
ci(channels): compile and run WeChat channel tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,15 @@ jobs:
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      # `channel-wechat` is outside `default-channels` and `channels-full`, so
+      # the workspace run above compiles neither the module nor its unit tests.
+      # Adding it to `ci-all` gives Lint and Check compile coverage; this step
+      # is what actually executes the tests.
+      - name: Run WeChat channel lib unit tests
+        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-wechat --lib wechat::"
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
   parallel-runtime-test-changes:
     name: Detect parallel runtime test changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,7 +431,7 @@ plugins-wasm-pulley       = ["plugins-wasm", "zeroclaw-plugins/plugins-wasm-pull
 ci-all = [
     "agent-runtime",
     "channels-full",
-    "channel-nostr", "channel-matrix", "whatsapp-web",
+    "channel-nostr", "channel-matrix", "whatsapp-web", "channel-wechat",
     "observability-prometheus", "observability-otel",
     "hardware", "peripheral-rpi",
     "sandbox-landlock", "sandbox-bubblewrap",


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `channel-wechat` gates `pub mod wechat` in `crates/zeroclaw-channels/src/lib.rs`, but the feature was in no CI feature set: absent from `default-channels`, `channels-full` and the workspace `ci-all` list, and named in no workflow file. Nothing compiled the module and nothing executed its 51 lib unit tests.
  - Add `channel-wechat` to `ci-all` so `Lint` (`--features ci-all`) and `Check (all features)` compile and lint the module.
  - Feature membership alone is not enough: the `Test` job runs `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` with no `--features` flag, so it builds default features only. Add an explicit step that executes the tests, mirroring how the `zeroclaw-plugins` lib tests are run for the same class of gap in #9462.
- **Scope boundary:** No product code changes. No test logic changes; the 51 existing tests are untouched and already pass. No other feature is added to `ci-all` — `channel-wechat` was the only orphaned channel feature. Does not change which channels ship in default builds.
- **Blast radius:** CI only. `Lint` and `Check (all features)` now compile the WeChat module, and `Test` gains one step. If any of those surfaced a latent defect the job would fail; all were verified clean locally. `channel-wechat` remains outside default builds, so shipped binaries are unaffected.
- **Linked issue(s):** Closes #9951. Related #9428, which is where the gap surfaced.
- **Labels:** `bug`, `ci`, `dependencies`, `risk:low`, `size:XS`, `type:ci`, `principal contributor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `channel` (WeChat), via CI configuration
- **Setup / preconditions:** A checkout of this branch. No channel credentials or live account needed.
- **Steps to run:**

```sh
cargo test --locked -p zeroclaw-channels --lib -- --list | grep -c '^wechat::'
cargo test --locked -p zeroclaw-channels --features channel-wechat --lib wechat::
```

- **Expected on this branch (after):** The `Test` job has a `Run WeChat channel lib unit tests` step that executes 51 tests, and `ci-all` resolves `channel-wechat` as enabled.
- **Prior behavior on `master` (before):** The same `--list` command returns `0`, and no CI job compiles the module or runs those tests.

### How I tested

Reproduced the gap and verified the fix on `x86_64-unknown-linux-gnu`.

Feature resolution before and after, using `cargo metadata` rather than `cargo tree`. The latter dedups its feature output and reported a false negative even for a known-enabled control, so it is not a safe way to check this:

```sh
$ cargo metadata --format-version=1 --filter-platform x86_64-unknown-linux-gnu --features ci-all
# on master:      channel-wechat NOT ENABLED   (40 resolved zeroclaw-channels features)
# on this branch: channel-wechat ENABLED       (41 resolved features)
# control, both:  whatsapp-web / channel-nostr / channel-matrix ENABLED
```

Test execution:

```sh
$ cargo test --locked -p zeroclaw-channels --lib -- --list | grep -c ': test$'
1377                       # default features; 0 wechat:: tests
$ cargo test --locked -p zeroclaw-channels --features channels-full --lib -- --list | grep -c ': test$'
2423                       # channels-full; still 0 wechat:: tests
$ cargo test --locked -p zeroclaw-channels --features channel-wechat --lib wechat::
test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 1391 filtered out; finished in 0.06s
```

Lint on the widened feature set. This is the check most likely to catch a regression, since it now lints 51 previously unlinted tests:

```sh
$ cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 18s      # exit 0
$ cargo fmt --all -- --check                                                   # exit 0
$ actionlint .github/workflows/ci.yml                                          # clean
$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **CI checks relied on and why they cover this change:** `Lint` and `Check (all features)` both build `--features ci-all` and so exercise the newly included module; `Test` runs the new step; `actionlint` covers the workflow edit.
- **Known CI coverage gap, if any:** None for this change. The new step runs on Linux only, matching the existing `Test` job; the WeChat module is not platform-specific.
- **Beyond CI, what did you manually verify?** That `channel-wechat` was the only orphaned channel feature, by checking every `channel-*` feature plus `whatsapp-web` against `default-channels`, `channels-full` and `ci-all`. I also confirmed the one clippy warning (`proc-macro-error2` future-incompat) is pre-existing and dependency-side, reaching the graph via `matrix-sdk` from `channel-matrix`, which was already in `ci-all` before this change. I did NOT run against a live WeChat account; these are offline unit tests.
- **If any command was intentionally skipped, why:** `./dev/ci.sh all` was not run. The changed surface is one workflow step and one feature-list entry, and the affected jobs are reproduced literally above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. CI-only change that increases test coverage of an existing authorization-bearing module.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert 370418a424` is the plan. No runtime behavior to toggle.
