### PR TITLE
fix(publish): keep runtime and tools locale data inside their crates

### DIFF
--- a/crates/zeroclaw-runtime/src/generated_locales.rs
+++ b/crates/zeroclaw-runtime/src/generated_locales.rs
@@ -1,0 +1,38 @@
+// GENERATED from locales.toml by `cargo generate installers` - do not edit by hand.
+//
+// `locales.toml` at the repo root stays the single source of truth for locale
+// codes and labels. Regenerate with `cargo generate installers runtime-locales`;
+// CI fails on drift via `cargo generate installers --check`.
+
+/// One selectable locale: its `code` (e.g. `ja`) and display `label`
+/// (e.g. 日本語).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocaleOption {
+    pub code: &'static str,
+    pub label: &'static str,
+}
+
+/// Locales this build knows about, in `locales.toml` order. The first entry is
+/// the primary locale.
+pub const AVAILABLE_LOCALES: &[LocaleOption] = &[
+    LocaleOption {
+        code: "en",
+        label: "English",
+    },
+    LocaleOption {
+        code: "fr",
+        label: "Français",
+    },
+    LocaleOption {
+        code: "ja",
+        label: "日本語",
+    },
+    LocaleOption {
+        code: "es",
+        label: "Español",
+    },
+    LocaleOption {
+        code: "zh-CN",
+        label: "中文",
+    },
+];

--- a/crates/zeroclaw-runtime/src/i18n.rs
+++ b/crates/zeroclaw-runtime/src/i18n.rs
@@ -11,12 +11,14 @@ static CLI_STRINGS: OnceLock<HashMap<String, String>> = OnceLock::new();
 static CLI_FTL_SOURCES: OnceLock<CliFtlSources> = OnceLock::new();
 static LOCALE: OnceLock<String> = OnceLock::new();
 
-/// The canonical locale registry, embedded from repo-root `locales.toml` at
-/// compile time. Parsed once into a `'static` list so callers (e.g. the RPC
-/// `locales/list` handler) get a long-lived reference with no runtime file I/O.
+/// The canonical locale registry. Repo-root `locales.toml` remains the single
+/// place a locale is added; `cargo generate installers runtime-locales` renders
+/// it into `generated_locales.rs` inside this crate, and CI fails on drift.
+///
+/// This used to be `include_str!("../../../locales.toml")`. That reaches outside
+/// the crate directory, and `cargo package` copies only the package directory,
+/// so the read made this crate unpublishable.
 static AVAILABLE_LOCALES: OnceLock<Vec<LocaleOption>> = OnceLock::new();
-
-const LOCALES_TOML: &str = include_str!("../../../locales.toml");
 
 /// One selectable locale: its `code` (e.g. `ja`) and display `label`
 /// (e.g. `日本語`).
@@ -31,24 +33,13 @@ pub struct LocaleOption {
 pub fn available_locales() -> &'static [LocaleOption] {
     AVAILABLE_LOCALES
         .get_or_init(|| {
-            let table: toml::Value =
-                toml::from_str(LOCALES_TOML).expect("embedded locales.toml is valid TOML");
-            table
-                .get("locale")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|e| {
-                            let code = e.get("code").and_then(|v| v.as_str())?;
-                            let label = e.get("label").and_then(|v| v.as_str())?;
-                            Some(LocaleOption {
-                                code: code.to_string(),
-                                label: label.to_string(),
-                            })
-                        })
-                        .collect()
+            crate::generated_locales::AVAILABLE_LOCALES
+                .iter()
+                .map(|o| LocaleOption {
+                    code: o.code.to_string(),
+                    label: o.label.to_string(),
                 })
-                .unwrap_or_default()
+                .collect()
         })
         .as_slice()
 }

--- a/crates/zeroclaw-runtime/src/lib.rs
+++ b/crates/zeroclaw-runtime/src/lib.rs
@@ -6,6 +6,9 @@
 //! Agent runtime — orchestration, security, observability, cron, SOP, skills, hardware, and more.
 
 pub mod cli_input;
+/// Locale table rendered from repo-root `locales.toml` by
+/// `cargo generate installers runtime-locales`. Generated, not hand-edited.
+mod generated_locales;
 pub mod identity;
 pub mod migration;
 pub mod util;

