### PR TITLE
fix(desktop): declare Apple productivity permissions

### DIFF
--- a/apps/tauri/Entitlements.plist
+++ b/apps/tauri/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/tauri/Info.plist
+++ b/apps/tauri/Info.plist
@@ -10,6 +10,8 @@
     <string>ZeroClaw needs speech recognition for voice transcription.</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>ZeroClaw needs Automation permission to control other applications via AppleScript.</string>
+    <key>NSRemindersFullAccessUsageDescription</key>
+    <string>ZeroClaw needs Reminders access so approved tools can read and update reminders.</string>
     <key>NSScreenCaptureUsageDescription</key>
     <string>ZeroClaw needs Screen Recording to see what is on screen so the agent can act on the current context.</string>
     <key>NSInputMonitoringUsageDescription</key>

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -33,6 +33,9 @@
       "icons/128x128.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "./Entitlements.plist"
+    }
   }
 }

--- a/apps/tauri/tests/capability_security.rs
+++ b/apps/tauri/tests/capability_security.rs
@@ -32,3 +32,35 @@ fn webview_capabilities_do_not_grant_plugin_or_remote_access() {
         }
     }
 }
+
+#[test]
+fn macos_privacy_manifest_declares_agent_integration_usage() {
+    let info_plist = include_str!("../Info.plist");
+
+    for required_key in [
+        "NSAppleEventsUsageDescription",
+        "NSRemindersFullAccessUsageDescription",
+    ] {
+        assert!(
+            info_plist.contains(&format!("<key>{required_key}</key>")),
+            "Tauri Info.plist must declare {required_key} for agent integrations"
+        );
+    }
+}
+
+#[test]
+fn macos_signing_allows_agent_apple_events() {
+    let entitlements = include_str!("../Entitlements.plist");
+    assert!(
+        entitlements.contains("<key>com.apple.security.automation.apple-events</key>")
+            && entitlements.contains("<true/>"),
+        "Tauri signing must allow Apple Events so the hardened runtime can request Automation access"
+    );
+
+    let config: serde_json::Value = serde_json::from_str(include_str!("../tauri.conf.json"))
+        .expect("Tauri config must be valid JSON");
+    assert_eq!(
+        config["bundle"]["macOS"]["entitlements"], "./Entitlements.plist",
+        "Tauri bundling must apply the Apple Events entitlements file"
+    );
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds the macOS Apple Events hardened-runtime entitlement so a signed desktop-hosted daemon can request Automation access. Adds the required Reminders full-access usage description. Wires the entitlements file into Tauri signing and adds regression coverage for both declarations.
- **Scope boundary:** Does not grant TCC consent, change runtime tool policy, alter MCP configuration, or add Apple APIs.
- **Blast radius:** macOS desktop packaging and code signing only; Linux, Windows, core runtime, and non-desktop binaries are unchanged.
- **Linked issue(s):** None.
- **Labels:** Pending path-labeler output; expected desktop and macOS scope labels.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; signed macOS packaging is the relevant CI coverage gap.
- **Interface(s) exercised:** `tui` through a desktop-hosted daemon and its approved MCP tools.
- **Setup / preconditions:** Build and Developer ID-sign the universal macOS app with the normal release workflow. Configure a stdio MCP server that uses Apple Events and EventKit.
- **Steps to run:** Inspect both app executables with `codesign -d --entitlements :-`; inspect the bundled Info.plist; then request Notes Automation and Reminders access from the desktop-hosted daemon.
- **Expected on this branch (after):** Both signed executables carry `com.apple.security.automation.apple-events`; the app declares `NSAppleEventsUsageDescription` and `NSRemindersFullAccessUsageDescription`; macOS can present user-consent prompts.
- **Prior behavior on `master` (before):** The Developer ID app has hardened runtime but no Apple Events entitlement and no Reminders full-access usage description, so the responsible host cannot obtain those grants reliably.

### How I tested

- **CI checks relied on and why they cover this change:** The desktop workflow covers the Tauri crate on macOS; the focused regression test validates the canonical packaging inputs.
- **Known CI coverage gap, if any:** Local validation cannot reproduce Developer ID signing because no matching private signing identity is available. Reviewer or release CI should inspect the signed artifact entitlements.
- **Commands run and tail output:**

```sh
plutil -lint apps/tauri/Info.plist apps/tauri/Entitlements.plist
# both: OK

cargo fmt --all -- --check
# exit 0

cargo test -p zeroclaw-desktop --test capability_security
# 3 passed; 0 failed

cargo clippy -p zeroclaw-desktop --test capability_security -- -D warnings
# exit 0

git diff --check
# exit 0
```

- **Beyond CI, what did you manually verify?** Inspected the currently shipped Developer ID app: hardened runtime is enabled, neither executable carries entitlements, and the bundle lacks `NSRemindersFullAccessUsageDescription`. The same Notes MCP binary succeeds under Terminal but the desktop-hosted daemon fails, isolating responsible-host signing as the remaining boundary. No TCC database reset or local app re-sign was performed.
- **If any command was intentionally skipped, why:** A signed Tauri release build was skipped because this machine has no Developer ID signing identity; ad-hoc signing would not prove the release boundary.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: The signed macOS host becomes eligible to ask TCC for Apple Events and Reminders access. Both remain user-consent gated, tool policy remains unchanged, and only the narrowly required Apple Events entitlement is added.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this commit and rebuild/re-sign the macOS desktop release.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Notes automation returns Apple Event resolution/authorization errors; Reminders returns permission denied without a usable consent prompt.