### PR TITLE
ci(docker): sticky-disk layer cache for PR image builds on Blacksmith

### DIFF
--- a/.github/workflows/docker-image-pr.yml
+++ b/.github/workflows/docker-image-pr.yml
@@ -131,7 +131,11 @@ jobs:
   source-images:
     name: Source Image Build (no push)
     needs: changes
-    runs-on: ubuntu-latest
+    # On Blacksmith (CI_USE_BLACKSMITH=true) these builds get NVMe sticky-disk
+    # Docker layer caching; any other value / unset falls back to GitHub-hosted
+    # with the existing type=gha cache. Runner and build action are selected by
+    # the same toggle so the fallback is a full no-op relative to today.
+    runs-on: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -139,10 +143,32 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Multi-platform (arm64) builds need QEMU. GitHub-hosted runners ship
+      # binfmt already, so this is a harmless no-op there; Blacksmith runners
+      # need it registered explicitly.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      # GitHub-hosted path only: useblacksmith/build-push-action sets up its own
+      # sticky-disk-backed builder, so a separate buildx builder would bypass the
+      # cache and is skipped when running on Blacksmith.
       - name: Set up Docker Buildx
+        if: ${{ vars.CI_USE_BLACKSMITH != 'true' }}
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Build ${{ matrix.dockerfile }} (${{ matrix.platform }}) from source [Blacksmith]
+        if: ${{ vars.CI_USE_BLACKSMITH == 'true' }}
+        uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: ${{ matrix.gateway_smoke || (matrix.dockerfile == 'Dockerfile.alpine' && matrix.platform == 'linux/amd64') }}
+          platforms: ${{ matrix.platform }}
+          tags: ${{ matrix.tag }}
+
       - name: Build ${{ matrix.dockerfile }} (${{ matrix.platform }}) from source
+        if: ${{ vars.CI_USE_BLACKSMITH != 'true' }}
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `source-images` PR validation builds (~8 Dockerfile/platform variants, 15–49 min each, ~78 runs / 2 weeks) are the heaviest CI workload and already lean on `type=gha` Docker layer caching — which thrashes GitHub's 10 GB/repo cache cap across the variants, forcing cold rebuilds. When `CI_USE_BLACKSMITH=true`, this runs them on Blacksmith and builds with `useblacksmith/build-push-action`, which mounts a per-repo NVMe **sticky disk** as the layer cache (no 10 GB cap, no network export/import).
- **Scope boundary:** Only `source-images` in `docker-image-pr.yml`. The release publisher (`docker-publish.yml`, `push: true`) is untouched. No change to the Dockerfiles, matrix, or smoke tests.
- **Blast radius:** Docker layer-cache backend for PR image builds. Fully toggle-gated and fail-safe: any non-`true` value (including unset, and all fork PRs) keeps the existing `ubuntu-latest` + `docker/build-push-action` + `type=gha` path, byte-for-byte unchanged. On Blacksmith, `setup-buildx` is skipped (the Blacksmith action brings its own sticky-disk builder) and QEMU is set up explicitly for arm64.
- **Linked issue(s):** Related #7108 (CI critical path / cached builds).
- **Labels:** `ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` — this is a **same-repo** PR opened specifically so its own CI runs on Blacksmith and exercises the new `useblacksmith/build-push-action` path (fork PRs can't, since they stay on GitHub-hosted).
- **Interface(s) exercised:** CI infrastructure only; no `web` / `tui` / `cli` surface.
- **Setup / preconditions:** `CI_USE_BLACKSMITH=true` (current), so `source-images` runs on `blacksmith-8vcpu` and uses the sticky-disk cache.
- **Steps to run:** This PR modifies `docker-image-pr.yml`, which is in that workflow's trigger paths, so the build matrix runs on this PR. Confirm each build job's runner is `blacksmith-8vcpu`, the build succeeds, and (2nd run) layers restore from the sticky disk.
- **Expected on this branch (after):** Builds pass on Blacksmith with sticky-disk caching; smoke tests still pass. With `CI_USE_BLACKSMITH=false`, identical to `master` (docker/build-push-action + type=gha on ubuntu-latest).
- **Prior behavior on `master` (before):** All variants build on `ubuntu-latest` via `docker/build-push-action` with `type=gha` cache.

### How I tested

Workflow-only change; validated structurally, and the PR's own same-repo CI validates the Blacksmith build path.

```sh
$ actionlint .github/workflows/docker-image-pr.yml   # clean
$ ruby -ryaml -e 'YAML.load_file(".github/workflows/docker-image-pr.yml")'   # YAML OK
```

- **CI checks relied on and why they cover this change:** This same-repo PR's `source-images` jobs run on Blacksmith and exercise `useblacksmith/build-push-action` end-to-end — the real regression gate.
- **Known CI coverage gap, if any:** The `CI_USE_BLACKSMITH=false` fallback (docker/build-push-action on ubuntu-latest) is not re-exercised here; it is byte-for-byte the current `master` path, gated by `if: vars.CI_USE_BLACKSMITH != 'true'`.
- **Commands run and tail output:** actionlint clean; YAML parses.
- **Beyond CI, what did you manually verify?** Confirmed per Blacksmith's docs that `useblacksmith/build-push-action` runs without `setup-buildx` and without `cache-from/cache-to` (sticky disk is automatic), and that multi-platform still needs QEMU (added, harmless no-op on GitHub-hosted). Pinned all actions to SHAs (`useblacksmith/build-push-action@v2.3.0`, `docker/setup-qemu-action@v4.2.0`).
- **If any command was intentionally skipped, why:** `cargo *` skipped — no Rust/source change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` new ones — the Blacksmith action runs only on Blacksmith runners these jobs already move to; the sticky disk is local, replacing GitHub-cache network traffic.
- Secrets / tokens / credentials handling changed? `No` — `push: false`, no registry auth, no secrets referenced.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes` — `CI_USE_BLACKSMITH` false/unset (and every fork PR) uses the unchanged GitHub-hosted path.
- Config / env / CLI surface changed? `No` product surface; CI cache backend only.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` restores the single unified `docker/build-push-action` step. Setting `CI_USE_BLACKSMITH=false` also neutralizes it (falls back to the GitHub-hosted path) without a revert.
- **Feature flags or config toggles:** Repository Actions variable `CI_USE_BLACKSMITH`; only `true` selects the Blacksmith build path.
- **Observable failure symptoms:** A `source-images` job fails at the build step, "Set up job" shows a `blacksmith-8vcpu` runner erroring, or arm64 builds fail for lack of QEMU.
