### PR TITLE
fix(tests): gate non-UTF-8 browser path fixtures to Linux

### DIFF
--- a/crates/zeroclaw-tools/src/browser.rs
+++ b/crates/zeroclaw-tools/src/browser.rs
@@ -3491,8 +3491,13 @@ mod tests {
     /// backend receives the action. If the validator call is removed, this
     /// fails (the backends would otherwise succeed or error without the
     /// specific allowlist rejection).
+    ///
+    /// Linux-only: the fixture needs a directory whose name carries a raw
+    /// non-UTF-8 byte, and macOS (APFS) rejects such pathnames at
+    /// `create_dir_all` time with `EILSEQ`, so the fixture cannot be built
+    /// there.
     #[tokio::test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     async fn execute_action_rejects_non_utf8_canonical_target_before_backend_dispatch() {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
@@ -3551,8 +3556,12 @@ mod tests {
     /// ComputerUse shares the same canonical target validator, so a non-UTF-8
     /// canonical destination is rejected locally — before the sidecar round
     /// trip — and is never forwarded.
+    ///
+    /// Linux-only for the same reason as
+    /// `execute_action_rejects_non_utf8_canonical_target_before_backend_dispatch`:
+    /// macOS rejects the raw-byte pathname fixture with `EILSEQ`.
     #[tokio::test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     async fn computer_use_rejects_non_utf8_canonical_target_before_sidecar() {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `execute_action_rejects_non_utf8_canonical_target_before_backend_dispatch` and `computer_use_rejects_non_utf8_canonical_target_before_sidecar` build a fixture directory whose name carries a raw `0xFF` byte. They were gated `#[cfg(unix)]`, but macOS (APFS) rejects non-UTF-8 pathname bytes at `create_dir_all` time with `EILSEQ`, so on the hosted macOS job both tests panic in fixture setup before reaching the production assertion (#9955).
  - Narrowed the gate to `#[cfg(target_os = "linux")]` and documented the platform limitation in each test's doc comment.
  - Linux continues to exercise the raw-byte canonical-path rejection boundary unchanged.
- **Scope boundary:** No production code changes. The fail-closed screenshot-path validator and both backends are untouched; only two test attributes and their doc comments change.
- **Blast radius:** Test matrix only — the advisory macOS workspace job stops failing these two tests; Linux coverage is unchanged. No runtime behavior affected.
- **Linked issue(s):** Fixes #9955
- **Labels:** `bug`, `tool`, `tests`, `distinguished contributor`, `tool:browser`, `priority:p2`, `risk:low`, `size:XS`, `type:test`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes, if you have macOS handy; otherwise CI covers it.
- **Interface(s) exercised:** None — test-only change, no `web`/`tui`/`cli` surface.
- **Setup / preconditions:** A macOS host with the Rust toolchain.
- **Steps to run:** `cargo test -p zeroclaw-tools --lib browser::`
- **Expected on this branch (after):** Module passes; the two raw-byte fixture tests are compiled out on macOS (91 passed locally).
- **Prior behavior on `master` (before):** Both tests panic unwrapping `tokio::fs::create_dir_all` with `Os { code: 92, ... "Illegal byte sequence" }` before the validator assertion runs.

### How I tested

On macOS 15 (the platform the issue reports):

```text
$ cargo fmt -p zeroclaw-tools -- --check
(clean, exit 0)

$ cargo clippy -p zeroclaw-tools --all-targets -- -D warnings
    Checking zeroclaw-tools v0.8.4 (...)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 22s

$ cargo test -p zeroclaw-tools --lib browser::
test result: ok. 91 passed; 0 failed; 0 ignored; 0 measured; 1538 filtered out; finished in 0.35s
```

- **CI checks relied on and why they cover this change:** Required Linux workspace tests prove the two gated tests still compile and pass on Linux (`target_os = "linux"` is a strict subset of the previous `unix` gate, and only doc comments were added inside it). The author-provided macOS module run demonstrates that the unsupported fixtures are excluded and the remaining browser tests pass.
- **Known CI coverage gap, if any:** I could not cross-`cargo check` the Linux cfg locally (no cross gcc for a `cc`-built dependency); covered by required Linux CI as above.
- **Commands run and tail output:** See above.
- **Beyond CI, what did you manually verify?** Confirmed the two test names no longer appear in the compiled macOS test binary (filtered out of `--lib browser::`), and that the other `#[cfg(unix)]` symlink tests in the module still run and pass on macOS. Did not verify Windows (tests were already unix-gated; unchanged there).
- **If any command was intentionally skipped, why:** Full workspace suite skipped — the change is scoped to two test attributes in `zeroclaw-tools`; module-level run plus crate-level clippy match the surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.


