### PR TITLE
fix(deps): bump h2 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

- **Base:** `master` at `ccc6157d18028eb9f70e64aa6db7efd692752261`
- **What changed:** Updated the transitive `h2` lockfile resolution from `0.4.14` to patched release `0.4.16`.
- **Why:** `h2 0.4.14` is affected by [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258.html), which allows unbounded processing of empty HTTP/2 DATA frames. The repository's required Security job currently rejects the vulnerable lockfile.
- **Scope boundary:** `Cargo.lock` only. No manifests, source code, configuration, public APIs, or CI policy changed.
- **Blast radius:** `h2` is consumed transitively through `hyper` by the workspace's HTTP client/server paths (`axum`, `reqwest`, `hyper-util`, and `hyper-rustls`). The patch-level update therefore reaches network-facing workspace crates, but the resolved dependency structure is otherwise unchanged.
- **Linked issue(s):** Closes #10077
- **Labels:** `type:dependencies`, `dependencies`, `domain:security`, `distinguished contributor`, `risk:low`, `size:XS`

## Testing (required)

### Reviewer testing

No additional manual reviewer testing is requested. Please confirm the Security job reports no RUSTSEC-2026-0258 finding and the lockfile diff remains limited to the `h2` version and checksum.

### How I tested

- `cargo tree -i h2 --locked`
  - Pass: resolves `h2 v0.4.16` through `hyper v1.10.0`.
- `cargo deny check` using the CI-pinned `cargo-deny 0.19.9`
  - Pass: `advisories ok, bans ok, licenses ok, sources ok`.
  - The command retains pre-existing warnings for the now-unmatched temporary `lru` exception; those warnings are unrelated to this change and are non-blocking on current `master`.
- `python3 scripts/ci/lru_advisory_scope_test.py`
  - Pass: `lru advisory scope: constrained to Nostr 0.44 cache packages`.
- `cargo verify-project`
  - Pass.
- `cargo fetch --locked`
  - Pass.
- `cargo metadata --locked --format-version 1 --no-deps`
  - Pass with no lockfile drift.
- `cargo fmt --all -- --check`
  - Pass.
- `cargo check --workspace --all-targets --locked`
  - Pass; completed in 4m 40s and compiled the `h2 v0.4.16` path.
- `git diff --check`
  - Pass.

No runtime test count applies because this is a lockfile-only patch update with no project source changes.

## Security & Privacy Impact (required)

- **Security:** Positive impact. Removes the known HTTP/2 denial-of-service condition tracked by RUSTSEC-2026-0258.
- **Permissions / trust boundaries:** No permission, authentication, authorization, sandbox, or trust-boundary changes.
- **Secrets / credentials:** No secret handling or credential flow changes.
- **User data / telemetry:** No collection, storage, logging, or telemetry changes.
- **External dependencies / network:** Runtime dependency provenance remains crates.io. The only new artifact is `h2 0.4.16`, pinned by Cargo.lock checksum `a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27`.

## Compatibility (required)

- No public API, CLI, configuration, database, or serialization changes.
- No minimum supported Rust version or platform support changes.
- The update stays within the existing `h2 0.4.x` semver line and is accepted by the current `hyper 1.10.0` dependency constraints.
- Existing HTTP/2 interoperability is preserved; the intended behavioral difference is the upstream fix for pathological empty DATA-frame processing.

## Rollback

Revert the squash-merge commit with `git revert <squash-merge-sha>`. Reverting restores vulnerable `h2 0.4.14`, so it should be used only for an emergency regression and paired with an explicit temporary security-gate decision until a replacement patch is available.
