### PR TITLE
fix(container): match nested fixture manifests by glob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,10 +87,13 @@ COPY --parents crates/*/Cargo.toml ./
 # `zeroclaw_macros::Configurable` unresolved. Copy its real source now so the
 # proc-macro is built from the genuine implementation during the pre-fetch.
 COPY --parents crates/zeroclaw-macros/src/ ./
-# Nested workspace members (e.g. plugin test fixtures) are not matched by the
-# single-level crates/*/Cargo.toml glob above, so copy their manifests
-# explicitly to keep workspace manifest parsing intact during the pre-fetch.
-COPY --parents crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml ./
+# Nested workspace members (test fixture crates) are not matched by the
+# single-level crates/*/Cargo.toml glob above, so match them with their own
+# glob to keep workspace manifest parsing intact during the pre-fetch. A glob
+# rather than explicit paths means adding a fixture member does not require
+# editing this file — cargo fails the workspace load if any member manifest is
+# missing, and every such member lives at crates/*/tests/fixtures/*/.
+COPY --parents crates/*/tests/fixtures/*/Cargo.toml ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 # apps/zerocode: TUI app not shipped in the server image; copy only its manifest
@@ -124,8 +127,7 @@ RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-tra
     && mkdir -p crates/zeroclaw-hardware/examples \
     && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
     && for d in crates/*/; do [ "$d" = "crates/zeroclaw-macros/" ] && continue; mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done \
-    && mkdir -p crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src \
-    && printf '' > crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs
+    && for d in crates/*/tests/fixtures/*/; do [ -f "${d}Cargo.toml" ] || continue; mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -44,7 +44,7 @@ RUN apk add --no-cache build-base perl pkgconfig zig \
 
 COPY Cargo.toml Cargo.lock ./
 COPY --parents crates/*/Cargo.toml ./
-COPY --parents crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml ./
+COPY --parents crates/*/tests/fixtures/*/Cargo.toml ./
 COPY --parents crates/zeroclaw-macros/src/ ./
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 COPY apps/zerocode/Cargo.toml apps/zerocode/Cargo.toml
@@ -66,8 +66,11 @@ RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-tra
     && echo "fn main() {}" > xtask/src/bin/web.rs \
     && mkdir -p crates/zeroclaw-hardware/examples \
     && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
-    && mkdir -p crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src \
-    && echo "" > crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs \
+    && for d in crates/*/tests/fixtures/*/; do \
+        [ -f "${d}Cargo.toml" ] || continue; \
+        mkdir -p "${d}src"; \
+        printf '' > "${d}src/lib.rs"; \
+    done \
     && for d in crates/*/; do \
         [ "$d" = "crates/zeroclaw-macros/" ] && continue; \
         mkdir -p "${d}src"; \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -70,10 +70,13 @@ COPY Cargo.toml Cargo.lock ./
 # no longer requires editing this file.  --parents preserves the
 # crates/<name>/Cargo.toml directory structure.
 COPY --parents crates/*/Cargo.toml ./
-# Nested workspace members (e.g. plugin test fixtures) are not matched by the
-# single-level crates/*/Cargo.toml glob above, so copy their manifests
-# explicitly to keep workspace manifest parsing intact during the pre-fetch.
-COPY --parents crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml ./
+# Nested workspace members (test fixture crates) are not matched by the
+# single-level crates/*/Cargo.toml glob above, so match them with their own
+# glob to keep workspace manifest parsing intact during the pre-fetch. A glob
+# rather than explicit paths means adding a fixture member does not require
+# editing this file — cargo fails the workspace load if any member manifest is
+# missing, and every such member lives at crates/*/tests/fixtures/*/.
+COPY --parents crates/*/tests/fixtures/*/Cargo.toml ./
 # apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
 # apps/zerocode: TUI app not shipped in the server image; copy only its manifest
@@ -107,8 +110,7 @@ RUN mkdir -p src src/bin benches apps/tauri/src apps/zerocode/src tools/fill-tra
     && mkdir -p crates/zeroclaw-hardware/examples \
     && echo "fn main() {}" > crates/zeroclaw-hardware/examples/esp32_sim.rs \
     && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done \
-    && mkdir -p crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src \
-    && printf '' > crates/zeroclaw-plugins/tests/fixtures/channel-fixture/src/lib.rs
+    && for d in crates/*/tests/fixtures/*/; do [ -f "${d}Cargo.toml" ] || continue; mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The dependency pre-fetch stage in `Dockerfile`, `Dockerfile.debian`, and `Dockerfile.alpine` copies workspace-member manifests with a single-level `crates/*/Cargo.toml` glob. That glob cannot match members nested at `crates/<name>/tests/fixtures/<name>/`, so those were covered by one hand-written `COPY` naming the plugins `channel-fixture` explicitly.
  - That made the manifest list a **manual mirror** of `Cargo.toml`'s `members` array with nothing enforcing the two stay in sync. #9658 added the two `attribution-macro-*` fixture members without updating the Dockerfiles, so the pre-fetch `cargo build` now fails to load the workspace.
  - Replace the explicit path with a `crates/*/tests/fixtures/*/Cargo.toml` glob, and stub the fixture sources with the same `for d in ...; do` loop form already used for `crates/*/`. Adding a fixture member no longer requires editing three Dockerfiles.
