### PR TITLE
fix(security): make action budget accounting atomic

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -26,8 +26,15 @@ pub enum ToolOperation {
 /// Sliding-window action tracker for rate limiting.
 #[derive(Debug)]
 pub struct ActionTracker {
-    /// Timestamps of recent actions (kept within the last hour).
-    actions: Mutex<Vec<Instant>>,
+    state: Mutex<ActionTrackerState>,
+}
+
+#[derive(Debug)]
+struct ActionTrackerState {
+    /// Timestamps of successful actions (kept within the last hour).
+    committed: Vec<Instant>,
+    /// Calls admitted by a wrapper but not yet completed.
+    in_flight: usize,
 }
 
 const ACTION_WINDOW: Duration = Duration::from_secs(3600);
@@ -47,32 +54,108 @@ impl Default for ActionTracker {
 impl ActionTracker {
     pub fn new() -> Self {
         Self {
-            actions: Mutex::new(Vec::new()),
+            state: Mutex::new(ActionTrackerState {
+                committed: Vec::new(),
+                in_flight: 0,
+            }),
         }
     }
 
     /// Record an action and return the current count within the window.
     pub fn record(&self) -> usize {
-        let mut actions = self.actions.lock();
+        let mut state = self.state.lock();
         let now = Instant::now();
-        retain_actions_after(&mut actions, now.checked_sub(ACTION_WINDOW));
-        actions.push(now);
-        actions.len()
+        retain_actions_after(&mut state.committed, now.checked_sub(ACTION_WINDOW));
+        state.committed.push(now);
+        state.committed.len()
     }
 
     /// Count of actions in the current window without recording.
     pub fn count(&self) -> usize {
-        let mut actions = self.actions.lock();
-        retain_actions_after(&mut actions, Instant::now().checked_sub(ACTION_WINDOW));
-        actions.len()
+        let mut state = self.state.lock();
+        retain_actions_after(
+            &mut state.committed,
+            Instant::now().checked_sub(ACTION_WINDOW),
+        );
+        state.committed.len()
+    }
+
+    fn used(&self) -> usize {
+        let mut state = self.state.lock();
+        retain_actions_after(
+            &mut state.committed,
+            Instant::now().checked_sub(ACTION_WINDOW),
+        );
+        state.committed.len() + state.in_flight
+    }
+
+    fn try_record(&self, max: u32) -> bool {
+        if max == 0 {
+            return false;
+        }
+
+        let mut state = self.state.lock();
+        let now = Instant::now();
+        retain_actions_after(&mut state.committed, now.checked_sub(ACTION_WINDOW));
+        if state.committed.len() + state.in_flight >= max as usize {
+            return false;
+        }
+        state.committed.push(now);
+        true
+    }
+
+    fn reserve(&self, max: u32) -> bool {
+        if max == 0 {
+            return false;
+        }
+
+        let mut state = self.state.lock();
+        retain_actions_after(
+            &mut state.committed,
+            Instant::now().checked_sub(ACTION_WINDOW),
+        );
+        if state.committed.len() + state.in_flight >= max as usize {
+            return false;
+        }
+        state.in_flight += 1;
+        true
+    }
+
+    fn commit(&self) -> bool {
+        let mut state = self.state.lock();
+        if state.in_flight == 0 {
+            return false;
+        }
+        state.in_flight -= 1;
+        let now = Instant::now();
+        retain_actions_after(&mut state.committed, now.checked_sub(ACTION_WINDOW));
+        state.committed.push(now);
+        true
+    }
+
+    fn release(&self) -> (bool, bool) {
+        let mut state = self.state.lock();
+        if state.in_flight == 0 {
+            return (false, false);
+        }
+        state.in_flight -= 1;
+        retain_actions_after(
+            &mut state.committed,
+            Instant::now().checked_sub(ACTION_WINDOW),
+        );
+        let is_empty = state.committed.is_empty() && state.in_flight == 0;
+        (true, is_empty)
     }
 }
 
 impl Clone for ActionTracker {
     fn clone(&self) -> Self {
-        let actions = self.actions.lock();
+        let state = self.state.lock();
         Self {
-            actions: Mutex::new(actions.clone()),
+            state: Mutex::new(ActionTrackerState {
+                committed: state.committed.clone(),
+                in_flight: 0,
+            }),
         }
     }
 }
@@ -111,13 +194,64 @@ impl PerSenderTracker {
         self.record_within(&key, max)
     }
 
-    /// Record one action for `key`. Allows the action when count == max (≤ max);
-    /// blocks and returns false when count > max.
+    /// Record one action for `key` when a slot remains.
+    /// Rejected attempts are not recorded.
     pub fn record_within(&self, key: &str, max: u32) -> bool {
+        if max == 0 {
+            return false;
+        }
         let mut buckets = self.buckets.lock();
         let tracker = buckets.entry(key.to_string()).or_default();
-        let count = tracker.record();
-        count <= max as usize
+        tracker.try_record(max)
+    }
+
+    /// Atomically reserve one action slot for the current sender.
+    pub fn reserve_for_current(&self, max: u32) -> Option<ActionReservation> {
+        let key = Self::current_key();
+        self.reserve_within(key, max)
+    }
+
+    fn reserve_within(&self, key: String, max: u32) -> Option<ActionReservation> {
+        if max == 0 {
+            return None;
+        }
+        {
+            let mut buckets = self.buckets.lock();
+            let admitted = match buckets.get(&key) {
+                Some(tracker) => tracker.reserve(max),
+                None => {
+                    let tracker = ActionTracker::new();
+                    let admitted = tracker.reserve(max);
+                    buckets.insert(key.clone(), tracker);
+                    admitted
+                }
+            };
+            if !admitted {
+                return None;
+            }
+        }
+        Some(ActionReservation {
+            tracker: self.clone(),
+            key,
+            finished: false,
+        })
+    }
+
+    fn commit_reservation(&self, key: &str) -> bool {
+        let buckets = self.buckets.lock();
+        buckets.get(key).is_some_and(ActionTracker::commit)
+    }
+
+    fn release_reservation(&self, key: &str) -> bool {
+        let mut buckets = self.buckets.lock();
+        let Some(tracker) = buckets.get(key) else {
+            return false;
+        };
+        let (released, remove_bucket) = tracker.release();
+        if remove_bucket {
+            buckets.remove(key);
+        }
+        released
     }
 
     /// Check if the current sender is at or over the limit (without recording).
@@ -127,13 +261,38 @@ impl PerSenderTracker {
     }
 
     pub fn is_exhausted(&self, key: &str, max: u32) -> bool {
-        if max == 0 {
-            return true;
-        }
         let mut buckets = self.buckets.lock();
-        match buckets.get_mut(key) {
-            Some(tracker) => tracker.count() >= max as usize,
-            None => false,
+        let used = buckets.get(key).map_or(0, ActionTracker::used);
+        if used == 0 {
+            buckets.remove(key);
+        }
+        max == 0 || used >= max as usize
+    }
+}
+
+/// One sender-scoped in-flight action slot.
+///
+/// Dropping an uncommitted reservation releases only this invocation's slot.
+#[must_use = "dropping the reservation releases the action slot"]
+pub struct ActionReservation {
+    tracker: PerSenderTracker,
+    key: String,
+    finished: bool,
+}
+
+impl ActionReservation {
+    /// Convert this in-flight slot into one committed action.
+    pub fn commit(mut self) {
+        let committed = self.tracker.commit_reservation(&self.key);
+        assert!(committed, "owned action reservation must still exist");
+        self.finished = true;
+    }
+}
+
+impl Drop for ActionReservation {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.tracker.release_reservation(&self.key);
         }
     }
 }
