### PR TITLE
ci(cache): route rust-cache through a provider-aware composite action

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,0 +1,44 @@
+name: Rust cache (provider-aware)
+description: >
+  Restore/save the Rust build cache using Blacksmith's sticky-disk cache when
+  the job runs on a Blacksmith runner, otherwise Swatinem/rust-cache on a
+  GitHub-hosted runner. This preserves the CI_USE_BLACKSMITH fail-safe: any
+  non-'true' value (including unset) selects Swatinem, so GitHub-hosted jobs
+  stay fully cached and the toggle can be flipped off with no loss of caching.
+
+inputs:
+  use-blacksmith:
+    description: >
+      Pass 'true' only when this job is running on a Blacksmith runner
+      (useblacksmith/rust-cache needs the local sticky disk). Any other value
+      falls back to Swatinem/rust-cache.
+    required: true
+  cache-on-failure:
+    description: Save the cache even when the job fails.
+    required: false
+    default: "false"
+  save-if:
+    description: Only write the cache when this evaluates truthy (e.g. default branch only).
+    required: false
+    default: "true"
+
+outputs:
+  cache-hit:
+    description: Whether an exact cache match was restored, from whichever provider ran.
+    value: ${{ steps.bs.outputs.cache-hit || steps.gh.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - id: bs
+      if: ${{ inputs.use-blacksmith == 'true' }}
+      uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1
+      with:
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+        save-if: ${{ inputs.save-if }}
+    - id: gh
+      if: ${{ inputs.use-blacksmith != 'true' }}
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      with:
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+        save-if: ${{ inputs.save-if }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,10 @@ jobs:
         with:
           toolchain: 1.96.1
           components: clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -316,9 +317,10 @@ jobs:
         with:
           toolchain: 1.96.1
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH == 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install mold linker
@@ -398,9 +400,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: 1.96.1
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -447,9 +450,10 @@ jobs:
       - name: Install channel plugin fixture target
         if: steps.changed.outputs.run == 'true' && matrix.features == 'plugins-wasm-cranelift'
         run: rustup target add wasm32-wasip2
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         if: steps.changed.outputs.run == 'true'
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check
@@ -514,9 +518,10 @@ jobs:
         with:
           toolchain: 1.96.1
           targets: i686-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install 32-bit system libraries
@@ -536,9 +541,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: 1.96.1
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Ensure web/dist placeholder exists
@@ -591,9 +597,10 @@ jobs:
         with:
           toolchain: 1.96.1
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check firmware protocol crate

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -265,7 +265,7 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `actions/attest` (`v4.2.2`) | `release-stable-manual.yml` | Generate GitHub-hosted Build Level 2 provenance for release assets |
 | `actions/labeler` (`v6.1.0`) | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
 | `dtolnay/rust-toolchain` (`stable`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml` | Install Rust toolchain |
-| `Swatinem/rust-cache` (`v2.9.1`) | `ci.yml` (GitHub-hosted path of `./.github/actions/rust-cache`), `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching on GitHub-hosted runners |
+| `Swatinem/rust-cache` (`v2.9.2`) | `ci.yml` (GitHub-hosted path of `./.github/actions/rust-cache`), `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching on GitHub-hosted runners |
 | `useblacksmith/rust-cache` (`v3.0.1`) | `ci.yml` (Blacksmith path of `./.github/actions/rust-cache`) | Cargo build/dependency caching on Blacksmith sticky disk; selected only when `CI_USE_BLACKSMITH=true` |
 | `docker/setup-buildx-action` (`v3.11.1`, `v4.0.0`) | `release-stable-manual.yml`, `docker-publish.yml` | Docker Buildx setup |
 | `docker/login-action` (`v3.4.0`, `v4.1.0`) | `release-stable-manual.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | GHCR authentication |

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -230,7 +230,7 @@ transfers, coordinate the package rename or merge in one reviewed change.
 
 ## Build cache behavior
 
-Most Rust-heavy jobs in `ci.yml` use `Swatinem/rust-cache@v2`. The `fmt`, `nix-eval`, and `docs-style` jobs (none of which compile the workspace) do not. These behaviors are worth knowing when triaging cache-related flakes:
+Most Rust-heavy jobs in `ci.yml` cache through the local `./.github/actions/rust-cache` composite, which selects the cache backend from the same `CI_USE_BLACKSMITH` toggle that selects the runner: `useblacksmith/rust-cache` (Blacksmith NVMe sticky disk) when the job runs on a Blacksmith runner, and `Swatinem/rust-cache` otherwise. Any non-`true` toggle value (including unset, and every fork PR) falls back to `Swatinem/rust-cache` on GitHub-hosted runners, so caching is never lost when Blacksmith is off. Both action references live in the composite regardless of the toggle, so both must stay in the allowlist. The macOS and Windows build legs stay on `Swatinem/rust-cache`, and the `fmt`, `nix-eval`, and `docs-style` jobs (none of which compile the workspace) use no Rust cache. These behaviors are worth knowing when triaging cache-related flakes:
 
 - **Cache writes are master-only.** `save-if` is conditioned on `github.ref == 'refs/heads/master'`, so PR runs read the master-seeded cache but never update it. PR branches can't pollute the shared cache with branch-specific artifacts. The `push` trigger on `master` is what gives the workflow a trusted cache-writing run after merges.
 - **Cache saves on failure.** `cache-on-failure: true` is set on every job, so a partial run still seeds the next attempt warm.
@@ -265,7 +265,8 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `actions/attest` (`v4.2.2`) | `release-stable-manual.yml` | Generate GitHub-hosted Build Level 2 provenance for release assets |
 | `actions/labeler` (`v6.1.0`) | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
 | `dtolnay/rust-toolchain` (`stable`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml` | Install Rust toolchain |
-| `Swatinem/rust-cache` (`v2.9.1`) | `ci.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching |
+| `Swatinem/rust-cache` (`v2.9.1`) | `ci.yml` (GitHub-hosted path of `./.github/actions/rust-cache`), `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching on GitHub-hosted runners |
+| `useblacksmith/rust-cache` (`v3.0.1`) | `ci.yml` (Blacksmith path of `./.github/actions/rust-cache`) | Cargo build/dependency caching on Blacksmith sticky disk; selected only when `CI_USE_BLACKSMITH=true` |
 | `docker/setup-buildx-action` (`v3.11.1`, `v4.0.0`) | `release-stable-manual.yml`, `docker-publish.yml` | Docker Buildx setup |
 | `docker/login-action` (`v3.4.0`, `v4.1.0`) | `release-stable-manual.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | GHCR authentication |
 | `docker/build-push-action` (`v6.18.0`, `v7.1.0`) | `release-stable-manual.yml`, `docker-publish.yml` | Multi-platform image build and push |
@@ -284,6 +285,7 @@ Equivalent allowlist patterns (kept narrow on purpose):
 actions/*
 dtolnay/rust-toolchain@*
 Swatinem/rust-cache@*
+useblacksmith/rust-cache@*
 docker/*
 sigstore/cosign-installer@*
 anchore/sbom-action@*


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The seven compile-heavy jobs that move to Blacksmith when `CI_USE_BLACKSMITH=true` (`lint`, `build` Linux leg, `check`, `check-plugin-backends`, `check-32bit`, `bench`, `test`) still used `Swatinem/rust-cache`, which stores the cache on GitHub's Actions Cache service. From a Blacksmith runner that means pulling the multi-GB `target/` cache back over the network and living under GitHub's 10 GB/repo quota — faster cores, but not a faster cache.
  - Adds a local composite action `.github/actions/rust-cache` that selects `useblacksmith/rust-cache` (local NVMe sticky disk) when the job runs on a Blacksmith runner and `Swatinem/rust-cache` otherwise. Selection is the SAME `CI_USE_BLACKSMITH` toggle, so the fail-safe is preserved: any non-`true` value (including unset) keeps GitHub-hosted jobs on Swatinem with full caching.
  - `build` keys selection on `matrix.target == 'x86_64-unknown-linux-gnu'` so only its Linux leg can use the Blacksmith cache; its macOS and Windows legs stay on Swatinem.
- **Scope boundary:** Only the seven Blacksmith-routed jobs are converted. The six always-GitHub-hosted Rust jobs (`windows-clippy-tools`, `msrv`, `parallel-runtime-test`, `test-landlock`, `security`, `installer-drift`) keep `Swatinem/rust-cache` unchanged. No runner (`runs-on`) change, no toggle change, no other workflow touched.
- **Blast radius:** Cache backend for the seven jobs. Cache is a regenerable build artifact — worst case on any bug is a cold build, not data loss. Existing build-summary steps that read `steps.rust-cache.outputs.cache-hit` keep working because the composite forwards a `cache-hit` output and the invoking step keeps `id: rust-cache`.
- **Linked issue(s):** Related #7108 (CI critical path / cached Rust builds).
- **Labels:** `ci`, `docs`, `distinguished contributor`, `risk:high`, `size:S`, `type:ci`, `needs-maintainer-review`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` — this PR's own required gate exercises the new path.
- **Interface(s) exercised:** CI infrastructure only; no `web` / `tui` / `cli` product surface.
- **Setup / preconditions:** Repository variable `CI_USE_BLACKSMITH` is currently `true`, so the seven converted jobs run on Blacksmith runners and the composite selects `useblacksmith/rust-cache`.
- **Steps to run:** Open/refresh this PR and watch the Quality Gate. Each converted job's "Set up job" shows a `blacksmith-8vcpu` runner; the cache step resolves the local composite and runs the Blacksmith cache action.
- **Expected on this branch (after):** All converted jobs pass with the Blacksmith cache; `cache-hit` still populates the build summary. With `CI_USE_BLACKSMITH=false`, the same jobs fall back to `ubuntu-latest` + `Swatinem/rust-cache` with no change from today.
- **Prior behavior on `master` (before):** Converted jobs use `Swatinem/rust-cache` (GitHub Actions Cache backend) even when running on Blacksmith.

### How I tested

Workflow + composite-action change; validated structurally and by the PR's own gate.

```sh
$ actionlint .github/workflows/ci.yml
# clean
$ ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml OK"'
ci.yml OK
$ ruby -ryaml -e 'd=YAML.load_file(".github/actions/rust-cache/action.yml"); \
    raise unless d["outputs"]["cache-hit"] && d["runs"]["using"]=="composite"; puts "action.yml OK"'
action.yml OK
```

- **CI checks relied on and why they cover this change:** This PR's own fork-PR gate exercises the `Swatinem/rust-cache` fallback on `ubuntu-latest` (fork PRs do not receive `CI_USE_BLACKSMITH`, so they stay GitHub-hosted). The Blacksmith path was validated separately on same-repo PR #9984 using the same workflow and composite tree at `173283632b17356e692eaac2084aa939a4d4b412`; the only later source delta in this PR is documentation, so that evidence carries forward to the current head. Both paths are proven.
- **Known CI coverage gap, if any:** None for path validation — both the Blacksmith and Swatinem-fallback paths are proven (above). PR runs set `save-if: false`, so the warm-cache *speedup* cannot be measured here; it requires a trusted `master` run to save the cache and a later run to restore it.
- **Commands run and tail output:** see the validation block above (actionlint clean, both YAML files parse).
- **Beyond CI, what did you manually verify?** Confirmed the transform converted exactly the seven Blacksmith-routed jobs and left the six always-GitHub-hosted jobs on `Swatinem/rust-cache`; that `build` selection is gated on `matrix.target` so macOS/Windows legs never select the Blacksmith cache; that every job reading `steps.rust-cache.outputs.cache-hit` retains `id: rust-cache` and the composite exposes that output. Pinned `useblacksmith/rust-cache` to the latest tag `v3.0.1` (SHA `f53e7f1…`).
- **If any command was intentionally skipped, why:** `cargo fmt/clippy/test` skipped — no Rust source or manifest changed; they add no coverage for a workflow/action edit.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` new ones — the Blacksmith cache action runs only on Blacksmith runners already used by these jobs, and the sticky disk is local to the runner (it removes GitHub-cache network traffic rather than adding any).
- Secrets / tokens / credentials handling changed? `No` — no secrets referenced; token scope unchanged.
- **Allowlist impact (required for `uses:` changes):** introduces a newly allowed third-party action, `useblacksmith/rust-cache` (v3.0.1, SHA `f53e7f1…`), added to the repo Actions allowlist and documented in `docs/book/src/maintainers/ci-and-actions.md`. Because the composite references both `useblacksmith/rust-cache` and `Swatinem/rust-cache` unconditionally, the allowlist entry is required even when `CI_USE_BLACKSMITH` is off — action resolution happens regardless of the `if:` guard.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes` — with `CI_USE_BLACKSMITH` false/unset every converted job behaves exactly as today (Swatinem on `ubuntu-latest`).
- Config / env / CLI surface changed? `No` product surface; CI cache backend only, gated by the existing repository variable.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` is the complete rollback: it removes the composite, restores the single `Swatinem/rust-cache` step, and drops the `useblacksmith/rust-cache` action-resolution/allowlist dependency. Setting `CI_USE_BLACKSMITH=false` skips the Blacksmith cache *step* (every job runs the Swatinem fallback) but does NOT remove that dependency — both action references remain in the composite — so it is a fast neutralizer, not a full removal.
- **Feature flags or config toggles:** Repository Actions variable `CI_USE_BLACKSMITH`; only `true` selects the Blacksmith cache path.
- **Observable failure symptoms:** A converted job fails at the cache step, "Set up job" shows the composite action failing to resolve, or the build summary's `cache_hit` reads `unknown` where it previously had a value.

