### PR TITLE
fix(providers): enforce OAuth callback and refresh contracts

### DIFF
--- a/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
@@ -1,6 +1,6 @@
 //! Google/Gemini OAuth2 authentication flow.
 
-use crate::auth::oauth_common::{parse_query_params, url_decode, url_encode};
+use crate::auth::oauth_common::{is_structured_callback_input, parse_query_params, url_encode};
 use crate::auth::profiles::TokenSet;
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -178,7 +178,7 @@ pub async fn refresh_access_token(
     if !status.is_success() {
         if let Ok(err) = serde_json::from_str::<OAuthErrorResponse>(&body) {
             anyhow::bail!(
-                "Google OAuth refresh error: {} - {}",
+                "Google OAuth refresh error ({status}): {} - {}",
                 err.error,
                 err.error_description.unwrap_or_default()
             );
@@ -363,14 +363,15 @@ async fn receive_loopback_code_inner(expected_state: &str, timeout: Duration) ->
                         .context("Failed to read from callback connection")?;
 
                     let request = String::from_utf8_lossy(&buffer[..n]);
-                    let (code, state) = parse_callback_request(&request)?;
-
-                    if state != expected_state {
+                    let code = match parse_callback_request(&request, expected_state) {
+                        Ok(code) => code,
+                        Err(error) => {
                         let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n\
-                             <html><body><h1>State mismatch</h1><p>Please try again.</p></body></html>";
+                             <html><body><h1>Invalid callback</h1><p>Please try again.</p></body></html>";
                         let _ = stream.write_all(response.as_bytes()).await;
-                        anyhow::bail!("OAuth state mismatch");
-                    }
+                            return Err(error);
+                        }
+                    };
 
                     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
                          <html><body><h1>Success!</h1><p>You can close this window and return to the terminal.</p></body></html>";
@@ -424,7 +425,7 @@ async fn receive_code_from_stdin(expected_state: &str) -> Result<String> {
             );
             return Err(anyhow::Error::msg("No input received"));
         }
-        parse_code_from_redirect(&trimmed, Some(&expected))
+        parse_manual_code_input(&trimmed, &expected)
     })
     .await
     .context("Failed to read from stdin")??;
@@ -432,44 +433,30 @@ async fn receive_code_from_stdin(expected_state: &str) -> Result<String> {
     Ok(input)
 }
 
-fn parse_callback_request(request: &str) -> Result<(String, String)> {
+fn parse_callback_request(request: &str, expected_state: &str) -> Result<String> {
     let first_line = request.lines().next().unwrap_or("");
-    let path = first_line
-        .split_whitespace()
-        .nth(1)
-        .unwrap_or("")
-        .to_string();
+    let path = first_line.split_whitespace().nth(1).unwrap_or("");
 
-    let query_start = path.find('?').map(|i| i + 1).unwrap_or(path.len());
-    let query = &path[query_start..];
+    parse_callback_code(&path, expected_state)
+}
 
-    let mut code = None;
-    let mut state = None;
-
-    for pair in query.split('&') {
-        if let Some((key, value)) = pair.split_once('=') {
-            match key {
-                "code" => code = Some(url_decode(value)),
-                "state" => state = Some(url_decode(value)),
-                _ => {}
-            }
-        }
+fn parse_callback_code(input: &str, expected_state: &str) -> Result<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("No OAuth code provided");
     }
 
-    let code = code.ok_or_else(|| {
-        ::zeroclaw_log::record!(
-            WARN,
-            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
-                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                .with_attrs(::serde_json::json!({
-                    "oauth_provider": "gemini",
-                    "missing": "code",
-                })),
-            "gemini_oauth: callback missing code parameter"
-        );
-        anyhow::Error::msg("No 'code' parameter in callback")
-    })?;
-    let state = state.ok_or_else(|| {
+    let query = trimmed.split_once('?').map_or(trimmed, |(_, query)| query);
+    let params = parse_query_params(query);
+
+    parse_callback_params(&params, expected_state)
+}
+
+fn parse_callback_params(
+    params: &std::collections::BTreeMap<String, String>,
+    expected_state: &str,
+) -> Result<String> {
+    let state = params.get("state").ok_or_else(|| {
         ::zeroclaw_log::record!(
             WARN,
             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
@@ -482,43 +469,73 @@ fn parse_callback_request(request: &str) -> Result<(String, String)> {
         );
         anyhow::Error::msg("No 'state' parameter in callback")
     })?;
+    if state != expected_state {
+        anyhow::bail!("OAuth state mismatch");
+    }
 
-    Ok((code, state))
+    if let Some(error) = params.get("error") {
+        let description = params
+            .get("error_description")
+            .map_or("OAuth authorization failed", String::as_str);
+        anyhow::bail!("Google OAuth error: {error} - {description}");
+    }
+
+    let code = params
+        .get("code")
+        .filter(|code| !code.trim().is_empty())
+        .ok_or_else(|| {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "oauth_provider": "gemini",
+                        "missing": "code",
+                    })),
+                "gemini_oauth: callback missing code parameter"
+            );
+            anyhow::Error::msg("No 'code' parameter in callback")
+        })?;
+
+    Ok(code.trim().to_string())
 }
 