- **Scope boundary:** Only the three Dockerfiles' pre-fetch manifest-copy and source-stub steps change. No base image, pinned digest, toolchain version, build command, dependency, runtime behavior, or generated region is touched. The edits sit well below every `>>> generated:... <<<` block (all of which end by line 57), so `cargo generate installers` output is unaffected.
- **Blast radius:** The three source-image build paths. All consume the pre-fetch stage that currently fails, so this is strictly a repair of a broken path.
- **Linked issue(s):** Related #9658 (introduced the unreferenced members), Related #9527 (blocked by this failure).
- **Labels:** `bug`, `ci`, `dev`, `principal contributor`, `priority:p1`, `risk:low`, `size:XS`, `type:ci`

### The failure

`docker-image-pr.yml` is path-filtered to Docker-related paths, so #9658 never ran these builds and the breakage landed silently. It only surfaces on a later PR that happens to touch a Docker path:

```
error: failed to load manifest for workspace member
  `/app/crates/zeroclaw-log/tests/fixtures/attribution-macro-support`
  failed to read `/app/crates/.../attribution-macro-support/Cargo.toml`
  No such file or directory (os error 2)
```

`Dockerfile.alpine` fails identically despite #9527 not modifying it, which confirms the cause is the missing manifests rather than any toolchain change.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the `Docker Image PR Check` on this PR builds all three affected Dockerfiles and is the direct evidence. This PR touches a Docker path, so the path filter dispatches the full source matrix.

### How I tested

- **CI checks relied on and why they cover this change:** `Docker Image PR Check` exercises exactly the changed stage — root `Dockerfile` on linux/amd64 + linux/arm64, `Dockerfile.debian` on linux/amd64, and `Dockerfile.alpine` on linux/amd64 + linux/arm64. A green matrix means the pre-fetch workspace load succeeds on every changed file. `Installer Drift` confirms the generated regions are untouched.
- **Known CI coverage gap, if any:** None for the changed surface. `Containerfile` (StageX) is unaffected — it has no such pre-fetch manifest stage.
- **Commands run and tail output:** I replicated the pre-fetch context in a sandbox rather than running a full image build, since the failure is a workspace-resolution error that reproduces without compiling. Copying exactly what the Dockerfile copies, then applying the stub loops:

```
=== glob crates/*/tests/fixtures/*/Cargo.toml matches ===
crates/zeroclaw-log/tests/fixtures/attribution-macro-consumer/Cargo.toml
crates/zeroclaw-log/tests/fixtures/attribution-macro-support/Cargo.toml
crates/zeroclaw-plugins/tests/fixtures/channel-fixture/Cargo.toml

=== declared nested members in Cargo.toml ===
crates/zeroclaw-log/tests/fixtures/attribution-macro-support
crates/zeroclaw-log/tests/fixtures/attribution-macro-consumer
crates/zeroclaw-plugins/tests/fixtures/channel-fixture

stubs created; resolving workspace...
WORKSPACE RESOLVE: OK
```

  Control run, same context with the fixture manifests removed, reproduces the CI error exactly:

```
error: failed to load manifest for workspace member
  `/tmp/.../crates/zeroclaw-log/tests/fixtures/attribution-macro-support`
referenced by workspace at `/tmp/.../Cargo.toml`
```

- **Beyond CI, what did you manually verify?**
  - The glob's match set is **identical** to the nested-member set declared in `Cargo.toml` (both listed above) — it neither misses a member nor pulls in a non-member.
  - A bare `src/lib.rs` stub satisfies workspace resolution for **every** fixture shape present, including the `cdylib` (`channel-fixture`, which declares `[lib] crate-type = ["cdylib"]`) and the bin-only member (`attribution-macro-consumer`, whose real source is `src/main.rs`). I checked an earlier variant that also wrote `src/main.rs`, and rejected it: `cargo metadata` showed it auto-discovers a spurious extra `bin` target on `channel-fixture`. Deriving the target kind from the manifest is unnecessary — resolution only needs the manifest plus any source file.
  - `.dockerignore` has no rule excluding `tests/` or `fixtures/`, so the newly-globbed manifests are present in the build context.
  - `git diff --check` is clean; the edits are outside all generated regions.
- **If any command was intentionally skipped, why:** I did not run a full local `docker build`. The image build is dominated by base-image pulls and a release compile, while the defect is a manifest-resolution failure that the sandbox reproduces and refutes deterministically in under a second. CI builds all five image/platform combinations regardless.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

Note: the glob widens what enters the build context to every `crates/*/tests/fixtures/*/Cargo.toml`. These are committed manifests of declared workspace members, they are copied into an intermediate builder stage only, and `RUN rm -rf ... crates ...` removes that tree before the runtime stage. Nothing new reaches the final image.

## Compatibility (required)

- Backward compatible? **Yes** — repairs a currently-failing build path; no interface changes.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <squash-merge-sha>` is the plan. This repository lands PRs via squash merge, so the result is a single-parent commit; do not use `git revert -m 1`. Reverting restores the previous failure for any PR touching a Docker path.
