### PR TITLE
fix(web): show channel descriptor defaults in Quickstart

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "happy-dom": "^20.11.6",
         "jiti": "^2.7.0",
         "openapi-typescript": "^7.13.0",
         "rollup": "^4.59.0",
@@ -1498,6 +1499,23 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
       "version": "4.25.9",
       "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
@@ -1666,6 +1684,19 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/ccount": {
@@ -1870,6 +1901,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -1944,6 +1988,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
+      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
@@ -4198,6 +4261,38 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "dev": "vite",
-    "test": "node --experimental-strip-types --test src/pages/quickstart/runtime-selection.test.ts src/pages/quickstart/channel-fields.test.ts src/pages/acp-console/thought-stream.test.ts && npm run test:sops",
+    "test": "node --experimental-strip-types --test src/pages/quickstart/runtime-selection.test.ts src/pages/quickstart/channel-fields.test.ts src/pages/acp-console/thought-stream.test.ts && npm run test:sops && jiti src/pages/quickstart/channel-form.test.ts",
     "test:sops": "node --experimental-strip-types --test src/hooks/useRunOverlay.logic.test.ts src/pages/runs.logic.test.ts",
     "test:permissions": "jiti src/components/ToolPermissionGrid.logic.test.ts && jiti src/lib/toolCatalog.logic.test.ts && jiti src/components/ToolCatalogWarningPanel.test.ts && jiti src/lib/validationWarnings.test.ts && npm run test:navigation",
     "test:navigation": "jiti src/components/layout/sidebarNav.test.ts && jiti src/components/layout/Sidebar.test.ts",
@@ -46,6 +46,7 @@
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "happy-dom": "^20.11.6",
     "jiti": "^2.7.0",
     "openapi-typescript": "^7.13.0",
     "rollup": "^4.59.0",

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -b && vite build",
     "dev": "vite",
-    "test": "node --experimental-strip-types --test src/pages/quickstart/runtime-selection.test.ts src/pages/acp-console/thought-stream.test.ts && npm run test:sops",
+    "test": "node --experimental-strip-types --test src/pages/quickstart/runtime-selection.test.ts src/pages/quickstart/channel-fields.test.ts src/pages/acp-console/thought-stream.test.ts && npm run test:sops",
     "test:sops": "node --experimental-strip-types --test src/hooks/useRunOverlay.logic.test.ts src/pages/runs.logic.test.ts",
     "test:permissions": "jiti src/components/ToolPermissionGrid.logic.test.ts && jiti src/lib/toolCatalog.logic.test.ts && jiti src/components/ToolCatalogWarningPanel.test.ts && jiti src/lib/validationWarnings.test.ts && npm run test:navigation",
     "test:navigation": "jiti src/components/layout/sidebarNav.test.ts && jiti src/components/layout/Sidebar.test.ts",

