### PR TITLE
feat(memory): honor the preference subtype only for user-authored turns

### DIFF
--- a/crates/zeroclaw-api/src/ingress.rs
+++ b/crates/zeroclaw-api/src/ingress.rs
@@ -52,6 +52,33 @@ pub enum TurnOrigin {
     SubTurn,
 }
 
+impl TurnOrigin {
+    /// Whether this turn's user-side text is a person's own words.
+    ///
+    /// True only for origins where the "user" half of the turn was typed by a
+    /// human: an interactive operator session or a channel peer message.
+    /// Autonomous origins (cron, heartbeat) put operator-configured task text
+    /// there, and `AgentDirect`/`SubTurn` put whatever the embedding program
+    /// or parent turn composed — none of that is a person speaking for
+    /// themself, even when it quotes one.
+    ///
+    /// Consumers use this as a provenance attestation (e.g. memory
+    /// consolidation only honors the model-emitted `preference` subtype for
+    /// user-authored turns), so the default for any new origin must be `false`
+    /// until someone argues otherwise — which is why this match has no
+    /// wildcard arm.
+    #[must_use]
+    pub fn user_authored(self) -> bool {
+        match self {
+            TurnOrigin::Interactive | TurnOrigin::Channel => true,
+            TurnOrigin::Cron
+            | TurnOrigin::Daemon
+            | TurnOrigin::AgentDirect
+            | TurnOrigin::SubTurn => false,
+        }
+    }
+}
+
 /// Trust class resolved for the turn's sender. Minimal for phase 1; peer-group
 /// resolution (the real source) is phase 2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -169,6 +196,29 @@ pub enum IngressDecision {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The full truth table, pinned per variant. `user_authored` is a
