### PR TITLE
fix(prompt): let the embedder declare whether the surface is a channel

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -12734,6 +12734,7 @@ pub async fn start_channels(
             true,
             config.channels.show_tool_calls,
             runtime.shell_profile().as_ref(),
+            config.channels.emit_channel_capabilities,
         );
         if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(
@@ -20481,6 +20482,7 @@ BTC is currently around $65,000 based on latest tool output."#
             true,
             false,
             None,
+            true,
         );
         let callable = prompt
             .split_once("<callable_tools")
@@ -25439,6 +25441,7 @@ BTC is currently around $65,000 based on latest tool output."#
             false,
             false,
             None,
+            true,
         );
         if expose_text_protocol {
             let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
@@ -25503,6 +25506,7 @@ BTC is currently around $65,000 based on latest tool output."#
             false,
             false,
             None,
+            true,
         );
 
         assert!(!prompt.contains("<callable_tools"));
@@ -25995,6 +25999,7 @@ BTC is currently around $65,000 based on latest tool output."#
             false,
             false,
             None,
+            true,
         );
 
         assert!(
@@ -26029,6 +26034,7 @@ BTC is currently around $65,000 based on latest tool output."#
             false,
             false,
             None,
+            true,
         );
 
         assert!(

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -12734,7 +12734,7 @@ pub async fn start_channels(
             true,
             config.channels.show_tool_calls,
             runtime.shell_profile().as_ref(),
-            config.channels.emit_channel_capabilities,
+            true,
         );
         if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -14329,14 +14329,6 @@ pub struct ChannelsConfig {
     /// not forwarded as individual channel messages. Default: `false`.
     #[serde(default = "default_false")]
     pub show_tool_calls: bool,
-    /// Emit the `## Channel Capabilities` section of the system prompt, which
-    /// tells the agent it is a messaging bot whose reply is delivered to a
-    /// user's channel, including voice-note transcription and TTS behaviour.
-    /// That is accurate for chat surfaces and misleading for CLI, coding and
-    /// headless runs, where it gives the agent a messaging-assistant persona.
-    /// Default: `true`, preserving existing behaviour for chat deployments.
-    #[serde(default = "default_true")]
-    pub emit_channel_capabilities: bool,
     /// Persist channel conversation history to JSONL files so sessions survive
     /// daemon restarts. Files are stored in `{workspace}/sessions/`. Default: `true`.
     #[serde(default = "default_true")]
@@ -14764,7 +14756,6 @@ impl Default for ChannelsConfig {
             max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: false,
-            emit_channel_capabilities: true,
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
@@ -28388,7 +28379,6 @@ auto_save = true
                 max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
                 ack_reactions: true,
                 show_tool_calls: true,
-                emit_channel_capabilities: true,
                 session_persistence: true,
                 session_backend: default_session_backend(),
                 session_ttl_hours: 0,
@@ -30294,7 +30284,6 @@ allowed_users = ["@u:matrix.org"]
             max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: true,
-            emit_channel_capabilities: true,
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
@@ -30846,7 +30835,6 @@ allowed_numbers = ["+1", "+2"]
             max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: true,
-            emit_channel_capabilities: true,
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -14329,6 +14329,14 @@ pub struct ChannelsConfig {
     /// not forwarded as individual channel messages. Default: `false`.
     #[serde(default = "default_false")]
     pub show_tool_calls: bool,
+    /// Emit the `## Channel Capabilities` section of the system prompt, which
+    /// tells the agent it is a messaging bot whose reply is delivered to a
+    /// user's channel, including voice-note transcription and TTS behaviour.
+    /// That is accurate for chat surfaces and misleading for CLI, coding and
+    /// headless runs, where it gives the agent a messaging-assistant persona.
+    /// Default: `true`, preserving existing behaviour for chat deployments.
+    #[serde(default = "default_true")]
+    pub emit_channel_capabilities: bool,
     /// Persist channel conversation history to JSONL files so sessions survive
     /// daemon restarts. Files are stored in `{workspace}/sessions/`. Default: `true`.
     #[serde(default = "default_true")]
@@ -14756,6 +14764,7 @@ impl Default for ChannelsConfig {
             max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: false,
+            emit_channel_capabilities: true,
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
@@ -28379,6 +28388,7 @@ auto_save = true
                 max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
                 ack_reactions: true,
                 show_tool_calls: true,
+                emit_channel_capabilities: true,
                 session_persistence: true,
                 session_backend: default_session_backend(),
                 session_ttl_hours: 0,
@@ -30284,6 +30294,7 @@ allowed_users = ["@u:matrix.org"]
             max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: true,
+            emit_channel_capabilities: true,
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
@@ -30835,6 +30846,7 @@ allowed_numbers = ["+1", "+2"]
             max_concurrent_per_channel: default_channel_max_concurrent_per_channel(),
             ack_reactions: true,
             show_tool_calls: true,
+            emit_channel_capabilities: true,
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -2096,6 +2096,7 @@ impl Agent {
             security_summary: self.security_summary.clone(),
             autonomy_level: self.autonomy_level,
             shell_profile: self.shell_profile.clone(),
+            is_messaging_channel_turn: false,
         };
         let mut prompt = self.prompt_builder.build(&ctx)?;
         append_timestamp_orientation(&mut prompt);

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -666,6 +666,10 @@ pub(crate) fn build_system_prompt_for_turn(
             inject_memory,
             show_tool_calls,
             shell_profile,
+            // The agent loop is the CLI / headless coding surface, not a
+            // messaging channel: do not tell it that its replies are delivered
+            // to a chat.
+            false,
         );
 
     if expose_text_tool_protocol {
@@ -3225,6 +3229,7 @@ pub async fn process_message(
                 false,
                 config.channels.show_tool_calls,
                 runtime.shell_profile().as_ref(),
+                false,
             );
         if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -622,6 +622,10 @@ pub(crate) fn build_system_prompt_for_turn(
     show_tool_calls: bool,
     thinking_prefix: Option<&str>,
     shell_profile: Option<&zeroclaw_api::runtime_traits::ShellProfile>,
+    // Whether this surface is a messaging channel. Threaded from config the
+    // same way as `show_tool_calls`: zeroclaw is a general-purpose agent, so
+    // the embedder declares the surface instead of the runtime inferring it.
+    emit_channel_capabilities: bool,
 ) -> Result<String> {
     let native_tools = model_provider
         .capabilities_for_model(model_name)
@@ -666,10 +670,7 @@ pub(crate) fn build_system_prompt_for_turn(
             inject_memory,
             show_tool_calls,
             shell_profile,
-            // The agent loop is the CLI / headless coding surface, not a
-            // messaging channel: do not tell it that its replies are delivered
-            // to a chat.
-            false,
+            emit_channel_capabilities,
         );
 
     if expose_text_tool_protocol {
@@ -1718,6 +1719,7 @@ pub async fn run(
             config.channels.show_tool_calls,
             None,
             runtime.shell_profile().as_ref(),
+            config.channels.emit_channel_capabilities,
         )?;
 
         // ── Approval manager (supervised mode) ───────────────────────
@@ -1813,6 +1815,7 @@ pub async fn run(
                 config.channels.show_tool_calls,
                 thinking_params.system_prompt_prefix.as_deref(),
                 runtime.shell_profile().as_ref(),
+                config.channels.emit_channel_capabilities,
             )?;
 
             let excluded_tool_names: HashSet<&str> =
@@ -1933,6 +1936,7 @@ pub async fn run(
                         config.channels.show_tool_calls,
                         thinking_params.system_prompt_prefix.as_deref(),
                         runtime.shell_profile().as_ref(),
+                        config.channels.emit_channel_capabilities,
                     )?;
                 }
                 match zeroclaw_api::NATIVE_THINKING_OVERRIDE
@@ -2489,6 +2493,7 @@ pub async fn run(
                             config.channels.show_tool_calls,
                             thinking_params.system_prompt_prefix.as_deref(),
                             runtime.shell_profile().as_ref(),
+                            config.channels.emit_channel_capabilities,
                         )?;
                     }
                     match zeroclaw_api::NATIVE_THINKING_OVERRIDE
@@ -3229,7 +3234,7 @@ pub async fn process_message(
                 false,
                 config.channels.show_tool_calls,
                 runtime.shell_profile().as_ref(),
-                false,
+                config.channels.emit_channel_capabilities,
             );
         if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(
@@ -13795,6 +13800,7 @@ Let me check the result."#;
             false,
             None,
             None,
+            true,
         )
         .expect("startup prompt should build");
         assert!(startup_prompt.contains(NATIVE_TOOLS_TASK_FRAMING));
@@ -13828,6 +13834,7 @@ Let me check the result."#;
             false,
             None,
             None,
+            true,
         )
         .expect("no-tools turn prompt should build");
         assert!(
@@ -13864,6 +13871,7 @@ Let me check the result."#;
             false,
             None,
             None,
+            true,
         )
         .expect("tools turn prompt should build");
         assert!(tools_turn_prompt.contains(NATIVE_TOOLS_TASK_FRAMING));
@@ -14098,6 +14106,7 @@ Let me check the result."#;
             false,
             None,
             None,
+            true,
         )
         .expect("compact-mode text prompt should build");
 

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -622,10 +622,9 @@ pub(crate) fn build_system_prompt_for_turn(
     show_tool_calls: bool,
     thinking_prefix: Option<&str>,
     shell_profile: Option<&zeroclaw_api::runtime_traits::ShellProfile>,
-    // Whether this surface is a messaging channel. Threaded from config the
-    // same way as `show_tool_calls`: zeroclaw is a general-purpose agent, so
-    // the embedder declares the surface instead of the runtime inferring it.
-    emit_channel_capabilities: bool,
+    // Whether this turn is on a messaging channel surface. The caller owns
+    // this per-turn fact; it must not come from process-wide channel config.
+    is_messaging_channel_turn: bool,
 ) -> Result<String> {
     let native_tools = model_provider
         .capabilities_for_model(model_name)
@@ -670,7 +669,7 @@ pub(crate) fn build_system_prompt_for_turn(
             inject_memory,
             show_tool_calls,
             shell_profile,
-            emit_channel_capabilities,
+            is_messaging_channel_turn,
         );
 
     if expose_text_tool_protocol {
@@ -1719,7 +1718,7 @@ pub async fn run(
             config.channels.show_tool_calls,
             None,
             runtime.shell_profile().as_ref(),
-            config.channels.emit_channel_capabilities,
+            false,
         )?;
 
         // ── Approval manager (supervised mode) ───────────────────────
@@ -1815,7 +1814,7 @@ pub async fn run(
                 config.channels.show_tool_calls,
                 thinking_params.system_prompt_prefix.as_deref(),
                 runtime.shell_profile().as_ref(),
-                config.channels.emit_channel_capabilities,
+                false,
             )?;
 
             let excluded_tool_names: HashSet<&str> =
@@ -1936,7 +1935,7 @@ pub async fn run(
                         config.channels.show_tool_calls,
                         thinking_params.system_prompt_prefix.as_deref(),
                         runtime.shell_profile().as_ref(),
-                        config.channels.emit_channel_capabilities,
+                        false,
                     )?;
                 }
                 match zeroclaw_api::NATIVE_THINKING_OVERRIDE
@@ -2493,7 +2492,7 @@ pub async fn run(
                             config.channels.show_tool_calls,
                             thinking_params.system_prompt_prefix.as_deref(),
                             runtime.shell_profile().as_ref(),
-                            config.channels.emit_channel_capabilities,
+                            false,
                         )?;
                     }
                     match zeroclaw_api::NATIVE_THINKING_OVERRIDE
@@ -3234,7 +3233,7 @@ pub async fn process_message(
                 false,
                 config.channels.show_tool_calls,
                 runtime.shell_profile().as_ref(),
-                config.channels.emit_channel_capabilities,
+                false,
             );
         if expose_text_tool_protocol {
             system_prompt.push_str(&build_tool_instructions_for_names(
@@ -13744,6 +13743,7 @@ Let me check the result."#;
             false,
             Some("THINKING_PREFIX"),
             None,
+            false,
         )
         .expect("turn prompt");
 
@@ -13981,6 +13981,7 @@ Let me check the result."#;
             false,
             None,
             None,
+            false,
         )
         .expect("turn prompt should build");
 
@@ -14037,6 +14038,7 @@ Let me check the result."#;
             false,
             None,
             None,
+            false,
         )
         .expect("strict turn prompt should build");
         assert!(!strict_prompt.contains("<callable_tools"));

--- a/crates/zeroclaw-runtime/src/agent/prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/prompt.rs
@@ -126,6 +126,10 @@ pub struct PromptContext<'a> {
     /// Resolved from `RuntimeAdapter::shell_profile` so the reported shell
     /// cannot drift from the executed one.
     pub shell_profile: Option<zeroclaw_api::runtime_traits::ShellProfile>,
+    /// True when this turn is running on a messaging channel surface, where
+    /// replies are delivered back through the user's channel and channel media
+    /// markers may be present. The prompt caller owns this per-turn fact.
+    pub is_messaging_channel_turn: bool,
 }
 
 pub trait PromptSection: Send + Sync {
@@ -488,7 +492,11 @@ impl PromptSection for ChannelMediaSection {
         "channel_media"
     }
 
-    fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
+    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        if !ctx.is_messaging_channel_turn {
+            return Ok(String::new());
+        }
+
         Ok("## Channel Media Markers\n\n\
             Messages from channels may contain media markers:\n\
             - `[Voice] <text>` — The user sent a voice/audio message that has already been transcribed to text. Respond to the transcribed content directly.\n\
@@ -681,6 +689,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let section = IdentitySection;
@@ -716,6 +725,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
         assert!(prompt.contains("## Tools"));
@@ -741,6 +751,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = InteractionSection.build(&ctx).unwrap();
@@ -778,6 +789,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
@@ -803,6 +815,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
         assert!(!prompt.contains("## Tools"));
@@ -828,6 +841,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
@@ -883,6 +897,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -938,6 +953,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -982,6 +998,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -1033,6 +1050,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -1063,6 +1081,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let rendered = DateTimeSection.build(&ctx).unwrap();
@@ -1117,6 +1136,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
@@ -1155,6 +1175,7 @@ mod tests {
             security_summary: Some(summary.clone()),
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SafetySection.build(&ctx).unwrap();
@@ -1194,6 +1215,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SafetySection.build(&ctx).unwrap();
@@ -1225,6 +1247,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Full,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SafetySection.build(&ctx).unwrap();
@@ -1264,6 +1287,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile: None,
+            is_messaging_channel_turn: false,
         };
 
         let output = SafetySection.build(&ctx).unwrap();
@@ -1297,6 +1321,7 @@ mod tests {
             security_summary: None,
             autonomy_level: AutonomyLevel::Supervised,
             shell_profile,
+            is_messaging_channel_turn: false,
         }
     }
 
@@ -1423,5 +1448,62 @@ mod tests {
         // A shell-less runtime keeps the POSIX wording it rendered before.
         let none = SafetySection.build(&shell_ctx(&tools, None)).unwrap();
         assert!(none.contains("trash"), "{none}");
+    }
+
+    #[test]
+    fn channel_media_section_follows_per_turn_surface_context() {
+        let tools: Vec<Box<dyn Tool>> = vec![];
+        let channel_ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            agent_workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            interaction: None,
+            dispatcher_instructions: "",
+            sends_native_tool_specs: false,
+            security_summary: None,
+            autonomy_level: AutonomyLevel::Supervised,
+            shell_profile: None,
+            is_messaging_channel_turn: true,
+        };
+        let embedded_ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            agent_workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: zeroclaw_config::schema::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            interaction: None,
+            dispatcher_instructions: "",
+            sends_native_tool_specs: false,
+            security_summary: None,
+            autonomy_level: AutonomyLevel::Supervised,
+            shell_profile: None,
+            is_messaging_channel_turn: false,
+        };
+
+        let channel = ChannelMediaSection.build(&channel_ctx).unwrap();
+        let embedded = ChannelMediaSection.build(&embedded_ctx).unwrap();
+
+        assert!(
+            channel.contains("## Channel Media Markers"),
+            "messaging channel turns should receive channel media guidance"
+        );
+        assert!(
+            channel.contains("[Voice] <text>"),
+            "messaging channel turns should preserve media marker guidance"
+        );
+        assert!(
+            !embedded.contains("## Channel Media Markers"),
+            "embedded/direct prompt contexts must not receive channel media guidance"
+        );
+        assert!(
+            !embedded.contains("[Voice] <text>"),
+            "embedded/direct prompt contexts must not receive voice-note channel guidance"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -132,6 +132,7 @@ pub fn build_system_prompt_with_tool_calls(
         true,
         show_tool_calls,
         None,
+        true,
     )
 }
 
@@ -165,6 +166,7 @@ pub fn build_system_prompt_with_mode(
         true,
         false,
         None,
+        true,
     )
 }
 
@@ -193,6 +195,10 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     // guidance entirely). Resolved from `RuntimeAdapter::shell_profile` so the
     // reported shell cannot drift from the executed one.
     shell_profile: Option<&ShellProfile>,
+    // When `false`, the "Channel Capabilities" section is omitted. Set
+    // `false` for CLI / coding / headless runs, which are not messaging
+    // channels and should not be told they are a messaging bot.
+    emit_channel_capabilities: bool,
 ) -> String {
     build_system_prompt_with_mode_and_effective_tools(
         workspace_dir,
@@ -210,6 +216,7 @@ pub fn build_system_prompt_with_mode_and_autonomy(
         inject_memory,
         show_tool_calls,
         shell_profile,
+        emit_channel_capabilities,
     )
 }
 
@@ -234,6 +241,8 @@ pub fn build_system_prompt_with_mode_and_effective_tools(
     inject_memory: bool,
     show_tool_calls: bool,
     shell_profile: Option<&ShellProfile>,
+    // Whether to emit messaging-channel-specific response and voice guidance.
+    emit_channel_capabilities: bool,
 ) -> String {
     use std::fmt::Write;
     let mut prompt = String::with_capacity(8192);
@@ -491,9 +500,10 @@ pub fn build_system_prompt_with_mode_and_effective_tools(
         }
     }
 
-    // ── 8. Channel Capabilities (full copy skipped in compact_context
-    //       mode; the timestamp orientation below emits in both modes) ──
-    if !compact_context {
+    // ── 8. Channel Capabilities (full copy skipped in compact_context mode
+    //       and for non-messaging surfaces; the timestamp orientation below
+    //       emits in both modes) ──
+    if !compact_context && emit_channel_capabilities {
         prompt.push_str("## Channel Capabilities\n\n");
         prompt.push_str("- You are running as a messaging bot. Your response is automatically sent back to the user's channel.\n");
         prompt
@@ -519,7 +529,7 @@ pub fn build_system_prompt_with_mode_and_effective_tools(
             prompt.push_str("- NEVER narrate or describe your tool usage. Do NOT say 'Let me fetch...', 'I will use...', 'Searching...', or similar. Give the FINAL ANSWER only — no intermediate steps, no tool mentions, no progress updates.\n");
         }
         prompt.push_str("- Calibration note: agents in this system currently err on the side of silence when a response would be appropriate, which users find frustrating. Skew toward replying. Memory is supplementary context that informs how you respond, not a gate on whether you respond.\n\n");
-    } // end if !compact_context (full Channel Capabilities copy)
+    } // end full Channel Capabilities copy
 
     // Emitted unconditionally: small local models mistake the enrichment
     // prefix for log/API data without this orientation. The prefix format
@@ -674,6 +684,7 @@ mod tests {
             false,
             false,
             None,
+            true,
         );
 
         assert!(prompt.contains("INLINE_FALLBACK_INSTRUCTIONS"));
@@ -696,6 +707,7 @@ mod tests {
             true,
             false,
             None,
+            true,
         )
     }
 
@@ -721,6 +733,7 @@ mod tests {
             true,
             false,
             None,
+            true,
         )
     }
 
