### PR TITLE
fix(channels): bound QQ and Mattermost downloads

### DIFF
--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -622,36 +622,24 @@ impl MattermostChannel {
             return None;
         }
 
-        if let Some(content_length) = response.content_length()
-            && content_length > MAX_MATTERMOST_AUDIO_BYTES
-        {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(
-                        ::serde_json::json!({"content_length": content_length, "file_id": file_id})
-                    ),
-                "audio file too large ( bytes)"
-            );
-            return None;
-        }
-
-        let bytes = match response.bytes().await {
-            Ok(b) => b,
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(
-                            ::serde_json::json!({"error": format!("{}", e), "file_id": file_id})
-                        ),
-                    "failed to read audio bytes for"
-                );
-                return None;
-            }
-        };
+        let bytes =
+            match crate::util::read_response_body_limited(response, MAX_MATTERMOST_AUDIO_BYTES)
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                            .with_attrs(
+                                ::serde_json::json!({"error": format!("{}", e), "file_id": file_id})
+                            ),
+                        "failed to read audio bytes for"
+                    );
+                    return None;
+                }
+            };
 
         match manager.transcribe(&bytes, file_name).await {
             Ok(text) => {
@@ -2630,6 +2618,77 @@ mod tests {
 
             let result = ch.try_transcribe_audio_attachment(&post).await;
             assert_eq!(result.as_deref(), Some("[Voice] test transcript"));
+        }
+
+        #[tokio::test]
+        async fn mattermost_audio_rejects_declared_oversize_before_transcription() {
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                MAX_MATTERMOST_AUDIO_BYTES + 1
+            )
+            .into_bytes();
+            let (mattermost_url, server) =
+                crate::util::spawn_raw_http_response(response, true).await;
+            let mock_server = MockServer::start().await;
+
+            Mock::given(method("POST"))
+                .and(path("/v1/audio/transcriptions"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"text": "wrong"})))
+                .expect(0)
+                .mount(&mock_server)
+                .await;
+
+            let ch = MattermostChannel::new(
+                mattermost_url,
+                Some("test_token".to_string()),
+                None,
+                None,
+                Vec::new(),
+                "mattermost_test_alias",
+                Arc::new(|| vec!["*".into()]),
+                false,
+                false,
+            )
+            .with_transcription(zeroclaw_config::schema::TranscriptionConfig {
+                enabled: true,
+                api_key: None,
+                api_url: "https://api.groq.com/openai/v1/audio/transcriptions".to_string(),
+                model: "whisper-large-v3".to_string(),
+                language: None,
+                initial_prompt: None,
+                max_audio_bytes: None,
+                max_duration_secs: 600,
+                openai: None,
+                deepgram: None,
+                assemblyai: None,
+                google: None,
+                local_whisper: Some(zeroclaw_config::schema::LocalWhisperConfig {
+                    url: format!("{}/v1/audio/transcriptions", mock_server.uri()),
+                    bearer_token: Some("test_token".to_string()),
+                    max_audio_bytes: 25_000_000,
+                    timeout_secs: 300,
+                }),
+                transcribe_non_ptt_audio: false,
+            });
+            let post = json!({
+                "metadata": {
+                    "files": [{
+                        "id": "file1",
+                        "mime_type": "audio/ogg",
+                        "name": "voice.ogg"
+                    }]
+                }
+            });
+
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                ch.try_transcribe_audio_attachment(&post),
+            )
+            .await
+            .expect("declared oversize must be rejected before reading the body");
+            server.abort();
+
+            assert!(result.is_none());
         }
 
         #[tokio::test]

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -1211,7 +1211,7 @@ impl QQChannel {
             anyhow::bail!("Download failed ({}): {url}", resp.status());
         }
 
-        let bytes = resp.bytes().await?.to_vec();
+        let bytes = crate::util::read_response_body_limited(resp, QQ_MAX_UPLOAD_BYTES).await?;
         tokio::fs::write(&dest, &bytes).await?;
 
         Ok((dest, bytes))
@@ -2460,6 +2460,51 @@ allowed_users = ["user1"]
         assert!(result.contains("[VOICE:"));
         assert!(result.contains("qq_files/download_"));
         assert!(result.contains(".wav]"));