-pub fn parse_code_from_redirect(input: &str, expected_state: Option<&str>) -> Result<String> {
+pub(super) fn parse_manual_code_input(input: &str, expected_state: &str) -> Result<String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         anyhow::bail!("No OAuth code provided");
     }
 
-    // Extract query string
-    let query = if let Some((_, right)) = trimmed.split_once('?') {
-        right
-    } else {
-        trimmed
-    };
-
+    let query = trimmed.split_once('?').map_or(trimmed, |(_, query)| query);
     let params = parse_query_params(query);
-
-    // If we have code param, extract it
-    if let Some(code) = params.get("code") {
-        // Validate state if expected
-        if let Some(expected) = expected_state
-            && let Some(actual) = params.get("state")
-            && actual != expected
-        {
-            anyhow::bail!("OAuth state mismatch: expected {expected}, got {actual}");
-        }
-        return Ok(code.clone());
+    if is_structured_callback_input(trimmed, "/auth/callback") {
+        return parse_callback_params(&params, expected_state);
     }
 
-    // Otherwise, assume it's the raw code (if long enough and no spaces)
     if trimmed.len() > 10 && !trimmed.contains(' ') && !trimmed.contains('&') {
         return Ok(trimmed.to_string());
     }
 
     anyhow::bail!("Could not parse OAuth code from input")
+}
+
+pub fn parse_code_from_redirect(input: &str, expected_state: Option<&str>) -> Result<String> {
+    match expected_state {
+        Some(state) => parse_callback_code(input, state),
+        None => {
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                anyhow::bail!("No OAuth code provided");
+            }
+            if is_structured_callback_input(trimmed, "/auth/callback") {
+                anyhow::bail!("Expected OAuth state is required for callback input");
+            }
+            if trimmed.len() > 10 && !trimmed.contains(' ') && !trimmed.contains('&') {
+                return Ok(trimmed.to_string());
+            }
+            anyhow::bail!("Could not parse OAuth code from input")
+        }
+    }
 }
 
 /// Extract account email from Google ID token.
@@ -597,17 +614,40 @@ mod tests {
     }
 
     #[test]