@@ -3020,10 +3179,8 @@ impl SecurityPolicy {
     // no side effects. Act operations must pass both the autonomy gate
     // (not read-only) and the sliding-window rate limiter.
 
-    /// Enforce policy for a tool operation.
-    /// Read operations are always allowed by autonomy/rate gates.
-    /// Act operations require non-readonly autonomy and available action budget.
-    pub fn enforce_tool_operation(
+    /// Check whether autonomy permits a tool operation without recording it.
+    pub fn authorize_tool_operation(
         &self,
         operation: ToolOperation,
         operation_name: &str,
@@ -3036,14 +3193,27 @@ impl SecurityPolicy {
                         "Security policy: read-only mode, cannot perform '{operation_name}'"
                     ));
                 }
-
-                if !self.record_action() {
-                    return Err("Rate limit exceeded: action budget exhausted".to_string());
-                }
-
                 Ok(())
             }
         }
+    }
+
+    /// Enforce policy and record an action for callers without a rate-limit wrapper.
+    pub fn enforce_tool_operation(
+        &self,
+        operation: ToolOperation,
+        operation_name: &str,
+    ) -> Result<(), String> {
+        self.authorize_tool_operation(operation, operation_name)?;
+        if operation == ToolOperation::Act && !self.record_action() {
+            return Err("Rate limit exceeded: action budget exhausted".to_string());
+        }
+        Ok(())
+    }
+
+    /// Atomically reserve one action slot for a production-wrapped invocation.
+    pub fn reserve_action(&self) -> Option<ActionReservation> {
+        self.tracker.reserve_for_current(self.max_actions_per_hour)
     }
 
     /// Record an action for the current sender and check if rate-limited.
@@ -3866,6 +4036,25 @@ mod tests {
             .enforce_tool_operation(ToolOperation::Act, "memory_store")
             .unwrap_err();
         assert!(err.contains("Rate limit exceeded"));
+    }
+
+    #[test]
+    fn authorize_tool_operation_does_not_consume_rate_budget() {
+        let p = SecurityPolicy {
+            max_actions_per_hour: 1,
+            ..default_policy()
+        };
+
+        assert!(
+            p.authorize_tool_operation(ToolOperation::Act, "coding_agent")
+                .is_ok()
+        );
+        assert!(
+            p.authorize_tool_operation(ToolOperation::Act, "coding_agent")
+                .is_ok()
+        );
+        assert!(p.record_action(), "authorization must leave the slot free");
+        assert!(!p.record_action(), "the committed action must consume it");
     }
 
     // ── is_command_allowed ───────────────────────────────────
@@ -4742,6 +4931,16 @@ mod tests {
         assert_eq!(cloned.count(), 2); // clone is independent
     }
 
+    #[test]
+    fn action_tracker_clone_does_not_copy_in_flight_usage() {
+        let tracker = ActionTracker::new();
+        assert!(tracker.reserve(1));
+
+        let cloned = tracker.clone();
+
+        assert_eq!(cloned.used(), 0);
+    }
+
     // ── Edge cases: command injection ────────────────────────
 
     #[test]
@@ -5609,6 +5808,98 @@ mod tests {
             ..SecurityPolicy::default()
         };
         assert!(!p.record_action());
