### PR TITLE
test(cron): avoid ETXTBSY race in custom shell test

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -2854,30 +2854,29 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "android")))]
     async fn build_cron_shell_command_executes_with_custom_native_shell() {
-        use std::os::unix::fs::PermissionsExt;
-
         let tmp = TempDir::new().unwrap();
         let shim = tmp.path().join("cron-shell-shim");
-        std::fs::write(
-            &shim,
-            "#!/bin/sh\nprintf 'CUSTOM_SHELL\\n'\nprintf 'arg:%s\\n' \"$@\"\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // Avoid writing an executable after the test process is multithreaded:
+        // a concurrently forked child can inherit the write descriptor and
+        // make the subsequent exec fail with ETXTBSY.
+        let shell = which::which("sh").unwrap();
+        std::os::unix::fs::symlink(shell, &shim).unwrap();
 
         let mut config = Config::default();
         config.runtime.shell = Some(shim.to_string_lossy().into_owned());
-        let mut cmd =
-            build_configured_shell_command(&config, "echo cron-custom", tmp.path()).unwrap();
+        let mut cmd = build_configured_shell_command(
+            &config,
+            "printf 'CUSTOM_SHELL:%s\\n' \"$0\"",
+            tmp.path(),
+        )
+        .unwrap();
         let output = cmd.output().await.unwrap();
         let stdout = String::from_utf8_lossy(&output.stdout);
 
         assert!(output.status.success());
-        assert!(stdout.contains("CUSTOM_SHELL"), "{stdout}");
-        assert!(stdout.contains("arg:-c"), "{stdout}");
-        assert!(stdout.contains("arg:echo cron-custom"), "{stdout}");
+        assert_eq!(stdout.trim(), format!("CUSTOM_SHELL:{}", shim.display()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replace the custom-shell regression test's runtime-written executable script with a per-test symlink to a PATH-resolved `sh`, avoiding the scheduling window in which a concurrently forked child can retain the script's write descriptor and make execution fail with `ETXTBSY`.
  - Assert that the shell sees the configured symlink as `$0`, preserving the test's proof that cron uses the configured custom shell path.
  - Exclude Android, where the native runtime intentionally ignores `runtime.shell`.
- **Scope boundary:** Test-only change. This PR does not alter production cron execution, shell selection, runtime configuration, the endpoint-lock flake tracked in #10006, or the separate TTS observation recorded on #9965.
- **Blast radius:** The Unix cron custom-shell regression test and the `Parallel Runtime Test` CI job. Production binaries are unchanged.
- **Linked issue(s):** Refs #9965
- **Labels:** `type:test`, `risk:high`, `size:XS`, `cron`, `runtime`

### What this does, simply

The test used to create an executable shell script after the asynchronous test process was already running with many threads. Under unlucky scheduling, another child process could inherit the script's open write descriptor, and the operating system would reject the test's attempt to execute that same file as busy.

The test now creates a symlink to an existing shell instead. Creating the symlink does not open an executable for writing, so it removes that race while still verifying that cron launches the exact custom shell path supplied by configuration. The repair does not depend on proving the inherited-descriptor hypothesis because the changed fixture no longer writes an executable at all.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is a test-only repair, and the hosted parallel runtime gate exercises the scheduling boundary more directly than a manual check.

### How I tested

- **CI checks relied on and why they cover this change:** `Parallel Runtime Test` passed on the exact PR head after running the runtime and channel library suites three times with 16 test threads, matching the gate in which #9965 was observed. The remaining required checks also passed.
- **Known CI coverage gap, if any:** None for this test-only scope after fresh required CI, including `Parallel Runtime Test`.
- **Commands run and tail output:**

```sh
cargo fmt --check
# passed

bash scripts/ci/comment_hygiene_gate.sh
# Comment hygiene gate passed.

cargo test --locked -p zeroclaw-runtime --lib cron::scheduler::tests::build_cron_shell_command_executes_with_custom_native_shell -- --exact
# test cron::scheduler::tests::build_cron_shell_command_executes_with_custom_native_shell ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3739 filtered out
```

- **Beyond CI, what did you manually verify?** The focused regression confirmed that `$0` exactly matched the configured per-test symlink path. I did not attempt to reproduce the nondeterministic `ETXTBSY` failure locally; the issue reporter's identical-tree fail/pass evidence establishes the scheduling dependence, and the hosted parallel gate is the relevant full check.
- **If any command was intentionally skipped, why:** Broad local workspace validation was skipped because the diff changes only one regression fixture. Fresh required CI, including `Parallel Runtime Test`, passed on the exact head and covers the broader integration surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the PR's merge commit.
- **Feature flags or config toggles:** None; this is test-only.
- **Observable failure symptoms:** `Parallel Runtime Test` continues to report `ExecutableFileBusy` for `build_cron_shell_command_executes_with_custom_native_shell`, or the focused test no longer reports the configured symlink path as `$0`.