-    fn parse_code_from_url() {
+    fn callback_redirect_requires_matching_state() {
         let url = "http://localhost:1456/auth/callback?code=4/0test&state=xyz";
-        let code = parse_code_from_redirect(url, Some("xyz")).unwrap();
+        let code = parse_callback_code(url, "xyz").unwrap();
         assert_eq!(code, "4/0test");
+
+        assert!(parse_callback_code("/auth/callback?code=4/0test", "xyz").is_err());
+        assert!(parse_callback_code("4/0test", "xyz").is_err());
     }
 
     #[test]
-    fn parse_code_from_raw() {
+    fn manual_code_input_accepts_raw_code() {
         let raw = "4/0AcvDMrC1234567890abcdef";
-        let code = parse_code_from_redirect(raw, None).unwrap();
+        let code = parse_manual_code_input(raw, "xyz").unwrap();
         assert_eq!(code, raw);
+    }
+
+    #[test]
+    fn manual_callback_input_rejects_missing_or_mismatched_state() {
+        assert!(parse_manual_code_input("/auth/callback?code=4/0test", "xyz").is_err());
+        assert!(parse_manual_code_input("/auth/callback?code=4/0test&state=wrong", "xyz").is_err());
+    }
+
+    #[test]
+    fn manual_callback_input_rejects_url_or_path_without_query() {
+        for input in ["http://localhost:1456/auth/callback", "/auth/callback"] {
+            assert!(parse_manual_code_input(input, "xyz").is_err(), "{input}");
+        }
+    }
+
+    #[test]
+    fn compatibility_parser_accepts_raw_code_only_without_state_expectation() {
+        let raw = "4/0AcvDMrC1234567890abcdef";
+        assert_eq!(parse_code_from_redirect(raw, None).unwrap(), raw);
+        assert!(parse_code_from_redirect(raw, Some("xyz")).is_err());
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
@@ -437,7 +437,7 @@ fn parse_callback_request(request: &str, expected_state: &str) -> Result<String>
     let first_line = request.lines().next().unwrap_or("");
     let path = first_line.split_whitespace().nth(1).unwrap_or("");
 
-    parse_callback_code(&path, expected_state)
+    parse_callback_code(path, expected_state)
 }
 
 fn parse_callback_code(input: &str, expected_state: &str) -> Result<String> {

--- a/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/gemini_oauth.rs
@@ -633,7 +633,13 @@ mod tests {
     #[test]
     fn manual_callback_input_rejects_missing_or_mismatched_state() {
         assert!(parse_manual_code_input("/auth/callback?code=4/0test", "xyz").is_err());
-        assert!(parse_manual_code_input("/auth/callback?code=4/0test&state=wrong", "xyz").is_err());
+        for input in [
+            "/auth/callback?code=4/0test&state=wrong",
+            "?code=4/0test&state=wrong",
+            "https://example.test/other?code=4/0test&state=wrong",
+        ] {
+            assert!(parse_manual_code_input(input, "xyz").is_err(), "{input}");
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/auth/mod.rs
+++ b/crates/zeroclaw-providers/src/auth/mod.rs
@@ -6,13 +6,14 @@ pub mod openai_oauth;
 pub mod profiles;
 pub mod xai_oauth;
 
-use crate::auth::oauth_common::{RefreshRetryPolicy, refresh_with_retries};
+use crate::auth::oauth_common::{RefreshAttemptError, RefreshRetryPolicy, refresh_with_retries};
 use crate::auth::openai_oauth::refresh_access_token;
 use crate::auth::profiles::{
     AuthProfile, AuthProfileKind, AuthProfilesData, AuthProfilesStore, TokenSet, profile_id,
 };
 use anyhow::Result;
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -705,13 +706,8 @@ async fn refresh_openai_access_token_with_retries(
     client: &reqwest::Client,
     refresh_token: &str,
 ) -> Result<TokenSet> {
-    refresh_with_retries(
-        RefreshRetryPolicy {
-            max_attempts: OAUTH_REFRESH_MAX_ATTEMPTS,
-            base_delay_ms: OAUTH_REFRESH_RETRY_BASE_DELAY_MS,
-        },
+    refresh_oauth_access_token_with_retries(
         || refresh_access_token(client, refresh_token),
-        |_| false,
         |failure| {
             ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"attempt": failure.attempt, "max_attempts": failure.max_attempts, "retry": failure.should_retry, "error": format!("{}", failure.error)})), "OpenAI token refresh failed");
         },
@@ -725,15 +721,10 @@ async fn refresh_gemini_access_token_with_retries(
     client_secret: &str,
     refresh_token: &str,
 ) -> Result<TokenSet> {
-    refresh_with_retries(
-        RefreshRetryPolicy {
-            max_attempts: OAUTH_REFRESH_MAX_ATTEMPTS,
-            base_delay_ms: OAUTH_REFRESH_RETRY_BASE_DELAY_MS,
-        },
+    refresh_oauth_access_token_with_retries(
         || {
             gemini_oauth::refresh_access_token(client, client_id, client_secret, refresh_token)
         },
-        |_| false,
         |failure| {
             ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"attempt": failure.attempt, "max_attempts": failure.max_attempts, "retry": failure.should_retry, "error": format!("{}", failure.error)})), "Gemini token refresh failed");
         },
@@ -748,11 +739,7 @@ async fn refresh_email_access_token_with_retries(
     refresh_token: &str,
     scopes: &[String],
 ) -> Result<TokenSet> {
-    refresh_with_retries(
-        RefreshRetryPolicy {
-            max_attempts: OAUTH_REFRESH_MAX_ATTEMPTS,
-            base_delay_ms: oauth_refresh_retry_base_delay_ms(),
-        },
+    refresh_oauth_access_token_with_retries(
         || {
             email_oauth2::refresh_access_token(
                 client,
@@ -762,7 +749,6 @@ async fn refresh_email_access_token_with_retries(
                 scopes,
             )
         },
-        is_non_retryable_oauth_refresh_error,
         |failure| {
             ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"attempt": failure.attempt, "max_attempts": failure.max_attempts, "retry": failure.should_retry, "non_retryable": failure.non_retryable, "error": format!("{}", failure.error)})), "Email OAuth2 token refresh failed");
         },
@@ -782,14 +768,39 @@ async fn refresh_xai_access_token_with_retries(
     client: &reqwest::Client,
     refresh_token: &str,
 ) -> Result<TokenSet> {
+    refresh_oauth_access_token_with_retries(
+        || crate::auth::xai_oauth::refresh_access_token(client, refresh_token),
+        |_| {},
+    )
+    .await
+}
+
+async fn refresh_oauth_access_token_with_retries<Operation, OperationFuture, Observe>(
+    mut operation: Operation,
+    observe_error: Observe,
+) -> Result<TokenSet>
+where
+    Operation: FnMut() -> OperationFuture,
+    OperationFuture: Future<Output = Result<TokenSet>>,
+    Observe: FnMut(RefreshAttemptError<'_>),
+{
     refresh_with_retries(
         RefreshRetryPolicy {
             max_attempts: OAUTH_REFRESH_MAX_ATTEMPTS,
-            base_delay_ms: OAUTH_REFRESH_RETRY_BASE_DELAY_MS,
+            base_delay_ms: oauth_refresh_retry_base_delay_ms(),
         },
-        || crate::auth::xai_oauth::refresh_access_token(client, refresh_token),
-        |_| false,
-        |_| {},
+        || {
+            let future = operation();
+            async move {
+                let tokens = future.await?;
+                if tokens.access_token.trim().is_empty() {
+                    anyhow::bail!("Malformed OAuth token response: access_token is empty");
+                }
+                Ok(tokens)
+            }
+        },
+        is_non_retryable_oauth_refresh_error,
+        observe_error,
     )
     .await
 }
@@ -798,8 +809,11 @@ fn is_non_retryable_oauth_refresh_error(err: &anyhow::Error) -> bool {
     let msg = err.to_string();
     let msg_lower = msg.to_lowercase();
 
-    if msg_lower.contains("temporarily_unavailable") || msg_lower.contains("server_error") {
-        return false;
+    if err
+        .chain()
+        .any(|cause| cause.downcast_ref::<serde_json::Error>().is_some())
+    {
+        return true;
     }
 
     let permanent_oauth_hints = [
@@ -817,19 +831,46 @@ fn is_non_retryable_oauth_refresh_error(err: &anyhow::Error) -> bool {
         return true;
     }
 
-    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
-        && let Some(status) = reqwest_err.status()
-    {
-        let code = status.as_u16();
-        return status.is_client_error() && code != 429 && code != 408;
+    if msg_lower.contains("malformed oauth token response") {
+        return true;
     }
 
-    for word in msg.split(|c: char| !c.is_ascii_digit()) {
-        if let Ok(code) = word.parse::<u16>()
-            && (400..500).contains(&code)
-        {
-            return code != 429 && code != 408;
+    let textual_status = msg
+        .split(|c: char| !c.is_ascii_digit())
+        .filter_map(|word| word.parse::<u16>().ok())
+        .find(|code| (400..600).contains(code));
+
+    if matches!(textual_status, Some(401 | 403)) {
+        return true;
+    }
+
+    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
+        && matches!(
+            reqwest_err.status().map(|status| status.as_u16()),
+            Some(401 | 403)
+        )
+    {
+        return true;
+    }
+
+    if msg_lower.contains("temporarily_unavailable") || msg_lower.contains("server_error") {
+        return false;
+    }
+
+    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
+        if reqwest_err.is_decode() {
+            return true;
         }
+        if let Some(status) = reqwest_err.status() {
+            let code = status.as_u16();
+            return status.is_client_error() && code != 429 && code != 408;
+        }
+    }
+
+    if let Some(code) = textual_status
+        && (400..500).contains(&code)
+    {
+        return code != 429 && code != 408;
     }
 
     let auth_failure_hints = [
@@ -1241,10 +1282,8 @@ impl AuthProviderFlow for OpenaiCodexFlow {
             );
             anyhow::Error::msg("paste-redirect requires the redirect URL or OAuth code")
         })?;
-        let code = crate::auth::openai_oauth::parse_code_from_redirect(
-            redirect_input,
-            Some(&pending.state),
-        )?;
+        let code =
+            crate::auth::openai_oauth::parse_manual_code_input(redirect_input, &pending.state)?;
         let pkce = crate::auth::openai_oauth::PkceState {
             code_verifier: pending.code_verifier.clone(),
             code_challenge: String::new(),
@@ -1498,10 +1537,8 @@ impl AuthProviderFlow for GeminiFlow {
             );
             anyhow::Error::msg("paste-redirect requires the redirect URL or OAuth code")
         })?;
-        let code = crate::auth::gemini_oauth::parse_code_from_redirect(
-            redirect_input,
-            Some(&pending.state),
-        )?;
+        let code =
+            crate::auth::gemini_oauth::parse_manual_code_input(redirect_input, &pending.state)?;
         let pkce = crate::auth::gemini_oauth::PkceState {
             code_verifier: pending.code_verifier.clone(),
             code_challenge: String::new(),
@@ -2021,15 +2058,33 @@ mod tests {
     }
 
     #[test]
-    fn email_oauth_refresh_classifier_keeps_permanent_and_transient_errors_separate() {
+    fn oauth_refresh_classifier_keeps_permanent_and_transient_errors_separate() {
         assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             r#"Email OAuth2 token request failed (400 Bad Request): {"error":"invalid_grant"}"#
         )));
         assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             "Email OAuth2 token request failed (401 Unauthorized): invalid client"
         )));
+        assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "Google OAuth refresh error (400 Bad Request): invalid_request"
+        )));
+        assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "Google OAuth refresh error (401 Unauthorized): invalid_client - server_error in description"
+        )));
+        assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "OAuth refresh failed (401 Unauthorized): server_error"
+        )));
+        assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "OAuth refresh failed (403 Forbidden): temporarily_unavailable"
+        )));
+        assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "OAuth refresh failed (408 Request Timeout): retry later"
+        )));
         assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             "Email OAuth2 token request failed (429 Too Many Requests): retry later"
