### PR TITLE
test(runtime): isolate the endpoint-lock reacquire test from sibling forks

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/local.rs
+++ b/crates/zeroclaw-runtime/src/rpc/local.rs
@@ -957,9 +957,50 @@ mod tests {
         drop(guard);
     }
 
+    /// Set on the re-executed child so `endpoint_lock_is_held_through_guard_cleanup`
+    /// runs its real assertions instead of relaunching itself again.
+    #[cfg(unix)]
+    const ENDPOINT_LOCK_TEST_CHILD_ENV: &str = "ZEROCLAW_ENDPOINT_LOCK_TEST_CHILD";
+
     #[cfg(unix)]
     #[tokio::test]
     async fn endpoint_lock_is_held_through_guard_cleanup() {
+        // This test drops a real EndpointLock and then requires that a
+        // fresh acquire of the same path immediately succeeds. `flock()`,
+        // which EndpointLock uses, is scoped to the *open file
+        // description*, and `fork()` duplicates a process's whole
+        // descriptor table into any child it creates. If some unrelated
+        // test elsewhere in this binary forks a subprocess (the shell
+        // tool, a sandbox backend, ...) at the exact instant our lock's
+        // descriptor happens to be open, that child inherits a reference
+        // that keeps the lock alive past our own `drop()`, and the
+        // reacquire below spuriously observes it as still owned. This is
+        // not about path uniqueness — this test's `tempfile::tempdir()`
+        // path is already unique — it is about the whole test binary
+        // process's descriptor table being shared with every other
+        // concurrently running test.
+        //
+        // The only way to make the reacquire deterministic is to guarantee
+        // nothing else can fork while it happens, so the real body below
+        // runs in a freshly exec'd child process dedicated to this one
+        // test, whose descriptor table nothing else can share.
+        if std::env::var_os(ENDPOINT_LOCK_TEST_CHILD_ENV).is_none() {
+            let exe = std::env::current_exe().expect("resolve current test binary");
+            let status = tokio::process::Command::new(exe)
+                .arg("rpc::local::tests::endpoint_lock_is_held_through_guard_cleanup")
+                .arg("--exact")
+                .arg("--test-threads=1")
+                .env(ENDPOINT_LOCK_TEST_CHILD_ENV, "1")
+                .status()
+                .await
+                .expect("relaunch endpoint_lock_is_held_through_guard_cleanup in isolation");
+            assert!(
+                status.success(),
+                "isolated endpoint_lock_is_held_through_guard_cleanup failed: {status}"
+            );
+            return;
+        }
+
         let tmp = tempfile::tempdir().unwrap();
         let sock_path = tmp.path().join("daemon.sock");
         let (listener, guard) = platform::bind(&sock_path).await.unwrap();


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `rpc::local::tests::endpoint_lock_is_held_through_guard_cleanup` now runs its real body in a freshly exec'd child process dedicated to that one test, so no sibling test can `fork()` during its critical section. Test-only; 41 added lines, no production code touched.
- **Scope boundary:** One test. The assertions are unchanged — no retry, no sleep, no loosened check, not `#[ignore]`d.
- **Blast radius:** One extra short-lived process when that test runs.
- **Linked issue(s):** Closes #10006. Related #9846, Related #9965.
- **Labels:** `bug`, `runtime`, `tests`, `distinguished contributor`, `priority:p1`, `risk:high`, `size:XS`, `type:test`

## Diagnosis: it is not a path collision, and not application state

The issue's suggested remedy ("per-test unique endpoint path") would not have worked, and it is worth recording why, because the real mechanism is non-obvious and will otherwise be re-proposed.

- Every test here already uses `tempfile::tempdir()`, so paths were **already unique** — note the `.tmpjJNDEj` in the reported failure. Adding more uniqueness changes nothing.
- There is no process-global `OnceLock`/`Mutex`/registry in the lock path either; I read the whole `platform` module to confirm. `EndpointLock` is a genuine per-(device, inode) OS advisory lock.

The actual mechanism is an OS-level `fork()`/`flock()` hazard:

1. `flock()` locks are scoped to the **open file description**, not to the path and not to the process.
2. `fork()` duplicates a process's **entire file descriptor table** into the child — including descriptors owned by unrelated threads, because the fd table is shared process-wide.
3. This test is the only one in the crate that drops a lock and then demands an *immediate* successful reacquire in the same process. If any concurrently running test forks a subprocess at the instant this test's lock fd is open, the child inherits a reference to that same open file description. Rust sets `O_CLOEXEC`, but the descriptor still lives from `fork()` until `exec()` — and under CPU oversubscription that window widens. Our `drop(guard)` then does not actually release the lock, and the reacquire reports "already owned".

Roughly fifteen modules in this crate spawn real subprocesses (`tools/shell.rs`, the sandbox backends, `cron/scheduler.rs`, `doctor`, `tunnel`, and others), so the colliding partner is structural rather than one specific test.

**Evidence for the diagnosis, independent of this codebase:** a ~90-line standalone Rust program — 8 threads doing "open unique tempfile, lock, drop, immediately relock" against guaranteed-unique paths, racing 8 threads spawning `/usr/bin/true` — reproduces 150-190 spurious "still locked" observations per 24,000 attempts, every run, with zero shared paths and zero zeroclaw code. That isolates the mechanism to fd-table inheritance.

**Evidence inside the crate:** running `rpc::local::` alone at `--test-threads=64` for 60 iterations produced **zero** reproductions. Adding `tools::shell::` alongside it at `--test-threads=96` reproduced the exact reported failure (`local.rs:988`, "already owned at ...") in **14 of 20 runs**.

### Alternatives considered and rejected

- **Guard `shell.rs`'s spawn with a crate-wide lock** — closes the dominant collider but not the other ~15 spawn sites. Partial fix.
- **`pthread_atfork` global fork lock** — POSIX does not guarantee it fires for `posix_spawn`-based children, so unreliable here.
- **Move the test to a `tests/*.rs` integration binary** — `EndpointLock` and `platform::bind` are private to the module; making them public is a larger, security-relevant API change for a test's benefit.
- **Switch the production lock from `flock` to POSIX/`fcntl` record locks** (which are per-process and not fork-inherited) — a real production semantics change, far out of proportion to a test flake.

Re-exec isolation was chosen because it eliminates the race **structurally** for this test, independent of which sibling would have collided and independent of tests added later.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the relevant evidence is reproduction-before / clean-after under the parallel gate, reported below.
- **Interface(s) exercised:** `cli` / local IPC endpoint lifecycle.

### How I tested

```sh
cargo fmt --all -- --check                                                       # pass
cargo test -p zeroclaw-runtime endpoint_lock                                     # 6 passed, 0 failed
cargo test --no-run --locked --workspace --exclude zeroclaw-desktop              # pass (exit 0)
RUSTFLAGS="-D warnings" cargo check --locked --workspace \
  --exclude zeroclaw-desktop --no-default-features                               # pass
./scripts/ci/rust_quality_gate.sh --strict                                       # fmt + clippy pass; see gap note
./scripts/ci/comment_hygiene_gate.sh                                             # "Comment hygiene gate passed."
```

Race-specific evidence:

- Targeted combo `rpc::local:: + tools::shell::` at `--test-threads=96`: **14/20 runs reproduced the failure before the change, 0/40 after.**
- The CI gate's exact invocation (`cargo test --locked --quiet -p zeroclaw-runtime --lib -- --test-threads=16`, 3 repeats, matching `parallel_runtime_test_gate.sh`): **3737 passed / 0 failed on each of the three runs.**

Mutation proof that the test still bites — adding `let _ = file.unlock();` after a successful `try_lock()` in `EndpointLock::acquire`, defeating exclusivity:

```text
thread 'rpc::local::tests::endpoint_lock_is_held_through_guard_cleanup' panicked at
crates/zeroclaw-runtime/src/rpc/local.rs:1017:22:
the endpoint lock must remain held until guard cleanup finishes
test result: FAILED. 0 passed; 1 failed
```

The failure propagates through the isolation wrapper as `isolated endpoint_lock_is_held_through_guard_cleanup failed: exit status: 101`, confirming the wrapper does not swallow a real failure. Mutation reverted afterward.

- **CI checks relied on and why they cover this change:** `Parallel Runtime Test` is the gate that was going red and is the one that matters; `scripts/ci/parallel_runtime_test_scope.sh` selects it for any `crates/zeroclaw-runtime/*` change, so it runs on this PR. Note that the `Test` job uses `cargo nextest`, which already runs each test in its own process — the race only ever manifested under the `cargo test` single-binary gate.
- **Known CI coverage gap, if any:** None specific to this change. See the honesty note below on evidence strength.
- **Commands run and tail output:**

```text
test rpc::local::tests::endpoint_lock_is_held_through_guard_cleanup ... ok
test result: ok. 6 passed; 0 failed; 0 ignored
test result: ok. 3737 passed; 0 failed    (x3, CI-exact parallel gate invocation)
```

- **Beyond CI, what did you manually verify?** That the isolation cannot recurse: the child is marked by an explicit env var set on the spawn, so it runs the real body rather than relaunching. That a real failure still propagates (shown by the mutation above). That the child invocation (`<test name> --exact --test-threads=1`) is accepted by the standard libtest harness. And that the diagnosis holds outside this codebase, via the standalone repro.
- **If any command was intentionally skipped, why:** None skipped. `rust_quality_gate.sh --strict` passes fmt and strict clippy; its only finding is the pre-existing provider-dispatch flag on `crates/zeroclaw-runtime/src/sop/capability/llm_generate.rs:239`, byte-identical to `origin/master` and untouched here. Docs gates were not run because the diff touches no `docs/book/src/**` files.

### Honest note on evidence strength

The claim rests on the **mechanism**, not on repetition counts. Once the critical section runs alone in a freshly exec'd process, there is no other thread in that process that can call `fork()` during the window — that is a structural statement, not "very unlikely". The 40/40 and 3737x3 numbers corroborate it rather than carry it.

One caveat I will not paper over: I verified the pre-fix race empirically against `tools::shell` (the dominant collider) but did not exhaustively prove every other subprocess-spawning module can trigger it. That does not weaken the fix, which isolates this test regardless of which sibling would have collided — but it does mean "roughly fifteen modules could collide" is reasoned from the mechanism, not individually demonstrated.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

The test spawns its own test binary. This crate's suite already spawns real subprocesses extensively, so no new capability is required.

## Compatibility (required)

- Backward compatible? `Yes` — test-only.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk and test-only: `git revert <sha>` is the plan, at the cost of restoring the flake.