@@ -747,6 +760,7 @@ mod tests {
             true,
             false,
             shell_profile,
+            true,
         )
     }
 
@@ -882,6 +896,7 @@ mod tests {
             true,
             false,
             Some(&profile),
+            true,
         );
         assert!(
             !prompt.contains("## Shell"),
@@ -1015,6 +1030,7 @@ mod tests {
             true,
             false,
             None,
+            true,
         )
     }
 
@@ -1266,6 +1282,7 @@ mod tests {
             true,
             false,
             None,
+            true,
         );
 
         let safety = prompt.find("## Safety").expect("safety framing");
@@ -1321,6 +1338,7 @@ mod tests {
             true,
             false,
             None,
+            true,
         );
 
         assert_eq!(prompt.chars().count(), 8_000);
@@ -1394,6 +1412,67 @@ mod tests {
         assert!(
             !prompt.contains("## Tool Authorization"),
             "Tool Authorization should be skipped when no power tools (shell/file_write/file_edit) are registered"
+        );
+    }
+    /// The CLI / coding surface must not be told it is a messaging bot.
+    ///
+    /// `## Channel Capabilities` states that the agent's reply is delivered to a
+    /// user's channel and describes voice-note/TTS behaviour. That is correct for
+    /// chat surfaces and actively misleading everywhere else: a model running the
+    /// agent loop under it self-describes as "a personal assistant" with no coding
+    /// persona. Fails on the old behaviour, which emitted the section for every
+    /// surface.
+    #[test]
+    fn channel_capabilities_are_omitted_for_non_channel_surfaces() {
+        let ws = tempfile::tempdir().expect("tempdir");
+        let tools: Vec<(&str, &str)> = vec![("file_edit", "edit files")];
+
+        let channel = build_system_prompt_with_mode_and_autonomy(
+            ws.path(),
+            "m",
+            &tools,
+            &[],
+            None,
+            None,
+            None,
+            true,
+            zeroclaw_config::schema::SkillsPromptInjectionMode::default(),
+            false,
+            0,
+            true,
+            false,
+            None,
+            true,
+        );
+        let cli = build_system_prompt_with_mode_and_autonomy(
+            ws.path(),
+            "m",
+            &tools,
+            &[],
+            None,
+            None,
+            None,
+            true,
+            zeroclaw_config::schema::SkillsPromptInjectionMode::default(),
+            false,
+            0,
+            true,
+            false,
+            None,
+            false,
+        );
+
+        assert!(
+            channel.contains("Channel Capabilities"),
+            "chat surfaces must keep the channel section"
+        );
+        assert!(
+            !cli.contains("Channel Capabilities"),
+            "CLI surface must not receive the channel section"
+        );
+        assert!(
+            !cli.contains("messaging bot"),
+            "CLI surface must not be told it is a messaging bot"
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -195,10 +195,9 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     // guidance entirely). Resolved from `RuntimeAdapter::shell_profile` so the
     // reported shell cannot drift from the executed one.
     shell_profile: Option<&ShellProfile>,
-    // When `false`, the "Channel Capabilities" section is omitted. Set
-    // `false` for CLI / coding / headless runs, which are not messaging
-    // channels and should not be told they are a messaging bot.
-    emit_channel_capabilities: bool,
+    // Whether this turn is on a messaging channel surface. The caller owns
+    // this per-turn fact; it must not come from process-wide channel config.
+    is_messaging_channel_turn: bool,
 ) -> String {
     build_system_prompt_with_mode_and_effective_tools(
         workspace_dir,
@@ -216,7 +215,7 @@ pub fn build_system_prompt_with_mode_and_autonomy(
         inject_memory,
         show_tool_calls,
         shell_profile,
-        emit_channel_capabilities,
+        is_messaging_channel_turn,
     )
 }
 
@@ -241,8 +240,9 @@ pub fn build_system_prompt_with_mode_and_effective_tools(
     inject_memory: bool,
     show_tool_calls: bool,
     shell_profile: Option<&ShellProfile>,
-    // Whether to emit messaging-channel-specific response and voice guidance.
-    emit_channel_capabilities: bool,
+    // Whether this turn is on a messaging channel surface. The caller owns
+    // this per-turn fact; it must not come from process-wide channel config.
+    is_messaging_channel_turn: bool,
 ) -> String {
     use std::fmt::Write;
     let mut prompt = String::with_capacity(8192);
@@ -503,7 +503,7 @@ pub fn build_system_prompt_with_mode_and_effective_tools(
     // ── 8. Channel Capabilities (full copy skipped in compact_context mode
     //       and for non-messaging surfaces; the timestamp orientation below
     //       emits in both modes) ──
-    if !compact_context && emit_channel_capabilities {
+    if !compact_context && is_messaging_channel_turn {
         prompt.push_str("## Channel Capabilities\n\n");
         prompt.push_str("- You are running as a messaging bot. Your response is automatically sent back to the user's channel.\n");
         prompt
@@ -760,7 +760,7 @@ mod tests {
             true,
             false,
             shell_profile,
-            true,
+            false,
         )
     }
 
@@ -896,7 +896,7 @@ mod tests {
             true,
             false,
             Some(&profile),
-            true,
+            false,
         );
         assert!(
             !prompt.contains("## Shell"),

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1828,7 +1828,7 @@ fn build_owned_step_system_prompt(
         config.channels.show_tool_calls,
         None,
         owned.shell_profile.as_ref(),
-        config.channels.emit_channel_capabilities,
+        false,
     )
 }
 

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1828,6 +1828,7 @@ fn build_owned_step_system_prompt(
         config.channels.show_tool_calls,
         None,
         owned.shell_profile.as_ref(),
+        config.channels.emit_channel_capabilities,
     )
 }
 

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -3150,6 +3150,7 @@ impl DelegateTool {
             security_summary: None,
             autonomy_level: crate::security::AutonomyLevel::default(),
             shell_profile,
+            is_messaging_channel_turn: false,
         };
 
         let builder = SystemPromptBuilder::default()


### PR DESCRIPTION
## Summary

**Base branch:** `master`

**What changed and why:**

`build_system_prompt` emits a `## Channel Capabilities` section for every surface whenever `compact_context` is false. It tells the agent it is "running as a messaging bot", that its response "is automatically sent back to the user's channel", and describes voice-note transcription and TTS.

That is accurate for chat surfaces and wrong everywhere else. The agent loop is not a messaging channel, yet it receives the same text. Asked what it was, a model running under it answered:

> I'm not a "messaging bot" and I don't have a **coding** persona defined in my core prompt. What I am is a **personal assistant** running in Rust with tools for files, shell, web, **messaging channels**, and more.

The section looks like a historical artifact. `system_prompt.rs` opens with:

> These functions were originally in `channels/mod.rs` but live here to break a circular dependency between the channels and agent modules.

The channel framing moved with them and was never re-scoped to the surfaces that actually are channels.

zeroclaw is a general-purpose agent, so the runtime should not decide which persona applies — the embedder should declare it. There was previously no way to say so.

This adds `channels.emit_channel_capabilities` (default `true`, so chat deployments are byte-identical) and threads it exactly like the existing `show_tool_calls` parameter: supplied from config at every production call site, with **no hardcoded assumption about what any particular surface is for**. A chat deployment leaves it `true`; an embedder driving non-conversational work sets it `false`.

**Scope boundary:** prompt assembly only. No tool, routing, provider, or channel behaviour changes. No public API is removed; the new parameter is additive and every existing wrapper preserves current output.

**Blast radius:** none by default — `true` reproduces today's prompt on every surface. Behaviour changes only where an operator opts out.

**Linked issue(s):** none filed.

**Labels:** `runtime`, `type:fix`

## Testing (required)

### How you can test (when useful)

```
cargo test -p zeroclaw-runtime --lib channel_capabilities
```

To confirm the test actually catches the defect rather than passing alongside it, revert only the gate and re-run — it must fail:

```
perl -0pi -e 's/if !compact_context && emit_channel_capabilities \{/if !compact_context {/' \
  crates/zeroclaw-runtime/src/agent/system_prompt.rs
cargo test -p zeroclaw-runtime --lib channel_capabilities
```

### How I tested

Toolchain 1.96.1 on macOS arm64, at `afa698bba0`.

`cargo +1.96.1 fmt --all -- --check`

```
(no output = clean)
```

`cargo +1.96.1 clippy -p zeroclaw-runtime -p zeroclaw-config -p zeroclaw-channels --all-targets -- -D warnings`

```
    Checking zeroclaw-runtime v0.8.4 (/Users/jasonperlow/Projects/zeroclaw/crates/zeroclaw-runtime)
    Checking zeroclaw-channels v0.8.4 (/Users/jasonperlow/Projects/zeroclaw/crates/zeroclaw-channels)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 49s
```

`cargo +1.96.1 test -p zeroclaw-runtime --lib channel_capabilities`

```
test agent::system_prompt::tests::channel_capabilities_are_omitted_for_non_channel_surfaces ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3740 filtered out; finished in 0.01s
```

Same test with **only the gate reverted** to the previous behaviour — it fails, so it is testing the defect and not merely coexisting with it:

```
test agent::system_prompt::tests::channel_capabilities_are_omitted_for_non_channel_surfaces ... FAILED
thread '...' panicked at crates/zeroclaw-runtime/src/agent/system_prompt.rs:672:9:
CLI surface must not receive the channel section
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3740 filtered out; finished in 0.06s
```

**End-to-end, against a running daemon.** I built the binary, installed it, set `emit_channel_capabilities = false`, and asked the model to list the `##` headings actually present in its system prompt. `## Channel Capabilities` is absent, and the same model that previously called itself a personal assistant now answers:

> I am a **coding agent, not a messaging bot** — my responses and actions occur within this chat interface for helping with projects and code.

Two caveats worth stating plainly. Removing this section does **not** by itself give the agent any particular persona: the remaining `## Identity` / `## About You` text comes from the injected workspace bootstrap files (`IDENTITY.md`, `SOUL.md`), which are operator configuration this PR does not touch. And the section is not wrong in general — it is correct for the chat surfaces zeroclaw is built around. The defect is that there was no way to say a surface is *not* one, so the claim was asserted unconditionally.

## Security & Privacy Impact (required)

- **Does this change authentication, authorization, or access control?** No.
- **Does it touch secrets, tokens, or credentials?** No.
- **Does it add or change network egress?** No.
- **Does it log or persist user data?** No.

Prompt text only. No key, token, or PII appears in the diff or tests.

## Compatibility (required)

Backwards compatible. `emit_channel_capabilities` defaults to `true`, so an existing deployment that does not set it produces a byte-identical prompt. The new builder parameter is additive and every existing wrapper passes `true`, so no caller changes behaviour implicitly. No call site hardcodes the value; it comes from config everywhere in production, so nothing changes until an operator opts out.

## Rollback (required for medium/high-risk PRs)

Set `channels.emit_channel_capabilities = true` to restore the previous prompt on every surface without reverting code. A full revert is a single-commit revert with no migration or state to unwind.