+    /// provenance attestation consumed fail-closed (preference capture,
+    /// eventually other origin-gated memory behavior), so every variant's
+    /// answer is an explicit decision here, not a wildcard default.
+    #[test]
+    fn user_authored_is_true_only_for_a_person_typing() {
+        assert!(TurnOrigin::Interactive.user_authored());
+        assert!(TurnOrigin::Channel.user_authored());
+
+        assert!(!TurnOrigin::Cron.user_authored());
+        assert!(!TurnOrigin::Daemon.user_authored());
+        assert!(!TurnOrigin::AgentDirect.user_authored());
+        assert!(!TurnOrigin::SubTurn.user_authored());
+    }
+
+    /// The serde fail-closed default (`SubTurn`) must also be fail-closed
+    /// for provenance: a legacy envelope with no origin never attests
+    /// user authorship.
+    #[test]
+    fn default_origin_is_not_user_authored() {
+        assert!(!TurnOrigin::default().user_authored());
+    }
 
     #[test]
     fn sub_turn_envelope_is_internal_and_trusted() {

--- a/crates/zeroclaw-api/src/memory_traits.rs
+++ b/crates/zeroclaw-api/src/memory_traits.rs
@@ -676,6 +676,13 @@ pub trait Memory: Send + Sync + crate::attribution::Attributable {
 #[async_trait]
 pub trait MemoryStrategy: Send + Sync {
     /// Consolidate a conversation turn into long-term memory.
+    ///
+    /// `origin` is the turn's provenance ([`crate::ingress::TurnOrigin`]).
+    /// Implementations use it to gate origin-sensitive classification —
+    /// notably, the `preference` memory subtype is only honored for
+    /// user-authored origins. Callers must pass the origin of the turn that
+    /// produced `user_message`, not the origin of the consolidation call
+    /// itself.
     async fn consolidate_turn(
         &self,
         user_message: &str,
@@ -683,6 +690,7 @@ pub trait MemoryStrategy: Send + Sync {
         provider: &dyn crate::model_provider::ModelProvider,
         model: &str,
         temperature: Option<f64>,
+        origin: crate::ingress::TurnOrigin,
     ) -> anyhow::Result<()>;
 
     /// Run memory governance (cleanup, archiving, background consolidation).

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -7603,6 +7603,9 @@ async fn process_channel_message_body(
                             model_provider.as_ref(),
                             &model,
                             temperature,
+                            // A channel peer's message: the user text is a
+                            // person's own words.
+                            zeroclaw_api::ingress::TurnOrigin::Channel,
                         )
                         .await
                     {

--- a/crates/zeroclaw-gateway/src/ws.rs
+++ b/crates/zeroclaw-gateway/src/ws.rs
@@ -1430,6 +1430,10 @@ async fn process_chat_message(
                             &memory_config,
                             &user_msg,
                             &assistant_resp,
+                            // A WS chat turn is a person typing in the web
+                            // UI — the same origin the gateway stamps on its
+                            // turn envelopes.
+                            zeroclaw_api::ingress::TurnOrigin::Interactive,
                         )
                         .await
                         {

--- a/crates/zeroclaw-memory/src/classify.rs
+++ b/crates/zeroclaw-memory/src/classify.rs
@@ -2,14 +2,27 @@
 
 use crate::consolidation::ConsolidationResult;
 use crate::traits::{MemoryKind, SemanticSubtype};
+use zeroclaw_api::ingress::TurnOrigin;
 
 /// Classify the long-lived Core write for a consolidation result.
-pub fn kind_of_core(result: &ConsolidationResult) -> MemoryKind {
+///
+/// Provenance clause: the `Preference` subtype asserts "the user themself
+/// expressed this preference," so it is honored only when the turn's text is
+/// a person's own words ([`TurnOrigin::user_authored`]). On an autonomous
+/// turn the model is summarizing its own work — a "preference" it emits
+/// there is inference, not something anyone said — so the update is recorded
+/// as a plain `Fact`: the content survives, the preference authority does
+/// not. Every other subtype is origin-independent.
+pub fn kind_of_core(result: &ConsolidationResult, origin: TurnOrigin) -> MemoryKind {
     let subtype = result
         .kind
         .as_deref()
         .map(parse_semantic_subtype)
         .unwrap_or(SemanticSubtype::Fact);
+    let subtype = match subtype {
+        SemanticSubtype::Preference if !origin.user_authored() => SemanticSubtype::Fact,
+        honored => honored,
+    };
     MemoryKind::Semantic(subtype)
 }
 
@@ -27,6 +40,16 @@ pub fn parse_semantic_subtype(raw: &str) -> SemanticSubtype {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn result_with_kind(kind: Option<&str>) -> ConsolidationResult {
+        ConsolidationResult {
+            history_entry: "Discussed rollout".into(),
+            memory_update: Some("Use staged rollout".into()),
+            facts: Vec::new(),
+            trend: None,
+            kind: kind.map(Into::into),
+        }
+    }
 
     #[test]
     fn parse_semantic_subtype_defaults_unknown_to_fact() {
@@ -46,25 +69,81 @@ mod tests {
 
     #[test]
     fn kind_of_core_uses_result_kind_or_fact_default() {
-        let decision = ConsolidationResult {
-            history_entry: "Discussed rollout".into(),
-            memory_update: Some("Use staged rollout".into()),
-            facts: Vec::new(),
-            trend: None,
-            kind: Some("decision".into()),
-        };
         assert_eq!(
-            kind_of_core(&decision),
+            kind_of_core(&result_with_kind(Some("decision")), TurnOrigin::Interactive),
             MemoryKind::Semantic(SemanticSubtype::Decision)
         );
-
-        let missing = ConsolidationResult {
-            kind: None,
-            ..decision
-        };
         assert_eq!(
-            kind_of_core(&missing),
+            kind_of_core(&result_with_kind(None), TurnOrigin::Interactive),
             MemoryKind::Semantic(SemanticSubtype::Fact)
         );
+    }
+
+    #[test]
+    fn preference_is_honored_when_a_person_typed_the_turn() {
+        for origin in [TurnOrigin::Interactive, TurnOrigin::Channel] {
+            assert_eq!(
+                kind_of_core(&result_with_kind(Some("preference")), origin),
+                MemoryKind::Semantic(SemanticSubtype::Preference),
+                "{origin:?} carries the user's own words, so preference stands"
+            );
+        }
+    }
+
+    /// The provenance clause itself: an autonomous turn has no user speech
+    /// in it, so a model-emitted "preference" is inference and must be
+    /// recorded without preference authority.
+    #[test]
+    fn preference_downgrades_to_fact_on_turns_no_person_authored() {
+        for origin in [
+            TurnOrigin::Cron,
+            TurnOrigin::Daemon,
+            TurnOrigin::AgentDirect,
+            TurnOrigin::SubTurn,
+        ] {
+            assert_eq!(
+                kind_of_core(&result_with_kind(Some("preference")), origin),
+                MemoryKind::Semantic(SemanticSubtype::Fact),
+                "{origin:?} is not a person speaking, so preference must downgrade to fact"
+            );
+        }
+    }
+
+    /// Alias spellings get no side door: every token that parses to
+    /// Preference downgrades the same way.
+    #[test]
+    fn preference_alias_spellings_downgrade_identically() {
+        for spelling in ["pref", "user_preference", " Preference "] {
+            assert_eq!(
+                kind_of_core(&result_with_kind(Some(spelling)), TurnOrigin::Cron),
+                MemoryKind::Semantic(SemanticSubtype::Fact),
+                "{spelling:?} parses to Preference and must downgrade on autonomous turns"
+            );
+        }
+    }
+
+    /// Only preference carries a provenance claim. Facts, decisions, and
+    /// entities describe the world, not the speaker, so autonomous turns
+    /// keep them unchanged.
+    #[test]
+    fn non_preference_subtypes_are_origin_independent() {
+        for origin in [
+            TurnOrigin::Interactive,
+            TurnOrigin::Cron,
+            TurnOrigin::SubTurn,
+        ] {
+            assert_eq!(
+                kind_of_core(&result_with_kind(Some("decision")), origin),
+                MemoryKind::Semantic(SemanticSubtype::Decision)
+            );
+            assert_eq!(
+                kind_of_core(&result_with_kind(Some("entity")), origin),
+                MemoryKind::Semantic(SemanticSubtype::Entity)
+            );
+            assert_eq!(
+                kind_of_core(&result_with_kind(Some("fact")), origin),
+                MemoryKind::Semantic(SemanticSubtype::Fact)
+            );
+        }
     }
 }

--- a/crates/zeroclaw-memory/src/consolidation.rs
+++ b/crates/zeroclaw-memory/src/consolidation.rs
@@ -10,6 +10,7 @@ use crate::policy_gate;
 use crate::traits::{
     Memory, MemoryCategory, MemoryEntry, MemoryKind, SemanticSubtype, StoreOptions,
 };
+use zeroclaw_api::ingress::TurnOrigin;
 use zeroclaw_api::model_provider::ModelProvider;
 use zeroclaw_config::schema::MemoryConfig;
 use zeroclaw_providers::ProviderDispatch;
@@ -73,6 +74,7 @@ pub async fn consolidate_turn(
     memory_config: &MemoryConfig,
     user_message: &str,
     assistant_response: &str,
+    origin: TurnOrigin,
 ) -> anyhow::Result<()> {
     let turn_text = format!(
         "User: {}\nAssistant: {}",
@@ -158,6 +160,23 @@ pub async fn consolidate_turn(
     if let Some(ref update) = result.memory_update
         && !update.trim().is_empty()
     {
+        // Provenance clause (see `classify::kind_of_core`): a model-emitted
+        // preference label on a turn no person authored is recorded as a
+        // plain fact. Logged so an operator wondering why an update lost
+        // its preference tag can see the decision, not just its result.
+        if memory_config.types.enabled
+            && !origin.user_authored()
+            && result.kind.as_deref().map(classify::parse_semantic_subtype)
+                == Some(SemanticSubtype::Preference)
+        {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(::serde_json::json!({"origin": format!("{origin:?}")})),
+                "memory consolidation downgraded preference to fact: turn is not user-authored"
+            );
+        }
+
         let mem_key = format!("core_{}", uuid::Uuid::new_v4());
 
         // Compute importance score heuristically.
@@ -202,7 +221,7 @@ pub async fn consolidate_turn(
                             memory_config
                                 .types
                                 .enabled
-                                .then(|| classify::kind_of_core(&result))
+                                .then(|| classify::kind_of_core(&result, origin))
                         }),
                         pinned: survivor.pinned,
                         tenant_id: survivor.tenant_id.clone(),
@@ -249,7 +268,7 @@ pub async fn consolidate_turn(
             kind: memory_config
                 .types
                 .enabled
-                .then(|| classify::kind_of_core(&result)),
+                .then(|| classify::kind_of_core(&result, origin)),
             ..StoreOptions::default()
         };
         memory
@@ -748,6 +767,15 @@ mod tests {
         memory: &dyn Memory,
         config: &MemoryConfig,
     ) -> anyhow::Result<()> {
+        run_consolidation_from(TurnOrigin::Interactive, provider, memory, config).await
+    }
+
+    async fn run_consolidation_from(
+        origin: TurnOrigin,
+        provider: &ScriptedProvider,
+        memory: &dyn Memory,
+        config: &MemoryConfig,
+    ) -> anyhow::Result<()> {
         consolidate_turn(
             provider,
             "test-model",
@@ -756,8 +784,69 @@ mod tests {
             config,
             "How do we deploy?",
             "We use a staged rollout.",
+            origin,
         )
         .await
+    }
+
+    const PREFERENCE_RESPONSE: &str = r#"{"history_entry": "Talked deploy style.", "memory_update": "Prefers staged rollouts over big-bang deploys.", "kind": "preference", "facts": [], "trend": null}"#;
+
+    /// Reads back the kind actually persisted for the primary Core write.
+    fn stored_core_kind(memory: &RecordingMemory) -> Option<MemoryKind> {
+        let writes = memory.writes.lock();
+        writes
+            .iter()
+            .find_map(|write| match write {
+                RecordedWrite::StoreWithOptions { key, options, .. }
+                    if key.starts_with("core_") && !key.starts_with("core_fact_") =>
+                {
+                    Some(options.kind.clone())
+                }
+                _ => None,
+            })
+            .expect("primary Core write")
+    }
+
+    /// The provenance clause, end to end: the same model output is stored
+    /// with preference authority when a person typed the turn and without
+    /// it when no person did. Drives the real `consolidate_turn`, so the
+    /// clause cannot silently detach from the store path.
+    #[tokio::test]
+    async fn preference_from_the_model_is_stored_as_fact_on_autonomous_turns() {
+        let config = MemoryConfig {
+            types: MemoryTypesConfig { enabled: true },
+            ..MemoryConfig::default()
+        };
+
+        for (origin, expected) in [
+            (
+                TurnOrigin::Interactive,
+                MemoryKind::Semantic(SemanticSubtype::Preference),
+            ),
+            (
+                TurnOrigin::Channel,
+                MemoryKind::Semantic(SemanticSubtype::Preference),
+            ),
+            (
+                TurnOrigin::Daemon,
+                MemoryKind::Semantic(SemanticSubtype::Fact),
+            ),
+            (
+                TurnOrigin::Cron,
+                MemoryKind::Semantic(SemanticSubtype::Fact),
+            ),
+        ] {
+            let provider = ScriptedProvider::new(PREFERENCE_RESPONSE);
+            let memory = RecordingMemory::default();
+            run_consolidation_from(origin, &provider, &memory, &config)
+                .await
+                .unwrap();
+            assert_eq!(
+                stored_core_kind(&memory),
+                Some(expected.clone()),
+                "{origin:?}: stored kind must reflect turn provenance"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1378,6 +1467,7 @@ mod consolidate_turn_tests {
             cfg,
             "user message",
             "assistant response",
+            TurnOrigin::Interactive,
         )
         .await
     }
@@ -1473,6 +1563,7 @@ mod consolidate_turn_tests {
             &MemoryConfig::default(),
             "please review [IMAGE:/home/user/private/cat.png]",
             "described the picture in [DOCUMENT:/tmp/notes.pdf]",
+            TurnOrigin::Interactive,
         )
         .await
         .unwrap();

--- a/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_strategy.rs
@@ -42,6 +42,7 @@ impl MemoryStrategy for DefaultMemoryStrategy {
         provider: &dyn ModelProvider,
         model: &str,
         temperature: Option<f64>,
+        origin: zeroclaw_api::ingress::TurnOrigin,
     ) -> anyhow::Result<()> {
         zeroclaw_memory::consolidation::consolidate_turn(
             provider,
@@ -51,6 +52,7 @@ impl MemoryStrategy for DefaultMemoryStrategy {
             &self.memory_config,
             user_message,
             assistant_response,
+            origin,
         )
         .await
     }

--- a/tests/integration/memory_loop_continuity.rs
+++ b/tests/integration/memory_loop_continuity.rs
@@ -397,6 +397,7 @@ async fn consolidation_extracts_facts_to_memory() {
         &MemoryConfig::default(),
         "The project deadline is April 15th 2026",
         "Got it, I'll remember the deadline is April 15th.",
+        zeroclaw_api::ingress::TurnOrigin::Interactive,
     )
     .await;
 
@@ -429,6 +430,7 @@ async fn memory_survives_rapid_consolidation() {
             &MemoryConfig::default(),
             &format!("User message {i}"),
             &format!("Assistant response {i}"),
+            zeroclaw_api::ingress::TurnOrigin::Interactive,
         )
         .await;
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The consolidation model labels each Core memory update with a semantic subtype, and `classify::kind_of_core` trusted a model-emitted `preference` unconditionally. `Preference` is a provenance claim — "the user themself expressed this" — but nothing verified a user was present in the turn. Both current consolidation callers (channel orchestrator, gateway WS chat) happen to be user-authored surfaces, so the claim holds by accident of wiring, not by contract; the first autonomous caller would silently mint preferences out of the model's own inference.
- This PR states the invariant at the layer that applies the label: `TurnOrigin::user_authored()` in `zeroclaw-api` (true only for `Interactive` and `Channel`; exhaustive match, no wildcard, so future origin variants force an explicit decision), `kind_of_core(result, origin)` downgrades an autonomous-turn `preference` to `Fact` (content survives, preference authority does not), and `consolidate_turn` / `MemoryStrategy::consolidate_turn` gain an `origin` parameter with each caller passing the origin its surface already stamps. The downgrade is logged at DEBUG.
- **Scope boundary:** No change to what gets stored, deduped, merged, or superseded — only to the `kind` metadata a non-user-authored `preference` receives. Non-preference subtypes are origin-independent. No config surface, no prompt change, no change to the verbatim autosave paths (heartbeat Daily stores, Conversation stores), which never classified.
- **Blast radius:** `MemoryStrategy` is a public trait in `zeroclaw-api` and its `consolidate_turn` gains a parameter — a compile-time break for external implementers (one implementer and two callers exist in-tree, all updated). Callers of `zeroclaw_memory::consolidation::consolidate_turn` likewise. Behavior changes only for a model-emitted `preference` on non-user-authored turns, a path no in-tree caller currently exercises.
- **Linked issue(s):** N/A
- **Labels:** `enhancement`, `agent`, `channel`, `gateway`, `memory`, `runtime`, `tests`, `distinguished contributor`, `channel:core`, `domain:security`, `priority:p2`, `risk:high`, `size:M`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the changed behavior (subtype metadata on a not-yet-wired autonomous consolidation path) has no user-visible surface today; the deterministic tests below are the observable contract.

### How I tested

Written test-first. With the `origin` parameter threaded but the downgrade not yet implemented, the new regressions failed and the negative controls passed:

```
failures:
    classify::tests::preference_alias_spellings_downgrade_identically
    classify::tests::preference_downgrades_to_fact_on_turns_no_person_authored
test result: FAILED. 7 passed; 2 failed
consolidation::tests::preference_from_the_model_is_stored_as_fact_on_autonomous_turns
  Daemon: stored kind must reflect turn provenance: left: Some(Semantic(Preference)) right: Some(Semantic(Fact))
```

After the one-match implementation, all green. New coverage:

- `user_authored_is_true_only_for_a_person_typing` + `default_origin_is_not_user_authored` (zeroclaw-api) — the full truth table per variant, and the serde fail-closed default is also provenance-fail-closed
- `preference_is_honored_when_a_person_typed_the_turn` — Interactive and Channel keep preference authority (negative control; passed at red)
- `preference_downgrades_to_fact_on_turns_no_person_authored` — Cron, Daemon, AgentDirect, SubTurn
- `preference_alias_spellings_downgrade_identically` — `pref`, `user_preference`, ` Preference ` get no side door
- `non_preference_subtypes_are_origin_independent` — facts/decisions/entities untouched (negative control; passed at red)
- `preference_from_the_model_is_stored_as_fact_on_autonomous_turns` — end-to-end through the real `consolidate_turn` store path with a scripted provider: the same model output stores as `Preference` for Interactive/Channel and `Fact` for Daemon/Cron, so the clause cannot silently detach from the store path

```sh
cargo test -p zeroclaw-memory     # 506 passed; 0 failed (+4, 0)
cargo test -p zeroclaw-api        # 166 passed; 0 failed (+1)
cargo test -p zeroclaw-runtime    # 3737 passed; 0 failed; 3 ignored
cargo test -p zeroclaw-channels   # 1391 passed; 1 failed (see note)
cargo test -p zeroclaw-gateway    # 436 passed; 0 failed (+9)
cargo clippy -p zeroclaw-api -p zeroclaw-memory -p zeroclaw-runtime \
  -p zeroclaw-channels -p zeroclaw-gateway --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                                                # clean
bash scripts/ci/comment_hygiene_gate.sh                                   # passed
```

- **CI checks relied on and why they cover this change:** the workspace test and lint gates over the five touched crates; the trait change is compile-checked by every consumer in the workspace matrix.
- **Known CI coverage gap, if any:** none specific to this change.
- **Beyond CI, what did you manually verify?** The full-suite `zeroclaw-channels` run had one failure, `tts::tests::edge_tts_timeout_kills_child_and_removes_temp_output` — a TTS child-process timing test this diff does not touch; it passes twice consecutively in isolation, so it is parallel-load flakiness, not a regression from this change. I verified both production call sites pass the origin their surface already stamps: the gateway stamps `TurnOrigin::Interactive` on its turn envelopes (`gateway/src/lib.rs`), and the orchestrator consolidates channel peer turns.
- **If any command was intentionally skipped, why:** no live-provider consolidation run; the scripted-provider e2e drives the identical store path.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No** — this narrows what a model-emitted label can claim: consolidation output can no longer assert user-preference provenance on turns no user authored.
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **No** — `MemoryStrategy::consolidate_turn` and `zeroclaw_memory::consolidation::consolidate_turn` gain an `origin: TurnOrigin` parameter (compile-time break for external implementers/callers).
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No`: pass the `TurnOrigin` of the turn that produced the user message — `Interactive` for operator chat surfaces, `Channel` for channel peer messages, `Cron`/`Daemon` for scheduled work. If the origin is unknown, `TurnOrigin::default()` (SubTurn) is the fail-closed choice: consolidation still runs, but preference authority is withheld.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`; no data or configuration migration. Memories already downgraded to `Fact` keep that kind — no stored data changes shape in either direction.
- **Feature flags or config toggles:** the downgrade only engages when `memory.types.enabled` is on (the only mode that classifies at all).
- **Observable failure symptoms:** a preference stated by a real user in chat being stored with `kind: fact` — grep DEBUG logs for "downgraded preference to fact" with an `Interactive`/`Channel` origin attribute, which would indicate an origin mis-stamped upstream.