+        )));
+        assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "OAuth refresh failed (500 Internal Server Error): retry later"
         )));
         assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             r#"Email OAuth2 token request failed (400 Bad Request): {"error":"temporarily_unavailable"}"#
@@ -2037,6 +2092,57 @@ mod tests {
         assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             "Failed to refresh email OAuth2 token: connection reset"
         )));
+
+        let malformed =
+            serde_json::from_str::<serde_json::Value>("{").expect_err("fixture must be malformed");
+        assert!(is_non_retryable_oauth_refresh_error(
+            &anyhow::Error::new(malformed).context("Failed to parse Gemini refresh response")
+        ));
+    }
+
+    #[tokio::test]
+    async fn shared_oauth_refresh_policy_stops_after_permanent_failure() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = refresh_oauth_access_token_with_retries(
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async { anyhow::bail!("invalid_grant") }
+            },
+            |_| {},
+        )
+        .await
+        .expect_err("permanent OAuth failure must be returned");
+
+        assert_eq!(error.to_string(), "invalid_grant");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn shared_oauth_refresh_policy_rejects_empty_access_token_without_retry() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = refresh_oauth_access_token_with_retries(
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Ok(TokenSet {
+                        access_token: "   ".to_string(),
+                        refresh_token: None,
+                        id_token: None,
+                        expires_at: None,
+                        token_type: None,
+                        scope: None,
+                    })
+                }
+            },
+            |_| {},
+        )
+        .await
+        .expect_err("empty access token must fail permanently");
+
+        assert!(error.to_string().contains("access_token is empty"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     async fn email_oauth_permanent_failure_handler(

--- a/crates/zeroclaw-providers/src/auth/mod.rs
+++ b/crates/zeroclaw-providers/src/auth/mod.rs
@@ -809,6 +809,29 @@ fn is_non_retryable_oauth_refresh_error(err: &anyhow::Error) -> bool {
     let msg = err.to_string();
     let msg_lower = msg.to_lowercase();
 
+    let textual_status = msg.split('(').skip(1).find_map(|segment| {
+        let status_text = segment.split_once(')')?.0;
+        let (code, _) = status_text.split_once(' ')?;
+        let code = code.parse::<u16>().ok()?;
+        let status = reqwest::StatusCode::from_u16(code).ok()?;
+        (status.to_string() == status_text).then_some(code)
+    });
+    let reqwest_error = err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<reqwest::Error>());
+    let response_status = reqwest_error
+        .and_then(reqwest::Error::status)
+        .map(|status| status.as_u16())
+        .or(textual_status);
+
+    if matches!(response_status, Some(408 | 429 | 500..=599)) {
+        return false;
+    }
+
+    if matches!(response_status, Some(401 | 403)) {
+        return true;
+    }
+
     if err
         .chain()
         .any(|cause| cause.downcast_ref::<serde_json::Error>().is_some())
@@ -835,29 +858,11 @@ fn is_non_retryable_oauth_refresh_error(err: &anyhow::Error) -> bool {
         return true;
     }
 
-    let textual_status = msg
-        .split(|c: char| !c.is_ascii_digit())
-        .filter_map(|word| word.parse::<u16>().ok())
-        .find(|code| (400..600).contains(code));
-
-    if matches!(textual_status, Some(401 | 403)) {
-        return true;
-    }
-
-    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
-        && matches!(
-            reqwest_err.status().map(|status| status.as_u16()),
-            Some(401 | 403)
-        )
-    {
-        return true;
-    }
-
     if msg_lower.contains("temporarily_unavailable") || msg_lower.contains("server_error") {
         return false;
     }
 
-    if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>() {
+    if let Some(reqwest_err) = reqwest_error {
         if reqwest_err.is_decode() {
             return true;
         }
@@ -2086,8 +2091,14 @@ mod tests {
         assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             "OAuth refresh failed (500 Internal Server Error): retry later"
         )));
+        assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "OAuth refresh failed (499 <unknown status code>): retry later"
+        )));
         assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             r#"Email OAuth2 token request failed (400 Bad Request): {"error":"temporarily_unavailable"}"#
