### PR TITLE
fix(runtime): stream the max-iteration graceful summary to turn event consumers

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -1639,6 +1639,54 @@ async fn safety_net_graceful_summary_persists_assistant_summary() {
     );
 }
 
+// ACP and other event-driven channels render message content exclusively
+// from `TurnEvent::Chunk`. The graceful summary must reach that channel on
+// the max-iteration exit the same way an ordinary final response does, or
+// the client shows nothing even though the turn resolved successfully.
+#[tokio::test]
+async fn safety_net_graceful_summary_emits_turn_event_chunk() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut agent = build_agent_with_runtime(
+        Box::new(ScriptedProvider::new(vec![
+            tool_response(vec![tool_call("s1", "echo")]),
+            tool_response(vec![tool_call("s2", "echo")]),
+            text_response("wrap-up summary"),
+        ])),
+        vec![Box::new(CountingTool {
+            name: "echo",
+            calls,
+        })],
+        zeroclaw_config::schema::ResolvedRuntime {
+            max_tool_iterations: 2,
+            ..zeroclaw_config::schema::ResolvedRuntime::default()
+        },
+    );
+    let (tx, mut rx) = mpsc::channel(256);
+    let outcome = agent
+        .turn_streamed_with_steering_state("exhaust the cap", tx, None, None)
+        .await
+        .expect("graceful summary must succeed on the streamed path");
+    assert!(
+        outcome.response.contains("wrap-up summary"),
+        "unexpected response: {}",
+        outcome.response
+    );
+
+    let mut chunk_delta = None;
+    while let Ok(ev) = rx.try_recv() {
+        if let TurnEvent::Chunk { delta } = ev {
+            chunk_delta = Some(delta);
+        }
+    }
+    let delta = chunk_delta.expect(
+        "max-iteration exit must emit a TurnEvent::Chunk so ACP clients render the summary",
+    );
+    assert!(
+        delta.contains("wrap-up summary"),
+        "chunk must carry the graceful summary text: {delta}"
+    );
+}
+
 #[tokio::test]
 async fn safety_net_failed_graceful_summary_does_not_persist_prompt() {
     let calls = Arc::new(AtomicUsize::new(0));

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 use zeroclaw_api::agent::TurnEvent;
 use zeroclaw_config::schema::PacingConfig;
 use zeroclaw_providers::{ChatMessage, ModelProvider};
+use zeroclaw_tool_call_parser::{strip_think_tags, strip_trailing_terminal_markers};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn finish_after_max_iterations(
@@ -171,12 +172,49 @@ pub(crate) async fn finish_after_max_iterations(
         SummaryCall::Done(Ok(resp)) => resp,
     };
 
-    let text = resp.text.unwrap_or_default();
-    if text.is_empty() {
+    let raw_text = resp.text.unwrap_or_default();
+    if raw_text.is_empty() {
         history.pop();
         anyhow::bail!("Agent exceeded maximum tool iterations ({max_iterations})")
     }
-    let summary_msg = ChatMessage::assistant(text.clone());
+    // The summary is raw provider text, and emitting it as a chunk makes this
+    // a new automatic display sink: ACP renders `agent_message_chunk` live,
+    // while gateway and RPC forward the same chunk without another
+    // normalization step. Apply the display hygiene the ordinary final
+    // response already gets before anything is emitted -- strip hidden think
+    // content and trailing terminal markers, then withhold text that looks
+    // like an internal tool-protocol envelope. The summary call passes
+    // `tools: None`, so the tools-free detector is the matching contract.
+    let display_text = strip_trailing_terminal_markers(&strip_think_tags(&raw_text));
+    let protocol_suppressed =
+        super::protocol_detect::detect_internal_protocol_without_tools(&display_text).is_some();
+    if protocol_suppressed {
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                .with_category(::zeroclaw_log::EventCategory::Tool)
+                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                .with_attrs(::serde_json::json!({
+                    "model": model,
+                    "max_iterations": max_iterations,
+                    "trace_id": turn_id,
+                    "error": "malformed internal tool protocol omitted from max-iteration summary",
+                })),
+            "max_iteration_summary_protocol_suppressed"
+        );
+    }
+    let display_text = if protocol_suppressed {
+        crate::i18n::get_required_cli_string("channel-runtime-malformed-tool-output").to_string()
+    } else {
+        display_text
+    };
+    if display_text.trim().is_empty() {
+        history.pop();
+        anyhow::bail!("Agent exceeded maximum tool iterations ({max_iterations})")
+    }
+    // History and result payloads keep the unmodified provider text; only the
+    // display path is normalized, matching the final-response contract.
+    let summary_msg = ChatMessage::assistant(raw_text.clone());
     if let Some(out) = &mut new_messages_out {
         out.push(summary_prompt_mirror);
         out.push(summary_msg.clone());
@@ -188,7 +226,7 @@ pub(crate) async fn finish_after_max_iterations(
         "turn-max-iterations-reached",
         &[("max_iterations", &max_iterations.to_string())],
     );
-    let segment = format!("{text}\n\n{stop_reason}");
+    let segment = format!("{display_text}\n\n{stop_reason}");
     // This summary is the turn's only visible output on the max-iteration
     // exit path, and it comes from a fresh non-streaming call — there is no
     // live delta a client could have already received, so unlike the normal
@@ -576,6 +614,139 @@ mod graceful_summary_metering_tests {
         assert!(
             !delta.contains("earlier narration"),
             "chunk must not re-send narration already streamed in earlier iterations: {delta}"
+        );
+    }
+
+    /// Provider stub returning caller-supplied raw summary text, so a test can
+    /// drive the display-hygiene path with think content, terminal markers, or
+    /// an internal tool-protocol envelope.
+    struct RawTextProvider {
+        text: String,
+    }
+
+    #[async_trait]
+    impl ModelProvider for RawTextProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok(self.text.clone())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            Ok(ChatResponse {
+                text: Some(self.text.clone()),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+    }
+
+    impl Attributable for RawTextProvider {
+        fn role(&self) -> Role {
+            Role::Provider(ProviderKind::Model(ModelProviderKind::Custom))
+        }
+        fn alias(&self) -> &str {
+            "raw-text-provider"
+        }
+    }
+
+    async fn emitted_chunk_for_raw_summary(raw: &str) -> String {
+        let provider = RawTextProvider {
+            text: raw.to_string(),
+        };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
+        run_summary_with_events(&provider, "earlier narration".to_string(), Some(&tx))
+            .await
+            .expect("graceful summary should succeed");
+        let mut chunk_delta = None;
+        while let Ok(event) = rx.try_recv() {
+            if let TurnEvent::Chunk { delta } = event {
+                chunk_delta = Some(delta);
+            }
+        }
+        chunk_delta.expect("max-iteration exit must emit a TurnEvent::Chunk")
+    }
+
+    // The emitted chunk is a live display sink (ACP renders it directly;
+    // gateway and RPC forward it unchanged), so the summary must go through
+    // the same display-safe contract as the ordinary final response: hidden
+    // think content stripped, trailing terminal markers stripped, and an
+    // internal tool-protocol envelope suppressed rather than rendered.
+    #[tokio::test]
+    async fn graceful_summary_chunk_strips_hidden_think_content() {
+        let delta =
+            emitted_chunk_for_raw_summary("<think>secret chain of thought</think>wrap-up summary")
+                .await;
+        assert!(
+            !delta.contains("secret chain of thought"),
+            "hidden think content must not reach the display chunk: {delta}"
+        );
+        assert!(
+            delta.contains("wrap-up summary"),
+            "visible summary text must survive: {delta}"
+        );
+        assert!(
+            delta.contains("Turn stopped: reached maximum tool iterations (2)"),
+            "chunk must still carry the stop reason: {delta}"
+        );
+        assert!(
+            !delta.contains("earlier narration"),
+            "chunk must not re-send earlier narration: {delta}"
+        );
+    }
+
+    #[tokio::test]
+    async fn graceful_summary_chunk_strips_trailing_terminal_marker() {
+        let delta = emitted_chunk_for_raw_summary("wrap-up summary<|eom|>").await;
+        assert!(
+            !delta.contains("eom"),
+            "trailing terminal marker must not reach the display chunk: {delta}"
+        );
+        assert!(
+            delta.contains("wrap-up summary"),
+            "visible summary text must survive: {delta}"
+        );
+        assert!(
+            delta.contains("Turn stopped: reached maximum tool iterations (2)"),
+            "chunk must still carry the stop reason: {delta}"
+        );
+    }
+
+    #[tokio::test]
+    async fn graceful_summary_chunk_suppresses_internal_tool_protocol_envelope() {
+        let delta = emitted_chunk_for_raw_summary(
+            "<tool_call>{\"name\": \"shell\", \"arguments\": {\"command\": \"ls\"}}</tool_call>",
+        )
+        .await;
+        assert!(
+            !delta.contains("tool_call"),
+            "internal tool-protocol envelope must not be rendered: {delta}"
+        );
+        assert!(
+            !delta.contains("shell"),
+            "internal tool-protocol payload must not be rendered: {delta}"
+        );
+        assert!(
+            delta.contains("internal tool-call format error"),
+            "suppressed protocol output must fall back to the safe notice: {delta}"
+        );
+        assert!(
+            delta.contains("Turn stopped: reached maximum tool iterations (2)"),
+            "chunk must still carry the stop reason: {delta}"
+        );
+        assert!(
+            !delta.contains("earlier narration"),
+            "chunk must not re-send earlier narration: {delta}"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -6,7 +6,9 @@ use super::knobs::{LoopKnobs, MaxIterationBehavior};
 use super::outcome::ToolLoopCancelled;
 use anyhow::{Context, Result};
 use std::time::Duration;
+use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
+use zeroclaw_api::agent::TurnEvent;
 use zeroclaw_config::schema::PacingConfig;
 use zeroclaw_providers::{ChatMessage, ModelProvider};
 
@@ -23,6 +25,7 @@ pub(crate) async fn finish_after_max_iterations(
     mut accumulated_display_text: String,
     turn_id: &str,
     knobs: &LoopKnobs,
+    event_tx: Option<&Sender<TurnEvent>>,
     mut new_messages_out: Option<&mut Vec<ChatMessage>>,
 ) -> Result<String> {
     ::zeroclaw_log::record!(
@@ -179,14 +182,22 @@ pub(crate) async fn finish_after_max_iterations(
         out.push(summary_msg.clone());
     }
     history.push(summary_msg);
-    accumulated_display_text.push_str(&text);
     // Graceful shutdown with a visible reason so the user knows why the
     // agent stopped making progress.
-    accumulated_display_text.push_str("\n\n");
-    accumulated_display_text.push_str(&crate::i18n::get_required_cli_string_with_args(
+    let stop_reason = crate::i18n::get_required_cli_string_with_args(
         "turn-max-iterations-reached",
         &[("max_iterations", &max_iterations.to_string())],
-    ));
+    );
+    let segment = format!("{text}\n\n{stop_reason}");
+    // This summary is the turn's only visible output on the max-iteration
+    // exit path, and it comes from a fresh non-streaming call — there is no
+    // live delta a client could have already received, so unlike the normal
+    // final-response path this emit needs no live-vs-post-hoc guard. Only the
+    // newly-produced segment goes out; `accumulated_display_text` holds
+    // narration earlier iterations already streamed, and resending it here
+    // would duplicate it in the client.
+    super::events::emit_posthoc_turn_chunk(event_tx, &segment).await;
+    accumulated_display_text.push_str(&segment);
     Ok(accumulated_display_text)
 }
 
@@ -206,6 +217,8 @@ mod graceful_summary_metering_tests {
     use zeroclaw_config::schema::{CostConfig, PacingConfig};
     use zeroclaw_providers::traits::TokenUsage;
     use zeroclaw_providers::{ChatMessage, ModelProvider};
+
+    use super::{Sender, TurnEvent};
 
     /// Provider stub that counts calls and returns a summary WITH token usage.
     struct CountingUsageProvider {
@@ -253,7 +266,11 @@ mod graceful_summary_metering_tests {
         }
     }
 
-    async fn run_summary(provider: &dyn ModelProvider) -> anyhow::Result<String> {
+    async fn run_summary_with_events(
+        provider: &dyn ModelProvider,
+        accumulated_display_text: String,
+        event_tx: Option<&Sender<TurnEvent>>,
+    ) -> anyhow::Result<String> {
         let mut history = vec![ChatMessage::user("do the work")];
         let pacing = PacingConfig::default();
         let knobs = LoopKnobs::default(); // GracefulSummary
@@ -266,12 +283,17 @@ mod graceful_summary_metering_tests {
             &pacing,
             None,
             2,
-            String::new(),
+            accumulated_display_text,
             "trace-req-test",
             &knobs,
+            event_tx,
             None,
         )
         .await
+    }
+
+    async fn run_summary(provider: &dyn ModelProvider) -> anyhow::Result<String> {
+        run_summary_with_events(provider, String::new(), None).await
     }
 
     // The graceful summary now routes through the metered provider seam: under a
@@ -500,6 +522,7 @@ mod graceful_summary_metering_tests {
             "trace-req-audio",
             &knobs,
             None,
+            None,
         )
         .await
         .expect("graceful summary should succeed");
@@ -513,6 +536,46 @@ mod graceful_summary_metering_tests {
         assert!(
             captured.contains("[media attachment]"),
             "audio marker should be replaced with a placeholder: {captured}"
+        );
+    }
+
+    // ACP and other event-driven clients render message content exclusively
+    // from `TurnEvent::Chunk`. The max-iteration exit must emit one, and it
+    // must carry only the newly-produced segment — narration from earlier
+    // iterations already reached the client through prior chunks, so
+    // re-sending `accumulated_display_text` here would duplicate it.
+    #[tokio::test]
+    async fn graceful_summary_emits_a_turn_event_chunk_with_only_the_new_segment() {
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = CapturingProvider {
+            seen: Arc::clone(&seen),
+        };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
+
+        let out = run_summary_with_events(&provider, "earlier narration".to_string(), Some(&tx))
+            .await
+            .expect("graceful summary should succeed");
+
+        assert!(out.contains("wrap-up summary"), "unexpected summary: {out}");
+
+        let mut chunk_delta = None;
+        while let Ok(event) = rx.try_recv() {
+            if let TurnEvent::Chunk { delta } = event {
+                chunk_delta = Some(delta);
+            }
+        }
+        let delta = chunk_delta.expect("max-iteration exit must emit a TurnEvent::Chunk");
+        assert!(
+            delta.contains("wrap-up summary"),
+            "chunk must carry the summary text: {delta}"
+        );
+        assert!(
+            delta.contains("Turn stopped: reached maximum tool iterations (2)"),
+            "chunk must carry the max-iterations stop reason: {delta}"
+        );
+        assert!(
+            !delta.contains("earlier narration"),
+            "chunk must not re-send narration already streamed in earlier iterations: {delta}"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1291,6 +1291,7 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
         accumulated_display_text,
         turn_id,
         knobs,
+        event_tx.as_ref(),
         turn_state.canonical.as_deref_mut(),
     )
     .await


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - When a turn exhausts `max_tool_iterations`, `finish_after_max_iterations` asks the model for a graceful summary and appends it to the returned display text — but never emitted a `TurnEvent::Chunk`. ACP clients render message content exclusively from `agent_message_chunk`, which is fed by that event, so the summary was silently dropped and the turn resolved with `stopReason: "end_turn"` showing nothing.
  - The max-iteration exit now emits the newly-produced segment (summary + stop reason) as one post-hoc chunk, matching what the normal final-response path already does with `display_text`.
  - The emit is deliberately **unguarded**. The normal path gates on `!response_streamed_live && !protocol_suppressed` to avoid double-delivering text the provider streamed live; the summary comes from a fresh non-streaming `run_model_query` call, so there is no live delta to double-deliver. Those bindings are also per-iteration loop-body state and out of scope at the exit.
  - Only the **new** segment is emitted, never `accumulated_display_text` — that holds narration earlier iterations already streamed, and resending it would duplicate content in the client. A test pins this specifically.
- **Scope boundary:** This PR fixes the max-iteration exit only. Two adjacent gaps are deliberately left alone as separate concerns: the malformed-tool-protocol fallback return in `run_tool_call_loop` skips the same emit, and neither path feeds the `on_delta` `StreamDelta` seam. Neither is the reported defect, and folding them in would put three concerns in one PR.
- **Blast radius:** `zeroclaw-runtime` agent turn loop. `TurnEvent::Chunk` consumers gain one additional chunk on a path that previously emitted none: the ACP server, the gateway WebSocket, and the runtime RPC turn. All three already accumulate chunks and separately surface the returned string, so the shape is identical to the normal final-response path. Turns that do not hit the iteration cap are unaffected.
- **Linked issue(s):** Closes #10018
- **Labels:** `bug`, `agent`, `runtime`, `distinguished contributor`, `priority:p2`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the behavior is pinned by a boundary test that drives a real streamed turn to the iteration cap and asserts on the emitted event stream. Reproducing by hand needs a live ACP client (Zed/JetBrains) attached to a daemon, which the automated test replaces end to end.
- **Interface(s) exercised:** `channel` (ACP), plus any `TurnEvent` consumer — gateway `web` and RPC `tui` surfaces observe the same event.

### How I tested

Two tests, at different altitudes, both verified to fail without the production change:

- `agent::turn::max_iter::graceful_summary_metering_tests::graceful_summary_emits_a_turn_event_chunk_with_only_the_new_segment` — unit level. Seeds a non-empty prior `accumulated_display_text` (`"earlier narration"`), asserts the emitted chunk carries the summary and the stop reason and does **not** carry the prior narration. This is the anti-duplication guard.
- `agent::agent::safety_net::safety_net_graceful_summary_emits_turn_event_chunk` — boundary level. Scripts a provider to return tool calls until `max_tool_iterations: 2` is hit, drives a real streamed turn, and asserts a `TurnEvent::Chunk` carrying the summary reaches the receiver. This is what proves the call-site wiring.

Both were mutation-checked. Passing `None` at the `mod.rs` call site fails the boundary test (`max-iteration exit must emit a TurnEvent::Chunk so ACP clients render the summary`); stubbing the emit fails the unit test. Emitting the full accumulated text instead of the new segment fails the unit test on the `earlier narration` assertion.

```sh
cargo fmt -p zeroclaw-runtime -- --check                                  # pass
cargo test -p zeroclaw-runtime --lib graceful_summary                     # 8 passed, 0 failed
cargo test --no-run --locked --workspace --exclude zeroclaw-desktop       # pass (exit 0)
./scripts/ci/rust_quality_gate.sh --strict                                # fmt + clippy pass; see gap note
./scripts/ci/comment_hygiene_gate.sh                                      # "Comment hygiene gate passed."
```

- **CI checks relied on and why they cover this change:** `Lint` covers the changed Rust via workspace clippy with `-D warnings` and `--features ci-all`; `Test` runs `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`, which includes both new tests. The full-workspace test compile was run locally because this change alters a function signature, and a per-crate build would not surface a broken call site elsewhere.
- **Known CI coverage gap, if any:** No automated coverage drives a real ACP client over the wire; the boundary test asserts at the `TurnEvent` seam that feeds `agent_message_chunk`, which is the closest programmatic boundary to where the user observes the bug.
- **Commands run and tail output:**

```text
test agent::turn::max_iter::graceful_summary_metering_tests::graceful_summary_emits_a_turn_event_chunk_with_only_the_new_segment ... ok
test agent::agent::safety_net::safety_net_graceful_summary_emits_turn_event_chunk ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 3734 filtered out
```

- **Beyond CI, what did you manually verify?** Traced all three `TurnEvent::Chunk` consumers (`orchestrator/acp_server.rs`, `gateway/ws.rs`, `runtime/rpc/turn.rs`) to confirm the added chunk cannot double-render: each already accumulates chunks and separately includes the returned string, exactly as on the normal final-response path this mirrors. Also confirmed `protocol_suppressed` is computed by `StreamTextGuard` purely as a byproduct of streaming consumption inside the loop and never applied to the non-streaming summary call, before or after this change. Not verified: behavior against a live Zed or JetBrains ACP client.
- **If any command was intentionally skipped, why:** None skipped. `./scripts/ci/rust_quality_gate.sh --strict` passes fmt and strict clippy, then reports its provider-dispatch check against `crates/zeroclaw-runtime/src/sop/capability/llm_generate.rs:239`. That file is byte-identical to `origin/master` and untouched by this diff, so the finding is pre-existing and not introduced here. Docs gates were not run because the diff touches no `docs/book/src/**` files.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No` — the summary text already flowed to every consumer through the returned display string and session history; this only routes the same text through the event seam as well. No new text reaches the model.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

The one signature change is `finish_after_max_iterations`, which is `pub(crate)` and has no callers outside this crate.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Max-iteration graceful summaries are missing, duplicated, or display hidden/provider-protocol content in ACP, gateway WebSocket, or RPC clients.
