### PR TITLE
test(providers): cover per-agent runtime option isolation

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -4675,6 +4675,75 @@ mod tests {
     }
 
     #[test]
+    fn provider_runtime_options_cross_family_no_leak() {
+        // Two different provider families (openai and anthropic) each with
+        // distinct max_tokens. Each agent resolves only its own provider's
+        // options, so a different provider's max_tokens cannot leak across
+        // agent boundaries.
+        use zeroclaw_config::schema::{
+            AliasedAgentConfig, AnthropicModelProviderConfig, Config, ModelProviderConfig,
+            OpenAIModelProviderConfig,
+        };
+
+        let mut config = Config::default();
+
+        // OpenAI alias with max_tokens = 16384.
+        config.providers.models.openai.insert(
+            "gpt".to_string(),
+            OpenAIModelProviderConfig {
+                base: ModelProviderConfig {
+                    model: Some("gpt-4o".to_string()),
+                    api_key: Some("fake-openai-key-not-real".to_string()),
+                    max_tokens: Some(16_384),
+                    ..ModelProviderConfig::default()
+                },
+            },
+        );
+
+        // Anthropic alias with a different max_tokens.
+        config.providers.models.anthropic.insert(
+            "sonnet".to_string(),
+            AnthropicModelProviderConfig {
+                base: ModelProviderConfig {
+                    model: Some("claude-sonnet-4".to_string()),
+                    api_key: Some("fake-anthropic-key-not-real".to_string()),
+                    max_tokens: Some(8_192),
+                    ..ModelProviderConfig::default()
+                },
+            },
+        );
+
+        config.agents.insert(
+            "openai_agent".to_string(),
+            AliasedAgentConfig {
+                model_provider: "openai.gpt".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+        config.agents.insert(
+            "anthropic_agent".to_string(),
+            AliasedAgentConfig {
+                model_provider: "anthropic.sonnet".into(),
+                ..AliasedAgentConfig::default()
+            },
+        );
+
+        let openai_opts = provider_runtime_options_for_agent(&config, "openai_agent");
+        let anthropic_opts = provider_runtime_options_for_agent(&config, "anthropic_agent");
+
+        assert_eq!(
+            openai_opts.provider_max_tokens,
+            Some(16_384),
+            "openai agent must get its own max_tokens, not the anthropic provider's"
+        );
+        assert_eq!(
+            anthropic_opts.provider_max_tokens,
+            Some(8_192),
+            "anthropic agent must get its own max_tokens, not the openai provider's"
+        );
+    }
+
+    #[test]
     fn resilient_alias_deep_acyclic_fallback_does_not_overflow() {
         use zeroclaw_config::schema::{Config, ModelProviderConfig, OpenAIModelProviderConfig};
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a cross-family regression test for agent-selected provider runtime options.
  - Configures OpenAI and Anthropic aliases with different `max_tokens` values, then verifies each agent resolves its own value.
  - Ports the resolver-level regression originally proposed by @perlowja in #7990 for the provider/runtime-options tracker.
- **Scope boundary:** Test coverage only. This PR does not change provider construction, configuration, request payloads, or model behavior, and it does not add a call-site smoke test.
- **Blast radius:** Provider unit tests only. The test guards `provider_runtime_options_for_agent`, used by the agent-loop fallback and the delegate tool path.
- **Linked issue(s):** Closes #7870. Supersedes #7990.
- **Labels:** `provider`, `risk:low`, `size:XS`

### What this does, simply

An agent can select a different model-provider configuration from another agent. Options such as `max_tokens` must follow the selected provider, not a different configured provider. This test pins that rule across OpenAI and Anthropic aliases so a future resolver change cannot silently mix their runtime options. It checks the shared per-agent resolver with in-memory configuration only; it does not send a provider request or expand the existing alias-specific constructor coverage.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is a focused in-memory unit regression with no user-facing interaction or network request.

### How I tested

- **CI checks relied on and why they cover this change:** The focused provider test and the successful required `Test` job exercise test code; successful `Format` checks Rust formatting; successful `Lint` covers Clippy; and `CI Required Gate` confirms the required-check policy completed successfully. The full current-head workflow is green.
- **Known CI coverage gap, if any:** No manual provider request smoke was run because the change only adds an in-memory resolver test. None for the resolver regression after the focused local test and current-head CI passed.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` exited successfully with no formatter output.
  - `cargo test -p zeroclaw-providers provider_runtime_options_`:
    ```text
    running 8 tests
    test tests::provider_runtime_options_cross_family_no_leak ... ok
    test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1288 filtered out
    ```
- **Beyond CI, what did you manually verify?** Inspected the agent-construction, agent-loop, LLM-task, and delegate-tool paths and confirmed they resolve runtime options through agent- or alias-specific helpers. The gateway boot-time seed-logging path intentionally uses the first configured provider and is outside #7870. The new fixture uses clearly fake provider keys.
- **If any command was intentionally skipped, why:** Broader workspace checks were not run because this is one provider-crate test; required CI remains the broader validation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: revert the resulting squash commit.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#7990 by @perlowja`, one per line): #7990 by @perlowja
- Scope materially carried forward: The cross-family provider runtime-options regression, including distinct OpenAI and Anthropic `max_tokens` fixtures and the selected-agent assertions.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`): `Yes` — included in the squash commit message used for merge.
- If `No`, why (inspiration-only, no direct code/design carry-over): N/A.