+        )));
+        assert!(is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
+            "OAuth refresh failed after 500 ms: invalid_grant"
         )));
         assert!(!is_non_retryable_oauth_refresh_error(&anyhow::Error::msg(
             "Failed to refresh email OAuth2 token: connection reset"
@@ -2116,6 +2127,32 @@ mod tests {
 
         assert_eq!(error.to_string(), "invalid_grant");
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn shared_oauth_refresh_policy_retries_mixed_signal_retryable_statuses() {
+        for message in [
+            r#"OAuth refresh failed (408 Request Timeout): {"error":"invalid_grant"}"#,
+            r#"OAuth refresh failed (429 Too Many Requests): {"error":"invalid_grant"}"#,
+            r#"OAuth refresh failed (500 Internal Server Error): {"error":"invalid_grant","error_description":"authentication failed"}"#,
+            r#"OAuth refresh failed (520 <unknown status code>): {"error":"invalid_grant"}"#,
+        ] {
+            let attempts = AtomicUsize::new(0);
+
+            let error = refresh_oauth_access_token_with_retries(
+                || {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    let message = message.to_string();
+                    async move { anyhow::bail!(message) }
+                },
+                |_| {},
+            )
+            .await
+            .expect_err("mixed-signal retryable errors must exhaust the retry budget");
+
+            assert_eq!(error.to_string(), message);
+            assert_eq!(attempts.load(Ordering::SeqCst), 3, "message: {message}");
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-providers/src/auth/oauth_common.rs
+++ b/crates/zeroclaw-providers/src/auth/oauth_common.rs
@@ -165,10 +165,60 @@ pub fn parse_query_params(input: &str) -> BTreeMap<String, String> {
     out
 }
 
+pub(super) fn is_structured_callback_input(input: &str, expected_path: &str) -> bool {
+    let trimmed = input.trim();
+    let target = trimmed
+        .split_once('?')
+        .map_or(trimmed, |(target, _)| target);
+    let path = ["http://", "https://"]
+        .iter()
+        .find_map(|scheme| target.strip_prefix(scheme))
+        .and_then(|authority_and_path| {
+            authority_and_path
+                .find('/')
+                .map(|index| &authority_and_path[index..])
+        })
+        .unwrap_or(target);
+
+    path == expected_path
+        || ["code=", "state=", "error="]
+            .iter()
+            .any(|prefix| trimmed.starts_with(prefix))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn callback_shape_distinguishes_structured_input_from_bare_codes() {
+        for input in [
+            "http://localhost:1455/auth/callback",
+            "/auth/callback",
+            "code=abc",
+            "state=xyz",
+            "error=access_denied",
+        ] {
+            assert!(
+                is_structured_callback_input(input, "/auth/callback"),
+                "{input}"
+            );
+        }
+
+        for input in [
+            "raw-code",
+            "4/0AcvDMrC1234567890abcdef",
+            "/opaque-code",
+            "opaque?code",
+            "opaque://code",
+        ] {
+            assert!(
+                !is_structured_callback_input(input, "/auth/callback"),
+                "{input}"
+            );
+        }
+    }
 
     fn retry_policy(max_attempts: usize, base_delay_ms: u64) -> RefreshRetryPolicy {
         RefreshRetryPolicy {

--- a/crates/zeroclaw-providers/src/auth/oauth_common.rs
+++ b/crates/zeroclaw-providers/src/auth/oauth_common.rs
@@ -167,9 +167,7 @@ pub fn parse_query_params(input: &str) -> BTreeMap<String, String> {
 
 pub(super) fn is_structured_callback_input(input: &str, expected_path: &str) -> bool {
     let trimmed = input.trim();
-    let target = trimmed
-        .split_once('?')
-        .map_or(trimmed, |(target, _)| target);
+    let (target, query) = trimmed.split_once('?').unwrap_or((trimmed, trimmed));
     let path = ["http://", "https://"]
         .iter()
         .find_map(|scheme| target.strip_prefix(scheme))
@@ -179,11 +177,13 @@ pub(super) fn is_structured_callback_input(input: &str, expected_path: &str) -> 
                 .map(|index| &authority_and_path[index..])
         })
         .unwrap_or(target);
-
-    path == expected_path
-        || ["code=", "state=", "error="]
+    let has_callback_param = query.split('&').any(|param| {
+        ["code=", "state=", "error="]
             .iter()
-            .any(|prefix| trimmed.starts_with(prefix))
+            .any(|prefix| param.starts_with(prefix))
+    });
+
+    path.trim_end_matches('/') == expected_path.trim_end_matches('/') || has_callback_param
 }
 
 #[cfg(test)]
@@ -195,10 +195,13 @@ mod tests {
     fn callback_shape_distinguishes_structured_input_from_bare_codes() {
         for input in [
             "http://localhost:1455/auth/callback",
+            "http://localhost:1455/auth/callback/",
             "/auth/callback",
             "code=abc",
             "state=xyz",
             "error=access_denied",
+            "?code=abc&state=xyz",
+            "https://example.test/other?code=abc&state=xyz",
         ] {
             assert!(
                 is_structured_callback_input(input, "/auth/callback"),

--- a/crates/zeroclaw-providers/src/auth/openai_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/openai_oauth.rs
@@ -570,8 +570,14 @@ mod tests {
         let missing = parse_manual_code_input("/auth/callback?code=x", "b").unwrap_err();
         assert!(missing.to_string().contains("Missing OAuth state"));
 
-        let err = parse_manual_code_input("/auth/callback?code=x&state=a", "b").unwrap_err();
-        assert!(err.to_string().contains("state mismatch"));
+        for input in [
+            "/auth/callback?code=x&state=a",
+            "?code=x&state=a",
+            "https://example.test/other?code=x&state=a",
+        ] {
+            let err = parse_manual_code_input(input, "b").unwrap_err();
+            assert!(err.to_string().contains("state mismatch"), "{input}");
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/auth/openai_oauth.rs
+++ b/crates/zeroclaw-providers/src/auth/openai_oauth.rs
@@ -1,4 +1,4 @@
-use crate::auth::oauth_common::{parse_query_params, url_encode};
+use crate::auth::oauth_common::{is_structured_callback_input, parse_query_params, url_encode};
 
 use crate::auth::profiles::TokenSet;
 use anyhow::{Context, Result};
@@ -276,7 +276,7 @@ async fn receive_loopback_code_inner(expected_state: &str, timeout: Duration) ->
         anyhow::Error::msg("Callback request missing path")
     })?;
 
-    let code = parse_code_from_redirect(path, Some(expected_state))?;
+    let code = parse_callback_code(path, expected_state)?;
 
     let body =
         "<html><body><h2>ZeroClaw login complete</h2><p>You can close this tab.</p></body></html>";
@@ -290,7 +290,7 @@ async fn receive_loopback_code_inner(expected_state: &str, timeout: Duration) ->
     Ok(code)
 }
 
-pub fn parse_code_from_redirect(input: &str, expected_state: Option<&str>) -> Result<String> {
+pub(super) fn parse_manual_code_input(input: &str, expected_state: &str) -> Result<String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         anyhow::bail!("No OAuth code provided");
@@ -303,10 +303,35 @@ pub fn parse_code_from_redirect(input: &str, expected_state: Option<&str>) -> Re
     };
 
     let params = parse_query_params(query);
-    let is_callback_payload = trimmed.contains('?')
-        || params.contains_key("code")
-        || params.contains_key("state")
-        || params.contains_key("error");
+    if !is_structured_callback_input(trimmed, "/auth/callback") {
+        return Ok(trimmed.to_string());
+    }
+
+    parse_callback_params(&params, expected_state)
+}
+
+fn parse_callback_code(input: &str, expected_state: &str) -> Result<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("No OAuth code provided");
+    }
+
+    let query = trimmed.split_once('?').map_or(trimmed, |(_, query)| query);
+    let params = parse_query_params(query);
+
+    parse_callback_params(&params, expected_state)
+}
+
+fn parse_callback_params(
+    params: &std::collections::BTreeMap<String, String>,
+    expected_state: &str,
+) -> Result<String> {
+    let state = params
+        .get("state")
+        .ok_or_else(|| anyhow::Error::msg("Missing OAuth state in callback"))?;
+    if state != expected_state {
+        anyhow::bail!("OAuth state mismatch");
+    }
 
     if let Some(err) = params.get("error") {
         let desc = params
@@ -316,25 +341,29 @@ pub fn parse_code_from_redirect(input: &str, expected_state: Option<&str>) -> Re
         anyhow::bail!("OpenAI OAuth error: {err} ({desc})");
     }
 
-    if let Some(expected_state) = expected_state {
-        if let Some(got) = params.get("state") {
-            if got != expected_state {
-                anyhow::bail!("OAuth state mismatch");
-            }
-        } else if is_callback_payload {
-            anyhow::bail!("Missing OAuth state in callback");
-        }
-    }
-
-    if let Some(code) = params.get("code").cloned() {
-        return Ok(code);
-    }
-
-    if !is_callback_payload {
-        return Ok(trimmed.to_string());
+    if let Some(code) = params.get("code")
+        && !code.trim().is_empty()
+    {
+        return Ok(code.trim().to_string());
     }
 
     anyhow::bail!("Missing OAuth code in callback")
+}
+
+pub fn parse_code_from_redirect(input: &str, expected_state: Option<&str>) -> Result<String> {
+    match expected_state {
+        Some(state) => parse_callback_code(input, state),
+        None => {
+            let trimmed = input.trim();
+            if trimmed.is_empty() {
+                anyhow::bail!("No OAuth code provided");
+            }
+            if is_structured_callback_input(trimmed, "/auth/callback") {
+                anyhow::bail!("Expected OAuth state is required for callback input");
+            }
+            Ok(trimmed.to_string())
+        }
+    }
 }
 
 pub fn extract_account_id_from_jwt(token: &str) -> Option<String> {
@@ -518,32 +547,54 @@ mod tests {
     }
 
     #[test]
-    fn parse_redirect_url_extracts_code() {
-        let code = parse_code_from_redirect(
+    fn callback_redirect_requires_matching_state() {
+        let code = parse_callback_code(
             "http://127.0.0.1:1455/auth/callback?code=abc123&state=xyz",
-            Some("xyz"),
+            "xyz",
         )
         .unwrap();
         assert_eq!(code, "abc123");
+
+        assert!(parse_callback_code("/auth/callback?code=abc123", "xyz").is_err());
+        assert!(parse_callback_code("abc123", "xyz").is_err());
     }
 
     #[test]
-    fn parse_redirect_accepts_raw_code() {
-        let code = parse_code_from_redirect("raw-code", None).unwrap();
+    fn manual_code_input_accepts_raw_code() {
+        let code = parse_manual_code_input("raw-code", "xyz").unwrap();
         assert_eq!(code, "raw-code");
     }
 
     #[test]
-    fn parse_redirect_rejects_state_mismatch() {
-        let err = parse_code_from_redirect("/auth/callback?code=x&state=a", Some("b")).unwrap_err();
+    fn manual_callback_input_rejects_missing_or_mismatched_state() {
+        let missing = parse_manual_code_input("/auth/callback?code=x", "b").unwrap_err();
+        assert!(missing.to_string().contains("Missing OAuth state"));
+
+        let err = parse_manual_code_input("/auth/callback?code=x&state=a", "b").unwrap_err();
         assert!(err.to_string().contains("state mismatch"));
     }
 
     #[test]
+    fn manual_callback_input_rejects_url_or_path_without_query() {
+        for input in ["http://localhost:1455/auth/callback", "/auth/callback"] {
+            assert!(parse_manual_code_input(input, "xyz").is_err(), "{input}");
+        }
+    }
+
+    #[test]
+    fn compatibility_parser_accepts_raw_code_only_without_state_expectation() {
+        assert_eq!(
+            parse_code_from_redirect("raw-code", None).unwrap(),
+            "raw-code"
+        );
+        assert!(parse_code_from_redirect("raw-code", Some("xyz")).is_err());
+    }
+
+    #[test]
     fn parse_redirect_rejects_error_without_code() {
-        let err = parse_code_from_redirect(
-            "/auth/callback?error=access_denied&error_description=user+cancelled",
-            Some("xyz"),
+        let err = parse_manual_code_input(
+            "/auth/callback?error=access_denied&error_description=user+cancelled&state=xyz",
+            "xyz",
         )
         .unwrap_err();
         assert!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Separate structured OAuth callback parsing from explicit manual-code entry so recognized callback URLs and OAuth query-form pastes cannot bypass PKCE state validation.
  - Apply one permanent/transient refresh-error policy to OpenAI, Gemini, xAI, and Email OAuth refreshes so permanent failures stop retrying while temporary failures keep bounded retries.
  - Reject empty access tokens before they can be persisted, and preserve Gemini refresh HTTP status for reliable classification.
- **Scope boundary:** This does not change OAuth configuration, token storage locations, permissions, provider endpoints, request types, or maximum retry attempts. Permanent failures may now make fewer refresh requests because retries stop earlier; an HTTP-success response that cannot be decoded as JSON is also treated as permanent and is not retried.
- **Blast radius:** OpenAI and Gemini callback/manual-code parsing, plus refresh retry decisions shared by OpenAI, Gemini, xAI, and Email OAuth consumers.
- **Linked issue(s):** None.
- **Labels:** `bug`, `provider`, `distinguished contributor`, `domain:security`, `risk:high`, `size:L`

### What this does, simply

When someone connects ZeroClaw to a service, the service sends back a short-lived sign-in reply. That reply includes a random value so ZeroClaw can tell it belongs to the sign-in the user just started. Later, ZeroClaw renews access automatically when it expires.

Previously, pasted text could sometimes be mistaken for a manually entered sign-in code and skip that matching check. Different services also disagreed about which renewal failures should be retried, and one could save a blank credential.

This PR makes those rules consistent: browser replies must match the sign-in attempt, temporary renewal failures are retried, permanent failures stop immediately, and blank credentials are rejected. It does not change where credentials are stored or which services ZeroClaw connects to.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the affected callback, manual-code, retry, and malformed-token boundaries are deterministic and covered directly by unit tests without requiring reviewers to use live OAuth credentials.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed on exact head `d142063c6e`; any changed head must pass fresh required CI before merge.
- **Known CI coverage gap, if any:** No live-provider authorization smoke was run; the changed behavior is local callback parsing and refresh-response classification rather than provider endpoint selection.
- **Commands run and tail output:**

```text
rustfmt --edition 2024 --check crates/zeroclaw-providers/src/auth/mod.rs
Result: passed.

git diff --check
Result: passed.

Focused provider OAuth test filter
8 passed; 0 failed; 0 ignored; 1293 filtered out.
```

- **Beyond CI, what did you manually verify?** The regression matrix covers matching, missing, and mismatched callback state; callback-shaped inputs without query parameters; opaque manual codes; compatibility-wrapper behavior; permanent versus transient failures including mixed signals; status-like incidental text; standard and nonstandard retryable HTTP statuses; and empty access-token rejection. I did not use real provider credentials or complete a live authorization flow.
- **If any command was intentionally skipped, why:** No additional local command was intentionally skipped. Required CI supplies the cross-target compile and broader test result.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: OAuth callback and refresh responses are validated more strictly. Recognized callback URLs and OAuth query-form pastes now require the expected state, permanent refresh failures stop bounded retries, and empty access tokens are rejected before persistence; no token is newly logged, exposed, or stored elsewhere.

## Compatibility (required)

- Backward compatible? **No**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: The public `parse_code_from_redirect` signature remains available. Structured callback input now requires `Some(expected_state)`; passing callback material with `None` now returns a missing-expected-state error. Explicit opaque manual codes remain supported through the dedicated manual-entry path, so direct Rust integrations should route callback material and manual codes separately.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Before merge, `git revert d142063c6e 1e90b3560 4fbec2ab7c 19f3e100ff`; after merge, revert the resulting merge or squash commit on `master`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** OpenAI or Gemini authorization rejects a callback or manual code unexpectedly; logs show OAuth state mismatch, missing state, malformed token response, or repeated refresh errors.

