### PR TITLE
fix(gateway): contain filesystem dashboard assets

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1941,7 +1941,7 @@ pub async fn run_gateway(
         // ── WebSocket node discovery ──
         .route("/ws/nodes", get(nodes::handle_ws_nodes))
         // ── Static assets (web dashboard) ──
-        .route("/_app/{*path}", get(static_files::handle_static))
+        .merge(static_file_routes())
         // ── SPA fallback: non-API GET requests serve index.html ──
         .fallback(get(static_files::handle_spa_fallback))
         .with_state(state.clone())
@@ -2121,6 +2121,12 @@ pub async fn run_gateway(
 
     drop(broadcast_hook_guard);
     Ok(())
+}
+
+fn static_file_routes() -> Router<AppState> {
+    Router::new()
+        .route("/_app/", get(static_files::handle_static))
+        .route("/_app/{*path}", get(static_files::handle_static))
 }
 
 fn format_paircode_recovery_command(_host: &str, port: u16) -> String {
@@ -4074,11 +4080,13 @@ async fn handle_pair_code(State(state): State<AppState>) -> impl IntoResponse {
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use axum::http::{HeaderValue, Uri};
+    use axum::body::Body;
+    use axum::http::{HeaderValue, Request, Uri};
     use axum::response::IntoResponse;
     use http_body_util::BodyExt;
     use parking_lot::{Mutex, RwLock};
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower::ServiceExt;
     #[cfg(feature = "channel-whatsapp-cloud")]
     use zeroclaw_api::channel::ChannelMessage;
     use zeroclaw_memory::{Memory, MemoryCategory, MemoryEntry};
@@ -4428,6 +4436,23 @@ mod tests {
         static_files::handle_spa_fallback(State(state), Uri::from_static(path)).await
     }
 
+    async fn static_route_response(
+        path: &'static str,
+        prefix: Option<&str>,
+        state: AppState,
+    ) -> axum::response::Response {
+        let routes = static_file_routes();
+        let app = match prefix {
+            Some(prefix) => Router::new().nest(prefix, routes),
+            None => routes,
+        }
+        .with_state(state);
+
+        app.oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
     /// Pair a device into both the pairing guard and the device registry,
     /// returning the plaintext token so the test can assert it is revoked.
     async fn pair_device(state: &AppState, device_id: &str) -> String {
@@ -4673,6 +4698,56 @@ mod tests {
     fn app_state_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<AppState>();
+    }
+
+    #[tokio::test]
+    async fn static_routes_reject_malformed_paths_before_spa_fallback() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut prefixed_state = spa_fallback_state(&tmp);
+        prefixed_state.path_prefix = "/gw".to_string();
+
+        for (path, prefix, state) in [
+            ("/_app/", None, spa_fallback_state(&tmp)),
+            ("/_app//index.html", None, spa_fallback_state(&tmp)),
+            ("/_app/assets/./app.js", None, spa_fallback_state(&tmp)),
+            ("/_app/assets/../secret", None, spa_fallback_state(&tmp)),
+            ("/_app/assets/app.js/", None, spa_fallback_state(&tmp)),
+            ("/gw/_app/", Some("/gw"), prefixed_state),
+        ] {
+            let response = static_route_response(path, prefix, state).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "route path should be rejected: {path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn static_routes_serve_valid_assets_with_and_without_prefix() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dist_dir = tmp.path().join("web").join("dist");
+        let assets = dist_dir.join("assets");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(assets.join("route-test.js"), b"route-ok").unwrap();
+
+        let mut state = spa_fallback_state(&tmp);
+        let unprefixed =
+            static_route_response("/_app/assets/route-test.js", None, state.clone()).await;
+        assert_eq!(unprefixed.status(), StatusCode::OK);
+        assert_eq!(
+            unprefixed.into_body().collect().await.unwrap().to_bytes(),
+            &b"route-ok"[..]
+        );
+
+        state.path_prefix = "/gw".to_string();
+        let prefixed =
+            static_route_response("/gw/_app/assets/route-test.js", Some("/gw"), state).await;
+        assert_eq!(prefixed.status(), StatusCode::OK);
+        assert_eq!(
+            prefixed.into_body().collect().await.unwrap().to_bytes(),
+            &b"route-ok"[..]
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-gateway/src/static_files.rs
+++ b/crates/zeroclaw-gateway/src/static_files.rs
@@ -20,11 +20,9 @@ static EMBEDDED_WEB_DIST: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../web/
 
 /// Serve static files from `/_app/*` path
 pub async fn handle_static(State(state): State<AppState>, uri: Uri) -> Response {
-    let path = uri
-        .path()
-        .strip_prefix("/_app/")
-        .unwrap_or(uri.path())
-        .trim_start_matches('/');
+    let Some(path) = static_request_path(&uri) else {
+        return (StatusCode::BAD_REQUEST, "Invalid path").into_response();
+    };
 
     #[cfg(feature = "embedded-web")]
     if let Some(resp) = serve_embedded_file(path) {
@@ -116,6 +114,10 @@ async fn load_index_html_bytes(dist_dir: Option<&PathBuf>) -> Option<Vec<u8>> {
 }
 
 async fn serve_fs_file(dist_dir: Option<&PathBuf>, path: &str) -> Response {
+    if !is_valid_relative_path(path) {
+        return (StatusCode::BAD_REQUEST, "Invalid path").into_response();
+    }
+
     let Some(dir) = dist_dir else {
         return (StatusCode::NOT_FOUND, "Not found").into_response();
     };
@@ -163,6 +165,25 @@ async fn serve_fs_file(dist_dir: Option<&PathBuf>, path: &str) -> Response {
 enum FsPathError {
     Invalid,
     Unavailable,
+}
+
+fn static_request_path(uri: &Uri) -> Option<&str> {
+    let path = uri.path().strip_prefix("/_app/").unwrap_or(uri.path());
+
+    is_valid_relative_path(path).then_some(path)
+}
+
+fn is_valid_relative_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.ends_with('/')
+        && !path.contains('\\')
+        && path
+            .split('/')
+            .all(|component| !matches!(component, "" | "." | ".."))
+        && Path::new(path)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
 }
 
 async fn resolve_fs_file(root: &Path, relative: &Path) -> Result<PathBuf, FsPathError> {
@@ -233,6 +254,23 @@ mod tests {
             .to_vec()
     }
 
+    #[test]
+    fn static_route_rejects_malformed_path_syntax() {
+        for path in [
+            "/_app//index.html",
+            "/_app/assets//app.js",
+            "/_app/assets/./app.js",
+            "/_app/assets/app.js/",
+        ] {
+            let uri: Uri = path.parse().unwrap();
+            assert_eq!(
+                static_request_path(&uri),
+                None,
+                "route path should be rejected: {path}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn fs_asset_serves_contained_nested_file() {
         let tmp = tempfile::tempdir().unwrap();
@@ -260,6 +298,13 @@ mod tests {
             "assets/../secret",
             "./index.html",
             "/etc/passwd",
+            "assets//app.js",
+            "assets/./app.js",
+            "assets/app.js/",
+            r"assets\\app.js",
+            r"assets\.\app.js",
+            r"\assets\app.js",
+            r"assets\app.js\",
         ] {
             let response = serve_fs_file(Some(&root), path).await;
             assert_eq!(

--- a/crates/zeroclaw-gateway/src/static_files.rs
+++ b/crates/zeroclaw-gateway/src/static_files.rs
@@ -8,7 +8,7 @@ use axum::{
     http::{StatusCode, Uri, header},
     response::{IntoResponse, Response},
 };
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 use super::AppState;
 
@@ -109,8 +109,9 @@ async fn load_index_html_bytes(dist_dir: Option<&PathBuf>) -> Option<Vec<u8>> {
         return Some(file.contents().to_vec());
     }
 
-    let dir = dist_dir?;
-    let index_path = dir.join("index.html");
+    let index_path = resolve_fs_file(dist_dir?, Path::new("index.html"))
+        .await
+        .ok()?;
     tokio::fs::read(&index_path).await.ok()
 }
 
@@ -119,12 +120,15 @@ async fn serve_fs_file(dist_dir: Option<&PathBuf>, path: &str) -> Response {
         return (StatusCode::NOT_FOUND, "Not found").into_response();
     };
 
-    // Sanitize: reject path traversal attempts
-    if path.contains("..") {
-        return (StatusCode::BAD_REQUEST, "Invalid path").into_response();
-    }
-
-    let file_path = dir.join(path);
+    let file_path = match resolve_fs_file(dir, Path::new(path)).await {
+        Ok(path) => path,
+        Err(FsPathError::Invalid) => {
+            return (StatusCode::BAD_REQUEST, "Invalid path").into_response();
+        }
+        Err(FsPathError::Unavailable) => {
+            return (StatusCode::NOT_FOUND, "Not found").into_response();
+        }
+    };
 
     match tokio::fs::read(&file_path).await {
         Ok(content) => {
@@ -155,6 +159,42 @@ async fn serve_fs_file(dist_dir: Option<&PathBuf>, path: &str) -> Response {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FsPathError {
+    Invalid,
+    Unavailable,
+}
+
+async fn resolve_fs_file(root: &Path, relative: &Path) -> Result<PathBuf, FsPathError> {
+    if relative.as_os_str().is_empty()
+        || !relative
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Err(FsPathError::Invalid);
+    }
+
+    let canonical_root = tokio::fs::canonicalize(root)
+        .await
+        .map_err(|_| FsPathError::Unavailable)?;
+    let canonical_file = tokio::fs::canonicalize(canonical_root.join(relative))
+        .await
+        .map_err(|_| FsPathError::Unavailable)?;
+
+    if !canonical_file.starts_with(&canonical_root) {
+        return Err(FsPathError::Unavailable);
+    }
+
+    let metadata = tokio::fs::metadata(&canonical_file)
+        .await
+        .map_err(|_| FsPathError::Unavailable)?;
+    if !metadata.is_file() {
+        return Err(FsPathError::Unavailable);
+    }
+
+    Ok(canonical_file)
+}
+
 #[cfg(feature = "embedded-web")]
 fn serve_embedded_file(path: &str) -> Option<Response> {
     if path.contains("..") {
@@ -179,4 +219,136 @@ fn serve_embedded_file(path: &str) -> Option<Response> {
         )
             .into_response(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    async fn response_body(response: Response) -> Vec<u8> {
+        to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body")
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn fs_asset_serves_contained_nested_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let assets = tmp.path().join("assets");
+        std::fs::create_dir(&assets).unwrap();
+        std::fs::write(assets.join("app.js"), b"console.log('ok');").unwrap();
+        let root = tmp.path().to_path_buf();
+
+        let response = serve_fs_file(Some(&root), "assets/app.js").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response_body(response).await,
+            b"console.log('ok');".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_asset_rejects_invalid_components_before_lookup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        for path in [
+            "../secret",
+            "assets/../secret",
+            "./index.html",
+            "/etc/passwd",
+        ] {
+            let response = serve_fs_file(Some(&root), path).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "path should be rejected: {path}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn fs_asset_rejects_windows_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        let response = serve_fs_file(Some(&root), r"C:\\Windows\\win.ini").await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn fs_asset_returns_not_found_for_missing_or_non_file_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("assets")).unwrap();
+        let root = tmp.path().to_path_buf();
+
+        for path in ["missing.js", "assets"] {
+            let response = serve_fs_file(Some(&root), path).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "target should not be served: {path}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fs_asset_rejects_symlink_that_resolves_outside_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), b"outside-secret").unwrap();
+        symlink(
+            outside.path().join("secret.txt"),
+            root.path().join("escape.txt"),
+        )
+        .unwrap();
+        let root_path = root.path().to_path_buf();
+
+        let response = serve_fs_file(Some(&root_path), "escape.txt").await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_ne!(response_body(response).await, b"outside-secret".to_vec());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn fs_asset_allows_symlink_that_resolves_inside_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("app.js"), b"inside-asset").unwrap();
+        symlink("app.js", root.path().join("alias.js")).unwrap();
+        let root_path = root.path().to_path_buf();
+
+        let response = serve_fs_file(Some(&root_path), "alias.js").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_body(response).await, b"inside-asset".to_vec());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spa_index_rejects_symlink_that_resolves_outside_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("index.html"), b"outside-shell").unwrap();
+        symlink(
+            outside.path().join("index.html"),
+            root.path().join("index.html"),
+        )
+        .unwrap();
+        let root_path = root.path().to_path_buf();
+
+        assert!(load_index_html_bytes(Some(&root_path)).await.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Canonicalize filesystem-backed dashboard asset paths before reading them.
  - Check at resolution time that filesystem-backed dashboard paths remain inside the configured distribution root, rejecting stable symlink escapes.
  - Reject malformed raw asset paths before platform path normalization, including empty, dot, repeated-separator, trailing-separator, and backslash forms.
  - Route both `/_app/` and wildcard asset requests through the same validation boundary, including gateways hosted under a path prefix.
  - Apply the same canonical containment check to the SPA `index.html` fallback.
- **Scope boundary:** Valid embedded and filesystem-backed dashboard assets, API routing, and frontend output are unchanged.
- **Blast radius:** Gateway static-asset routing, filesystem-backed dashboard assets, and the SPA shell load path.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk:high`, `size:M`, `gateway`, `domain:security`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; focused resolver and router-level tests exercise malformed and valid asset requests directly.

### How I tested

- **CI checks relied on and why they cover this change:** All required checks are green on the repaired head. The matrix provides cross-platform compilation and the repository regression suite.
- **Known CI coverage gap, if any:** The focused local runs were on macOS. The Windows check compiles the Windows-only prefix regression but does not execute it on Windows; raw HTTP asset paths now reject backslashes before platform-specific path parsing. Canonicalization and file opening remain separate operations, so an actor able to replace files inside the configured dashboard root during a request could race the check.
- **Commands run and tail output:**

`cargo fmt --all -- --check` passed with no output.

```sh
cargo fmt --all -- --check
cargo test -p zeroclaw-gateway static_files -- --nocapture
cargo test -p zeroclaw-gateway static_routes -- --nocapture
```

```text
running 7 tests
test static_files::tests::static_route_rejects_malformed_path_syntax ... ok
test static_files::tests::fs_asset_rejects_invalid_components_before_lookup ... ok
test static_files::tests::spa_index_rejects_symlink_that_resolves_outside_root ... ok
test static_files::tests::fs_asset_rejects_symlink_that_resolves_outside_root ... ok
test static_files::tests::fs_asset_returns_not_found_for_missing_or_non_file_targets ... ok
test static_files::tests::fs_asset_serves_contained_nested_file ... ok
test static_files::tests::fs_asset_allows_symlink_that_resolves_inside_root ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 410 filtered out

running 2 tests
test tests::static_routes_reject_malformed_paths_before_spa_fallback ... ok
test tests::static_routes_serve_valid_assets_with_and_without_prefix ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 415 filtered out
```

- **Beyond CI, what did you manually verify?** The focused tests verify contained nested assets, malformed raw paths, missing and non-file targets, inside-root symlinks, outside-root asset and SPA symlinks, the bare `/_app/` route, and exact asset bytes through ordinary and path-prefixed static-asset routers. No browser smoke was run because those valid static-asset responses are covered at the router boundary.
- **If any command was intentionally skipped, why:** Broad local workspace validation was deferred to required CI because the change is localized to gateway static-file admission and routing, and focused tests exercise both boundaries directly.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A. This adds a resolution-time containment check for existing filesystem reads and rejects malformed asset paths before platform-specific normalization. Atomic handle-relative opening remains a separate hardening opportunity for deployments where another actor can mutate the dashboard tree concurrently.

## Compatibility (required)

- Backward compatible? **Yes for valid contained dashboard paths.** Malformed paths and symlinks that resolve outside the configured root are intentionally rejected.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the two containment commits.
- **Feature flags or config toggles:** None. Valid embedded dashboard assets remain supported through the same route admission boundary.
- **Observable failure symptoms:** Malformed asset requests return `400`; filesystem-backed assets return `404`, or the SPA shell returns the existing dashboard-unavailable `503`, when a configured distribution path cannot be canonicalized or escapes its root.
