### PR TITLE
fix(providers): keep Gemini API keys out of URLs

### DIFF
--- a/crates/zeroclaw-providers/src/gemini.rs
+++ b/crates/zeroclaw-providers/src/gemini.rs
@@ -11,10 +11,12 @@ use crate::traits::{
 use async_trait::async_trait;
 use base64::Engine;
 use directories::UserDirs;
-use reqwest::Client;
+use reqwest::{Client, header::HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
+
+const GOOGLE_API_KEY_HEADER: &str = "x-goog-api-key";
 
 /// Gemini model_provider supporting multiple authentication methods.
 pub struct GeminiModelProvider {
@@ -50,7 +52,7 @@ struct OAuthTokenState {
 /// Resolved credential — the variant determines both the HTTP auth method
 /// and the diagnostic label returned by `auth_source()`.
 enum GeminiAuth {
-    /// Explicit API key from config: sent as `?key=` query parameter.
+    /// Explicit API key from config: sent as `x-goog-api-key`.
     ExplicitKey(String),
     /// OAuth access token from Gemini CLI: sent as `Authorization: Bearer`.
     /// Wrapped in a Mutex to allow runtime token refresh.
@@ -61,22 +63,9 @@ enum GeminiAuth {
 }
 
 impl GeminiAuth {
-    /// Whether this credential is an API key (sent as `?key=` query param).
-    fn is_api_key(&self) -> bool {
-        matches!(self, GeminiAuth::ExplicitKey(_))
-    }
-
     /// Whether this credential is an OAuth token (CLI or managed).
     fn is_oauth(&self) -> bool {
         matches!(self, GeminiAuth::OAuthToken(_) | GeminiAuth::ManagedOAuth)
-    }
-
-    /// The raw credential string (for API key variants only).
-    fn api_key_credential(&self) -> &str {
-        match self {
-            GeminiAuth::ExplicitKey(s) => s,
-            GeminiAuth::OAuthToken(_) | GeminiAuth::ManagedOAuth => "",
-        }
     }
 }
 
@@ -918,13 +907,7 @@ impl GeminiModelProvider {
             }
             _ => {
                 let model_name = Self::format_model_name(model);
-                let base_url = format!("{BASE_URL}/{model_name}:generateContent");
-
-                if auth.is_api_key() {
-                    format!("{base_url}?key={}", auth.api_key_credential())
-                } else {
-                    base_url
-                }
+                format!("{BASE_URL}/{model_name}:generateContent")
             }
         }
     }
@@ -1023,9 +1006,12 @@ impl GeminiModelProvider {
         include_generation_config: bool,
         project: Option<&str>,
         oauth_token: Option<&str>,
-    ) -> reqwest::RequestBuilder {
+    ) -> anyhow::Result<reqwest::RequestBuilder> {
         let req = self.http_client().post(url).json(request);
-        match auth {
+        Ok(match auth {
+            GeminiAuth::ExplicitKey(key) => {
+                req.header(GOOGLE_API_KEY_HEADER, Self::sensitive_api_key_header(key)?)
+            }
             GeminiAuth::OAuthToken(_) | GeminiAuth::ManagedOAuth => {
                 let token = oauth_token.unwrap_or_default();
                 // Internal Code Assist API uses a wrapped payload shape:
@@ -1049,8 +1035,21 @@ impl GeminiModelProvider {
                     .json(&internal_request)
                     .bearer_auth(token)
             }
-            _ => req,
-        }
+        })
+    }
+
+    fn sensitive_api_key_header(key: &str) -> anyhow::Result<HeaderValue> {
+        let mut value = HeaderValue::from_str(key)
+            .map_err(|_| anyhow::Error::msg("Gemini API key contains invalid header characters"))?;
+        value.set_sensitive(true);
+        Ok(value)
+    }
+
+    fn build_api_key_probe_request(&self, key: &str) -> anyhow::Result<reqwest::RequestBuilder> {
+        Ok(self
+            .http_client()
+            .get(format!("{BASE_URL}/models"))
+            .header(GOOGLE_API_KEY_HEADER, Self::sensitive_api_key_header(key)?))
     }
 
     fn should_retry_oauth_without_generation_config(
@@ -1224,7 +1223,7 @@ impl GeminiModelProvider {
                 true,
                 project.as_deref(),
                 oauth_token.as_deref(),
-            )
+            )?
             .send()
             .await?;
 
@@ -1295,7 +1294,7 @@ impl GeminiModelProvider {
                             true,
                             project.as_deref(),
                             oauth_token.as_deref(),
-                        )
+                        )?
                         .send()
                         .await?;
                 } else {
@@ -1319,7 +1318,7 @@ impl GeminiModelProvider {
                         false,
                         project.as_deref(),
                         oauth_token.as_deref(),
-                    )
+                    )?
                     .send()
                     .await?;
             } else {
@@ -1348,7 +1347,7 @@ impl GeminiModelProvider {
                         false,
                         project.as_deref(),
                         oauth_token.as_deref(),
-                    )
+                    )?
                     .send()
                     .await?;
             } else {
@@ -1527,19 +1526,9 @@ impl ModelProvider for GeminiModelProvider {
                     // CLI OAuth — cloudcode-pa does not expose a lightweight model-list probe.
                     // Token will be validated on first real request.
                 }
-                _ => {
+                GeminiAuth::ExplicitKey(key) => {
                     // API key path — verify with public API models endpoint.
-                    let url = if auth.is_api_key() {
-                        format!(
-                            "https://generativelanguage.googleapis.com/v1beta/models?key={}",
-                            auth.api_key_credential()
-                        )
-                    } else {
-                        "https://generativelanguage.googleapis.com/v1beta/models".to_string()
-                    };
-
-                    self.http_client()
-                        .get(&url)
+                    self.build_api_key_probe_request(key)?
                         .send()
                         .await?
                         .error_for_status()?;
@@ -1550,7 +1539,7 @@ impl ModelProvider for GeminiModelProvider {
     }
 
     async fn list_models(&self) -> anyhow::Result<Vec<String>> {
-        // Gemini's /v1beta/models requires ?key=<api_key>. Onboard pulls the
+        // Gemini's /v1beta/models requires authentication. Onboard pulls the
         // catalog from models.dev before the user has entered a key.
         crate::models_dev::list_models_for("google").await
     }
@@ -1824,10 +1813,12 @@ mod tests {
     }
 
     #[test]
-    fn api_key_url_includes_key_query_param() {
+    fn api_key_url_excludes_credential() {
         let auth = GeminiAuth::ExplicitKey("api-key-123".into());
         let url = GeminiModelProvider::build_generate_content_url("gemini-2.0-flash", &auth);
-        assert!(url.contains(":generateContent?key=api-key-123"));
+        assert!(url.ends_with(":generateContent"));
+        assert!(!url.contains("api-key-123"));
+        assert!(!url.contains("?key="));
     }
 
     #[test]
@@ -1875,6 +1866,7 @@ mod tests {
                 Some("test-project"),
                 Some("ya29.mock-token"),
             )
+            .unwrap()
             .build()
             .unwrap();
 
@@ -1914,6 +1906,7 @@ mod tests {
                 Some("test-project"),
                 Some("ya29.mock-token"),
             )
+            .unwrap()
             .build()
             .unwrap();
 
@@ -1930,7 +1923,7 @@ mod tests {
     }
 
     #[test]
-    fn api_key_request_does_not_set_bearer_header() {
+    fn api_key_request_uses_header_without_url_credential() {
         let model_provider =
             test_model_provider(Some(GeminiAuth::ExplicitKey("api-key-123".into())));
         let auth = GeminiAuth::ExplicitKey("api-key-123".into());
@@ -1957,10 +1950,69 @@ mod tests {
                 None,
                 None,
             )
+            .unwrap()
             .build()
             .unwrap();
 
         assert!(request.headers().get(AUTHORIZATION).is_none());
+        assert_eq!(
+            request
+                .headers()
+                .get(GOOGLE_API_KEY_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("api-key-123")
+        );
+        assert!(
+            request
+                .headers()
+                .get(GOOGLE_API_KEY_HEADER)
+                .expect("API key header")
+                .is_sensitive()
+        );
+        assert!(!request.url().as_str().contains("api-key-123"));
+        assert!(!request.url().query_pairs().any(|(name, _)| name == "key"));
+    }
+
+    #[test]
+    fn api_key_probe_uses_header_without_url_credential() {
+        let model_provider = test_model_provider(None);
+        let request = model_provider
+            .build_api_key_probe_request("api-key-123")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get(GOOGLE_API_KEY_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("api-key-123")
+        );
+        assert!(
+            request
+                .headers()
+                .get(GOOGLE_API_KEY_HEADER)
+                .expect("API key header")
+                .is_sensitive()
+        );
+        assert_eq!(
+            request.url().as_str(),
+            "https://generativelanguage.googleapis.com/v1beta/models"
+        );
+    }
+
+    #[test]
+    fn api_key_header_rejects_control_characters_without_echoing_credential() {
+        let credential = "api-key-123\r\ninjected: value";
+        let error = GeminiModelProvider::sensitive_api_key_header(credential)
+            .expect_err("control characters must be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "Gemini API key contains invalid header characters"
+        );
+        assert!(!error.to_string().contains(credential));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Removes Gemini API keys from generation and warmup request URLs, preventing exposure through URLs and URL-based diagnostics.
  - Sends API keys through Google's documented `x-goog-api-key` header and marks the header value sensitive for diagnostic formatting.
  - Adds request-level regressions for generation, warmup, and malformed header values while preserving OAuth request behavior.
- **Scope boundary:** This PR does not change Gemini credential storage, configuration, OAuth authentication, token refresh, request payloads, or onboarding model discovery, which still reads the models.dev catalog.
- **Blast radius:** Gemini API-key generation requests and the Gemini warmup models probe. OAuth request construction is unchanged apart from the shared fallible builder return type and is covered by non-regression tests.
- **Linked issue(s):** None.
- **Labels:** `bug`, `security`, `provider`, `provider:gemini`, `priority:p1`, `risk:high`, `size:S`, `distinguished contributor`, `domain:security`

### What this does, simply

- Gemini API keys were being placed directly in request URLs. URLs are commonly captured by logs, proxies, diagnostics, and monitoring systems, so the secret could travel through more systems than the request itself.

  This PR sends the key in Google's dedicated authentication header and marks that header as sensitive. The change stays inside Gemini request construction because credential storage and OAuth are not the source of this exposure; changing them would add risk without removing any additional URL leak.

## Testing

### How you can test

- **Reviewer testing requested?** N/A. The security property is asserted directly on built requests; a manual check would require a live credential or an intercepting proxy without adding stronger evidence.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on head `5ef619fb194cc7ff0b687da5a8cd4e5819f34648`. Provider tests and Clippy cover the changed Gemini request-construction module, while the required workspace gate covers the wider build, test, platform, security, and format surfaces.
- **Known CI coverage gap, if any:** No live Google API call verifies vendor acceptance of the documented header.
- **Commands run and output tails:**

  ```text
  cargo fmt --all -- --check
  # no output; exit 0

  cargo test -p zeroclaw-providers gemini::tests:: -- --nocapture
  test result: ok. 69 passed; 0 failed; 0 ignored; 0 measured

  cargo test -p zeroclaw-providers gemini::tests::api_key_ -- --nocapture
  test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured

  cargo test -p zeroclaw-providers gemini::tests::oauth_request_ -- --nocapture
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured

  cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo]

  bash scripts/ci/comment_hygiene_gate.sh
  Comment hygiene gate passed.
  ```

- **Beyond CI, what did you manually verify?** Inspected the built generation and warmup requests to confirm the credential is absent from each URL, present only in a sensitive `x-goog-api-key` header, and omitted from malformed-header errors. No live vendor-authentication call was made.
- **If any command was intentionally skipped, why:** A live Gemini request was skipped to avoid requiring or exposing a real credential.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any **Yes**, describe the risk and mitigation: Gemini API keys move from URL query parameters to Google's documented authentication header. The header value is marked sensitive, malformed values fail without echoing the credential, and request tests verify that URLs remain credential-free.

## Compatibility

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is **No** or either surface/floor question is **Yes**: Not applicable.

## Rollback

- **Fast rollback command/path:** `git revert <merged commit>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Gemini API-key requests return authentication failures such as HTTP 401 or 403 while OAuth-backed requests continue to work.
