### PR TITLE
[validation only] rust-cache useblacksmith path on Blacksmith (do not merge)

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,0 +1,44 @@
+name: Rust cache (provider-aware)
+description: >
+  Restore/save the Rust build cache using Blacksmith's sticky-disk cache when
+  the job runs on a Blacksmith runner, otherwise Swatinem/rust-cache on a
+  GitHub-hosted runner. This preserves the CI_USE_BLACKSMITH fail-safe: any
+  non-'true' value (including unset) selects Swatinem, so GitHub-hosted jobs
+  stay fully cached and the toggle can be flipped off with no loss of caching.
+
+inputs:
+  use-blacksmith:
+    description: >
+      Pass 'true' only when this job is running on a Blacksmith runner
+      (useblacksmith/rust-cache needs the local sticky disk). Any other value
+      falls back to Swatinem/rust-cache.
+    required: true
+  cache-on-failure:
+    description: Save the cache even when the job fails.
+    required: false
+    default: "false"
+  save-if:
+    description: Only write the cache when this evaluates truthy (e.g. default branch only).
+    required: false
+    default: "true"
+
+outputs:
+  cache-hit:
+    description: Whether an exact cache match was restored, from whichever provider ran.
+    value: ${{ steps.bs.outputs.cache-hit || steps.gh.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - id: bs
+      if: ${{ inputs.use-blacksmith == 'true' }}
+      uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3.0.1
+      with:
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+        save-if: ${{ inputs.save-if }}
+    - id: gh
+      if: ${{ inputs.use-blacksmith != 'true' }}
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      with:
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+        save-if: ${{ inputs.save-if }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,10 @@ jobs:
         with:
           toolchain: 1.96.1
           components: clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -316,9 +317,10 @@ jobs:
         with:
           toolchain: 1.96.1
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH == 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install mold linker
@@ -398,9 +400,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: 1.96.1
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -447,9 +450,10 @@ jobs:
       - name: Install channel plugin fixture target
         if: steps.changed.outputs.run == 'true' && matrix.features == 'plugins-wasm-cranelift'
         run: rustup target add wasm32-wasip2
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         if: steps.changed.outputs.run == 'true'
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check
@@ -514,9 +518,10 @@ jobs:
         with:
           toolchain: 1.96.1
           targets: i686-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install 32-bit system libraries
@@ -536,9 +541,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: 1.96.1
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Ensure web/dist placeholder exists
@@ -591,9 +597,10 @@ jobs:
         with:
           toolchain: 1.96.1
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/rust-cache
         id: rust-cache
         with:
+          use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check firmware protocol crate


### PR DESCRIPTION
Temporary same-repo PR to exercise the useblacksmith/rust-cache path on a real Blacksmith runner (fork PR #9962 only ran the Swatinem fallback). Identical code to #9962. Will be closed once the Blacksmith cache path is confirmed green.