### PR TITLE
fix(memory): qualify PostgreSQL recall time predicates

### DIFF
--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -355,6 +355,22 @@ fn quote_identifier(value: &str) -> String {
     format!("\"{value}\"")
 }
 
+fn recall_time_filter(since: bool, until: bool, first_placeholder: usize) -> String {
+    match (since, until) {
+        (true, true) => format!(
+            " AND m.created_at >= ${first_placeholder}::TIMESTAMPTZ AND m.created_at <= ${}::TIMESTAMPTZ",
+            first_placeholder + 1
+        ),
+        (true, false) => {
+            format!(" AND m.created_at >= ${first_placeholder}::TIMESTAMPTZ")
+        }
+        (false, true) => {
+            format!(" AND m.created_at <= ${first_placeholder}::TIMESTAMPTZ")
+        }
+        (false, false) => String::new(),
+    }
+}
+
 #[async_trait]
 impl Memory for PostgresMemory {
     fn name(&self) -> &str {
@@ -393,14 +409,7 @@ impl Memory for PostgresMemory {
             let since_ref = since_owned.as_deref();
             let until_ref = until_owned.as_deref();
 
-            let time_filter: String = match (since_ref, until_ref) {
-                (Some(_), Some(_)) => {
-                    " AND created_at >= $4::TIMESTAMPTZ AND created_at <= $5::TIMESTAMPTZ".into()
-                }
-                (Some(_), None) => " AND created_at >= $4::TIMESTAMPTZ".into(),
-                (None, Some(_)) => " AND created_at <= $4::TIMESTAMPTZ".into(),
-                (None, None) => String::new(),
-            };
+            let time_filter = recall_time_filter(since_ref.is_some(), until_ref.is_some(), 4);
 
             let stmt = format!(
                 "
@@ -763,14 +772,7 @@ impl Memory for PostgresMemory {
             let since_ref = since_owned.as_deref();
             let until_ref = until_owned.as_deref();
 
-            let time_filter: String = match (since_ref, until_ref) {
-                (Some(_), Some(_)) => {
-                    " AND m.created_at >= $5::TIMESTAMPTZ AND m.created_at <= $6::TIMESTAMPTZ".into()
-                }
-                (Some(_), None) => " AND m.created_at >= $5::TIMESTAMPTZ".into(),
-                (None, Some(_)) => " AND m.created_at <= $5::TIMESTAMPTZ".into(),
-                (None, None) => String::new(),
-            };
+            let time_filter = recall_time_filter(since_ref.is_some(), until_ref.is_some(), 5);
 
             let stmt = format!(
                 "
@@ -851,6 +853,37 @@ impl ::zeroclaw_api::attribution::Attributable for PostgresMemory {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recall_time_filter_qualifies_alias_and_preserves_placeholder_order() {
+        let cases = [
+            (false, false, 4, ""),
+            (true, false, 4, " AND m.created_at >= $4::TIMESTAMPTZ"),
+            (false, true, 4, " AND m.created_at <= $4::TIMESTAMPTZ"),
+            (
+                true,
+                true,
+                4,
+                " AND m.created_at >= $4::TIMESTAMPTZ AND m.created_at <= $5::TIMESTAMPTZ",
+            ),
+            (false, false, 5, ""),
+            (true, false, 5, " AND m.created_at >= $5::TIMESTAMPTZ"),
+            (false, true, 5, " AND m.created_at <= $5::TIMESTAMPTZ"),
+            (
+                true,
+                true,
+                5,
+                " AND m.created_at >= $5::TIMESTAMPTZ AND m.created_at <= $6::TIMESTAMPTZ",
+            ),
+        ];
+
+        for (since, until, first_placeholder, expected) in cases {
+            assert_eq!(
+                recall_time_filter(since, until, first_placeholder),
+                expected
+            );
+        }
+    }
 
     #[test]
     fn valid_identifiers_pass_validation() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - qualify bounded plain PostgreSQL recall predicates as `m.created_at` so joining the agents table cannot make the column ambiguous
  - share one time-filter builder between plain and agent-scoped recall while preserving each path's placeholder offset and existing output
  - cover every `since` / `until` combination at both production offsets with one table-driven unit test
- **Scope boundary:** This does not change parameter binding, ranking, limits, ordering, timestamp parsing, schema, configuration, or knowledge-graph behavior.
- **Blast radius:** Bounded plain PostgreSQL recall, which previously emitted an ambiguous `created_at` predicate. Agent-scoped recall already qualified the alias and is refactored onto the shared builder with identical output.
- **Linked issue(s):** None.
- **Labels:** `bug`, `memory`, `memory:backend`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The changed behavior is a pure SQL-fragment construction contract covered directly by the focused unit test.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on `2930dc2a213dc88c30fa1345a034c6af547f06b2`, including `CI Required Gate`, `Test`, `Lint`, `Check (all features)`, cross-platform checks, and security coverage.
- **Known CI coverage gap, if any:** The focused test does not execute a live PostgreSQL statement; it proves exact alias qualification, operators, casts, conjunction order, and placeholder numbering while source inspection confirms the unchanged parameter arrays.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
cargo test -p zeroclaw-memory --features memory-postgres postgres::tests::recall_time_filter -- --nocapture
bash scripts/ci/comment_hygiene_gate.sh

running 1 test
test postgres::tests::recall_time_filter_qualifies_alias_and_preserves_placeholder_order ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 513 filtered out

Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** Inspected both query parameter arrays against the generated `$4`/`$5` and `$5`/`$6` fragments and confirmed no bare bounded `created_at` predicate remains. I did not run a live PostgreSQL service.
- **If any command was intentionally skipped, why:** No live PostgreSQL integration run was added because the focused test directly covers the changed statement-construction logic; live service execution remains an explicit evidence gap.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 2930dc2a213dc88c30fa1345a034c6af547f06b2`
- **Feature flags or config toggles:** None beyond the existing `memory-postgres` build feature.
- **Observable failure symptoms:** Bounded plain PostgreSQL recall returns an ambiguous-column error; a helper regression may surface as a bind-placeholder error. Unbounded recall remains unaffected.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A.