+    }
+
+    #[tokio::test]
+    async fn oversized_attachment_keeps_remote_marker_without_writing_file() {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            QQ_MAX_UPLOAD_BYTES + 1
+        )
+        .into_bytes();
+        let (server_url, server) = crate::util::spawn_raw_http_response(response, true).await;
+
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let ch = QQChannel::new(
+            "id".into(),
+            "secret".into(),
+            "qq_test_alias",
+            Arc::new(Vec::new),
+        )
+        .with_workspace_dir(workspace.path().to_path_buf());
+        let remote_url = format!("{server_url}/oversized.png");
+        let payload = json!({
+            "attachments": [{
+                "content_type": "image/png",
+                "filename": "oversized.png",
+                "url": remote_url
+            }]
+        });
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            composed_content(&ch, &payload),
+        )
+        .await
+        .expect("declared oversize must be rejected before reading the body")
+        .unwrap();
+        server.abort();
+
+        assert!(
+            result.contains(&format!("[IMAGE:{remote_url}]")),
+            "unexpected composed content: {result:?}"
+        );
+        let mut files = tokio::fs::read_dir(workspace.path().join("qq_files"))
+            .await
+            .unwrap();
+        assert!(files.next_entry().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -79,7 +79,7 @@ pub(crate) async fn spawn_raw_http_response(
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
-    let server = tokio::spawn(async move {
+    let server = zeroclaw_spawn::spawn!(async move {
         let (mut socket, _) = listener.accept().await.unwrap();
         let mut request = [0_u8; 1024];
         let _ = socket.read(&mut request).await.unwrap();

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -41,6 +41,58 @@ pub fn floor_char_boundary(s: &str, max_bytes: usize) -> usize {
     end
 }
 
+#[cfg(any(feature = "channel-mattermost", feature = "channel-qq"))]
+pub(crate) async fn read_response_body_limited(
+    mut response: reqwest::Response,
+    max_bytes: u64,
+) -> anyhow::Result<Vec<u8>> {
+    if let Some(content_length) = response.content_length()
+        && content_length > max_bytes
+    {
+        anyhow::bail!(
+            "response body content length {content_length} exceeds {max_bytes}-byte limit"
+        );
+    }
+
+    let mut body = Vec::new();
+
+    while let Some(chunk) = response.chunk().await? {
+        let chunk_len = u64::try_from(chunk.len()).unwrap_or(u64::MAX);
+        let next_len = u64::try_from(body.len())
+            .unwrap_or(u64::MAX)
+            .saturating_add(chunk_len);
+        if next_len > max_bytes {
+            anyhow::bail!("response body exceeds {max_bytes}-byte limit");
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body)
+}
+
+#[cfg(all(test, any(feature = "channel-mattermost", feature = "channel-qq")))]
+pub(crate) async fn spawn_raw_http_response(
+    raw_response: Vec<u8>,
+    hold_open: bool,
+) -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = socket.read(&mut request).await.unwrap();
+        socket.write_all(&raw_response).await.unwrap();
+        if hold_open {
+            std::future::pending::<()>().await;
+        }
+        socket.shutdown().await.unwrap();
+    });
+
+    (format!("http://{address}"), server)
+}
+
 pub const BLOCK_KIT_PREFIX: &str = "__ZEROCLAW_BLOCK_KIT__";
 
 pub fn strip_tool_call_tags(message: &str) -> String {
@@ -476,6 +528,77 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(any(feature = "channel-mattermost", feature = "channel-qq"))]
+    async fn response_from_raw_http(
+        raw_response: Vec<u8>,
+        hold_open: bool,
+    ) -> (reqwest::Response, tokio::task::JoinHandle<()>) {
+        let (url, server) = spawn_raw_http_response(raw_response, hold_open).await;
+        let response = reqwest::get(url).await.unwrap();
+        (response, server)
+    }
+
+    #[cfg(any(feature = "channel-mattermost", feature = "channel-qq"))]
+    #[tokio::test]
+    async fn bounded_response_body_rejects_declared_oversize() {
+        let (response, server) = response_from_raw_http(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\n".to_vec(),
+            true,
+        )
+        .await;
+
+        let error = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            read_response_body_limited(response, 5),
+        )
+        .await
+        .expect("declared oversize must be rejected before reading the body")
+        .unwrap_err();
+        server.abort();
+
+        assert!(
+            error
+                .to_string()
+                .contains("content length 6 exceeds 5-byte limit")
+        );
+    }
+
+    #[cfg(any(feature = "channel-mattermost", feature = "channel-qq"))]
+    #[tokio::test]
+    async fn bounded_response_body_accepts_chunked_body_at_limit() {
+        let (response, server) = response_from_raw_http(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n2\r\nab\r\n3\r\ncde\r\n0\r\n\r\n".to_vec(),
+            false,
+        )
+        .await;
+
+        let body = read_response_body_limited(response, 5).await.unwrap();
+        server.await.unwrap();
+
+        assert_eq!(body, b"abcde");
+    }
+
+    #[cfg(any(feature = "channel-mattermost", feature = "channel-qq"))]
+    #[tokio::test]
+    async fn bounded_response_body_rejects_chunked_body_over_limit() {
+        let (response, server) = response_from_raw_http(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n3\r\nabc\r\n3\r\ndef\r\n".to_vec(),
+            true,
+        )
+        .await;
+
+        let error = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            read_response_body_limited(response, 5),
+        )
+        .await
+        .expect("chunked oversize must be rejected before the response ends")
+        .unwrap_err();
+        server.abort();
+
+        assert!(error.to_string().contains("exceeds 5-byte limit"));
+    }
 
     #[cfg(any(feature = "channel-slack", feature = "channel-telegram"))]
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Add one shared bounded HTTP response reader, deliberately reuse QQ's existing 10 MiB `QQ_MAX_UPLOAD_BYTES` media limit for inbound attachment downloads, and enforce Mattermost's existing 25 MiB audio limit even when `Content-Length` is missing or dishonest.
- **Scope boundary:** This does not change configuration, transcription providers, outbound uploads, Email or Telegram handling, or the broader attachment architecture.
- **Blast radius:** QQ attachments saved into the workspace and Mattermost audio downloaded for transcription. Responses at the limit remain accepted; oversized responses are rejected before persistence or transcription.
- **Linked issue(s):** Related #9488
- **Labels:** `bug`, `channel`, `security`, `channel:mattermost`, `channel:qq`, `risk:high`, `size:S`

### What this does, simply

- QQ and Mattermost download attachments from messaging servers before ZeroClaw can save or transcribe them.

  Previously, QQ collected the complete response without enforcing its attachment limit, while Mattermost relied on the server's declared size and collected the complete response when that header was absent. A server could therefore make ZeroClaw hold an unexpectedly large response in memory.

  This PR reads each response in chunks and stops as soon as the applicable limit would be crossed. QQ writes to the workspace only after the complete attachment stays within 10 MiB; Mattermost sends audio to transcription only after the complete body stays within 25 MiB. Oversized responses and response-read errors remain non-fatal to the channel and follow the existing warning-and-skip path.

## Testing

### How you can test

- **Reviewer testing requested?** N/A. The security boundary depends on precisely controlled incomplete and chunked HTTP responses, which the focused automated tests exercise directly.

### How I tested

- **CI checks relied on and why they cover this change:** Required GitHub checks passed on head `80c677806345f7fa48e656363673eb75930a948a`, providing broader workspace, lint, platform, and feature coverage around the focused channel tests below.
- **Known CI coverage gap, if any:** None known.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
cargo test -p zeroclaw-channels --no-default-features --features channel-qq,channel-mattermost bounded_response_body -- --nocapture
cargo test -p zeroclaw-channels --no-default-features --features channel-qq,channel-mattermost oversized_attachment_keeps_remote_marker_without_writing_file -- --nocapture
cargo test -p zeroclaw-channels --no-default-features --features channel-qq,channel-mattermost mattermost_audio_rejects_declared_oversize_before_transcription -- --nocapture
```

```text
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 720 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 722 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 722 filtered out
```

These five focused tests cover three shared response boundaries, one QQ persistence/fallback path, and one Mattermost transcription boundary.

- **Beyond CI, what did you manually verify?** Inspected both production callers and verified that QQ writes only a completed bounded body, while Mattermost invokes transcription only after a bounded body succeeds. The tests withhold the declared body or chunked terminator to prove rejection happens before EOF.
- **If any command was intentionally skipped, why:** No broad local workspace run; required CI provides broader regression coverage, while focused tests exercise the changed network-resource boundary.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. The accumulated accepted body is capped at the existing channel limit. QQ persists it only after the bounded read succeeds, Mattermost forwards it only after the bounded read succeeds, and an oversized body is dropped through the existing warning-and-skip path.

## Compatibility

- Backward compatible? `No`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: QQ inbound attachments above 10 MiB now remain remote markers instead of being saved locally, and Mattermost audio above 25 MiB remains untranscribed. No configuration migration is required.

## Rollback

- **Fast rollback command/path:** Revert this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Valid in-limit QQ attachments unexpectedly remain remote URLs, or valid in-limit Mattermost audio stops reaching transcription; inspect channel warning logs for bounded-response read failures.