+        assert!(p.reserve_action().is_none());
+    }
+
+    #[test]
+    fn action_reservation_drop_releases_exact_slot() {
+        let p = SecurityPolicy {
+            max_actions_per_hour: 2,
+            ..SecurityPolicy::default()
+        };
+
+        let first = p.reserve_action().expect("first reservation");
+        let second = p.reserve_action().expect("second reservation");
+        assert!(p.reserve_action().is_none(), "both slots are reserved");
+
+        drop(first);
+        let replacement = p.reserve_action().expect("only first slot was released");
+        second.commit();
+        assert!(
+            p.reserve_action().is_none(),
+            "second reservation committed while replacement remains in flight"
+        );
+
+        drop(replacement);
+        let final_slot = p.reserve_action().expect("replacement slot was released");
+        final_slot.commit();
+        assert!(p.reserve_action().is_none(), "both slots are now committed");
+    }
+
+    #[test]
+    fn action_reservations_are_isolated_by_sender() {
+        let tracker = PerSenderTracker::new();
+        let sender_a = tracker
+            .reserve_within("sender-a".to_string(), 1)
+            .expect("sender A reservation");
+
+        assert!(
+            tracker.reserve_within("sender-a".to_string(), 1).is_none(),
+            "sender A has no second slot"
+        );
+        let sender_b = tracker
+            .reserve_within("sender-b".to_string(), 1)
+            .expect("sender B has an independent slot");
+
+        sender_a.commit();
+        drop(sender_b);
+        assert!(
+            tracker.reserve_within("sender-b".to_string(), 1).is_some(),
+            "releasing sender B is independent from sender A's commit"
+        );
+    }
+
+    #[test]
+    fn released_reservation_removes_empty_sender_bucket() {
+        let tracker = PerSenderTracker::new();
+        let reservation = tracker
+            .reserve_within("ephemeral-sender".to_string(), 1)
+            .expect("reservation");
+        assert!(tracker.buckets.lock().contains_key("ephemeral-sender"));
+
+        drop(reservation);
+
+        assert!(!tracker.buckets.lock().contains_key("ephemeral-sender"));
+    }
+
+    #[test]
+    fn zero_budget_does_not_create_sender_bucket() {
+        let tracker = PerSenderTracker::new();
+
+        assert!(!tracker.record_within("zero-budget", 0));
+        assert!(
+            tracker
+                .reserve_within("zero-budget".to_string(), 0)
+                .is_none()
+        );
+        assert!(tracker.buckets.lock().is_empty());
+    }
+
+    #[test]
+    fn expired_success_is_evicted_when_budget_is_read() {
+        let tracker = PerSenderTracker::new();
+        assert!(tracker.record_within("expired-sender", 1));
+        {
+            let buckets = tracker.buckets.lock();
+            let action_tracker = buckets.get("expired-sender").expect("sender bucket");
+            let mut state = action_tracker.state.lock();
+            state.committed[0] = Instant::now()
+                .checked_sub(ACTION_WINDOW + Duration::from_secs(1))
+                .expect("test timestamp");
+        }
+
+        assert!(!tracker.is_exhausted("expired-sender", 1));
+        assert!(!tracker.buckets.lock().contains_key("expired-sender"));
     }
 
     #[test]