--- a/crates/zeroclaw-tools/locales/en/tools.ftl
+++ b/crates/zeroclaw-tools/locales/en/tools.ftl
@@ -1,0 +1,193 @@
+# GENERATED from crates/zeroclaw-runtime/locales/en/tools.ftl by
+# `cargo generate installers` - do not edit by hand. Edit the runtime catalogue
+# instead, then regenerate. CI fails on drift via `cargo generate installers --check`.
+
+# English tool descriptions (default locale, embedded at compile time)
+#
+# Keys follow the pattern: tool-{name-with-hyphens}
+# e.g. "file_read" → "tool-file-read", "web_search_tool" → "tool-web-search-tool"
+#
+# Literal { and } in values must be escaped as {"{"}  and  {"}"} respectively.
+
+tool-backup = Create, list, verify, and restore workspace backups
+
+tool-browser = Web/browser automation with pluggable backends (agent-browser, rust-native, computer_use). Supports DOM actions plus optional OS-level actions (mouse_move, mouse_click, mouse_drag, key_type, key_press, screen_capture) through a computer-use sidecar. Use 'snapshot' to map interactive elements to refs (@e1, @e2). Enforces browser.allowed_domains for open actions.
+
+tool-browser-delegate = Delegate browser-based tasks to a browser-capable CLI for interacting with web applications like Teams, Outlook, Jira, Confluence
+
+tool-browser-open = Open an approved HTTPS URL in the system browser. Security constraints: allowlist-only domains, no local/private hosts, no scraping.
+
+tool-channel-room = Create rooms and invite users through an active channel. Provide a channel key such as 'matrix.default', action 'create_room' or 'invite_user', and the action-specific room fields.
+tool-channel-room-param-action = Room-management action to perform.
+tool-channel-room-param-channel = Active channel key such as 'matrix.default'.
+tool-channel-room-param-name = Optional room name for create_room.
+tool-channel-room-param-topic = Optional room topic for create_room.
+tool-channel-room-param-invites = Optional user IDs to invite while creating the room.
+tool-channel-room-param-visibility = Optional room visibility for create_room.
+tool-channel-room-param-encryption = Whether to request room encryption during create_room.
+tool-channel-room-param-room-id = Existing room ID for invite_user.
+tool-channel-room-param-user-id = User ID to invite for invite_user.
+tool-channel-room-error-security = Action blocked: { $err }
+tool-channel-room-error-invalid-action = Invalid action '{ $action }': must be 'create_room' or 'invite_user'.
+tool-channel-room-error-not-initialized = No channels available yet (channels not initialized).
+tool-channel-room-error-channel-not-found = Channel '{ $channel }' not found. Available channels: { $available }
+tool-channel-room-error-create-failed = Failed to create room: { $err }
+tool-channel-room-error-invite-failed = Failed to invite user: { $err }
+tool-channel-room-error-invites-array = 'invites' must be an array of strings.
+tool-channel-room-error-invites-item = 'invites' must be an array of non-empty strings.
+tool-channel-room-error-invalid-visibility = Invalid room visibility: { $err }
+tool-channel-room-error-missing-param = Missing '{ $param }' parameter.
+tool-channel-room-error-string-param = '{ $param }' must be a string.
+tool-channel-room-error-bool-param = '{ $param }' must be a boolean.
+
+tool-cloud-ops = Cloud transformation advisory tool. Analyzes IaC plans, assesses migration paths, reviews costs, and checks architecture against Well-Architected Framework pillars. Read-only: does not create or modify cloud resources.
+
+tool-cloud-patterns = Cloud pattern library. Given a workload description, suggests applicable cloud-native architectural patterns (containerization, serverless, database modernization, etc.).
+
+tool-composio = Execute actions on 1000+ apps via Composio (Gmail, Notion, GitHub, Slack, etc.). Use action='list' to see available actions (includes parameter names). action='execute' with action_name/tool_slug and params to run an action. If you are unsure of the exact params, pass 'text' instead with a natural-language description of what you want (Composio will resolve the correct parameters via NLP). action='list_accounts' or action='connected_accounts' to list OAuth-connected accounts. action='connect' with app/auth_config_id to get OAuth URL. connected_account_id is auto-resolved when omitted.
+
+tool-content-search = Search file contents by regex pattern within the workspace. Supports ripgrep (rg) with grep or internal fallback. Output modes: 'content' (matching lines with context), 'files_with_matches' (file paths only), 'count' (match counts per file). Example: pattern='fn main', include='*.rs', output_mode='content'.
+
+tool-cron-add = Create a scheduled cron job (shell or agent) with cron/at/every schedules. Use job_type='agent' with a prompt to run the AI agent on schedule. To deliver output to a channel (Discord, Telegram, Slack, Mattermost, Matrix), set delivery={"{"}"mode":"announce","channel":"discord","to":"<channel_id_or_chat_id>"{"}"}. This is the preferred tool for sending scheduled/delayed messages to users via channels.
+
+tool-cron-list = List all scheduled cron jobs
+
+tool-cron-remove = Remove a cron job by id
+
+tool-cron-run = Force-run a cron job immediately and record run history
+
+tool-cron-runs = List recent run history for a cron job
+
+tool-cron-update = Patch an existing cron job (schedule, command, prompt, enabled, delivery, model, etc.)
+
+tool-data-management = Workspace data retention, purge, and storage statistics
+
+tool-delegate = Delegate a subtask to a specialized agent. Use when: a task benefits from a different model (e.g. fast summarization, deep reasoning, code generation). The sub-agent runs a single prompt by default; with agentic=true it can iterate with a filtered tool-call loop.
+
+tool-file-edit = Edit a file by replacing an exact string match with new content
+
+tool-file-download = Download a file from the configured remote endpoint and write it to the agent's workspace. Supply the identifier of the document to fetch and a workspace-relative destination path; the endpoint URL is fixed by host config and is never model-controlled. Bytes are streamed straight to disk and are not loaded into model context. Returns the HTTP status, the number of bytes written, and the destination path.
+tool-file-download-param-document-id = Identifier of the document to fetch from the configured endpoint.
+tool-file-download-param-dest-path = Workspace-relative path to write the file to. The parent directory must already exist.
+tool-file-download-error-disabled = file_download is disabled: [file_download].url is not configured
+tool-file-download-error-read-only = Action blocked: autonomy is read-only
+tool-file-download-error-rate-limited-hour = Rate limit exceeded: too many actions in the last hour
+tool-file-download-error-rate-limited-budget = Rate limit exceeded: action budget exhausted
+tool-file-download-error-missing-document-id = Missing 'document_id' parameter
+tool-file-download-error-missing-dest-path = Missing 'dest_path' parameter
+tool-file-download-error-invalid-file-name = Invalid dest_path '{ $dest_path }': must end in a concrete file name
+tool-file-download-error-no-parent = Invalid dest_path '{ $dest_path }': has no parent directory
+tool-file-download-error-resolve-dir = Cannot resolve destination directory for '{ $dest_path }': { $err }
+tool-file-download-error-client-build = Failed to build download client: { $err }
+tool-file-download-error-request = Download request failed: { $err }
+tool-file-download-error-status = Download endpoint returned status { $status }
+tool-file-download-error-too-large-reported = Download too large: endpoint reports { $len } bytes (limit: { $limit } bytes)
+tool-file-download-error-too-large-stream = Download too large: exceeded limit of { $limit } bytes
+tool-file-download-error-temp-create = Failed to create temporary download file: { $err }
+tool-file-download-error-read-body = Failed while reading response body: { $err }
+tool-file-download-error-write-body = Failed while writing downloaded bytes: { $err }
+tool-file-download-error-flush = Failed to flush downloaded file: { $err }
+tool-file-download-error-move = Failed to move downloaded file into place: { $err }
+tool-file-download-success = Downloaded { $written } bytes to { $dest_path } ({ $status })
+
+tool-file-read = Read file contents with line numbers. Supports partial reading via offset and limit. Binary and image files are rejected (use the image_info tool for images). Set encoding="base64" to return raw bytes base64-encoded (for binary files such as .pdf/.xlsx/.docx); offset/limit are ignored in that mode.
+
+tool-file-write = Write contents to a file in the workspace
+
+tool-git-operations = Perform structured Git operations (status, diff, log, branch, commit, add, checkout, stash). Provides parsed JSON output and integrates with security policy for autonomy controls.
+tool-git-operations-error-not-in-repo = Not in a Git repository at '{ $path }'. Choose a path inside a Git worktree, pass 'path' for a repository subdirectory, or initialize a repository before running git_operations.
+
+tool-git-forge-error-requires-field = { $resource }.{ $action } requires '{ $field }'.
+tool-git-forge-error-requires-number = { $resource }.{ $action } requires 'number'.
+tool-git-forge-error-issue-close-reason = issue.close 'reason' must be 'completed' or 'not_planned'.
+tool-git-forge-error-pull-merge-method = pull.merge 'method' must be 'merge', 'squash', or 'rebase'.
+tool-git-forge-error-review-verdict = review.create 'verdict' must be approve|request_changes|comment, got '{ $verdict }'.
+tool-git-forge-error-unknown-cell = unknown or unsupported resource/action '{ $resource }.{ $action }'. Call action 'describe' for the supported grid, or use 'raw' for anything unlisted.
+tool-git-forge-error-no-channels = No channels available yet (channels not initialized).
+tool-git-forge-error-raw-requires-method = 'raw' requires 'method'.
+tool-git-forge-error-raw-requires-path = 'raw' requires 'path'.
+tool-git-forge-error-requires-resource = a typed call requires 'resource' (or use action 'raw'/'describe').
+tool-git-forge-error-missing-repo = Missing 'repo' (expected 'owner/repo').
+
+tool-glob-search = Search for files matching a glob pattern within the workspace. Returns a sorted list of matching file paths relative to the workspace root. Examples: '**/*.rs' (all Rust files), 'src/**/mod.rs' (all mod.rs in src).
+
+tool-google-workspace = Interact with Google Workspace services (Drive, Gmail, Calendar, Sheets, Docs, etc.) via the gws CLI. Requires gws to be installed and authenticated.
+
+tool-hardware-board-info = Return full board info (chip, architecture, memory map) for connected hardware. Use when: user asks for 'board info', 'what board do I have', 'connected hardware', 'chip info', 'what hardware', or 'memory map'.
+
+tool-hardware-memory-map = Return the memory map (flash and RAM address ranges) for connected hardware. Use when: user asks for 'upper and lower memory addresses', 'memory map', 'address space', or 'readable addresses'. Returns flash/RAM ranges from datasheets.
+
+tool-hardware-memory-read = Read actual memory/register values from Nucleo via USB. Use when: user asks to 'read register values', 'read memory at address', 'dump memory', 'lower memory 0-126', or 'give address and value'. Returns hex dump. Requires Nucleo connected via USB and probe feature. Params: address (hex, e.g. 0x20000000 for RAM start), length (bytes, default 128).
+
+tool-http-request = Make HTTP requests to external APIs. Supports GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS methods. Security constraints: allowlist-only domains, no local/private hosts, configurable timeout and response size limits.
+
+tool-image-info = Read image file metadata (format, dimensions, size) and optionally return base64-encoded data.
+
+tool-jira = Interact with Jira: read tickets, search with JQL, add comments, list projects and per-issue transitions, transition an issue through its workflow, and create new issues.
+
+tool-knowledge = Manage a knowledge graph of architecture decisions, solution patterns, lessons learned, experts, and relationship links.
+
+tool-linkedin = Manage LinkedIn: create posts, list your posts, comment, react, delete posts, view engagement, get profile info, and read the configured content strategy. Requires LINKEDIN_* credentials in .env file.
+
+tool-discord-search = Search Discord message history stored in discord.db. Use to find past messages, summarize channel activity, or look up what users said. Supports keyword search and optional filters: channel_id, since, until.
+
+tool-memory-forget = Remove a memory by key. Use to delete outdated facts or sensitive data. Returns whether the memory was found and removed.
+
+tool-memory-recall = Search long-term memory for relevant facts, preferences, or context. Returns scored results ranked by relevance. Omit the query or pass bare * to return recent memories.
+
+tool-memory-store = Store a fact, preference, or note in long-term memory. Use category 'core' for permanent facts, 'daily' for session notes, 'conversation' for chat context, or a custom category name.
+
+tool-microsoft365 = Microsoft 365 integration: manage Outlook mail, Teams messages, Calendar events, OneDrive files, and SharePoint search via Microsoft Graph API
+
+tool-model-routing-config = Manage default model settings, scenario-based provider/model routes, classification rules, and aliased agent profiles
+
+tool-notion = Interact with Notion: query databases, read/create/update pages, and search the workspace.
+
+
+tool-project-intel = Project delivery intelligence: generate status reports, detect risks, draft client updates, summarize sprints, and estimate effort. Read-only analysis tool.
+
+tool-proxy-config = Manage ZeroClaw proxy settings (scope: environment | zeroclaw | services), including runtime and process env application
+
+tool-pushover = Send a Pushover notification to your device. Requires PUSHOVER_TOKEN and PUSHOVER_USER_KEY in .env file.
+
+tool-schedule = Manage scheduled shell-only tasks. Actions: create/add/once/list/get/cancel/remove/pause/resume. WARNING: This tool creates shell jobs whose output is only logged, NOT delivered to any channel. To send a scheduled message to Discord/Telegram/Slack/Matrix, use the cron_add tool with job_type='agent' and a delivery config like {"{"}"mode":"announce","channel":"discord","to":"<channel_id>"{"}"}.
+
+tool-screenshot = Capture a screenshot of the current screen. Returns the file path and base64-encoded PNG data.
+tool-browser-screenshot-error-path-not-allowed = Screenshot path '{ $path }' is not in the workspace allowlist
+tool-browser-screenshot-error-parent-not-exist = Screenshot path '{ $path }' parent directory '{ $parent }' does not exist
+tool-browser-screenshot-error-path-outside-workspace = Screenshot path '{ $path }' resolves to '{ $canonical }' which is outside the workspace
+tool-browser-screenshot-error-missing-filename = Screenshot path '{ $path }' is missing a filename component
+tool-browser-screenshot-error-runtime-config-target = Cannot write screenshot to runtime config path '{ $target }'
+tool-browser-screenshot-error-symlink-target = Cannot write screenshot to symlink target '{ $target }'
+tool-browser-screenshot-error-path-not-utf8 = Screenshot path '{ $path }' resolves to a non-UTF-8 pathname; refusing to write through a lossy conversion
+tool-browser-screenshot-error-computeruse-non-string-path = Screenshot 'path' parameter must be a string, got { $path }
+tool-browser-screenshot-error-non-string-path = Screenshot 'path' must be a string or absent
+tool-browser-screenshot-error-args-not-object = Screenshot arguments must be a JSON object
+tool-browser-screenshot-error-sidecar-no-png-data = computer-use sidecar did not return PNG data
+tool-browser-screenshot-error-sidecar-empty-png = computer-use sidecar returned an empty screenshot payload
+tool-browser-screenshot-error-sidecar-not-png = computer-use sidecar returned a non-PNG screenshot payload
+tool-browser-screenshot-error-sidecar-non-json-success = computer-use sidecar returned a non-JSON success response for a path-bearing screenshot; the requested file was not written
+
+tool-security-ops = Security operations tool for managed cybersecurity services. Actions: triage_alert (classify/prioritize alerts), run_playbook (execute incident response steps), parse_vulnerability (parse scan results), generate_report (create security posture reports), list_playbooks (list available playbooks), alert_stats (summarize alert metrics).
+
+tool-shell = Execute a shell command in the workspace directory
+
+tool-sop-advance = Report the result of the current SOP step and advance to the next step. Provide the run_id, whether the step succeeded or failed, and a brief output summary.
+
+tool-sop-approve = Approve a pending SOP step that is waiting for operator approval. Returns the step instruction to execute. Use sop_status to see which runs are waiting.
+
+tool-sop-execute = Manually trigger a Standard Operating Procedure (SOP) by name. Returns the run ID and first step instruction. Use sop_list to see available SOPs.
+
+tool-sop-list = List all loaded Standard Operating Procedures (SOPs) with their triggers, priority, step count, and active run count. Optionally filter by name or priority.
+
+tool-sop-status = Query SOP execution status. Provide run_id for a specific run, or sop_name to list runs for that SOP. With no arguments, shows all active runs.
+
+tool-tool-search = Fetch full schema definitions for deferred MCP tools so they can be called. Use "select:name1,name2" for exact match or keywords to search.
+
+tool-web-fetch = Fetch a web page and return its content as clean plain text. HTML pages are automatically converted to readable text. JSON and plain text responses are returned as-is. Only GET requests; follows redirects. Security: allowlist-only domains, no local/private hosts.
+
+tool-web-search-tool = Search the web for information. Returns relevant search results with titles, URLs, and descriptions. Use this to find current information, news, or research topics.
+
+tool-workspace = Manage multi-client workspaces. Subcommands: list, switch, create, info, export. Each workspace provides isolated memory, audit, secrets, and tool restrictions.
+
+tool-weather = Get current weather conditions and forecast for any location worldwide. Supports city names (in any language or script), IATA airport codes (e.g. 'LAX'), GPS coordinates (e.g. '51.5,-0.1'), postal/zip codes, and domain-based geolocation. Returns temperature, feels-like, humidity, wind speed/direction, precipitation, visibility, pressure, UV index, and cloud cover. Optional 0-3 day forecast with hourly breakdown. Units default to metric (°C, km/h, mm) but can be set to imperial (°F, mph, inches) per request. No API key required.

