### PR TITLE
fix(email): stop implicit attachment file reads

### DIFF
--- a/crates/zeroclaw-channels/src/email_channel.rs
+++ b/crates/zeroclaw-channels/src/email_channel.rs
@@ -913,23 +913,7 @@ impl Channel for EmailChannel {
         {
             builder = builder.in_reply_to(reply_id.clone());
         }
-        let mut att_parts: Vec<(String, Vec<u8>, ContentType)> = Vec::new();
-        for att in &message.attachments {
-            let content_type = att
-                .mime_type
-                .as_deref()
-                .and_then(|m| ContentType::parse(m).ok())
-                .unwrap_or_else(|| {
-                    ContentType::parse("application/octet-stream").expect("hardcoded MIME type")
-                });
-            let att_data = resolve_attachment_data(&att.file_name, &att.data)?;
-            let att_name = std::path::Path::new(&att.file_name)
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or(&att.file_name)
-                .to_string();
-            att_parts.push((att_name, att_data, content_type));
-        }
+        let att_parts = build_attachment_parts(&message.attachments);
 
         let email = if self.config.html_body {
             let alt = MultiPart::alternative()
@@ -939,8 +923,8 @@ impl Channel for EmailChannel {
                 builder.multipart(alt)?
             } else {
                 let mut mixed = MultiPart::mixed().multipart(alt);
-                for (name, data, ct) in att_parts {
-                    mixed = mixed.singlepart(Attachment::new(name).body(data, ct));
+                for part in att_parts {
+                    mixed = mixed.singlepart(part);
                 }
                 builder.multipart(mixed)?
             }
@@ -950,8 +934,8 @@ impl Channel for EmailChannel {
                 builder.singlepart(plain)?
             } else {
                 let mut mixed = MultiPart::mixed().singlepart(plain);
-                for (name, data, ct) in att_parts {
-                    mixed = mixed.singlepart(Attachment::new(name).body(data, ct));
+                for part in att_parts {
+                    mixed = mixed.singlepart(part);
                 }
                 builder.multipart(mixed)?
             }
@@ -1011,14 +995,25 @@ impl Channel for EmailChannel {
     }
 }
 
-fn resolve_attachment_data(file_name: &str, data: &[u8]) -> anyhow::Result<Vec<u8>> {
-    if data.is_empty() && std::path::Path::new(file_name).exists() {
-        std::fs::read(file_name).map_err(|e| {
-            anyhow::Error::msg(format!("failed to read attachment '{}': {}", file_name, e))
+fn build_attachment_parts(attachments: &[zeroclaw_api::media::MediaAttachment]) -> Vec<SinglePart> {
+    attachments
+        .iter()
+        .map(|attachment| {
+            let content_type = attachment
+                .mime_type
+                .as_deref()
+                .and_then(|mime| ContentType::parse(mime).ok())
+                .unwrap_or_else(|| {
+                    ContentType::parse("application/octet-stream").expect("hardcoded MIME type")
+                });
+            let name = std::path::Path::new(&attachment.file_name)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(&attachment.file_name)
+                .to_string();
+            Attachment::new(name).body(attachment.data.clone(), content_type)
         })
-    } else {
-        Ok(data.to_vec())
-    }
+        .collect()
 }
 
 /// Build the SASL XOAUTH2 initial client response for IMAP `AUTHENTICATE`.
@@ -1090,64 +1085,74 @@ mod tests {
     }
     use super::*;
 
-    // -- resolve_attachment_data tests --
+    // -- build_attachment_parts tests --
+
+    fn outbound_attachment(
+        file_name: impl Into<String>,
+        data: Vec<u8>,
+    ) -> zeroclaw_api::media::MediaAttachment {
+        zeroclaw_api::media::MediaAttachment {
+            file_name: file_name.into(),
+            data,
+            mime_type: None,
+        }
+    }
+
+    fn rendered_attachment(attachment: zeroclaw_api::media::MediaAttachment) -> Vec<u8> {
+        let mut parts = build_attachment_parts(&[attachment]);
+        let email = Message::builder()
+            .from("sender@example.invalid".parse().unwrap())
+            .to("recipient@example.invalid".parse().unwrap())
+            .subject("attachment boundary")
+            .multipart(MultiPart::mixed().singlepart(parts.remove(0)))
+            .unwrap();
+        let formatted = email.formatted();
+        let parsed = MessageParser::default()
+            .parse(formatted.as_slice())
+            .unwrap();
+        parsed.attachments().next().unwrap().contents().to_vec()
+    }
 
     #[test]
-    fn resolve_attachment_data_returns_provided_bytes_when_non_empty() {
+    fn build_attachment_parts_serializes_provided_bytes() {
         let data = b"hello attachment".to_vec();
-        let result = resolve_attachment_data("ignored.bin", &data).unwrap();
+        let result = rendered_attachment(outbound_attachment("ignored.bin", data.clone()));
         assert_eq!(result, data);
     }
 
     #[test]
-    fn resolve_attachment_data_falls_back_to_file_when_data_empty_and_file_exists() {
+    fn build_attachment_parts_does_not_read_existing_file_when_data_empty() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("att.txt");
         std::fs::write(&path, b"file contents").unwrap();
-        let result = resolve_attachment_data(path.to_str().unwrap(), &[]).unwrap();
-        assert_eq!(result, b"file contents");
+        let result = rendered_attachment(outbound_attachment(path.display().to_string(), vec![]));
+        assert!(result.is_empty());
     }
 
     #[test]
-    fn resolve_attachment_data_returns_empty_when_data_empty_and_file_absent() {
+    fn build_attachment_parts_keeps_empty_data_for_absent_file_name() {
         // file_name does not exist on disk — should return empty vec, not error.
         // Use a temp dir to guarantee the path does not exist, rather than a
         // hard-coded /tmp path, for portability.
         let dir = tempfile::tempdir().unwrap();
         let absent = dir.path().join("does-not-exist.bin");
-        let result = resolve_attachment_data(absent.to_str().unwrap(), &[]).unwrap();
+        let result = rendered_attachment(outbound_attachment(absent.display().to_string(), vec![]));
         assert!(result.is_empty());
     }
 
+    #[cfg(unix)]
     #[test]
-    fn resolve_attachment_data_propagates_read_error_on_unreadable_file() {
-        // Create a file, then make it unreadable (Unix only).
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join("locked.bin");
-            std::fs::write(&path, b"secret").unwrap();
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
-            #[cfg(target_os = "linux")]
-            let is_root = std::fs::read_to_string("/proc/self/status")
-                .ok()
-                .and_then(|s| {
-                    s.lines()
-                        .find(|l| l.starts_with("Uid:"))
-                        .and_then(|l| l.split_whitespace().nth(1))
-                        .and_then(|uid| uid.parse::<u32>().ok())
-                })
-                .map(|uid| uid == 0)
-                .unwrap_or(false);
-            #[cfg(not(target_os = "linux"))]
-            let is_root = std::env::var("USER").map(|u| u == "root").unwrap_or(false);
-            if is_root {
-                return;
-            }
-            let result = resolve_attachment_data(path.to_str().unwrap(), &[]);
-            assert!(result.is_err());
-        }
+    fn build_attachment_parts_does_not_follow_symlink_when_data_empty() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("secret.txt");
+        let link = dir.path().join("attachment.txt");
+        std::fs::write(&target, b"secret contents").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let result = rendered_attachment(outbound_attachment(link.display().to_string(), vec![]));
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/docs/book/src/channels/email.md
+++ b/docs/book/src/channels/email.md
@@ -65,7 +65,7 @@ When attachments are present the body alternatives are wrapped in an outer `mult
 
 Inbound attachments are stored under `<workspace>/attachments/<conversation>/`. The agent gets file paths in its context and can read them via the `file_read` tool.
 
-Outbound attachments are resolved from the workspace path provided by the agent and sent as MIME parts. Filenames are taken from the `Content-Disposition` header first, falling back to the `Content-Type` `name` parameter.
+Outbound attachments are sent from the bytes supplied with each attachment. The Email channel treats the attachment filename as display metadata, not as a local path. Integrations that intentionally send a local file must validate or constrain the path and load it explicitly with `MediaAttachment::from_file` before sending.
 
 ## Rate and volume limits
 

--- a/docs/book/src/channels/email.md
+++ b/docs/book/src/channels/email.md
@@ -63,7 +63,7 @@ When attachments are present the body alternatives are wrapped in an outer `mult
 
 ## Attachment handling
 
-Inbound attachments are stored under `<workspace>/attachments/<conversation>/`. The agent gets file paths in its context and can read them via the `file_read` tool.
+Inbound attachments are stored under `<workspace>/attachments/<conversation>/`. The agent gets file paths in its context and can read them via the `file_read` tool. Filenames are taken from the `Content-Disposition` header first, falling back to the `Content-Type` `name` parameter.
 
 Outbound attachments are sent from the bytes supplied with each attachment. The Email channel treats the attachment filename as display metadata, not as a local path. Integrations that intentionally send a local file must validate or constrain the path and load it explicitly with `MediaAttachment::from_file` before sending.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Build outbound Email MIME attachments only from `MediaAttachment.data` so an empty payload cannot turn its display filename into an implicit local-file read.
  - Parse the serialized MIME in regressions covering supplied bytes, existing paths, absent paths, and symlinks.
  - Document explicit local-file loading through `MediaAttachment::from_file` for integrations that intentionally attach workspace files.
- **Scope boundary:** This PR does not change inbound Email extraction, QQ or Mattermost download limits, Telegram filename handling, or the explicit `MediaAttachment::from_file` API.
- **Blast radius:** Outbound Email attachments only. No in-repository producer uses the removed convention; external callers that relied on an empty payload plus a path-valued filename must load the file explicitly before sending.
- **Linked issue(s):** None.
- **Labels:** `bug`, `docs`, `channel`, `channel:email`, `security`, `risk:high`, `size:S`

### What this does, simply

- An attachment name is now only a name. Email sends the bytes that the caller supplied and no longer opens a local file merely because those bytes are empty.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The changed boundary is covered by serialized MIME regressions; a live SMTP check would require an external account without adding evidence about local-file access.

### How I tested

- **CI checks relied on and why they cover this change:** Required GitHub CI passed on exact head `1cbd082d0c249894d9d0d32b01d360cf3c55e0c7`; the Quality Gate covered formatting, lint, tests, security, MSRV, and the supported target and feature matrix.
- **Known CI coverage gap, if any:** No live SMTP delivery was exercised. The focused tests validate the MIME bytes immediately before SMTP transport.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

cargo test -p zeroclaw-channels --features channel-email build_attachment_parts -- --nocapture
# 4 passed; 0 failed; 1389 filtered out
```

- **Beyond CI, what did you manually verify?** Reviewed the production Email send path and parsed its serialized MIME for non-empty data, an existing file path, a missing path, and a Unix symlink. I did not send through a live SMTP server.
- **If any command was intentionally skipped, why:** A live SMTP smoke was skipped because it would not strengthen the filesystem-boundary evidence and requires external credentials.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`; this removes an implicit local-file read path.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `No`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: External integrations that constructed `MediaAttachment` with empty `data` and a local path in `file_name` must validate or constrain that path and use `MediaAttachment::from_file` before sending. Byte-backed attachments and current in-repository producers need no change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A downstream integration that has not migrated from the implicit path fallback may send a zero-byte Email attachment. Standard byte-backed attachments remain unchanged.
