### PR TITLE
fix(tools): accept camelCase segments in google_workspace validation

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -20836,9 +20836,12 @@ impl Config {
                     "google_workspace.allowed_operations[{i}].service contains invalid characters: {service}"
                 );
             }
+            // Unlike service IDs, resource/sub_resource/method names are camelCase
+            // in the Google APIs (calendarList, quickAdd, batchUpdate), so
+            // uppercase must be accepted here and in the runtime tool check.
             if !resource
                 .chars()
-                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
             {
                 anyhow::bail!(
                     "google_workspace.allowed_operations[{i}].resource contains invalid characters: {resource}"
@@ -20854,7 +20857,7 @@ impl Config {
                 }
                 if !sub
                     .chars()
-                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
                 {
                     anyhow::bail!(
                         "google_workspace.allowed_operations[{i}].sub_resource contains invalid characters: {sub}"
@@ -20880,7 +20883,7 @@ impl Config {
                 }
                 if !normalized
                     .chars()
-                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
                 {
                     anyhow::bail!(
                         "google_workspace.allowed_operations[{i}].methods[{j}] contains invalid characters: {normalized}"
@@ -30380,6 +30383,35 @@ api_token = "tok"
                 resource: "files".into(),
                 sub_resource: None,
                 methods: vec!["list".into(), "get".into()],
+            },
+        ];
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    async fn google_workspace_allowed_operations_accept_camelcase_entries() {
+        // Google API resource/method identifiers are camelCase; the shipped
+        // examples (calendarList, quickAdd, batchUpdate) must validate.
+        let mut config = Config::default();
+        config.google_workspace.allowed_operations = vec![
+            GoogleWorkspaceAllowedOperation {
+                service: "calendar".into(),
+                resource: "calendarList".into(),
+                sub_resource: None,
+                methods: vec!["list".into(), "get".into()],
+            },
+            GoogleWorkspaceAllowedOperation {
+                service: "calendar".into(),
+                resource: "events".into(),
+                sub_resource: None,
+                methods: vec!["quickAdd".into()],
+            },
+            GoogleWorkspaceAllowedOperation {
+                service: "gmail".into(),
+                resource: "users".into(),
+                sub_resource: Some("sendAs".into()),
+                methods: vec!["list".into()],
             },
         ];
 

--- a/crates/zeroclaw-tools/src/google_workspace.rs
+++ b/crates/zeroclaw-tools/src/google_workspace.rs
@@ -237,13 +237,13 @@ impl Tool for GoogleWorkspaceTool {
             };
             if !s
                 .chars()
-                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
             {
                 return Ok(ToolResult {
                     success: false,
                     output: ToolOutput::default(),
                     error: Some(
-                        "Invalid characters in 'sub_resource': only lowercase alphanumeric, underscore, and hyphen are allowed"
+                        "Invalid characters in 'sub_resource': only alphanumeric, underscore, and hyphen are allowed"
                             .into(),
                     ),
                 });
@@ -289,7 +289,8 @@ impl Tool for GoogleWorkspaceTool {
             });
         }
 
-        // Validate inputs contain no shell metacharacters
+        // Validate inputs contain no shell metacharacters. Uppercase must pass:
+        // Google API identifiers are camelCase (calendarList, quickAdd).
         for (label, value) in [
             ("service", service),
             ("resource", resource),
@@ -297,13 +298,13 @@ impl Tool for GoogleWorkspaceTool {
         ] {
             if !value
                 .chars()
-                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
             {
                 return Ok(ToolResult {
                     success: false,
                     output: ToolOutput::default(),
                     error: Some(format!(
-                        "Invalid characters in '{label}': only lowercase alphanumeric, underscore, and hyphen are allowed"
+                        "Invalid characters in '{label}': only alphanumeric, underscore, and hyphen are allowed"
                     )),
                 });
             }
@@ -646,6 +647,58 @@ mod tests {
                 .as_deref()
                 .unwrap_or("")
                 .contains("Invalid characters")
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_camelcase_resource_and_method_past_charset_validation() {
+        // Google API identifiers are camelCase (calendarList, quickAdd). The
+        // invalid `format` stops execution deterministically after the charset
+        // check, so this test never spawns `gws`.
+        let tool =
+            GoogleWorkspaceTool::new(test_security(), vec![], vec![], None, None, 60, 30, false);
+        let result = tool
+            .execute(json!({
+                "service": "calendar",
+                "resource": "calendarList",
+                "method": "quickAdd",
+                "format": "xml"
+            }))
+            .await
+            .expect("camelCase segments should return a result");
+        assert!(!result.success);
+        let err = result.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("Invalid format"),
+            "camelCase should pass charset validation and fail on format, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_camelcase_sub_resource_past_charset_validation() {
+        // The zero-action rate limit trips right after the sub_resource charset
+        // check, so this test never spawns `gws`.
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            max_actions_per_hour: 0,
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        });
+        let tool = GoogleWorkspaceTool::new(security, vec![], vec![], None, None, 60, 30, false);
+        let result = tool
+            .execute(json!({
+                "service": "gmail",
+                "resource": "users",
+                "sub_resource": "sendAs",
+                "method": "list"
+            }))
+            .await
+            .expect("camelCase sub_resource should return a result");
+        assert!(!result.success);
+        let err = result.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("Rate limit"),
+            "camelCase sub_resource should pass charset validation and hit the rate limit, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `google_workspace` tool's charset validation accepted only lowercase in `service`/`resource`/`method`/`sub_resource`, but Google API identifiers are camelCase (`calendarList`, `quickAdd`, `batchUpdate`) — so operations the operator explicitly allowlisted were rejected at runtime with "Invalid characters in resource 'calendarList'".
  - The config validator applied the same lowercase-only check to `[google_workspace] allowed_operations` `resource`/`sub_resource`/`methods`, so a curated allowlist containing those identifiers could not even pass `Config::validate()`.
  - The config and runtime checks for `resource`/`sub_resource`/`method` now accept case-insensitive ASCII alphanumeric plus `_`/`-`. Configured service IDs stay lowercase-only, and runtime service admission remains constrained by exact allowed-services membership.
  - Shell-metacharacter rejection is unchanged: `;`, `$( )`, spaces, `!`, etc. are still refused, and the values are passed as argv to the spawned `gws` process (never through a shell).
- **Scope boundary:** No change to allowlist semantics, rate limiting, budget charging, `gws` invocation, or the config schema surface. Configured service IDs remain lowercase-only, and runtime service authorization remains exact allowed-services membership.
- **Blast radius:** `google_workspace` tool callers and validation of `[google_workspace]` config sections. No other subsystem consumes these checks.
- **Linked issue(s):** Related #9044 (documented the camelCase-method half of this; closed without a fix).
- **Labels:** `bug`, `config`, `tool`, `distinguished contributor`, `priority:p2`, `tool:google-workspace`, `risk:high`, `size:S`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — manual repro needs an authenticated `gws` install; the new unit tests encode the before/after delta at the exact validation boundary (they fail on `master`, pass here).

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust CI (fmt, clippy, tests) — the change is two validation predicates plus tests in `zeroclaw-tools` and `zeroclaw-config`.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
(clean)

$ cargo clippy -p zeroclaw-tools -p zeroclaw-config --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 45s

$ cargo test -p zeroclaw-tools google_workspace
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 1599 filtered out

$ cargo test -p zeroclaw-tools camelcase
test google_workspace::tests::accepts_camelcase_resource_and_method_past_charset_validation ... ok
test google_workspace::tests::accepts_camelcase_sub_resource_past_charset_validation ... ok
test result: ok. 2 passed; 0 failed

$ cargo test -p zeroclaw-config --lib google_workspace_allowed
test schema::tests::google_workspace_allowed_operations_accept_camelcase_entries ... ok
(and 10 pre-existing allowed_operations tests)
test result: ok. 11 passed; 0 failed
```

- **Beyond CI, what did you manually verify?** The bug itself was reproduced on a live 0.8.4 deployment before this fix (an agent call `calendar calendarList list`, permitted by the operator allowlist, failed with the "Invalid characters" error). The fixed binary was not deployed for live re-verification; the new unit tests cover the boundary deterministically without spawning `gws` (one stops on the invalid `format`, the other on a zero-action rate limit — both checks sit between charset validation and process spawn).
- **If any command was intentionally skipped, why:** full-workspace `cargo test` skipped locally; the change is scoped to the two crates tested above and CI runs the full suite.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: — (Note: the resource/method/sub-resource relaxation only adds uppercase ASCII letters to the accepted set; every shell metacharacter remains rejected, and the operation allowlist remains the authorization gate.)

## Compatibility (required)

- Backward compatible? Yes — strictly widens accepted input; configs and calls that validated before still validate identically.
- Config / env / CLI surface changed? No (validation behavior only; no schema change).
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-sha>`
- **Feature flags or config toggles:** Set `[google_workspace].enabled = false` to stop registering the tool while the revert is prepared.
- **Observable failure symptoms:** Valid camelCase resources, methods, or sub-resources fail config validation or return an `Invalid characters` tool error before `gws` starts.
