### PR TITLE
fix(zerocode): let users disable mouse capture to restore select-to-copy

### DIFF
--- a/apps/zerocode/src/config/mod.rs
+++ b/apps/zerocode/src/config/mod.rs
@@ -148,6 +148,8 @@ pub(crate) struct ZerocodeConfig {
     pub theme: ThemeSection,
     #[serde(default, skip_serializing_if = "ConnectionSection::is_empty")]
     pub connection: ConnectionSection,
+    #[serde(default, skip_serializing_if = "InputSection::is_default")]
+    pub input: InputSection,
     /// Sparse keybinding overrides keyed `"<tag>.<variant>"`. Absent
     /// entries fall back to compile-time defaults.
     #[serde(default)]
@@ -160,9 +162,43 @@ impl Default for ZerocodeConfig {
             locale: default_locale(),
             theme: ThemeSection::default(),
             connection: ConnectionSection::default(),
+            input: InputSection::default(),
             keybindings: HashMap::new(),
         }
     }
+}
+
+/// Terminal input behavior for the ZeroCode TUI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct InputSection {
+    /// When `true` (default), ZeroCode captures mouse events so scroll,
+    /// scrollbar dragging, and click targets work inside the TUI. This
+    /// prevents the terminal's own click-and-drag text selection, so
+    /// select-to-copy stops working.
+    ///
+    /// Set to `false` to release mouse events back to the terminal and
+    /// restore native select-to-copy — at the cost of in-app mouse
+    /// scrolling and clickable controls. Keyboard scrolling still works.
+    #[serde(default = "default_mouse_capture")]
+    pub mouse_capture: bool,
+}
+
+impl InputSection {
+    fn is_default(&self) -> bool {
+        self.mouse_capture == default_mouse_capture()
+    }
+}
+
+impl Default for InputSection {
+    fn default() -> Self {
+        Self {
+            mouse_capture: default_mouse_capture(),
+        }
+    }
+}
+
+fn default_mouse_capture() -> bool {
+    true
 }
 
 fn default_locale() -> Option<String> {
@@ -553,6 +589,49 @@ mod tests {
         assert!(
             body.contains("locale = \"en\""),
             "default config must surface the locale prop on disk; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn mouse_capture_defaults_to_on() {
+        let c = ZerocodeConfig::default();
+        assert!(
+            c.input.mouse_capture,
+            "mouse capture must default to on so scroll/scrollbar/clicks work"
+        );
+    }
+
+    #[test]
+    fn default_input_section_is_omitted_on_disk() {
+        // A default [input] section must not be serialized, keeping the
+        // on-disk config minimal for users who never touch it.
+        let body = toml::to_string_pretty(&ZerocodeConfig::default()).unwrap();
+        assert!(
+            !body.contains("[input]"),
+            "default input section must be skipped on disk; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn mouse_capture_false_parses_and_serializes() {
+        let parsed: ZerocodeConfig = toml::from_str("[input]\nmouse_capture = false\n").unwrap();
+        assert!(
+            !parsed.input.mouse_capture,
+            "explicit mouse_capture = false must be honored"
+        );
+        let body = toml::to_string_pretty(&parsed).unwrap();
+        assert!(
+            body.contains("mouse_capture = false"),
+            "non-default input section must round-trip to disk; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn missing_input_section_falls_back_to_default() {
+        let parsed: ZerocodeConfig = toml::from_str("locale = \"en\"\n").unwrap();
+        assert!(
+            parsed.input.mouse_capture,
+            "configs without an [input] section keep mouse capture on"
         );
     }
 

--- a/apps/zerocode/src/config_manager.rs
+++ b/apps/zerocode/src/config_manager.rs
@@ -52,15 +52,17 @@ fn retain_direct_children(fields: &mut Vec<ConfigFieldEntry>, prefix: &str) {
     fields.retain(|field| is_direct_child_path(&field.path, prefix));
 }
 
-pub(crate) fn init_terminal() -> Result<Term> {
+pub(crate) fn init_terminal(mouse_capture: bool) -> Result<Term> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(
-        stdout,
-        EnterAlternateScreen,
-        EnableMouseCapture,
-        EnableBracketedPaste,
-    )?;
+    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+    // Mouse capture routes click/drag/scroll to the app, which disables the
+    // terminal's native select-to-copy. Only enable it when the user wants
+    // in-app mouse support (the default); otherwise leave selection to the
+    // terminal. See issue #10022.
+    if mouse_capture {
+        execute!(stdout, EnableMouseCapture)?;
+    }
     if crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false) {
         let _ = execute!(
             stdout,

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -413,7 +413,7 @@ async fn run() -> anyhow::Result<()> {
         }
     };
 
-    let mut term = config_manager::init_terminal()?;
+    let mut term = config_manager::init_terminal(loaded_config.input.mouse_capture)?;
     TERMINAL_ACTIVE.store(true, Ordering::Relaxed);
 
     let result = run_until_exit(

--- a/docs/book/src/zerocode/running.md
+++ b/docs/book/src/zerocode/running.md
@@ -38,6 +38,31 @@ events, not native platform text-field events. On macOS, system text
 replacements therefore work only when your terminal expands them before
 zerocode receives the input.
 
+### Copying text from the chat
+
+By default zerocode captures mouse events so that scrolling, dragging the
+scrollbar, and clickable controls work inside the TUI. While mouse capture is
+on, the terminal hands mouse actions to zerocode instead of doing its own
+click-and-drag text selection, so you can't highlight chat text to copy it with
+a plain mouse drag.
+
+Two ways to copy text out of the chat:
+
+- **Keep mouse capture on (default):** use your terminal's selection override.
+  In iTerm2 and most macOS terminals, hold **Option (⌥)** and drag to select,
+  then copy as usual. Many terminals use a similar modifier.
+- **Turn mouse capture off:** set `mouse_capture = false` under `[input]` in the
+  zerocode config. The terminal's native select-to-copy then works everywhere,
+  at the cost of in-app mouse scrolling and clickable controls. Keyboard
+  scrolling still works.
+
+```toml
+[input]
+# Release mouse events to the terminal so click-and-drag select-to-copy works.
+# Default is true (zerocode captures the mouse for scroll/scrollbar/clicks).
+mouse_capture = false
+```
+
 ## CLI flags
 
 | Flag | Description |


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - ZeroCode called `EnableMouseCapture` unconditionally at startup. Mouse capture routes click/drag/scroll to the app, which disables the terminal's own click-and-drag text selection — so users could not highlight chat text to copy it (#10022).
  - Mouse capture is load-bearing (scroll wheel, scrollbar drag, clickable controls, SOP pane), so removing it is not viable. Instead this adds an opt-out: a new `[input]` section with `mouse_capture` (default `true`).
  - `init_terminal` now takes the flag and only emits `EnableMouseCapture` when it is on; when `false`, the terminal keeps native select-to-copy (tradeoff: no in-app mouse scroll/click; keyboard scrolling still works).
  - Documented the toggle and the terminal-override workaround (Option+drag) in the ZeroCode running guide.
- **Scope boundary:** Does NOT remove mouse capture, change any default behavior, add dynamic/focus-scoped capture, or touch the SOP pane / scrollbar logic. Default configs behave exactly as before.
- **Blast radius:** ZeroCode TUI terminal init only. No daemon, provider, channel, or runtime surface touched. The new config field is client-local (`zerocode-config.toml`).
- **Linked issue(s):** Fixes #10022
- **Labels:** `type:bug`, `zerocode`, `risk:low`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `tui` (zerocode)
- **Setup / preconditions:** Build `cargo build -p zerocode`. A terminal that supports a selection-override modifier (e.g. iTerm2 / most macOS terminals: Option+drag).
- **Steps to run:**
  1. Launch `./target/debug/zerocode` with no `[input]` section in `zerocode-config.toml` (default).
  2. Wait for a chat reply, then plain click-drag to select text.
  3. Add to `zerocode-config.toml`:
     ```toml
     [input]
     mouse_capture = false
     ```
  4. Relaunch and plain click-drag to select text again.
- **Expected on this branch (after):** With `mouse_capture = false`, plain click-drag selects text natively and copy works; mouse scroll/scrollbar no longer drive the TUI (keyboard scrolling still works). With the default (section absent or `true`), behavior is unchanged — capture on, scroll works.
- **Prior behavior on `master` (before):** Plain click-drag never selects text; there is no way to disable capture. Only workaround is the terminal's Option+drag override.

### How I tested

- **CI checks relied on and why they cover this change:** Rust build/clippy/test cover the config parsing and terminal-init change; docs gates cover the added Markdown.
- **Known CI coverage gap, if any:** The actual terminal escape-sequence emission (`EnableMouseCapture`) is not unit-testable without a PTY; verified by reading the conditional and by config-level tests. Manual PTY verification deferred to reviewer.
- **Commands run and tail output:**

```sh
$ cargo test -p zerocode config::
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 664 filtered out

$ cargo clippy -p zerocode --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.02s

$ cargo fmt -p zerocode   # no diff
```

- **Beyond CI, what did you manually verify?** Confirmed via `rg` that mouse events feed scroll/scrollbar/click/SOP paths (so removal was rejected in favor of a toggle). Added 4 config tests: default is on, default section omitted on disk, `mouse_capture = false` parses and round-trips, missing section falls back to on. Did NOT run an interactive terminal session (deferred to reviewer/author next-weekend testing).
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` skipped; change is isolated to the zerocode crate + docs.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes — adds an optional `[input].mouse_capture` field to `zerocode-config.toml`. Absent = previous behavior (`true`). No action required for existing users.
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` is the plan.