@@ -7373,14 +7664,14 @@ mod tests {
     #[test]
     fn per_sender_tracker_isolates_counts() {
         let t = PerSenderTracker::new();
-        // sender A hits limit=2 on 3rd call
-        assert!(t.record_within("chat_a", 2)); // count=1 ≤ 2 → ok
-        assert!(t.record_within("chat_a", 2)); // count=2 ≤ 2 → ok
-        assert!(!t.record_within("chat_a", 2)); // count=3 > 2 → blocked
+        // sender A rejects its third call without recording it
+        assert!(t.record_within("chat_a", 2)); // count=1
+        assert!(t.record_within("chat_a", 2)); // count=2
+        assert!(!t.record_within("chat_a", 2)); // remains count=2
         // sender B is unaffected — its bucket is empty
-        assert!(t.record_within("chat_b", 2)); // count=1 ≤ 2 → ok
-        assert!(t.record_within("chat_b", 2)); // count=2 ≤ 2 → ok
-        assert!(!t.record_within("chat_b", 2)); // count=3 > 2 → blocked
+        assert!(t.record_within("chat_b", 2)); // count=1
+        assert!(t.record_within("chat_b", 2)); // count=2
+        assert!(!t.record_within("chat_b", 2)); // remains count=2
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/deliver_file.rs
+++ b/crates/zeroclaw-runtime/src/tools/deliver_file.rs
@@ -231,7 +231,6 @@ impl Tool for DeliverFileTool {
         let full_path = match self.resolve_candidate(path) {
             Ok(p) => p,
             Err(e) => {
-                let _ = self.security.record_action();
                 return Ok(ToolResult {
                     success: false,
                     output: ToolOutput::default(),
@@ -243,7 +242,6 @@ impl Tool for DeliverFileTool {
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,
             Err(e) => {
-                let _ = self.security.record_action();
                 return Ok(ToolResult {
                     success: false,
                     output: ToolOutput::default(),
@@ -342,7 +340,6 @@ impl Tool for DeliverFileTool {
             "bytes": bytes,
         });
 
-        let _ = self.security.record_action();
         Ok(ToolResult {
             success: true,
             output: ToolOutput::json_with_text(data, summary),
@@ -355,6 +352,7 @@ impl Tool for DeliverFileTool {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use zeroclaw_tools::wrappers::{PathGuardedTool, RateLimitedTool};
 
     fn test_tool(workspace: std::path::PathBuf) -> DeliverFileTool {
         let security = Arc::new(SecurityPolicy {
@@ -403,6 +401,40 @@ mod tests {
         assert!(text.contains("Delivered a.pdf"));
         // Metadata is structural now: no machine trailer in the model-facing text.
         assert!(!text.contains("acp.deliver_file"));
+    }
+
+    #[tokio::test]
+    async fn wrapped_delivery_charges_success_once_and_failure_zero_times() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ok.txt"), b"ok").unwrap();
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: dir.path().to_path_buf(),
+            max_actions_per_hour: 3,
+            ..SecurityPolicy::default()
+        });
+        let tool = RateLimitedTool::new(
+            PathGuardedTool::new(DeliverFileTool::new(security.clone()), security.clone()),
+            security.clone(),
+        );
+
+        let failed = tool.execute(json!({"path": "missing.txt"})).await.unwrap();
+        assert!(!failed.success);
+        let succeeded = tool.execute(json!({"path": "ok.txt"})).await.unwrap();
+        assert!(succeeded.success);
+
+        assert!(
+            security.record_action(),
+            "one of three slots remains after debit two"
+        );
+        assert!(
+            security.record_action(),
+            "one success plus two debits fills budget"
+        );
+        assert!(
+            !security.record_action(),
+            "successful delivery was charged exactly once"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/file_read.rs
+++ b/crates/zeroclaw-runtime/src/tools/file_read.rs
@@ -115,7 +115,6 @@ impl FileReadTool {
         let full_path = match self.resolve_candidate(path) {
             Ok(p) => p,
             Err(e) => {
-                let _ = self.security.record_action();
                 return Ok(ToolResult {
                     success: false,
                     output: ToolOutput::default(),
@@ -128,7 +127,6 @@ impl FileReadTool {
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,
             Err(e) => {
-                let _ = self.security.record_action();
                 return Ok(ToolResult {
                     success: false,
                     output: ToolOutput::default(),
@@ -370,6 +368,7 @@ fn looks_binary(bytes: &[u8]) -> bool {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use zeroclaw_tools::wrappers::{PathGuardedTool, RateLimitedTool};
 
     fn test_tool(workspace: std::path::PathBuf) -> FileReadTool {
         let security = Arc::new(SecurityPolicy {
@@ -1436,15 +1435,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_read_nonexistent_consumes_rate_limit_budget() {
+    async fn wrapped_file_read_failure_preserves_rate_limit_budget() {
         let dir = std::env::temp_dir().join("zeroclaw_test_file_read_probe");
         let _ = tokio::fs::remove_dir_all(&dir).await;
         tokio::fs::create_dir_all(&dir).await.unwrap();
 
-        // Allow only 2 actions total.
-        let tool = test_tool_with(dir.clone(), AutonomyLevel::Supervised, 2);
+        let inner = test_tool_with(dir.clone(), AutonomyLevel::Supervised, 2);
+        let security = inner.security.clone();
+        let tool = RateLimitedTool::new(
+            PathGuardedTool::new(inner, security.clone()),
+            security.clone(),
+        );
 
-        // Two failing reads each consume one slot via the inner-tool charge.
+        // Failed production-wrapped reads release their reservations.
         let r1 = tool.execute(json!({"path": "nope1.txt"})).await.unwrap();
         assert!(!r1.success);
         assert!(
@@ -1466,7 +1469,12 @@ mod tests {
         let r3 = tool.execute(json!({"path": "nope3.txt"})).await.unwrap();
         assert!(!r3.success);
 
-        assert!(!tool.security.record_action(), "budget must be exhausted");
+        assert!(security.record_action(), "first slot remains available");
+        assert!(security.record_action(), "second slot remains available");
+        assert!(
+            !security.record_action(),
+            "successful debits exhaust the budget"
+        );
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }

--- a/crates/zeroclaw-tools/src/claude_code.rs
+++ b/crates/zeroclaw-tools/src/claude_code.rs
@@ -106,10 +106,10 @@ impl Tool for ClaudeCodeTool {
         // Rate limiting is applied by the RateLimitedTool wrapper at
         // registration time (see zeroclaw-runtime::tools::mod).
 
-        // Enforce act policy
+        // The production wrapper owns accounting; the adapter owns authorization.
         if let Err(error) = self
             .security
-            .enforce_tool_operation(ToolOperation::Act, "claude_code")
+            .authorize_tool_operation(ToolOperation::Act, "claude_code")
         {
             return Ok(ToolResult {
                 success: false,
@@ -377,7 +377,10 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = ClaudeCodeTool::new(security, test_config());
+        let tool = crate::wrappers::RateLimitedTool::new(
+            ClaudeCodeTool::new(security.clone(), test_config()),
+            security,
+        );
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/crates/zeroclaw-tools/src/claude_code_runner.rs
+++ b/crates/zeroclaw-tools/src/claude_code_runner.rs
@@ -53,7 +53,7 @@ impl ClaudeCodeRunnerTool {
     }
 
     #[cfg(all(test, unix))]
-    fn with_tmux_binary(mut self, tmux_binary: PathBuf) -> Self {
+    pub(crate) fn with_tmux_binary(mut self, tmux_binary: PathBuf) -> Self {
         self.tmux_binary = tmux_binary;
         self
     }
@@ -110,10 +110,10 @@ impl Tool for ClaudeCodeRunnerTool {
         // Rate limiting is applied by the RateLimitedTool wrapper at
         // registration time (see zeroclaw-runtime::tools::mod).
 
-        // Enforce act policy
+        // The production wrapper owns accounting; the adapter owns authorization.
         if let Err(error) = self
             .security
-            .enforce_tool_operation(ToolOperation::Act, "claude_code_runner")
+            .authorize_tool_operation(ToolOperation::Act, "claude_code_runner")
         {
             return Ok(ToolResult {
                 success: false,
@@ -526,8 +526,14 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool =
-            ClaudeCodeRunnerTool::new(security, test_config(), "http://localhost:3000".into());
+        let tool = crate::wrappers::RateLimitedTool::new(
+            ClaudeCodeRunnerTool::new(
+                security.clone(),
+                test_config(),
+                "http://localhost:3000".into(),
+            ),
+            security,
+        );
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/crates/zeroclaw-tools/src/codex_cli.rs
+++ b/crates/zeroclaw-tools/src/codex_cli.rs
@@ -76,10 +76,10 @@ impl Tool for CodexCliTool {
         // Rate limiting is applied by the RateLimitedTool wrapper at
         // registration time (see zeroclaw-runtime::tools::mod).
 
-        // Enforce act policy
+        // The production wrapper owns accounting; the adapter owns authorization.
         if let Err(error) = self
             .security
-            .enforce_tool_operation(ToolOperation::Act, "codex_cli")
+            .authorize_tool_operation(ToolOperation::Act, "codex_cli")
         {
             return Ok(ToolResult {
                 success: false,
@@ -286,7 +286,10 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = CodexCliTool::new(security, test_config());
+        let tool = crate::wrappers::RateLimitedTool::new(
+            CodexCliTool::new(security.clone(), test_config()),
+            security,
+        );
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/crates/zeroclaw-tools/src/coding_agent_budget_tests.rs
+++ b/crates/zeroclaw-tools/src/coding_agent_budget_tests.rs
@@ -1,0 +1,208 @@
+use crate::claude_code::ClaudeCodeTool;
+use crate::claude_code_runner::ClaudeCodeRunnerTool;
+use crate::codex_cli::CodexCliTool;
+use crate::coding_cli::{CodingCliCommand, CodingCliExecutionError, CodingCliExecutor};
+use crate::gemini_cli::GeminiCliTool;
+use crate::opencode_cli::OpenCodeCliTool;
+use crate::wrappers::RateLimitedTool;
+use async_trait::async_trait;
+use serde_json::json;
+use std::path::Path;
+use std::process::{ExitStatus, Output};
+use std::sync::Arc;
+use zeroclaw_api::tool::Tool;
+use zeroclaw_config::autonomy::AutonomyLevel;
+use zeroclaw_config::policy::SecurityPolicy;
+use zeroclaw_config::schema::{
+    ClaudeCodeConfig, ClaudeCodeRunnerConfig, CodexCliConfig, GeminiCliConfig, OpenCodeCliConfig,
+};
+
+#[derive(Debug)]
+struct SuccessfulExecutor;
+
+#[async_trait]
+impl CodingCliExecutor for SuccessfulExecutor {
+    async fn output(&self, _command: CodingCliCommand) -> Result<Output, CodingCliExecutionError> {
+        Ok(Output {
+            status: successful_exit_status(),
+            stdout: b"ok".to_vec(),
+            stderr: Vec::new(),
+        })
+    }
+}
+
+#[cfg(unix)]
+fn successful_exit_status() -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(0)
+}
+
+#[cfg(windows)]
+fn successful_exit_status() -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(0)
+}
+
+fn policy(
+    autonomy: AutonomyLevel,
+    max_actions_per_hour: u32,
+    workspace: &Path,
+) -> Arc<SecurityPolicy> {
+    Arc::new(SecurityPolicy {
+        autonomy,
+        max_actions_per_hour,
+        workspace_dir: workspace.to_path_buf(),
+        ..SecurityPolicy::default()
+    })
+}
+
+fn wrapped_tool<T: Tool + 'static>(inner: T, security: Arc<SecurityPolicy>) -> Box<dyn Tool> {
+    Box::new(RateLimitedTool::new(inner, security))
+}
+
+#[cfg(unix)]
+fn write_successful_tmux(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::write(path, "#!/bin/sh\nexit 0\n").expect("write tmux fixture");
+    let mut permissions = std::fs::metadata(path)
+        .expect("tmux fixture metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("make tmux fixture executable");
+}
+
+#[cfg(unix)]
+fn coding_agent_cases(
+    autonomy: AutonomyLevel,
+    max_actions_per_hour: u32,
+    workspace: &Path,
+    tmux_binary: &Path,
+) -> Vec<(Arc<SecurityPolicy>, Box<dyn Tool>)> {
+    let executor: Arc<dyn CodingCliExecutor> = Arc::new(SuccessfulExecutor);
+    let mut cases = Vec::new();
+
+    let security = policy(autonomy, max_actions_per_hour, workspace);
+    cases.push((
+        security.clone(),
+        wrapped_tool(
+            ClaudeCodeTool::new_with_executor(
+                security.clone(),
+                ClaudeCodeConfig::default(),
+                executor.clone(),
+            ),
+            security,
+        ),
+    ));
+
+    let security = policy(autonomy, max_actions_per_hour, workspace);
+    cases.push((
+        security.clone(),
+        wrapped_tool(
+            ClaudeCodeRunnerTool::new(
+                security.clone(),
+                ClaudeCodeRunnerConfig::default(),
+                "http://localhost:3000".into(),
+            )
+            .with_tmux_binary(tmux_binary.to_path_buf()),
+            security,
+        ),
+    ));
+
+    let security = policy(autonomy, max_actions_per_hour, workspace);
+    cases.push((
+        security.clone(),
+        wrapped_tool(
+            CodexCliTool::new_with_executor(
+                security.clone(),
+                CodexCliConfig::default(),
+                executor.clone(),
+            ),
+            security,
+        ),
+    ));
+
+    let security = policy(autonomy, max_actions_per_hour, workspace);
+    cases.push((
+        security.clone(),
+        wrapped_tool(
+            GeminiCliTool::new_with_executor(
+                security.clone(),
+                GeminiCliConfig::default(),
+                executor.clone(),
+            ),
+            security,
+        ),
+    ));
+
+    let security = policy(autonomy, max_actions_per_hour, workspace);
+    cases.push((
+        security.clone(),
+        wrapped_tool(
+            OpenCodeCliTool::new_with_executor(
+                security.clone(),
+                OpenCodeCliConfig::default(),
+                executor,
+            ),
+            security,
+        ),
+    ));
+
+    cases
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn coding_agent_wrappers_charge_one_action_each() {
+    let workspace = tempfile::TempDir::new().expect("workspace");
+    let tmux_binary = workspace.path().join("tmux");
+    write_successful_tmux(&tmux_binary);
+
+    for (security, tool) in
+        coding_agent_cases(AutonomyLevel::Full, 2, workspace.path(), &tmux_binary)
+    {
+        let tool_name = tool.name().to_string();
+        let result = tool
+            .execute(json!({"prompt": "hello"}))
+            .await
+            .expect("coding-agent invocation");
+        assert!(result.success, "{tool_name} should succeed: {result:?}");
+        assert!(
+            security.record_action(),
+            "{tool_name} should leave exactly one of two action slots available"
+        );
+        assert!(
+            !security.record_action(),
+            "{tool_name} must not leave a third action slot"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn coding_agent_readonly_rejection_consumes_no_action() {
+    let workspace = tempfile::TempDir::new().expect("workspace");
+    let tmux_binary = workspace.path().join("tmux");
+
+    for (security, tool) in
+        coding_agent_cases(AutonomyLevel::ReadOnly, 1, workspace.path(), &tmux_binary)
+    {
+        let tool_name = tool.name().to_string();
+        let result = tool
+            .execute(json!({"prompt": "hello"}))
+            .await
+            .expect("read-only rejection");
+        assert!(
+            !result.success,
+            "{tool_name} must be rejected in read-only mode"
+        );
+        assert!(
+            result.error.as_deref().unwrap_or("").contains("read-only"),
+            "{tool_name} should report the autonomy rejection"
+        );
+        assert!(
+            security.record_action(),
+            "{tool_name} rejection must leave the action slot available"
+        );
+    }
+}

--- a/crates/zeroclaw-tools/src/gemini_cli.rs
+++ b/crates/zeroclaw-tools/src/gemini_cli.rs
@@ -76,10 +76,10 @@ impl Tool for GeminiCliTool {
         // Rate limiting is applied by the RateLimitedTool wrapper at
         // registration time (see zeroclaw-runtime::tools::mod).
 
-        // Enforce act policy
+        // The production wrapper owns accounting; the adapter owns authorization.
         if let Err(error) = self
             .security
-            .enforce_tool_operation(ToolOperation::Act, "gemini_cli")
+            .authorize_tool_operation(ToolOperation::Act, "gemini_cli")
         {
             return Ok(ToolResult {
                 success: false,
@@ -265,7 +265,10 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = GeminiCliTool::new(security, test_config());
+        let tool = crate::wrappers::RateLimitedTool::new(
+            GeminiCliTool::new(security.clone(), test_config()),
+            security,
+        );
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/crates/zeroclaw-tools/src/image_info.rs
+++ b/crates/zeroclaw-tools/src/image_info.rs
@@ -163,7 +163,6 @@ impl Tool for ImageInfoTool {
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(path) => path,
             Err(e) => {
-                let _ = self.security.record_action();
                 let error = if e.kind() == std::io::ErrorKind::NotFound {
                     format!("File not found: {path_str}")
                 } else {
@@ -727,7 +726,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_file_probe_consumes_action_budget() {
+    async fn wrapped_missing_file_probe_preserves_action_budget() {
         let root = TempDir::new().unwrap();
         let security = Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Full,
@@ -736,12 +735,16 @@ mod tests {
             max_actions_per_hour: 1,
             ..SecurityPolicy::default()
         });
-        let tool = ImageInfoTool::new(security.clone());
+        let tool = wrapped_tool_with_security(security.clone());
 
         assert!(!security.is_rate_limited());
         let result = tool.execute(json!({"path": "missing.png"})).await.unwrap();
 
         assert!(!result.success);
+        assert!(
+            security.record_action(),
+            "failed call must release its reservation"
+        );
         assert!(security.is_rate_limited());
     }
 

--- a/crates/zeroclaw-tools/src/lib.rs
+++ b/crates/zeroclaw-tools/src/lib.rs
@@ -89,6 +89,9 @@ pub mod web_search_provider_routing;
 pub mod web_search_tool;
 pub mod wrappers;
 
+#[cfg(all(test, unix))]
+mod coding_agent_budget_tests;
+
 pub const MEMORY_TOOL_NAMES: &[&str] = &[
     "memory_store",
     "memory_recall",

--- a/crates/zeroclaw-tools/src/opencode_cli.rs
+++ b/crates/zeroclaw-tools/src/opencode_cli.rs
@@ -76,10 +76,10 @@ impl Tool for OpenCodeCliTool {
         // Rate limiting is applied by the RateLimitedTool wrapper at
         // registration time (see zeroclaw-runtime::tools::mod).
 
-        // Enforce act policy
+        // The production wrapper owns accounting; the adapter owns authorization.
         if let Err(error) = self
             .security
-            .enforce_tool_operation(ToolOperation::Act, "opencode_cli")
+            .authorize_tool_operation(ToolOperation::Act, "opencode_cli")
         {
             return Ok(ToolResult {
                 success: false,
@@ -265,7 +265,10 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = OpenCodeCliTool::new(security, test_config());
+        let tool = crate::wrappers::RateLimitedTool::new(
+            OpenCodeCliTool::new(security.clone(), test_config()),
+            security,
+        );
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/crates/zeroclaw-tools/src/wrappers.rs
+++ b/crates/zeroclaw-tools/src/wrappers.rs
@@ -54,22 +54,21 @@ impl<T: Tool> Tool for RateLimitedTool<T> {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: ToolOutput::default(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
+        let reservation = match self.security.reserve_action() {
+            Some(reservation) => reservation,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: ToolOutput::default(),
+                    error: Some("Rate limit exceeded: too many actions in the last hour".into()),
+                });
+            }
+        };
 
         let result = self.inner.execute(args).await?;
 
-        if result.success && !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: ToolOutput::default(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
+        if result.success {
+            reservation.commit();
         }
 
         Ok(result)
@@ -183,6 +182,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
     use zeroclaw_config::autonomy::AutonomyLevel;
     use zeroclaw_config::policy::SecurityPolicy;
 
@@ -291,6 +291,65 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 
+    struct BlockingTool {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    zeroclaw_api::mock_tool_attribution!(BlockingTool);
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn name(&self) -> &str {
+            "blocking"
+        }
+        fn description(&self) -> &str {
+            "waits until released"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(ToolResult {
+                success: true,
+                output: "ok".into(),
+                error: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn rate_limited_parallel_calls_cannot_overbook_one_slot() {
+        let sec = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: std::env::temp_dir(),
+            max_actions_per_hour: 1,
+            ..SecurityPolicy::default()
+        });
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let first = RateLimitedTool::new(
+            BlockingTool {
+                entered: entered.clone(),
+                release: release.clone(),
+            },
+            sec.clone(),
+        );
+        let first_call = tokio::spawn(async move { first.execute(serde_json::json!({})).await });
+        entered.notified().await;
+
+        let (second_inner, second_calls) = CountingTool::new();
+        let second = RateLimitedTool::new(second_inner, sec);
+        let blocked = second.execute(serde_json::json!({})).await.unwrap();
+        assert!(!blocked.success, "the in-flight call owns the only slot");
+        assert_eq!(second_calls.load(Ordering::SeqCst), 0);
+
+        release.notify_one();
+        assert!(first_call.await.unwrap().unwrap().success);
+    }
+
     // ── PathGuardedTool tests ─────────────────────────────────────────────────
 
     #[tokio::test]
@@ -375,8 +434,7 @@ mod tests {
     #[tokio::test]
     async fn rate_limited_does_not_consume_budget_on_failure() {
         // Inner tool that always reports failure (e.g. validation error).
-        // record_action() must NOT fire, so the budget stays at full and
-        // a subsequent successful call still goes through.
+        // Its reservation must be released so a later successful call can run.
         struct AlwaysFails;
         impl ::zeroclaw_api::attribution::Attributable for AlwaysFails {
             fn role(&self) -> ::zeroclaw_api::attribution::Role {
@@ -430,6 +488,124 @@ mod tests {
         let r = succeeding.execute(serde_json::json!({})).await.unwrap();
         assert!(r.success);
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rate_limited_releases_budget_on_inner_error() {
+        struct AlwaysErrors;
+        zeroclaw_api::mock_tool_attribution!(AlwaysErrors);
+
+        #[async_trait]
+        impl Tool for AlwaysErrors {
+            fn name(&self) -> &str {
+                "always_errors"
+            }
+            fn description(&self) -> &str {
+                ""
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({})
+            }
+            async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+                anyhow::bail!("inner error")
+            }
+        }
+
+        let sec = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: std::env::temp_dir(),
+            max_actions_per_hour: 1,
+            ..SecurityPolicy::default()
+        });
+        let erroring = RateLimitedTool::new(AlwaysErrors, sec.clone());
+        assert!(erroring.execute(serde_json::json!({})).await.is_err());
+
+        let (inner, calls) = CountingTool::new();
+        let succeeding = RateLimitedTool::new(inner, sec);
+        assert!(
+            succeeding
+                .execute(serde_json::json!({}))
+                .await
+                .unwrap()
+                .success
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rate_limited_releases_budget_when_call_is_cancelled() {
+        let sec = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: std::env::temp_dir(),
+            max_actions_per_hour: 1,
+            ..SecurityPolicy::default()
+        });
+        let entered = Arc::new(Notify::new());
+        let tool = RateLimitedTool::new(
+            BlockingTool {
+                entered: entered.clone(),
+                release: Arc::new(Notify::new()),
+            },
+            sec.clone(),
+        );
+        let call = tokio::spawn(async move { tool.execute(serde_json::json!({})).await });
+        entered.notified().await;
+        call.abort();
+        assert!(call.await.unwrap_err().is_cancelled());
+
+        let (inner, calls) = CountingTool::new();
+        let succeeding = RateLimitedTool::new(inner, sec);
+        assert!(
+            succeeding
+                .execute(serde_json::json!({}))
+                .await
+                .unwrap()
+                .success
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rate_limited_releases_budget_when_inner_panics() {
+        struct PanickingTool;
+        zeroclaw_api::mock_tool_attribution!(PanickingTool);
+
+        #[async_trait]
+        impl Tool for PanickingTool {
+            fn name(&self) -> &str {
+                "panicking"
+            }
+            fn description(&self) -> &str {
+                ""
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({})
+            }
+            async fn execute(&self, _args: serde_json::Value) -> anyhow::Result<ToolResult> {
+                panic!("inner panic")
+            }
+        }
+
+        let sec = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: std::env::temp_dir(),
+            max_actions_per_hour: 1,
+            ..SecurityPolicy::default()
+        });
+        let tool = RateLimitedTool::new(PanickingTool, sec.clone());
+        let call = tokio::spawn(async move { tool.execute(serde_json::json!({})).await });
+        assert!(call.await.unwrap_err().is_panic());
+
+        let (inner, calls) = CountingTool::new();
+        let succeeding = RateLimitedTool::new(inner, sec);
+        assert!(
+            succeeding
+                .execute(serde_json::json!({}))
+                .await
+                .unwrap()
+                .success
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/wrappers.rs
+++ b/crates/zeroclaw-tools/src/wrappers.rs
@@ -549,8 +549,7 @@ mod tests {
             },
             sec.clone(),
         );
-        let call =
-            zeroclaw_spawn::spawn!(async move { tool.execute(serde_json::json!({})).await });
+        let call = zeroclaw_spawn::spawn!(async move { tool.execute(serde_json::json!({})).await });
         entered.notified().await;
         call.abort();
         assert!(call.await.unwrap_err().is_cancelled());
@@ -595,8 +594,7 @@ mod tests {
             ..SecurityPolicy::default()
         });
         let tool = RateLimitedTool::new(PanickingTool, sec.clone());
-        let call =
-            zeroclaw_spawn::spawn!(async move { tool.execute(serde_json::json!({})).await });
+        let call = zeroclaw_spawn::spawn!(async move { tool.execute(serde_json::json!({})).await });
         assert!(call.await.unwrap_err().is_panic());
 
         let (inner, calls) = CountingTool::new();

--- a/crates/zeroclaw-tools/src/wrappers.rs
+++ b/crates/zeroclaw-tools/src/wrappers.rs
@@ -337,7 +337,8 @@ mod tests {
             },
             sec.clone(),
         );
-        let first_call = tokio::spawn(async move { first.execute(serde_json::json!({})).await });
+        let first_call =
+            zeroclaw_spawn::spawn!(async move { first.execute(serde_json::json!({})).await });
         entered.notified().await;
 
         let (second_inner, second_calls) = CountingTool::new();
@@ -548,7 +549,8 @@ mod tests {
             },
             sec.clone(),
         );
-        let call = tokio::spawn(async move { tool.execute(serde_json::json!({})).await });
+        let call =
+            zeroclaw_spawn::spawn!(async move { tool.execute(serde_json::json!({})).await });
         entered.notified().await;
         call.abort();
         assert!(call.await.unwrap_err().is_cancelled());
@@ -593,7 +595,8 @@ mod tests {
             ..SecurityPolicy::default()
         });
         let tool = RateLimitedTool::new(PanickingTool, sec.clone());
-        let call = tokio::spawn(async move { tool.execute(serde_json::json!({})).await });
+        let call =
+            zeroclaw_spawn::spawn!(async move { tool.execute(serde_json::json!({})).await });
         assert!(call.await.unwrap_err().is_panic());
 
         let (inner, calls) = CountingTool::new();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Reserve sender-scoped action-budget capacity atomically before a wrapped tool enters its side-effect boundary, so parallel calls cannot jointly exceed `max_actions_per_hour`.
  - Commit one action only after a successful result and release the reservation on rejection, failure, error, cancellation, or panic.
  - Keep autonomy authorization in the five coding-agent adapters while making `RateLimitedTool` the sole accounting owner for wrapped tools, preventing one successful call from being charged twice.
- **Scope boundary:** This does not change action-budget configuration, autonomy modes, tool permissions, or the one-hour accounting window. Direct unwrapped accounting keeps the same configured limit value, but rejected attempts no longer append a timestamp, and both `record_action` admission and `is_rate_limited` now count in-flight wrapper reservations. This does not add global eager cleanup of every expired sender bucket.
- **Blast radius:** Shared action accounting in `zeroclaw-config`; all tools registered behind `RateLimitedTool`; the Claude Code, Claude Code runner, Codex CLI, Gemini CLI, and OpenCode CLI adapters; and already-wrapped file read, file delivery, and image-info consumers.
- **Linked issue(s):** Closes #9594. Closes #9849.
- **Labels:** `bug`, `config`, `domain:security`, `follow-up`, `risk:high`, `runtime`, `security:policy`, `size:L`, `tool`, `tool:file`

### What this does, simply

ZeroClaw lets an operator put an hourly limit on an agent's tool actions. Once the allowance is used, another action should not be able to start.

Previously, a call checked the remaining allowance and recorded its use only after it finished. If several calls started together, each could see the same last available place and all proceed. Coding tools had the opposite problem: one successful action could be counted in two different places.

This PR gives each call a temporary place in the allowance before it starts:

1. A successful call turns that temporary place into one completed action.
2. A rejected, failed, cancelled, or crashed call gives the place back.
3. Every successful coding-tool action is counted once.

The result is that parallel calls share the real remaining allowance, unsuccessful work does not use it up, and the hourly limit is enforced before an extra action runs.

It does not change the configured limit, the one-hour window, tool permissions, or autonomy rules. It makes the existing accounting match those rules.

### Scope and maintenance tradeoff

- Both bugs arise from the same ownership boundary, so fixing only the five coding adapters would leave concurrent overbooking in every wrapped tool, while fixing only the race would preserve deterministic double charging in those adapters. The smallest coherent repair therefore centralizes reservation lifecycle in the existing shared policy tracker and wrapper.
- The production change adds an in-flight counter and a non-cloneable RAII reservation guard alongside the existing completed-action timestamps. This keeps one canonical sender-scoped state and avoids a second accounting table or adapter-specific exceptions. Focused tests account for most of the patch size.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. Deterministic unit tests directly exercise the concurrency, cancellation, panic, failure, expiry, and five-adapter accounting boundaries without invoking external coding tools or providers.

### How I tested

- **CI checks relied on and why they cover this change:** Current-head required CI passed, including formatting, lint, workspace tests, MSRV, all/default/no-default feature checks, targeted Windows Clippy, and the parallel runtime test. Together these cover the changed cross-crate accounting API, wrapper behavior, adapter integrations, feature combinations, and supported compiler floor.
- **Known CI coverage gap, if any:** The shared five-adapter runtime harness is Unix-only. No live outbound parallel provider smoke was run; the deterministic wrapper test holds the side-effect boundary and proves that only one call can enter with one slot remaining.
- **Commands run and tail output:**

```sh
cargo +1.96.1 fmt --all -- --check
# Finished successfully

bash scripts/ci/comment_hygiene_gate.sh
# Comment hygiene gate passed.

cargo test -p zeroclaw-config action_
cargo test -p zeroclaw-config zero_budget
cargo test -p zeroclaw-config expired_success
# 12 matched tests passed; 0 failed

cargo test -p zeroclaw-tools rate_limited_
cargo test -p zeroclaw-tools coding_agent_
# 12 matched tests passed; 0 failed

cargo clippy -p zeroclaw-tools --all-targets --all-features --no-deps -- -D warnings
# Finished successfully

cargo test -p zeroclaw-runtime wrapped_file_read_failure_preserves_rate_limit_budget
cargo test -p zeroclaw-runtime wrapped_delivery_charges_success_once_and_failure_zero_times
# 2 matched tests passed; 0 failed
```

- **Beyond CI, what did you manually verify?** Inspected the production `RateLimitedTool` registrations and the repository's action-accounting call sites to confirm that registered inner tools do not retain a second debit. Verified that success commits once; capacity rejection, failed `ToolResult`, inner error, cancellation, and panic release capacity; zero-budget and failed calls do not retain empty sender buckets; and policy clones do not copy in-flight usage. No external provider or coding-agent process was invoked.
- **If any command was intentionally skipped, why:** Broad local workspace validation was skipped because focused tests exercise the changed contract directly and required CI covers the workspace. The two runtime tests emitted the known non-blocking macOS linker warning `ld: __eh_frame section too large`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. This is a security-policy accounting repair: admission is now atomic before side effects, unsuccessful work refunds capacity, and existing autonomy authorization remains in place.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert ab760ae854 5af4d9d991 76334361f8`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Premature action-budget rejection after one coding-agent call, more wrapped side effects entering than the configured remaining budget permits, a successful result being discarded as over budget, or action capacity remaining unavailable after a failed or cancelled call.
