### PR TITLE
ci(clippy): share Clippy command runner across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,44 +131,15 @@ jobs:
         run: bash scripts/ci/apt_install.sh libudev-dev ripgrep
       - name: Ensure web/dist placeholder exists
         run: mkdir -p web/dist && touch web/dist/.gitkeep
+      - name: Clippy runner contract tests
+        run: bash scripts/ci/run_clippy.test.sh
       - name: Clippy
         shell: bash
         run: |
-          set +e
-          cargo_log="${RUNNER_TEMP}/cargo-clippy.log"
-          SECONDS=0
-          cargo clippy \
-            --locked \
-            --workspace \
-            --exclude zeroclaw-desktop \
-            --all-targets \
-            --features ci-all \
-            -- -D warnings 2>&1 | tee "$cargo_log"
-          cargo_status=${PIPESTATUS[0]}
-          duration_seconds=$SECONDS
-          set -e
-
-          workspace_path_compiles="$(grep -E -c 'Compiling.*\([^)]*zeroclaw' "$cargo_log" || true)"
-          total_compiles="$(grep -c 'Compiling' "$cargo_log" || true)"
-          downloaded_crates="$(grep -c 'Downloaded' "$cargo_log" || true)"
-          cache_hit="${RUST_CACHE_HIT:-unknown}"
-          summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
-
-          {
-            echo "### Lint diagnostics"
-            echo ""
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Runner OS | \`${{ runner.os }}\` |"
-            echo "| Rust cache exact hit | \`${cache_hit}\` |"
-            echo "| Clippy duration | \`${duration_seconds}s\` |"
-            echo "| Clippy status | \`${cargo_status}\` |"
-            echo "| Workspace path compile lines | \`${workspace_path_compiles}\` |"
-            echo "| Total compile lines | \`${total_compiles}\` |"
-            echo "| Downloaded crate lines | \`${downloaded_crates}\` |"
-          } >> "$summary_file"
-
-          exit "$cargo_status"
+          bash scripts/ci/run_clippy.sh \
+            --scope workspace \
+            --summary-title "Lint diagnostics" \
+            --log-name cargo-clippy.log
         env:
           RUST_CACHE_HIT: ${{ steps.rust-cache.outputs.cache-hit }}
       - name: Rustdoc warnings gate
@@ -219,7 +190,7 @@ jobs:
               ;;
           esac
 
-          if grep -Eq '^(crates/zeroclaw-tools/|\.github/workflows/(ci|cross-platform-clippy)\.yml$)' "$changed_files"; then
+          if grep -Eq '^(crates/zeroclaw-tools/|scripts/ci/run_clippy\.sh$|\.github/workflows/(ci|cross-platform-clippy)\.yml$)' "$changed_files"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -249,42 +220,11 @@ jobs:
       - name: Clippy
         shell: bash
         run: |
-          set +e
-          cargo_log="${RUNNER_TEMP}/cargo-clippy-windows-tools.log"
-          SECONDS=0
-          cargo clippy \
-            -p zeroclaw-tools \
-            --all-targets \
-            --all-features \
+          bash scripts/ci/run_clippy.sh \
+            --scope tools \
             --target x86_64-pc-windows-msvc \
-            --no-deps \
-            -- -D warnings 2>&1 | tee "$cargo_log"
-          cargo_status=${PIPESTATUS[0]}
-          duration_seconds=$SECONDS
-          set -e
-
-          workspace_path_compiles="$(grep -E -c 'Compiling.*\([^)]*zeroclaw' "$cargo_log" || true)"
-          total_compiles="$(grep -c 'Compiling' "$cargo_log" || true)"
-          downloaded_crates="$(grep -c 'Downloaded' "$cargo_log" || true)"
-          cache_hit="${RUST_CACHE_HIT:-unknown}"
-          summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
-
-          {
-            echo "### Targeted Windows Clippy diagnostics"
-            echo ""
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Target | \`x86_64-pc-windows-msvc\` |"
-            echo "| Runner OS | \`${{ runner.os }}\` |"
-            echo "| Rust cache exact hit | \`${cache_hit}\` |"
-            echo "| Clippy duration | \`${duration_seconds}s\` |"
-            echo "| Clippy status | \`${cargo_status}\` |"
-            echo "| Workspace path compile lines | \`${workspace_path_compiles}\` |"
-            echo "| Total compile lines | \`${total_compiles}\` |"
-            echo "| Downloaded crate lines | \`${downloaded_crates}\` |"
-          } >> "$summary_file"
-
-          exit "$cargo_status"
+            --summary-title "Targeted Windows Clippy diagnostics" \
+            --log-name cargo-clippy-windows-tools.log
         env:
           RUST_CACHE_HIT: ${{ steps.rust-cache.outputs.cache-hit }}
 

--- a/.github/workflows/cross-platform-clippy.yml
+++ b/.github/workflows/cross-platform-clippy.yml
@@ -49,41 +49,10 @@ jobs:
       - name: Clippy
         shell: bash
         run: |
-          set +e
-          cargo_log="${RUNNER_TEMP}/cargo-clippy-${{ matrix.target }}.log"
-          SECONDS=0
-          cargo clippy \
-            --workspace \
-            --exclude zeroclaw-desktop \
-            --all-targets \
-            --features ci-all \
+          bash scripts/ci/run_clippy.sh \
+            --scope workspace \
             --target ${{ matrix.target }} \
-            -- -D warnings 2>&1 | tee "$cargo_log"
-          cargo_status=${PIPESTATUS[0]}
-          duration_seconds=$SECONDS
-          set -e
-
-          workspace_path_compiles="$(grep -E -c 'Compiling.*\([^)]*zeroclaw' "$cargo_log" || true)"
-          total_compiles="$(grep -c 'Compiling' "$cargo_log" || true)"
-          downloaded_crates="$(grep -c 'Downloaded' "$cargo_log" || true)"
-          cache_hit="${RUST_CACHE_HIT:-unknown}"
-          summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
-
-          {
-            echo "### Cross-platform Clippy diagnostics: ${{ matrix.target }}"
-            echo ""
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Target | \`${{ matrix.target }}\` |"
-            echo "| Runner OS | \`${{ runner.os }}\` |"
-            echo "| Rust cache exact hit | \`${cache_hit}\` |"
-            echo "| Clippy duration | \`${duration_seconds}s\` |"
-            echo "| Clippy status | \`${cargo_status}\` |"
-            echo "| Workspace path compile lines | \`${workspace_path_compiles}\` |"
-            echo "| Total compile lines | \`${total_compiles}\` |"
-            echo "| Downloaded crate lines | \`${downloaded_crates}\` |"
-          } >> "$summary_file"
-
-          exit "$cargo_status"
+            --summary-title "Cross-platform Clippy diagnostics: ${{ matrix.target }}" \
+            --log-name cargo-clippy-${{ matrix.target }}.log
         env:
           RUST_CACHE_HIT: ${{ steps.rust-cache.outputs.cache-hit }}

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -134,6 +134,8 @@ Manual trigger for building release binaries across the full target matrix: Linu
 
 Manual and weekly scheduled advisory lint coverage on macOS aarch64 and Windows x86_64 targets. It mirrors the required PR lint command with `--target` set for each platform, but intentionally does not run on PRs and is not part of `CI Required Gate`.
 
+Required Linux Clippy, advisory cross-platform Clippy, and targeted Windows Clippy call `scripts/ci/run_clippy.sh`. That runner owns the supported command shapes, Cargo exit-status propagation, and the shared duration, cache, compile-count, and download-count diagnostics. The workflow files continue to own triggers, runners, toolchains, caches, timeouts, and required-gate membership.
+
 ### Release Stable (`release-stable-manual.yml`)
 
 Manual trigger for the full release pipeline. Builds all targets, creates the GitHub Release, pushes the prebuilt `latest`, versioned, and `debian` Docker images to GHCR, calls the generated Docker variant matrix at the release tag, triggers the website redeploy, and invokes the distribution sub-workflows (Scoop, AUR, Discord, tweet). Homebrew Core detects new releases through its own autobump service. Two environment gates require maintainer approval mid-run: `github-releases` (the `publish` job) and `docker`.

--- a/scripts/ci/run_clippy.sh
+++ b/scripts/ci/run_clippy.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: run_clippy.sh --scope workspace|tools --summary-title TITLE --log-name NAME [--target TRIPLE]
+EOF
+    exit 2
+}
+
+scope=""
+target=""
+summary_title=""
+log_name=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --scope)
+            [ "$#" -ge 2 ] || usage
+            scope="$2"
+            shift 2
+            ;;
+        --target)
+            [ "$#" -ge 2 ] || usage
+            target="$2"
+            shift 2
+            ;;
+        --summary-title)
+            [ "$#" -ge 2 ] || usage
+            summary_title="$2"
+            shift 2
+            ;;
+        --log-name)
+            [ "$#" -ge 2 ] || usage
+            log_name="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+[ -n "$scope" ] || usage
+[ -n "$summary_title" ] || usage
+[ -n "$log_name" ] || usage
+case "$log_name" in
+    */*) usage ;;
+esac
+
+command=(cargo clippy --locked)
+case "$scope" in
+    workspace)
+        command+=(
+            --workspace
+            --exclude zeroclaw-desktop
+            --all-targets
+            --features ci-all
+        )
+        if [ -n "$target" ]; then
+            command+=(--target "$target")
+        fi
+        ;;
+    tools)
+        [ -n "$target" ] || usage
+        command+=(
+            -p zeroclaw-tools
+            --all-targets
+            --all-features
+            --target "$target"
+            --no-deps
+        )
+        ;;
+    *)
+        usage
+        ;;
+esac
+command+=(-- -D warnings)
+
+cargo_log="${RUNNER_TEMP:?RUNNER_TEMP must be set}/${log_name}"
+SECONDS=0
+set +e
+"${command[@]}" 2>&1 | tee "$cargo_log"
+cargo_status=${PIPESTATUS[0]}
+set -e
+duration_seconds=$SECONDS
+
+workspace_path_compiles="$(grep -E -c 'Compiling.*\([^)]*zeroclaw' "$cargo_log" || true)"
+total_compiles="$(grep -c 'Compiling' "$cargo_log" || true)"
+downloaded_crates="$(grep -c 'Downloaded' "$cargo_log" || true)"
+cache_hit="${RUST_CACHE_HIT:-unknown}"
+runner_os="${RUNNER_OS:-unknown}"
+summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+{
+    echo "### ${summary_title}"
+    echo ""
+    echo "| Field | Value |"
+    echo "| --- | --- |"
+    if [ -n "$target" ]; then
+        echo "| Target | \`${target}\` |"
+    fi
+    echo "| Runner OS | \`${runner_os}\` |"
+    echo "| Rust cache exact hit | \`${cache_hit}\` |"
+    echo "| Clippy duration | \`${duration_seconds}s\` |"
+    echo "| Clippy status | \`${cargo_status}\` |"
+    echo "| Workspace path compile lines | \`${workspace_path_compiles}\` |"
+    echo "| Total compile lines | \`${total_compiles}\` |"
+    echo "| Downloaded crate lines | \`${downloaded_crates}\` |"
+} >> "$summary_file"
+
+exit "$cargo_status"

--- a/scripts/ci/run_clippy.test.sh
+++ b/scripts/ci/run_clippy.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="${script_dir}/run_clippy.sh"
+mock_dir="$(mktemp -d)"
+trap 'rm -rf "$mock_dir"' EXIT
+
+cargo_args="${mock_dir}/cargo.args"
+summary_file="${mock_dir}/summary.md"
+runner_temp="${mock_dir}/runner-temp"
+mkdir -p "${mock_dir}/bin" "$runner_temp"
+
+cat > "${mock_dir}/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$ZEROCLAW_CLIPPY_TEST_ARGS"
+printf '%s\n' \
+    'Downloaded demo-crate v1.0.0' \
+    'Compiling zeroclaw-runtime v0.8.5 (/workspace/zeroclaw/crates/zeroclaw-runtime)' \
+    'Compiling serde v1.0.0'
+exit "${ZEROCLAW_CLIPPY_TEST_STATUS:-0}"
+EOF
+chmod +x "${mock_dir}/bin/cargo"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_args() {
+    local name="$1"
+    shift
+    local actual
+    local expected
+
+    actual="$(cat "$cargo_args")"
+    expected="$(printf '%s\n' "$@")"
+    if [ "$actual" != "$expected" ]; then
+        printf 'FAIL: unexpected Cargo arguments for %s\nexpected:\n%s\nactual:\n%s\n' \
+            "$name" "$expected" "$actual" >&2
+        exit 1
+    fi
+}
+
+assert_summary_line() {
+    local expected="$1"
+    grep -Fqx -- "$expected" "$summary_file" || \
+        fail "missing summary line: $expected"
+}
+
+run_runner() {
+    : > "$cargo_args"
+    : > "$summary_file"
+    PATH="${mock_dir}/bin:$PATH" \
+        RUNNER_TEMP="$runner_temp" \
+        GITHUB_STEP_SUMMARY="$summary_file" \
+        RUNNER_OS=TestOS \
+        RUST_CACHE_HIT=true \
+        ZEROCLAW_CLIPPY_TEST_ARGS="$cargo_args" \
+        bash "$runner" "$@" >/dev/null
+}
+
+run_runner \
+    --scope workspace \
+    --summary-title "Lint diagnostics" \
+    --log-name cargo-clippy.log
+assert_args "workspace" \
+    clippy \
+    --locked \
+    --workspace \
+    --exclude zeroclaw-desktop \
+    --all-targets \
+    --features ci-all \
+    -- -D warnings
+assert_summary_line '### Lint diagnostics'
+assert_summary_line "| Runner OS | \`TestOS\` |"
+assert_summary_line "| Rust cache exact hit | \`true\` |"
+assert_summary_line "| Clippy status | \`0\` |"
+assert_summary_line "| Workspace path compile lines | \`1\` |"
+assert_summary_line "| Total compile lines | \`2\` |"
+assert_summary_line "| Downloaded crate lines | \`1\` |"
+
+run_runner \
+    --scope workspace \
+    --target aarch64-apple-darwin \
+    --summary-title "Cross-platform Clippy diagnostics: aarch64-apple-darwin" \
+    --log-name cargo-clippy-aarch64-apple-darwin.log
+assert_args "targeted workspace" \
+    clippy \
+    --locked \
+    --workspace \
+    --exclude zeroclaw-desktop \
+    --all-targets \
+    --features ci-all \
+    --target aarch64-apple-darwin \
+    -- -D warnings
+assert_summary_line "| Target | \`aarch64-apple-darwin\` |"
+
+run_runner \
+    --scope tools \
+    --target x86_64-pc-windows-msvc \
+    --summary-title "Targeted Windows Clippy diagnostics" \
+    --log-name cargo-clippy-windows-tools.log
+assert_args "targeted tools" \
+    clippy \
+    --locked \
+    -p zeroclaw-tools \
+    --all-targets \
+    --all-features \
+    --target x86_64-pc-windows-msvc \
+    --no-deps \
+    -- -D warnings
+
+assert_rejected() {
+    local name="$1"
+    shift
+    local status
+
+    : > "$cargo_args"
+    set +e
+    PATH="${mock_dir}/bin:$PATH" \
+        RUNNER_TEMP="$runner_temp" \
+        GITHUB_STEP_SUMMARY="$summary_file" \
+        ZEROCLAW_CLIPPY_TEST_ARGS="$cargo_args" \
+        bash "$runner" "$@" >/dev/null 2>&1
+    status=$?
+    set -e
+
+    if [ "$status" -ne 2 ]; then
+        fail "$name should exit 2, got $status"
+    fi
+    if [ -s "$cargo_args" ]; then
+        fail "$name invoked Cargo"
+    fi
+}
+
+assert_rejected "invalid scope" \
+    --scope invalid \
+    --summary-title "Invalid scope" \
+    --log-name invalid.log
+assert_rejected "tools scope without target" \
+    --scope tools \
+    --summary-title "Missing target" \
+    --log-name missing-target.log
+
+: > "$summary_file"
+set +e
+PATH="${mock_dir}/bin:$PATH" \
+    RUNNER_TEMP="$runner_temp" \
+    GITHUB_STEP_SUMMARY="$summary_file" \
+    RUNNER_OS=TestOS \
+    RUST_CACHE_HIT=false \
+    ZEROCLAW_CLIPPY_TEST_ARGS="$cargo_args" \
+    ZEROCLAW_CLIPPY_TEST_STATUS=17 \
+    bash "$runner" \
+        --scope workspace \
+        --summary-title "Failure diagnostics" \
+        --log-name cargo-clippy-failure.log >/dev/null
+status=$?
+set -e
+
+if [ "$status" -ne 17 ]; then
+    fail "expected Cargo status 17, got $status"
+fi
+assert_summary_line "| Clippy status | \`17\` |"
+
+echo "shared Clippy runner tests: pass"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Extracted the repeated required Linux, advisory cross-platform, and targeted Windows Clippy command and diagnostic logic into `scripts/ci/run_clippy.sh` so these jobs cannot silently drift apart.
  - Added a shell contract harness to the required Linux Lint job that verifies each supported command shape, invalid-input handling, summary diagnostics, and propagation of the underlying Cargo exit status before real Clippy runs. It uses a fake Cargo executable and completed locally in 2.28 seconds, so it does not add compilation work to the critical path.
  - Added `--locked` to the two advisory/targeted command shapes so every shared runner mode respects the committed lockfile.
  - Updated the targeted Windows path selector so edits to the shared runner are checked by the Windows tools Clippy job.
  - Documented that workflows still own scheduling, runners, toolchains, caches, timeouts, and required-gate membership.
- **Scope boundary:** This PR does not change workflow `on:` event triggers, runner matrices, Rust toolchains, cache configuration, timeouts, required-gate membership, or the crates covered by each Clippy job.
- **Blast radius:** Required Linux Clippy, advisory macOS/Windows Clippy, and targeted Windows tools Clippy now share command construction, status propagation, and summary diagnostics. A runner defect could affect lint execution or reporting across those jobs.
- **Linked issue(s):** Closes #7884
- **Labels:** `ci`, `docs`, `scripts`, `risk:high`, `size:M`, `type:ci`

### What this does, simply

ZeroClaw had three workflow blocks that independently assembled similar Clippy commands and diagnostic summaries. That made it easy to improve one path while leaving another with different flags or reporting. This PR gives those jobs one tested command runner while leaving each workflow in charge of when and where it runs.

### Scope and maintenance tradeoff

The shared helper adds one small shell ownership surface in exchange for removing three larger inline implementations. A reusable GitHub workflow would also hide runner, cache, and gate topology that maintainers need to inspect directly, so this slice shares only the command and diagnostics layer. The contract harness keeps the supported Linux workspace, cross-platform workspace, and targeted Windows tools modes explicit. It runs immediately before required Clippy because it validates the same wrapper that job is about to execute; path-gating the harness separately could let workflow-only changes bypass the contract check.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is a CI refactor with a self-contained shell contract harness; hosted jobs provide the meaningful platform execution.

### How I tested

- **CI checks relied on and why they cover this change:** On head `9eb543a243`, targeted Windows Clippy passed in 3m05s, required `Lint` passed in 14m04s while exercising the required Linux helper path, and `CI Required Gate` passed.
- **Known CI coverage gap, if any:** The advisory macOS/Windows matrix runs only on schedule or manual dispatch and has not run on this head.
- **Commands run and tail output:**

```sh
$ bash -n scripts/ci/run_clippy.sh scripts/ci/run_clippy.test.sh
$ shellcheck scripts/ci/run_clippy.sh scripts/ci/run_clippy.test.sh
$ bash scripts/ci/run_clippy.test.sh
shared Clippy runner tests: pass
$ actionlint .github/workflows/ci.yml .github/workflows/cross-platform-clippy.yml
$ bash scripts/ci/comment_hygiene_gate.sh
$ git diff --check
```

- **Beyond CI, what did you manually verify?** Compared all three generated Cargo argument lists with their previous inline workflow commands, including the intentional `--locked` additions, and verified that a simulated Cargo failure exits with status 17 after writing diagnostics. The harness also passed with the macOS system Bash 3.2. No real Cargo invocation or hosted macOS/Windows job was run locally.
- **If any command was intentionally skipped, why:** Cargo was intentionally skipped because this change does not modify Rust code; the shell harness validates command construction without compiling the workspace, and hosted CI will execute the real commands.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merge commit to restore the three inline workflow implementations.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Required or advisory Clippy jobs invoke the wrong scope or target, exit with a status different from Cargo, omit their job summary, fail the new runner contract test, or reject a lockfile mismatch that the prior unlocked advisory/targeted commands would have updated.