--- a/crates/zeroclaw-tools/src/i18n.rs
+++ b/crates/zeroclaw-tools/src/i18n.rs
@@ -8,7 +8,13 @@ static TOOL_STRINGS: OnceLock<HashMap<String, String>> = OnceLock::new();
 static TOOL_FTL_SOURCES: OnceLock<ToolFtlSources> = OnceLock::new();
 static LOCALE: OnceLock<String> = OnceLock::new();
 
-const EN_TOOLS_FTL: &str = include_str!("../../zeroclaw-runtime/locales/en/tools.ftl");
+/// English tool strings, embedded here rather than pulled from
+/// `zeroclaw-runtime` so the dependency direction (runtime -> tools) stays
+/// intact. The file is mirrored from the canonical runtime catalogue by
+/// `cargo generate installers tools-en-ftl`; CI fails on drift. Reading the
+/// runtime copy directly would reach outside this crate, and `cargo package`
+/// copies only the package directory.
+const EN_TOOLS_FTL: &str = include_str!("../locales/en/tools.ftl");
 
 struct ToolFtlSources {
     locale: String,

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -10,8 +10,10 @@ pub mod docs;
 pub mod flake;
 pub mod install_sh;
 pub mod packaging;
+pub mod runtime_locales;
 pub mod setup_bat;
 pub mod spec;
+pub mod tools_ftl;
 
 use container::ContainerSurface;
 use spec::Selection as Sel;
@@ -46,6 +48,16 @@ fn registry() -> Vec<Surface> {
             name: "install-docs",
             file: "docs/book/src/_snippets/install.md",
             render: docs::render_file,
+        },
+        Surface {
+            name: "runtime-locales",
+            file: "crates/zeroclaw-runtime/src/generated_locales.rs",
+            render: runtime_locales::render_file,
+        },
+        Surface {
+            name: "tools-en-ftl",
+            file: "crates/zeroclaw-tools/locales/en/tools.ftl",
+            render: tools_ftl::render_file,
         },
         Surface {
             name: "readme-unix-fast",

--- a/xtask/src/generate/runtime_locales.rs
+++ b/xtask/src/generate/runtime_locales.rs
@@ -1,0 +1,134 @@
+//! Render the runtime locale table from the canonical repo-root `locales.toml`.
+//!
+//! `locales.toml` stays the single place a locale is added. The runtime used to
+//! embed it with `include_str!("../../../locales.toml")`, which reaches outside
+//! the crate directory. `cargo package` copies only the package directory, so
+//! that read makes `zeroclaw-runtime` unpublishable. Generating a committed
+//! table inside the crate keeps the registry canonical while putting the data
+//! where packaging can see it, the same trade the installer surfaces make.
+
+use std::path::Path;
+
+const HEADER: &str = "\
+// GENERATED from locales.toml by `cargo generate installers` - do not edit by hand.
+//
+// `locales.toml` at the repo root stays the single source of truth for locale
+// codes and labels. Regenerate with `cargo generate installers runtime-locales`;
+// CI fails on drift via `cargo generate installers --check`.
+
+/// One selectable locale: its `code` (e.g. `ja`) and display `label`
+/// (e.g. \u{65e5}\u{672c}\u{8a9e}).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocaleOption {
+    pub code: &'static str,
+    pub label: &'static str,
+}
+
+/// Locales this build knows about, in `locales.toml` order. The first entry is
+/// the primary locale.
+pub const AVAILABLE_LOCALES: &[LocaleOption] = &[
+";
+
+/// Parse `locales.toml` and render the generated Rust table.
+pub fn render_file(root: &Path, _current: &str) -> anyhow::Result<String> {
+    let path = root.join("locales.toml");
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::Error::msg(format!("{}: {e}", path.display())))?;
+    render(&raw)
+}
+
+fn render(raw: &str) -> anyhow::Result<String> {
+    let table: toml::Value = toml::from_str(raw)?;
+    let entries = table
+        .get("locale")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow::Error::msg("locales.toml has no [[locale]] array"))?;
+
+    let mut out = String::from(HEADER);
+    for entry in entries {
+        let code = entry
+            .get("code")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::Error::msg("a [[locale]] entry is missing `code`"))?;
+        let label = entry
+            .get("label")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::Error::msg(format!("locale `{code}` is missing `label`")))?;
+        // Emit the shape rustfmt produces, so the committed file is
+        // fmt-stable and `cargo fmt --check` does not fight the generator.
+        out.push_str(&format!(
+            "    LocaleOption {{\n        code: {},\n        label: {},\n    }},\n",
+            quote(code),
+            quote(label)
+        ));
+    }
+    out.push_str("];\n");
+    Ok(out)
+}
+
+/// Emit a Rust string literal. Labels carry non-ASCII text, so escape only what
+/// Rust source requires rather than rewriting the label.
+fn quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_codes_and_labels_in_order() {
+        let out = render(
+            r#"
+[[locale]]
+code = "en"
+label = "English"
+
+[[locale]]
+code = "ja"
+label = "日本語"
+"#,
+        )
+        .expect("render");
+        assert!(out.contains(r#"code: "en","#) && out.contains(r#"label: "English","#));
+        assert!(out.contains(r#"code: "ja","#) && out.contains(r#"label: "日本語","#));
+        let en = out.find(r#"code: "en""#).expect("en present");
+        let ja = out.find(r#"code: "ja""#).expect("ja present");
+        assert!(en < ja, "locales.toml order must be preserved");
+    }
+
+    #[test]
+    fn a_label_with_a_quote_stays_valid_rust() {
+        let out = render(
+            r#"
+[[locale]]
+code = "xx"
+label = "a \"quoted\" label"
+"#,
+        )
+        .expect("render");
+        assert!(out.contains(r#"label: "a \"quoted\" label","#));
+    }
+
+    #[test]
+    fn a_locale_missing_its_label_is_an_error() {
+        let err = render(
+            r#"
+[[locale]]
+code = "xx"
+"#,
+        )
+        .expect_err("missing label must fail");
+        assert!(err.to_string().contains("xx"), "error names the locale");
+    }
+}

--- a/xtask/src/generate/tools_ftl.rs
+++ b/xtask/src/generate/tools_ftl.rs
@@ -1,0 +1,60 @@
+//! Mirror the canonical English tool catalogue into `zeroclaw-tools`.
+//!
+//! `crates/zeroclaw-runtime/locales/en/tools.ftl` stays the source of truth, and
+//! `cargo fluent fill` keeps translations beside it. `zeroclaw-tools` embeds the
+//! English strings itself rather than depending on `zeroclaw-runtime`, because
+//! the dependency runs runtime -> tools and importing back would invert it.
+//!
+//! That embed used to be `include_str!("../../zeroclaw-runtime/locales/en/tools.ftl")`,
+//! which reaches outside the crate directory. `cargo package` copies only the
+//! package directory, so the read made `zeroclaw-tools` unpublishable. Mirroring
+//! the file into the crate keeps the dependency direction intact and puts the
+//! bytes where packaging can see them; CI fails on drift.
+
+use std::path::Path;
+
+pub const SOURCE: &str = "crates/zeroclaw-runtime/locales/en/tools.ftl";
+
+const HEADER: &str = "\
+# GENERATED from crates/zeroclaw-runtime/locales/en/tools.ftl by
+# `cargo generate installers` - do not edit by hand. Edit the runtime catalogue
+# instead, then regenerate. CI fails on drift via `cargo generate installers --check`.
+";
+
+/// Render the mirrored catalogue: the canonical file with a provenance header.
+pub fn render_file(root: &Path, _current: &str) -> anyhow::Result<String> {
+    let path = root.join(SOURCE);
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::Error::msg(format!("{}: {e}", path.display())))?;
+    Ok(render(&raw))
+}
+
+fn render(canonical: &str) -> String {
+    format!("{HEADER}\n{canonical}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_canonical_body_survives_verbatim() {
+        let canonical = "tool-x-description = Does a thing\ntool-y-description = Does another\n";
+        let out = render(canonical);
+        assert!(
+            out.ends_with(canonical),
+            "the mirrored catalogue must carry the source bytes unchanged"
+        );
+    }
+
+    #[test]
+    fn the_mirror_is_marked_generated() {
+        let out = render("a = b\n");
+        assert!(out.starts_with('#'), "provenance header comes first");
+        assert!(out.contains("do not edit by hand"));
+        assert!(
+            out.contains(SOURCE),
+            "the header names the canonical source so an editor knows where to go"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Two crates read locale data from outside their own directory at compile time. `cargo package` copies only the package directory, so each read makes that crate unpublishable to crates.io:
  - `zeroclaw-runtime/src/i18n.rs` embedded repo-root `locales.toml` via `include_str!("../../../locales.toml")`.
  - `zeroclaw-tools/src/i18n.rs` embedded the runtime's English tool catalogue via `include_str!("../../zeroclaw-runtime/locales/en/tools.ftl")`.

  Both reads exist for good reasons, so neither source of truth moves. `locales.toml` stays the single place a locale is added, feeding the runtime, the docs language switcher, and the CI deploy target list. `zeroclaw-tools` still embeds English tool strings itself rather than depending on `zeroclaw-runtime`, because the dependency runs runtime -> tools and importing back would invert it (documented in Docs & Translations).

  Instead each is mirrored into the crate that needs it, using the generated-surface idiom the repo already has for installers: a `Surface` row renders the file, the output is committed, and `cargo generate installers --check` fails CI on drift.
  - `runtime-locales` renders `locales.toml` into `crates/zeroclaw-runtime/src/generated_locales.rs`.
  - `tools-en-ftl` mirrors the canonical catalogue into `crates/zeroclaw-tools/locales/en/tools.ftl` with a provenance header.
- **Scope boundary:** Removal of two out-of-crate reads only. Does **not** flip any `publish` flag, add a crates.io publisher, or change any locale content. `available_locales()` keeps its exact signature and `String`-field `LocaleOption`, so no caller changes.
- **Blast radius:** `zeroclaw-runtime` and `zeroclaw-tools` compile-time inputs, plus two new `xtask` generator surfaces. No runtime behavior change.
- **Linked issue(s):** Related #9381
- **Labels:** `runtime`, `tool`, `risk:low`, `size:M`, `type:refactor`

### Note on the generated file's formatting

The locale generator emits the multi-line struct shape rustfmt produces. Without that, `cargo fmt --check` and the generator fight on every regeneration.

### Unrelated drift a contributor will hit

`cargo generate installers` (non-check) calls `container_base::refresh_source()`, which fetches current base-image digests and rewrites `dev/ci/container-base-images.toml`, which in turn re-renders `Dockerfile`, `Dockerfile.alpine`, and `Dockerfile.debian`. That churn is network-driven and unrelated to this change; it is reverted here. Anyone running that command should expect it.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `No` — no user-visible behavior change; the locale table and tool catalogue are byte-identical to their sources.
- **Interface(s) exercised:** `cli`
- **Steps to run:** `cargo generate installers --check runtime-locales tools-en-ftl`, then `cargo test -p xtask --lib` and `cargo test -p zeroclaw-runtime --lib i18n`.
- **Expected on this branch (after):** drift gate reports both surfaces in sync; tests pass.

### How I tested

```sh
$ cargo generate installers --check runtime-locales tools-en-ftl
ok: runtime-locales in sync
ok: tools-en-ftl in sync

$ cargo test -p xtask --lib
test result: ok. 198 passed; 0 failed          # 5 new

$ cargo test -p zeroclaw-runtime --lib i18n
test result: ok. 28 passed; 0 failed

$ cargo test -p zeroclaw-runtime --lib locales
test result: ok. 13 passed; 0 failed

$ cargo test -p zeroclaw-tools --lib i18n
test result: ok. 5 passed; 0 failed

$ cargo clippy -p zeroclaw-runtime -p zeroclaw-tools -p xtask --all-targets -- -D warnings   # clean
$ cargo fmt --all --check                                                                     # clean
$ bash scripts/ci/docs_quality_gate.sh                                                        # 0 errors
$ bash scripts/ci/docs_links_gate.sh                                                          # OK
```

- **Beyond CI, what did you manually verify?**
  - Confirmed both crates now have **zero** out-of-crate compile-time reads, and that the mirrored files appear in `cargo package --list` for their crate.
  - Confirmed the mirrored catalogue carries the canonical bytes unchanged (a unit test pins this).
  - Rebased onto current master and re-ran the drift gate and a compile; both clean.
  - Confirmed this does not conflict with #9944 (`git merge-tree` reports zero conflict markers), which should merge first.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`. The locale list and tool strings are byte-identical to their canonical sources; `available_locales()` keeps its signature.
- Config / env / CLI surface changed? `No` — `cargo generate installers` gains two target names.
- Rust/MSRV/toolchain floor changed? `No`
- Upgrade steps for existing users: none.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** revert the squash-merge commit. Self-contained: no migration, no persisted state.
- **Observable failure symptoms:** a drift failure from `cargo generate installers --check` if `locales.toml` or the runtime catalogue is edited without regenerating; the gate names the surface.