--- a/web/src/pages/quickstart/ChannelAddForm.tsx
+++ b/web/src/pages/quickstart/ChannelAddForm.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useReducer, useState } from "react";
+import { Plus } from "lucide-react";
+import type {
+  QuickstartFieldDescriptor,
+  QuickstartState,
+} from "../../lib/api";
+import { quickstartFields } from "../../lib/api";
+import { Button } from "../../components/ui/Button";
+import { Card } from "../../components/ui/Card";
+import { t } from "../../lib/i18n";
+import {
+  channelFieldStateReducer,
+  initialChannelFieldState,
+} from "./channel-fields";
+import { LabeledInput } from "./quickstart-form-controls";
+
+const INPUT_CLASS =
+  "w-full h-9 px-3 rounded-[var(--radius-md)] border border-pc-border bg-pc-input text-sm text-pc-text placeholder:text-pc-text-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pc-accent/40 focus-visible:border-pc-accent/40";
+const MUTED = { color: "var(--pc-text-muted)" } as const;
+const ERROR = { color: "var(--color-status-error)" } as const;
+
+export interface StagedChannel {
+  mode: "fresh" | "existing";
+  channel_type: string;
+  alias: string;
+  fields: Record<string, string>;
+}
+
+export type ChannelFieldsLoader = (
+  type: string,
+) => Promise<{ fields: QuickstartFieldDescriptor[] }>;
+
+export interface ChannelAddFormProps {
+  state: QuickstartState | null;
+  inConfig: Set<string>;
+  inFlight: Set<string>;
+  reusable: string[];
+  onAdd: (c: StagedChannel) => void;
+  onCancel: () => void;
+  loadFields?: ChannelFieldsLoader;
+}
+
+const defaultLoadFields: ChannelFieldsLoader = (type) =>
+  quickstartFields({ section: "channel", type_key: type });
+
+export function ChannelAddForm({
+  state,
+  inConfig,
+  inFlight,
+  reusable,
+  onAdd,
+  onCancel,
+  loadFields = defaultLoadFields,
+}: ChannelAddFormProps) {
+  const [channelFields, dispatchChannelFields] = useReducer(
+    channelFieldStateReducer,
+    initialChannelFieldState(reusable.length > 0 ? "existing" : "fresh"),
+  );
+  const [existingRef, setExistingRef] = useState(reusable[0] ?? "");
+  const [alias, setAlias] = useState("");
+  const { mode, type, descriptors, fields } = channelFields;
+
+  useEffect(() => {
+    if (!type) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const f = await loadFields(type);
+        if (!cancelled) {
+          dispatchChannelFields({
+            kind: "descriptors-loaded",
+            channelType: type,
+            descriptors: f.fields,
+          });
+        }
+      } catch {
+        // Keep the current field state so a transient descriptor failure does
+        // not discard values the user has already entered.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [type, loadFields]);
+
+  const freshRef = type && alias.trim() ? `${type}.${alias.trim()}` : "";
+  const conflict =
+    freshRef !== "" && (inConfig.has(freshRef) || inFlight.has(freshRef));
+  const canAdd =
+    mode === "existing"
+      ? existingRef !== ""
+      : type !== "" && alias.trim() !== "" && !conflict;
+
+  const submit = () => {
+    if (mode === "existing") {
+      const [t, a] = existingRef.split(".");
+      if (!t || !a) return;
+      onAdd({ mode: "existing", channel_type: t, alias: a, fields: {} });
+    } else {
+      onAdd({
+        mode: "fresh",
+        channel_type: type,
+        alias: alias.trim(),
+        fields,
+      });
+    }
+  };
+
+  return (
+    <Card className="p-4 space-y-3 bg-pc-elevated">
+      <div className="flex gap-2">
+        <Button
+          variant={mode === "existing" ? "primary" : "ghost"}
+          size="sm"
+          disabled={reusable.length === 0}
+          onClick={() =>
+            dispatchChannelFields({ kind: "mode-changed", mode: "existing" })
+          }
+        >
+          {t("quickstart.use_existing")}
+        </Button>
+        <Button
+          variant={mode === "fresh" ? "primary" : "ghost"}
+          size="sm"
+          onClick={() =>
+            dispatchChannelFields({ kind: "mode-changed", mode: "fresh" })
+          }
+        >
+          {t("quickstart.create_new")}
+        </Button>
+        <div className="flex-1" />
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          {t("common.cancel")}
+        </Button>
+      </div>
+
+      {mode === "existing" ? (
+        reusable.length === 0 ? (
+          <div className="text-xs" style={MUTED}>
+            {t("quickstart.no_unassigned_channels")}
+          </div>
+        ) : (
+          <select
+            className={INPUT_CLASS}
+            value={existingRef}
+            onChange={(e) => setExistingRef(e.target.value)}
+          >
+            {reusable.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        )
+      ) : (
+        <>
+          <label className="block">
+            <div className="text-xs uppercase tracking-wider mb-1" style={MUTED}>
+              {t("quickstart.channel_type")}
+            </div>
+            <select
+              className={INPUT_CLASS}
+              value={type}
+              onChange={(e) => {
+                const next = e.target.value;
+                dispatchChannelFields({
+                  kind: "channel-type-changed",
+                  channelType: next,
+                });
+                setAlias((prev) => (prev === "" || prev === type ? next : prev));
+              }}
+            >
+              <option value="" disabled>
+                {t("quickstart.pick_channel_type")}
+              </option>
+              {state?.channel_types.map((opt) => (
+                <option key={opt.kind} value={opt.kind}>
+                  {opt.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <LabeledInput label={t("quickstart.alias_label")} value={alias} onChange={setAlias} />
+          {conflict && (
+            <div className="text-xs" style={ERROR}>
+              <code>{freshRef}</code> {t("quickstart.already_exists")}
+            </div>
+          )}
+
+          {descriptors.map((d) => (
+            <LabeledInput
+              key={d.key}
+              label={d.label}
+              type={d.is_secret ? "password" : "text"}
+              value={fields[d.key] ?? ""}
+              onChange={(v) =>
+                dispatchChannelFields({
+                  kind: "field-changed",
+                  key: d.key,
+                  value: v,
+                })
+              }
+              placeholder={d.help}
+              required={d.required}
+            />
+          ))}
+        </>
+      )}
+
+      <div className="flex justify-end">
+        <Button size="sm" disabled={!canAdd} onClick={submit}>
+          <Plus className="h-3.5 w-3.5" />
+          {t("quickstart.add")}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/pages/quickstart/Quickstart.tsx
+++ b/web/src/pages/quickstart/Quickstart.tsx
@@ -1059,7 +1059,7 @@ function ChannelAddForm({
   const [fields, setFields] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (mode !== "fresh" || !type) {
+    if (!type) {
       setDescriptors([]);
       return;
     }
@@ -1069,7 +1069,7 @@ function ChannelAddForm({
         const f = await quickstartFields({ section: "channel", type_key: type });
         if (!cancelled) {
           setDescriptors(f.fields);
-          setFields(initialChannelFieldValues(f.fields));
+          setFields((current) => initialChannelFieldValues(f.fields, current));
         }
       } catch {
         if (!cancelled) setDescriptors([]);
@@ -1078,7 +1078,7 @@ function ChannelAddForm({
     return () => {
       cancelled = true;
     };
-  }, [mode, type]);
+  }, [type]);
 
   const freshRef = type && alias.trim() ? `${type}.${alias.trim()}` : "";
   const conflict =

--- a/web/src/pages/quickstart/Quickstart.tsx
+++ b/web/src/pages/quickstart/Quickstart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Bot,
@@ -35,7 +35,10 @@ import {
   runtimeValueForSubmit,
   type RuntimeSelection,
 } from "./runtime-selection";
-import { initialChannelFieldValues } from "./channel-fields";
+import {
+  channelFieldStateReducer,
+  initialChannelFieldState,
+} from "./channel-fields";
 
 // Shared tokenized field control classes. Calm input surface with an accent
 // focus ring — replaces the legacy `input-electric` utility.
@@ -1047,32 +1050,30 @@ function ChannelAddForm({
   onAdd: (c: StagedChannel) => void;
   onCancel: () => void;
 }) {
-  const [mode, setMode] = useState<"existing" | "fresh">(
-    reusable.length > 0 ? "existing" : "fresh",
+  const [channelFields, dispatchChannelFields] = useReducer(
+    channelFieldStateReducer,
+    initialChannelFieldState(reusable.length > 0 ? "existing" : "fresh"),
   );
   const [existingRef, setExistingRef] = useState(reusable[0] ?? "");
-  const [type, setType] = useState("");
   const [alias, setAlias] = useState("");
-  const [descriptors, setDescriptors] = useState<QuickstartFieldDescriptor[]>(
-    [],
-  );
-  const [fields, setFields] = useState<Record<string, string>>({});
+  const { mode, type, descriptors, fields } = channelFields;
 
   useEffect(() => {
-    if (!type) {
-      setDescriptors([]);
-      return;
-    }
+    if (!type) return;
     let cancelled = false;
     void (async () => {
       try {
         const f = await quickstartFields({ section: "channel", type_key: type });
         if (!cancelled) {
-          setDescriptors(f.fields);
-          setFields((current) => initialChannelFieldValues(f.fields, current));
+          dispatchChannelFields({
+            kind: "descriptors-loaded",
+            channelType: type,
+            descriptors: f.fields,
+          });
         }
       } catch {
-        if (!cancelled) setDescriptors([]);
+        // Keep the current field state so a transient descriptor failure does
+        // not discard values the user has already entered.
       }
     })();
     return () => {
@@ -1110,14 +1111,18 @@ function ChannelAddForm({
           variant={mode === "existing" ? "primary" : "ghost"}
           size="sm"
           disabled={reusable.length === 0}
-          onClick={() => setMode("existing")}
+          onClick={() =>
+            dispatchChannelFields({ kind: "mode-changed", mode: "existing" })
+          }
         >
           {t("quickstart.use_existing")}
         </Button>
         <Button
           variant={mode === "fresh" ? "primary" : "ghost"}
           size="sm"
-          onClick={() => setMode("fresh")}
+          onClick={() =>
+            dispatchChannelFields({ kind: "mode-changed", mode: "fresh" })
+          }
         >
           {t("quickstart.create_new")}
         </Button>
@@ -1156,9 +1161,11 @@ function ChannelAddForm({
               value={type}
               onChange={(e) => {
                 const next = e.target.value;
-                setType(next);
+                dispatchChannelFields({
+                  kind: "channel-type-changed",
+                  channelType: next,
+                });
                 setAlias((prev) => (prev === "" || prev === type ? next : prev));
-                setFields({});
               }}
             >
               <option value="" disabled>
@@ -1185,7 +1192,13 @@ function ChannelAddForm({
               label={d.label}
               type={d.is_secret ? "password" : "text"}
               value={fields[d.key] ?? ""}
-              onChange={(v) => setFields((x) => ({ ...x, [d.key]: v }))}
+              onChange={(v) =>
+                dispatchChannelFields({
+                  kind: "field-changed",
+                  key: d.key,
+                  value: v,
+                })
+              }
               placeholder={d.help}
               required={d.required}
             />

--- a/web/src/pages/quickstart/Quickstart.tsx
+++ b/web/src/pages/quickstart/Quickstart.tsx
@@ -35,6 +35,7 @@ import {
   runtimeValueForSubmit,
   type RuntimeSelection,
 } from "./runtime-selection";
+import { initialChannelFieldValues } from "./channel-fields";
 
 // Shared tokenized field control classes. Calm input surface with an accent
 // focus ring — replaces the legacy `input-electric` utility.
@@ -660,6 +661,7 @@ function LabeledInput({
   placeholder,
   multiline = false,
   help,
+  required = false,
 }: {
   label: string;
   value: string;
@@ -668,11 +670,17 @@ function LabeledInput({
   placeholder?: string;
   multiline?: boolean;
   help?: string;
+  required?: boolean;
 }) {
   return (
     <label className="block">
       <div className="text-xs uppercase tracking-wider mb-1" style={MUTED}>
         {label}
+        {required && (
+          <Badge tone="warn" className="ml-2 uppercase tracking-wide">
+            {t("fieldform.badge_required")}
+          </Badge>
+        )}
       </div>
       {help ? (
         <div className="text-xs mb-1 italic" style={MUTED}>
@@ -685,6 +693,8 @@ function LabeledInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
+          required={required}
+          aria-required={required}
           autoCapitalize="none"
           autoCorrect="off"
           spellCheck={false}
@@ -696,6 +706,8 @@ function LabeledInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
+          required={required}
+          aria-required={required}
           // Aliases, model names, API keys etc. are technical identifiers —
           // the WebView must not autocapitalize/autocorrect them (e.g. agent
           // aliases must be lowercase).
@@ -1055,7 +1067,10 @@ function ChannelAddForm({
     void (async () => {
       try {
         const f = await quickstartFields({ section: "channel", type_key: type });
-        if (!cancelled) setDescriptors(f.fields);
+        if (!cancelled) {
+          setDescriptors(f.fields);
+          setFields(initialChannelFieldValues(f.fields));
+        }
       } catch {
         if (!cancelled) setDescriptors([]);
       }
@@ -1172,6 +1187,7 @@ function ChannelAddForm({
               value={fields[d.key] ?? ""}
               onChange={(v) => setFields((x) => ({ ...x, [d.key]: v }))}
               placeholder={d.help}
+              required={d.required}
             />
           ))}
         </>

--- a/web/src/pages/quickstart/Quickstart.tsx
+++ b/web/src/pages/quickstart/Quickstart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Bot,
@@ -35,10 +35,8 @@ import {
   runtimeValueForSubmit,
   type RuntimeSelection,
 } from "./runtime-selection";
-import {
-  channelFieldStateReducer,
-  initialChannelFieldState,
-} from "./channel-fields";
+import { ChannelAddForm, type StagedChannel } from "./ChannelAddForm";
+import { LabeledInput } from "./quickstart-form-controls";
 
 // Shared tokenized field control classes. Calm input surface with an accent
 // focus ring — replaces the legacy `input-electric` utility.
@@ -55,13 +53,6 @@ interface StagedProvider {
    *  The web surface knows nothing about which keys exist; the
    *  daemon authors them via `/api/quickstart/fields` and consumes
    *  them on the way back. */
-  fields: Record<string, string>;
-}
-
-interface StagedChannel {
-  mode: "fresh" | "existing";
-  channel_type: string;
-  alias: string;
   fields: Record<string, string>;
 }
 
@@ -106,7 +97,6 @@ const DEFAULT_FORM: FormState = {
 
 const MUTED = { color: "var(--pc-text-muted)" } as const;
 const FAINT = { color: "var(--pc-text-faint)" } as const;
-const ERROR = { color: "var(--color-status-error)" } as const;
 
 export default function Quickstart() {
   const navigate = useNavigate();
@@ -656,73 +646,6 @@ function StagedRow({
   );
 }
 
-function LabeledInput({
-  label,
-  value,
-  onChange,
-  type = "text",
-  placeholder,
-  multiline = false,
-  help,
-  required = false,
-}: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  type?: "text" | "password";
-  placeholder?: string;
-  multiline?: boolean;
-  help?: string;
-  required?: boolean;
-}) {
-  return (
-    <label className="block">
-      <div className="text-xs uppercase tracking-wider mb-1" style={MUTED}>
-        {label}
-        {required && (
-          <Badge tone="warn" className="ml-2 uppercase tracking-wide">
-            {t("fieldform.badge_required")}
-          </Badge>
-        )}
-      </div>
-      {help ? (
-        <div className="text-xs mb-1 italic" style={MUTED}>
-          {help}
-        </div>
-      ) : null}
-      {multiline ? (
-        <textarea
-          className={`${TEXTAREA_CLASS} min-h-24`}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          required={required}
-          aria-required={required}
-          autoCapitalize="none"
-          autoCorrect="off"
-          spellCheck={false}
-        />
-      ) : (
-        <input
-          className={INPUT_CLASS}
-          type={type}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          required={required}
-          aria-required={required}
-          // Aliases, model names, API keys etc. are technical identifiers —
-          // the WebView must not autocapitalize/autocorrect them (e.g. agent
-          // aliases must be lowercase).
-          autoCapitalize="none"
-          autoCorrect="off"
-          spellCheck={false}
-        />
-      )}
-    </label>
-  );
-}
-
 function LabeledSelect({
   label,
   value,
@@ -1032,187 +955,6 @@ function ChannelsList({
         </Button>
       )}
     </>
-  );
-}
-
-function ChannelAddForm({
-  state,
-  inConfig,
-  inFlight,
-  reusable,
-  onAdd,
-  onCancel,
-}: {
-  state: QuickstartState | null;
-  inConfig: Set<string>;
-  inFlight: Set<string>;
-  reusable: string[];
-  onAdd: (c: StagedChannel) => void;
-  onCancel: () => void;
-}) {
-  const [channelFields, dispatchChannelFields] = useReducer(
-    channelFieldStateReducer,
-    initialChannelFieldState(reusable.length > 0 ? "existing" : "fresh"),
-  );
-  const [existingRef, setExistingRef] = useState(reusable[0] ?? "");
-  const [alias, setAlias] = useState("");
-  const { mode, type, descriptors, fields } = channelFields;
-
-  useEffect(() => {
-    if (!type) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const f = await quickstartFields({ section: "channel", type_key: type });
-        if (!cancelled) {
-          dispatchChannelFields({
-            kind: "descriptors-loaded",
-            channelType: type,
-            descriptors: f.fields,
-          });
-        }
-      } catch {
-        // Keep the current field state so a transient descriptor failure does
-        // not discard values the user has already entered.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [type]);
-
-  const freshRef = type && alias.trim() ? `${type}.${alias.trim()}` : "";
-  const conflict =
-    freshRef !== "" && (inConfig.has(freshRef) || inFlight.has(freshRef));
-  const canAdd =
-    mode === "existing"
-      ? existingRef !== ""
-      : type !== "" && alias.trim() !== "" && !conflict;
-
-  const submit = () => {
-    if (mode === "existing") {
-      const [t, a] = existingRef.split(".");
-      if (!t || !a) return;
-      onAdd({ mode: "existing", channel_type: t, alias: a, fields: {} });
-    } else {
-      onAdd({
-        mode: "fresh",
-        channel_type: type,
-        alias: alias.trim(),
-        fields,
-      });
-    }
-  };
-
-  return (
-    <Card className="p-4 space-y-3 bg-pc-elevated">
-      <div className="flex gap-2">
-        <Button
-          variant={mode === "existing" ? "primary" : "ghost"}
-          size="sm"
-          disabled={reusable.length === 0}
-          onClick={() =>
-            dispatchChannelFields({ kind: "mode-changed", mode: "existing" })
-          }
-        >
-          {t("quickstart.use_existing")}
-        </Button>
-        <Button
-          variant={mode === "fresh" ? "primary" : "ghost"}
-          size="sm"
-          onClick={() =>
-            dispatchChannelFields({ kind: "mode-changed", mode: "fresh" })
-          }
-        >
-          {t("quickstart.create_new")}
-        </Button>
-        <div className="flex-1" />
-        <Button variant="ghost" size="sm" onClick={onCancel}>
-          {t("common.cancel")}
-        </Button>
-      </div>
-
-      {mode === "existing" ? (
-        reusable.length === 0 ? (
-          <div className="text-xs" style={MUTED}>
-            {t("quickstart.no_unassigned_channels")}
-          </div>
-        ) : (
-          <select
-            className={INPUT_CLASS}
-            value={existingRef}
-            onChange={(e) => setExistingRef(e.target.value)}
-          >
-            {reusable.map((r) => (
-              <option key={r} value={r}>
-                {r}
-              </option>
-            ))}
-          </select>
-        )
-      ) : (
-        <>
-          <label className="block">
-            <div className="text-xs uppercase tracking-wider mb-1" style={MUTED}>
-              {t("quickstart.channel_type")}
-            </div>
-            <select
-              className={INPUT_CLASS}
-              value={type}
-              onChange={(e) => {
-                const next = e.target.value;
-                dispatchChannelFields({
-                  kind: "channel-type-changed",
-                  channelType: next,
-                });
-                setAlias((prev) => (prev === "" || prev === type ? next : prev));
-              }}
-            >
-              <option value="" disabled>
-                {t("quickstart.pick_channel_type")}
-              </option>
-              {state?.channel_types.map((opt) => (
-                <option key={opt.kind} value={opt.kind}>
-                  {opt.display_name}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <LabeledInput label={t("quickstart.alias_label")} value={alias} onChange={setAlias} />
-          {conflict && (
-            <div className="text-xs" style={ERROR}>
-              <code>{freshRef}</code> {t("quickstart.already_exists")}
-            </div>
-          )}
-
-          {descriptors.map((d) => (
-            <LabeledInput
-              key={d.key}
-              label={d.label}
-              type={d.is_secret ? "password" : "text"}
-              value={fields[d.key] ?? ""}
-              onChange={(v) =>
-                dispatchChannelFields({
-                  kind: "field-changed",
-                  key: d.key,
-                  value: v,
-                })
-              }
-              placeholder={d.help}
-              required={d.required}
-            />
-          ))}
-        </>
-      )}
-
-      <div className="flex justify-end">
-        <Button size="sm" disabled={!canAdd} onClick={submit}>
-          <Plus className="h-3.5 w-3.5" />
-          {t("quickstart.add")}
-        </Button>
-      </div>
-    </Card>
   );
 }
 

--- a/web/src/pages/quickstart/channel-fields.test.ts
+++ b/web/src/pages/quickstart/channel-fields.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { QuickstartFieldDescriptor } from "../../lib/api.ts";
-import { initialChannelFieldValues } from "./channel-fields.ts";
+import {
+  channelFieldStateReducer,
+  initialChannelFieldState,
+  initialChannelFieldValues,
+} from "./channel-fields.ts";
 
 function descriptor(
   key: string,
@@ -33,15 +37,57 @@ test("does not invent values for descriptors without defaults", () => {
   assert.deepEqual(initialChannelFieldValues([descriptor("secret", null)]), {});
 });
 
-test("preserves edited values across a fresh-existing-fresh transition", () => {
+test("does not overwrite existing field values when merging defaults", () => {
   const fields = [descriptor("port", "8090"), descriptor("secret", null)];
-  const edited = initialChannelFieldValues(fields);
-  edited.port = "9123";
-  edited.secret = "user-entered-secret";
+  const edited = { port: "9123", secret: "user-entered-secret" };
 
-  // The existing-mode view hides, but does not discard, fresh-mode state.
   assert.deepEqual(initialChannelFieldValues(fields, edited), {
     port: "9123",
     secret: "user-entered-secret",
   });
+});
+
+test("preserves edited values across the fresh-existing-fresh transition", () => {
+  const descriptors = [descriptor("port", "8090"), descriptor("secret", null)];
+  let state = initialChannelFieldState("fresh");
+
+  state = channelFieldStateReducer(state, {
+    kind: "channel-type-changed",
+    channelType: "webhook",
+  });
+  state = channelFieldStateReducer(state, {
+    kind: "descriptors-loaded",
+    channelType: "webhook",
+    descriptors,
+  });
+  state = channelFieldStateReducer(state, {
+    kind: "field-changed",
+    key: "port",
+    value: "9123",
+  });
+  state = channelFieldStateReducer(state, {
+    kind: "field-changed",
+    key: "secret",
+    value: "user-entered-secret",
+  });
+  state = channelFieldStateReducer(state, {
+    kind: "mode-changed",
+    mode: "existing",
+  });
+  state = channelFieldStateReducer(state, {
+    kind: "mode-changed",
+    mode: "fresh",
+  });
+  state = channelFieldStateReducer(state, {
+    kind: "descriptors-loaded",
+    channelType: "webhook",
+    descriptors,
+  });
+
+  assert.equal(state.mode, "fresh");
+  assert.deepEqual(state.fields, {
+    port: "9123",
+    secret: "user-entered-secret",
+  });
+  assert.deepEqual(state.descriptors, descriptors);
 });

--- a/web/src/pages/quickstart/channel-fields.test.ts
+++ b/web/src/pages/quickstart/channel-fields.test.ts
@@ -32,3 +32,16 @@ test("initializes channel fields from descriptor defaults", () => {
 test("does not invent values for descriptors without defaults", () => {
   assert.deepEqual(initialChannelFieldValues([descriptor("secret", null)]), {});
 });
+
+test("preserves edited values across a fresh-existing-fresh transition", () => {
+  const fields = [descriptor("port", "8090"), descriptor("secret", null)];
+  const edited = initialChannelFieldValues(fields);
+  edited.port = "9123";
+  edited.secret = "user-entered-secret";
+
+  // The existing-mode view hides, but does not discard, fresh-mode state.
+  assert.deepEqual(initialChannelFieldValues(fields, edited), {
+    port: "9123",
+    secret: "user-entered-secret",
+  });
+});

--- a/web/src/pages/quickstart/channel-fields.test.ts
+++ b/web/src/pages/quickstart/channel-fields.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { QuickstartFieldDescriptor } from "../../lib/api.ts";
+import { initialChannelFieldValues } from "./channel-fields.ts";
+
+function descriptor(
+  key: string,
+  defaultValue: string | null,
+): QuickstartFieldDescriptor {
+  return {
+    key,
+    label: key,
+    help: "",
+    kind: "string",
+    is_secret: false,
+    enum_variants: null,
+    required: true,
+    default: defaultValue,
+  };
+}
+
+test("initializes channel fields from descriptor defaults", () => {
+  assert.deepEqual(
+    initialChannelFieldValues([
+      descriptor("port", "8090"),
+      descriptor("secret", null),
+    ]),
+    { port: "8090" },
+  );
+});
+
+test("does not invent values for descriptors without defaults", () => {
+  assert.deepEqual(initialChannelFieldValues([descriptor("secret", null)]), {});
+});

--- a/web/src/pages/quickstart/channel-fields.ts
+++ b/web/src/pages/quickstart/channel-fields.ts
@@ -1,0 +1,14 @@
+import type { QuickstartFieldDescriptor } from "../../lib/api.ts";
+
+/** Seed channel form state from the explicit defaults returned by the daemon. */
+export function initialChannelFieldValues(
+  descriptors: readonly QuickstartFieldDescriptor[],
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const descriptor of descriptors) {
+    if (descriptor.default !== null) {
+      values[descriptor.key] = descriptor.default;
+    }
+  }
+  return values;
+}

--- a/web/src/pages/quickstart/channel-fields.ts
+++ b/web/src/pages/quickstart/channel-fields.ts
@@ -3,10 +3,14 @@ import type { QuickstartFieldDescriptor } from "../../lib/api.ts";
 /** Seed channel form state from the explicit defaults returned by the daemon. */
 export function initialChannelFieldValues(
   descriptors: readonly QuickstartFieldDescriptor[],
+  current: Readonly<Record<string, string>> = {},
 ): Record<string, string> {
-  const values: Record<string, string> = {};
+  const values: Record<string, string> = { ...current };
   for (const descriptor of descriptors) {
-    if (descriptor.default !== null) {
+    if (
+      !Object.prototype.hasOwnProperty.call(values, descriptor.key) &&
+      descriptor.default !== null
+    ) {
       values[descriptor.key] = descriptor.default;
     }
   }

--- a/web/src/pages/quickstart/channel-fields.ts
+++ b/web/src/pages/quickstart/channel-fields.ts
@@ -1,5 +1,30 @@
 import type { QuickstartFieldDescriptor } from "../../lib/api.ts";
 
+export type ChannelFieldMode = "existing" | "fresh";
+
+export interface ChannelFieldState {
+  mode: ChannelFieldMode;
+  type: string;
+  descriptors: QuickstartFieldDescriptor[];
+  fields: Record<string, string>;
+}
+
+export type ChannelFieldAction =
+  | { kind: "mode-changed"; mode: ChannelFieldMode }
+  | { kind: "channel-type-changed"; channelType: string }
+  | {
+      kind: "descriptors-loaded";
+      channelType: string;
+      descriptors: readonly QuickstartFieldDescriptor[];
+    }
+  | { kind: "field-changed"; key: string; value: string };
+
+export function initialChannelFieldState(
+  mode: ChannelFieldMode,
+): ChannelFieldState {
+  return { mode, type: "", descriptors: [], fields: {} };
+}
+
 /** Seed channel form state from the explicit defaults returned by the daemon. */
 export function initialChannelFieldValues(
   descriptors: readonly QuickstartFieldDescriptor[],
@@ -15,4 +40,34 @@ export function initialChannelFieldValues(
     }
   }
   return values;
+}
+
+/** Apply one user or descriptor update at the channel form state boundary. */
+export function channelFieldStateReducer(
+  state: ChannelFieldState,
+  action: ChannelFieldAction,
+): ChannelFieldState {
+  switch (action.kind) {
+    case "mode-changed":
+      return { ...state, mode: action.mode };
+    case "channel-type-changed":
+      return {
+        ...state,
+        type: action.channelType,
+        descriptors: [],
+        fields: {},
+      };
+    case "descriptors-loaded":
+      if (state.type !== action.channelType) return state;
+      return {
+        ...state,
+        descriptors: [...action.descriptors],
+        fields: initialChannelFieldValues(action.descriptors, state.fields),
+      };
+    case "field-changed":
+      return {
+        ...state,
+        fields: { ...state.fields, [action.key]: action.value },
+      };
+  }
 }

--- a/web/src/pages/quickstart/channel-form.test.ts
+++ b/web/src/pages/quickstart/channel-form.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  Window,
+  type Document as HappyDocument,
+  type Event as HappyEvent,
+  type HTMLButtonElement as HappyHTMLButtonElement,
+  type HTMLInputElement as HappyHTMLInputElement,
+  type HTMLSelectElement as HappyHTMLSelectElement,
+} from "happy-dom";
+import { createJiti } from "jiti";
+import * as React from "react";
+import { act } from "react";
+import type { QuickstartFieldDescriptor, QuickstartState } from "../../lib/api.ts";
+import type { ChannelAddFormProps } from "./ChannelAddForm.tsx";
+
+const descriptor = (
+  key: string,
+  label: string,
+  defaultValue: string | null,
+  isSecret = false,
+): QuickstartFieldDescriptor => ({
+  key,
+  label,
+  help: "",
+  kind: "string",
+  is_secret: isSecret,
+  enum_variants: null,
+  required: true,
+  default: defaultValue,
+});
+
+const state: QuickstartState = {
+  quickstart_completed: false,
+  agents: [],
+  risk_profiles: [],
+  runtime_profiles: [],
+  model_providers: [],
+  channels: [],
+  unassigned_channels: [],
+  storage: [],
+  model_provider_types: [],
+  channel_types: [
+    { kind: "webhook", display_name: "Webhook", local: false },
+  ],
+  risk_presets: [],
+  runtime_presets: [],
+  memory_kinds: [],
+  personality_files: [],
+};
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function findButton(document: HappyDocument, text: string): HappyHTMLButtonElement {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === text,
+  );
+  assert.ok(button, `expected button ${text}`);
+  return button as HappyHTMLButtonElement;
+}
+
+function findInput(document: HappyDocument, text: string): HappyHTMLInputElement {
+  const label = Array.from(document.querySelectorAll("label")).find(
+    (candidate) => candidate.textContent?.includes(text),
+  );
+  assert.ok(label, `expected labeled input ${text}`);
+  const input = label.querySelector("input");
+  assert.ok(input, `expected input under label ${text}`);
+  return input as HappyHTMLInputElement;
+}
+
+function setInputValue(input: HappyHTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(input),
+    "value",
+  )?.set;
+  assert.ok(setter, "expected a native input value setter");
+  setter.call(input, value);
+  input.dispatchEvent(
+    new Event("input", { bubbles: true }) as unknown as HappyEvent,
+  );
+  input.dispatchEvent(
+    new Event("change", { bubbles: true }) as unknown as HappyEvent,
+  );
+}
+
+test("ChannelAddForm preserves edited fields across real mode interactions", async () => {
+  const domWindow = new Window();
+  const container = domWindow.document.createElement("div");
+  domWindow.document.body.appendChild(container);
+  const globalKeys = [
+    "window",
+    "document",
+    "navigator",
+    "HTMLElement",
+    "HTMLInputElement",
+    "HTMLSelectElement",
+    "HTMLButtonElement",
+    "Node",
+    "Element",
+    "Event",
+    "MouseEvent",
+    "KeyboardEvent",
+    "Text",
+    "getComputedStyle",
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+    "IS_REACT_ACT_ENVIRONMENT",
+  ] as const;
+  const previous = new Map<string, PropertyDescriptor | undefined>();
+  for (const key of globalKeys) {
+    previous.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+  }
+
+  const globals: Record<string, unknown> = {
+    window: domWindow,
+    document: domWindow.document,
+    navigator: domWindow.navigator,
+    HTMLElement: domWindow.HTMLElement,
+    HTMLInputElement: domWindow.HTMLInputElement,
+    HTMLSelectElement: domWindow.HTMLSelectElement,
+    HTMLButtonElement: domWindow.HTMLButtonElement,
+    Node: domWindow.Node,
+    Element: domWindow.Element,
+    Event: domWindow.Event,
+    MouseEvent: domWindow.MouseEvent,
+    KeyboardEvent: domWindow.KeyboardEvent,
+    Text: domWindow.Text,
+    getComputedStyle: domWindow.getComputedStyle.bind(domWindow),
+    requestAnimationFrame: (callback: FrameRequestCallback) =>
+      setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  for (const [key, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+
+  let root:
+    | { render: (children: React.ReactNode) => void; unmount: () => void }
+    | undefined;
+  try {
+    const { createRoot } = await import("react-dom/client");
+    const jiti = createJiti(import.meta.url, {
+      fsCache: false,
+      moduleCache: false,
+      jsx: { runtime: "automatic" },
+    });
+    const module = await jiti.import<typeof import("./ChannelAddForm.tsx")>(
+      "./ChannelAddForm.tsx",
+    );
+    const ChannelAddForm = module.ChannelAddForm as React.ComponentType<
+      ChannelAddFormProps
+    >;
+    let loadCount = 0;
+    const loadFields: ChannelAddFormProps["loadFields"] = async () => {
+      loadCount += 1;
+      return {
+        fields: [
+          descriptor("port", "Port", "8090"),
+          descriptor("secret", "Secret", null, true),
+        ],
+      };
+    };
+
+    root = createRoot(container as unknown as HTMLElement);
+    await act(async () => {
+      root?.render(
+        React.createElement(ChannelAddForm, {
+          state,
+          inConfig: new Set<string>(),
+          inFlight: new Set<string>(),
+          reusable: ["webhook.default"],
+          onAdd: () => {},
+          onCancel: () => {},
+          loadFields,
+        }),
+      );
+    });
+
+    await act(async () => {
+      findButton(domWindow.document, "Create new").click();
+    });
+
+    const typeSelect = domWindow.document.querySelector(
+      "select",
+    ) as HappyHTMLSelectElement | null;
+    assert.ok(typeSelect, "expected channel type selector");
+    await act(async () => {
+      typeSelect.value = "webhook";
+      typeSelect.dispatchEvent(new domWindow.Event("change", { bubbles: true }));
+      await flushEffects();
+    });
+
+    const port = findInput(domWindow.document, "Port");
+    const secret = findInput(domWindow.document, "Secret");
+    await act(async () => {
+      setInputValue(port, "9123");
+      setInputValue(secret, "user-entered-secret");
+    });
+
+    await act(async () => {
+      findButton(domWindow.document, "Use existing").click();
+      findButton(domWindow.document, "Create new").click();
+      await flushEffects();
+    });
+
+    assert.equal(port.value, "9123");
+    assert.equal(secret.value, "user-entered-secret");
+    assert.equal(loadCount, 1, "mode changes must not reload channel descriptors");
+  } finally {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    for (const key of globalKeys) {
+      const descriptor = previous.get(key);
+      if (descriptor) {
+        Object.defineProperty(globalThis, key, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, key);
+      }
+    }
+    domWindow.close();
+  }
+});

--- a/web/src/pages/quickstart/channel-form.test.ts
+++ b/web/src/pages/quickstart/channel-form.test.ts
@@ -71,6 +71,16 @@ function findInput(document: HappyDocument, text: string): HappyHTMLInputElement
   return input as HappyHTMLInputElement;
 }
 
+function findInputOrNull(
+  document: HappyDocument,
+  text: string,
+): HappyHTMLInputElement | null {
+  const label = Array.from(document.querySelectorAll("label")).find(
+    (candidate) => candidate.textContent?.includes(text),
+  );
+  return (label?.querySelector("input") as HappyHTMLInputElement | null) ?? null;
+}
+
 function setInputValue(input: HappyHTMLInputElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(
     Object.getPrototypeOf(input),
@@ -207,12 +217,33 @@ test("ChannelAddForm preserves edited fields across real mode interactions", asy
 
     await act(async () => {
       findButton(domWindow.document, "Use existing").click();
+      await flushEffects();
+    });
+
+    assert.ok(
+      domWindow.document.querySelector('option[value="webhook.default"]'),
+      "expected existing-channel control after switching modes",
+    );
+    assert.equal(
+      findInputOrNull(domWindow.document, "Port"),
+      null,
+      "fresh channel inputs must be absent in existing mode",
+    );
+    assert.equal(
+      findInputOrNull(domWindow.document, "Secret"),
+      null,
+      "fresh channel inputs must be absent in existing mode",
+    );
+
+    await act(async () => {
       findButton(domWindow.document, "Create new").click();
       await flushEffects();
     });
 
-    assert.equal(port.value, "9123");
-    assert.equal(secret.value, "user-entered-secret");
+    const livePort = findInput(domWindow.document, "Port");
+    const liveSecret = findInput(domWindow.document, "Secret");
+    assert.equal(livePort.value, "9123");
+    assert.equal(liveSecret.value, "user-entered-secret");
     assert.equal(loadCount, 1, "mode changes must not reload channel descriptors");
   } finally {
     if (root) {

--- a/web/src/pages/quickstart/quickstart-form-controls.tsx
+++ b/web/src/pages/quickstart/quickstart-form-controls.tsx
@@ -1,0 +1,72 @@
+import { Badge } from "../../components/ui/Badge";
+import { t } from "../../lib/i18n";
+
+const INPUT_CLASS =
+  "w-full h-9 px-3 rounded-[var(--radius-md)] border border-pc-border bg-pc-input text-sm text-pc-text placeholder:text-pc-text-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pc-accent/40 focus-visible:border-pc-accent/40";
+const TEXTAREA_CLASS =
+  "w-full px-3 py-2 rounded-[var(--radius-md)] border border-pc-border bg-pc-input text-sm text-pc-text placeholder:text-pc-text-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pc-accent/40 focus-visible:border-pc-accent/40";
+const MUTED = { color: "var(--pc-text-muted)" } as const;
+
+export function LabeledInput({
+  label,
+  value,
+  onChange,
+  type = "text",
+  placeholder,
+  multiline = false,
+  help,
+  required = false,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: "text" | "password";
+  placeholder?: string;
+  multiline?: boolean;
+  help?: string;
+  required?: boolean;
+}) {
+  return (
+    <label className="block">
+      <div className="text-xs uppercase tracking-wider mb-1" style={MUTED}>
+        {label}
+        {required && (
+          <Badge tone="warn" className="ml-2 uppercase tracking-wide">
+            {t("fieldform.badge_required")}
+          </Badge>
+        )}
+      </div>
+      {help ? (
+        <div className="text-xs mb-1 italic" style={MUTED}>
+          {help}
+        </div>
+      ) : null}
+      {multiline ? (
+        <textarea
+          className={`${TEXTAREA_CLASS} min-h-24`}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          required={required}
+          aria-required={required}
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+      ) : (
+        <input
+          className={INPUT_CLASS}
+          type={type}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          required={required}
+          aria-required={required}
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+      )}
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Seed the Web Quickstart channel form from each descriptor's explicit `default` value, while leaving descriptors without defaults empty.
  - Show the existing warning-style `Required` affordance and native accessibility metadata for descriptor-declared required fields.
  - Keep edited channel fields in production state when switching between **Create new** and **Use existing**.
  - Extract the production `ChannelAddForm` boundary and cover the real mode transition, descriptor-loading effect, and edited-field retention with component-level tests.
- **Scope boundary:** This changes only the Web Quickstart channel form; provider defaults, backend descriptor generation, CLI behavior, TUI behavior, and other configuration surfaces are unchanged.
- **Blast radius:** Web Quickstart users adding a fresh channel; existing-channel selection and non-Quickstart surfaces are unaffected.
- **Linked issue(s):** Fixes #9760
- **Labels:** `bug`, `trusted contributor`, `risk:medium`, `web`, `quickstart`, `size:XL`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `web` surface, Web Quickstart channel form
- **Setup / preconditions:** Run the gateway with the Web dashboard available and open Quickstart; no external channel credentials are needed. For the transition check, an unassigned local channel entry is enough to make **Use existing** available.
- **Steps to run:** Select **Add channel**, choose **Create new**, choose **Webhook**, and inspect the generated fields. For the regression flow, enter synthetic port and secret values, click **Use existing** and wait for the existing-channel select to render, then click **Create new** in a separate interaction and re-query the live inputs. Repeat the same steps on `master` for the before comparison.
- **Expected on this branch (after):** The Webhook port field is initialized to `8090`; descriptor-declared required fields show the existing `Required` badge and required accessibility metadata; fields without a declared default remain empty. After editing the port and secret, the values remain unchanged across **Create new** → **Use existing** → **Create new**.
- **Prior behavior on master (before):** The Webhook port field is blank despite the descriptor declaring `8090`, descriptor-declared required fields have no required-field affordance in this form, and the mode round-trip can replace edited values with descriptor defaults.

### How I tested

- **CI checks relied on and why they cover this change:** Required hosted CI is green on exact head `67efbfaa48b78f734d02e7a81c7459c185b421c7`, including `CI Required Gate`, the Web Permission Tests job, workspace tests, lint, format, build/check matrix, and security checks. The local Web and workspace checks below cover the same rebased code directly.
- **Known CI coverage gap, if any:** The required Web workflow does not execute the general `npm test` script, so the new component interaction suite is local-only coverage; the required permission/context suites remain covered separately. The local production build used an isolated output directory because the default `web/dist` cleanup was stopped by the repository safe-delete guard for 108 pre-existing assets; the equivalent Vite production build passed.
- **Commands run and tail output:**

```text
$ npm test
native node:test suites: 12 passed, 0 failed
SOPS suites: 5 passed, 0 failed
component interaction suite: 1 passed, 0 failed

$ npm run test:permissions
22 passed, 0 failed

$ npm run test:contexts
18 passed, 0 failed

$ cargo web check
status: 0 (OpenAPI bindings generated; npx tsc -b passed)

$ npm run build -- --outDir /tmp/zeroclaw-pr-10081-web-dist
2,181 modules transformed
✓ built in 276ms

$ cargo fmt --all -- --check
status: 0

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo clippy: No issues found

$ cargo test --locked
cargo test: 1105 passed, 9 ignored (10 suites, 40.82s)

$ git diff --check
status: 0
```

- **Beyond CI, what did you manually verify?** On exact head `67efbfaa4`, served the production dashboard from a local gateway and verified successful `200` responses for health, dashboard, Quickstart state, and Quickstart field endpoints. The real Webhook form rendered port `8090`, the required affordance, and an empty secret field. A separate awaited **Use existing** action rendered the existing-channel select before a separate **Create new** action; re-querying the remounted inputs confirmed the synthetic edited port and secret were retained. No external channel or credential flow was exercised.
- **Visual interface changed?** Yes
- **Tested revision, interface, and terminal or viewport dimensions:** `67efbfaa4` rebased onto `master` at `6d6b7cb6acf6ca63f851e4214c4296a58706cd9b`; Web dashboard Quickstart at `1440x1000`.
- **Screenshot evidence:** A privacy-safe screenshot of Quickstart → Add channel → Create new → Webhook was captured during exact-head local verification. It shows the initialized `8090` port, required affordance, empty secret field, and surrounding dashboard layout; it contains no credentials, tokens, personal data, or edited secret value. The screenshot is attached below.

<img width="1440" height="1000" alt="pr-10081-webhook-defaults" src="https://github.com/user-attachments/assets/471ba142-b1a2-491e-b9c3-7a138079419f" />
- **Action or changed state and observed result:** The default-value flow showed port `8090` and an empty secret; the separate mode-transition flow restored the fresh form with synthetic edited values intact.
- **If any command was intentionally skipped, why:** `cargo web build` was not used as the final build evidence because its default `web/dist` cleanup hit the repository safe-delete guard on pre-existing generated assets. The same production TypeScript/Vite build passed with the isolated output directory shown above.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A — no upgrade steps or migration are required.

## Rollback

- **Fast rollback command/path:** After squash merge, identify this PR's landed squash commit from the merged PR, verify it, and run `git revert <landed-squash-sha>`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Quickstart-created channels show incorrect descriptor defaults or required-field affordances, or edited channel fields change after the **Create new** → **Use existing** → **Create new** transition.
