### PR TITLE
chore(deps): bump nanoid to 3.3.18

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3347,9 +3347,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Update the resolved `nanoid` package from 3.3.17 to 3.3.18, the first release outside the affected advisory range.
  - Restore a clean high-severity npm audit without changing direct dependency constraints.
- **Scope boundary:** This changes only `web/package-lock.json`. It does not add a direct dependency or override, change application code, or modify the npm audit workflow.
- **Blast radius:** Web development and build dependency resolution only. The affected package remains transitive and development-only.
- **Linked issue(s):** Closes #9991
- **Labels:** `domain:security`, `risk:low`, `size:XS`, `type:dependencies`, `web`

### What this does, simply

- The web build no longer installs the `nanoid` release flagged by the daily security audit. The fixed patch release fits the dependency range PostCSS already uses.

### Why it matters

- This clears a known denial-of-service advisory from the resolved web dependency graph and restores the daily npm security check without changing dashboard behavior.

### Scope and maintenance tradeoff

- This is the smallest safe repair: three lockfile fields change for one existing package. Because PostCSS already accepts the fixed version, the PR adds no override, direct dependency, new package, or ongoing maintenance surface.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is a lockfile-only transitive dependency repair with no useful manual UI delta.

### How I tested

- **CI checks relied on and why they cover this change:** Current-head required CI is green. `Check npm advisories` evaluated the dependency delta at high severity, while the local `npm audit` verified the full lockfile graph; the broader required matrix passed on the same head.
- **Known CI coverage gap, if any:** None after the local audit, clean install, focused web suites, and production build.
- **Commands run and tail output:**

  ```text
  node --version
  v24.19.0

  npm audit --package-lock-only --audit-level=high
  found 0 vulnerabilities

  npm ci --no-audit --no-fund
  completed successfully

  npm test
  tests 8; pass 8; fail 0

  npm run test:permissions
  permission, catalog, warning, validation, and navigation suites passed

  npm run test:contexts
  tests 18; pass 18; fail 0

  npm run build
  TypeScript and Vite production build completed successfully

  npm ls nanoid --package-lock-only --all
  vite@8.0.16 -> postcss@8.5.23 -> nanoid@3.3.18
  ```

- **Beyond CI, what did you manually verify?** Confirmed the lockfile contains the registry URL and integrity metadata for `nanoid` 3.3.18, that it remains the single dev-only node, and that the tracked tree stays limited to the intended lockfile delta. No manual dashboard interaction was performed because application behavior does not change.
- **If any command was intentionally skipped, why:** Cargo checks were skipped because no Rust source, manifest, or lockfile changes. OpenAPI generation was skipped because no API contract or generated client input changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A. The patch removes an affected development dependency version without adding a new security-sensitive surface.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The npm audit reports the advisory again, or the clean install, focused web tests, or production build fails.

