### PR TITLE
feat(gateway): answer WhatsApp's passkey gate over HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -803,7 +803,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -1147,9 +1147,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
+checksum = "6f02e8d0327b42d3e2e4ab2119af397344eb9fc54a34bf0ddeaa1277af8681f1"
 dependencies = [
  "alsa",
  "block2",
@@ -1810,8 +1810,8 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "web-sys",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2260,9 +2260,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -2824,7 +2839,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -2927,25 +2942,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
 ]
 
 [[package]]
@@ -3135,7 +3131,7 @@ checksum = "7737298823a6f9ca743e372e8cb03658d55354fbab843424f575706ba9563046"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3178,6 +3174,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -3921,16 +3923,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4162,9 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4177,7 +4179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -4188,7 +4190,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -4231,7 +4233,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -4248,7 +4250,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "log",
@@ -4257,7 +4259,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -4270,7 +4272,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -4295,7 +4297,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5182,7 +5184,7 @@ dependencies = [
  "socket2 0.6.3",
  "tokio",
  "url",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5526,7 +5528,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "gloo-timers",
- "http 1.4.1",
+ "http 1.5.0",
  "imbl",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -5561,7 +5563,7 @@ dependencies = [
  "url",
  "urlencoding",
  "vodozemac",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "wiremock",
  "zeroize",
 ]
@@ -5582,7 +5584,7 @@ dependencies = [
  "eyeball-im",
  "futures-util",
  "growable-bloom-filter",
- "http 1.4.1",
+ "http 1.5.0",
  "matrix-sdk-common",
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
@@ -5754,7 +5756,7 @@ dependencies = [
  "as_variant",
  "ctor 0.2.9",
  "getrandom 0.4.2",
- "http 1.4.1",
+ "http 1.5.0",
  "insta",
  "matrix-sdk-common",
  "matrix-sdk-test-macros",
@@ -6017,6 +6019,12 @@ dependencies = [
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nanohtml2text"
@@ -6359,7 +6367,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http 1.4.1",
+ "http 1.5.0",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -6756,7 +6764,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.1",
+ "http 1.5.0",
  "opentelemetry",
  "reqwest 0.13.1",
 ]
@@ -6767,7 +6775,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.1",
+ "http 1.5.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -7044,6 +7052,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -7639,25 +7658,51 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.14.3"
+name = "prost-build"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -8162,7 +8207,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -8192,7 +8237,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -8207,7 +8252,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -8235,7 +8280,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -8305,7 +8350,7 @@ dependencies = [
  "as_variant",
  "assign",
  "bytes",
- "http 1.4.1",
+ "http 1.5.0",
  "js_int",
  "js_option",
  "maplit",
@@ -8331,7 +8376,7 @@ dependencies = [
  "date_header",
  "form_urlencoded",
  "getrandom 0.4.2",
- "http 1.4.1",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "js_int",
  "konst",
@@ -9332,6 +9377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoothutf8"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9604,7 +9655,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9654,8 +9705,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -9716,7 +9767,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http 1.4.1",
+ "http 1.5.0",
  "image",
  "jni 0.21.1",
  "libc",
@@ -9749,7 +9800,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9870,7 +9921,7 @@ dependencies = [
  "cookie 0.18.1",
  "dpi",
  "gtk",
- "http 1.4.1",
+ "http 1.5.0",
  "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
@@ -9883,7 +9934,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9893,7 +9944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
- "http 1.4.1",
+ "http 1.5.0",
  "jni 0.21.1",
  "log",
  "objc2",
@@ -9908,7 +9959,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -9925,7 +9976,7 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "http 1.4.1",
+ "http 1.5.0",
  "infer",
  "json-patch",
  "log",
@@ -10379,15 +10430,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "rand 0.10.1",
  "ring",
@@ -10563,7 +10614,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -10706,7 +10757,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -10725,7 +10776,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -11026,7 +11077,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -11036,7 +11087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "log",
 ]
@@ -11145,7 +11196,7 @@ dependencies = [
  "base64ct",
  "cbc 0.1.2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hkdf 0.12.4",
@@ -11159,7 +11210,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -11195,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "wacore"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "aes 0.9.1",
  "anyhow",
@@ -11205,6 +11256,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "compact_str",
  "ctr 0.10.1",
  "event-listener 5.4.2",
  "flate2",
@@ -11223,6 +11275,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "smoothutf8",
  "subtle",
  "thiserror 2.0.18",
  "typed-builder",
@@ -11237,12 +11290,13 @@ dependencies = [
 [[package]]
 name = "wacore-appstate"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "anyhow",
  "bytemuck",
  "hex",
  "hkdf 0.13.0",
+ "hmac 0.13.0",
  "log",
  "prost",
  "serde",
@@ -11258,23 +11312,25 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "bytes",
  "compact_str",
- "flate2",
  "hashify",
  "itoa",
  "serde",
  "serde_json",
+ "smallvec",
+ "smoothutf8",
  "stable_deref_trait",
  "yoke 0.8.2",
+ "zlib-rs",
 ]
 
 [[package]]
 name = "wacore-derive"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11284,16 +11340,17 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "aes 0.9.1",
  "arrayref",
+ "async-lock 3.4.2",
  "async-trait",
  "bytes",
  "cbc 0.2.1",
  "chrono",
  "ctr 0.10.1",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "derive_more 2.1.1",
  "displaydoc",
  "ghash",
@@ -11310,13 +11367,13 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "waproto",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
 ]
 
 [[package]]
 name = "wacore-noise"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11359,10 +11416,14 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
+ "heck 0.5.0",
  "prost",
+ "prost-build",
+ "prost-types",
  "serde",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -11840,7 +11901,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -11851,7 +11912,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -11979,14 +12040,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11999,8 +12060,8 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -12023,8 +12084,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -12102,7 +12163,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -12111,9 +12172,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "env_logger",
  "event-listener 5.4.2",
  "futures",
+ "getrandom 0.4.2",
  "hex",
  "itoa",
  "log",
@@ -12133,27 +12194,27 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-tokio-transport"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "log",
  "rustls",
  "tokio",
  "tokio-rustls",
  "tokio-websockets",
  "wacore",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=b5daf757fdb08c7cad068cdd04ea0461cc2f5f13#b5daf757fdb08c7cad068cdd04ea0461cc2f5f13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12242,11 +12303,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -12255,7 +12328,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -12267,8 +12349,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -12277,9 +12372,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -12322,8 +12428,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12336,12 +12452,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12468,6 +12602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12725,7 +12868,7 @@ dependencies = [
  "base64 0.22.1",
  "deadpool 0.12.3",
  "futures",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -12880,7 +13023,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http 1.4.1",
+ "http 1.5.0",
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",
@@ -12902,8 +13045,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -12944,9 +13087,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -13298,7 +13452,7 @@ dependencies = [
  "wacore",
  "wacore-binary",
  "waproto",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "whatsapp-rust",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
@@ -13358,7 +13512,7 @@ dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
  "url",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "zeroclaw-api",
  "zeroclaw-log",
  "zeroclaw-macros",
@@ -13733,9 +13887,9 @@ dependencies = [
  "tower-http",
  "urlencoding",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "which",
- "windows",
+ "windows 0.61.3",
  "wiremock",
  "zeroclaw-api",
  "zeroclaw-commands",
@@ -13826,7 +13980,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "urlencoding",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "which",
  "wiremock",
  "zeroclaw-api",
@@ -14002,9 +14156,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -130,8 +130,14 @@ rand = "0.10"
 webpki-roots = "1.0.6"
 tokio-socks = "0.5"
 
-# WhatsApp Web (optional). Pinned to oxidezap/whatsapp-rust @ b5daf75
-# until upstream ships 0.6.1 to crates.io.
+# WhatsApp Web (optional). Pinned to oxidezap/whatsapp-rust @ b5daf75.
+#
+# Upstream never shipped 0.6.1; it published 0.7.0 (2026-08-14) instead, which
+# IS on crates.io and would let these six git deps become registry versions —
+# the last blocker on publishing zeroclaw-channels. That is worth doing, but it
+# is not this change: 0.7.0 sits above the buffa migration described below, so
+# taking it means the full waproto port, and bundling that with a linking fix
+# would make both unreviewable. Tracked separately.
 #
 # b5daf75 (2026-07-02) is a DELIBERATE ceiling, not just "some recent commit".
 # It is the last revision before a6fb1174 "migrate from prost to buffa for
@@ -141,8 +147,8 @@ tokio-socks = "0.5"
 # this crate fails with 46 errors, versus 18 mechanical ones here.
 #
 # The floor is 3fb4729e (2026-07-01), the SHORTCAKE passkey companion-linking
-# fix for #8627; anything below it cannot complete a device link at all now
-# that WhatsApp's passkey gate is rolling out. So the usable window is
+# fix; anything below it cannot complete a device link at all now that
+# WhatsApp's passkey gate is rolling out. So the usable window is
 # 3fb4729e..a6fb1174~1, and this pin sits at the top of it.
 whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true, default-features = false, features = [
   "tokio-runtime",

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -130,19 +130,31 @@ rand = "0.10"
 webpki-roots = "1.0.6"
 tokio-socks = "0.5"
 
-# WhatsApp Web (optional). Pinned to oxidezap/whatsapp-rust @ cbcdd2a
+# WhatsApp Web (optional). Pinned to oxidezap/whatsapp-rust @ b5daf75
 # until upstream ships 0.6.1 to crates.io.
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false, features = [
+#
+# b5daf75 (2026-07-02) is a DELIBERATE ceiling, not just "some recent commit".
+# It is the last revision before a6fb1174 "migrate from prost to buffa for
+# protobuf codegen", which rewrites every generated waproto field from
+# Option<Box<T>> to MessageField<T>. Moving past a6fb1174 is a port of
+# whatsapp_web.rs and whatsapp_storage.rs, not a pin bump — at upstream HEAD
+# this crate fails with 46 errors, versus 18 mechanical ones here.
+#
+# The floor is 3fb4729e (2026-07-01), the SHORTCAKE passkey companion-linking
+# fix for #8627; anything below it cannot complete a device link at all now
+# that WhatsApp's passkey gate is rolling out. So the usable window is
+# 3fb4729e..a6fb1174~1, and this pin sits at the top of it.
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true, default-features = false, features = [
   "tokio-runtime",
 ] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true, default-features = false }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true, default-features = false }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true, default-features = false }
 serde-big-array = { version = "0.5", optional = true }
 
 cpal = { version = "0.18.1", optional = true }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "b5daf757fdb08c7cad068cdd04ea0461cc2f5f13", optional = true, default-features = false }
 qrcode = { version = "0.14", optional = true }
 # `bytes` is required for the `Bytes` return types in wacore 0.6 storage
 # traits (SignalStore::get_session / load_prekey). Feature-gated to

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -12,6 +12,7 @@ pub mod allowlist;
 pub(crate) mod identity_persist;
 pub mod listing;
 pub mod login_events;
+pub mod login_passkey;
 pub mod login_probe;
 pub mod login_relink;
 pub mod orchestrator;

--- a/crates/zeroclaw-channels/src/lib.rs
+++ b/crates/zeroclaw-channels/src/lib.rs
@@ -99,6 +99,8 @@ pub mod wecom_ws;
 #[cfg(any(feature = "channel-whatsapp-cloud", feature = "whatsapp-web"))]
 pub mod whatsapp;
 #[cfg(feature = "whatsapp-web")]
+pub mod whatsapp_passkey;
+#[cfg(feature = "whatsapp-web")]
 pub mod whatsapp_storage;
 #[cfg(feature = "whatsapp-web")]
 pub mod whatsapp_web;

--- a/crates/zeroclaw-channels/src/login_passkey.rs
+++ b/crates/zeroclaw-channels/src/login_passkey.rs
@@ -1,0 +1,482 @@
+//! Channel-owned passkey hooks for QR-pairing channels.
+//!
+//! WhatsApp Web's SHORTCAKE gate interrupts device linking to demand a
+//! WebAuthn assertion signed by a passkey already registered to the account.
+//! No process on the host can produce one — the private key lives
+//! non-extractable in a platform authenticator — so the channel publishes the
+//! server's challenge and waits for an operator to answer it from where a real
+//! authenticator exists (in practice a logged-in `web.whatsapp.com` tab, since
+//! a browser only signs for an rpId matching the page origin).
+//!
+//! This module is the dispatch layer between that wait and its callers, and
+//! mirrors [`crate::login_relink`] deliberately: each arm delegates to the
+//! channel module that owns the state, so knowledge of the on-disk protocol
+//! never leaks out of the channel and the gateway endpoint performs no file
+//! operations of its own. Paths are resolved from the canonical `Config` per
+//! call; nothing is cached.
+//!
+//! The match over [`QrPairingChannel`] is exhaustive, so adding a QR-pairing
+//! channel forces an explicit answer to "does this one have a passkey gate?"
+//! rather than silently inheriting WhatsApp's. Today only WhatsApp Web does;
+//! WeChat resolves to [`PasskeyState::NotApplicable`], an explicit no-op the
+//! caller can surface verbatim.
+//!
+//! Only the assertion crosses this boundary. It is a one-time signature over
+//! the server's challenge and carries no private key, so a captured payload
+//! cannot be replayed against a different challenge.
+
+use crate::listing::QrPairingChannel;
+use zeroclaw_config::schema::Config;
+
+/// Whether a channel alias is currently waiting for a passkey assertion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PasskeyState {
+    /// The channel published a challenge and is blocked until it is
+    /// answered. `options` is the server's WebAuthn request JSON, carried
+    /// verbatim — it is what the browser ceremony consumes, and
+    /// re-serializing it risks perturbing a field the server signs over.
+    Pending { options: String },
+    /// The assertion was accepted and the fresh link is waiting for the
+    /// operator to compare and acknowledge WhatsApp's display code.
+    ConfirmationPending { attempt_id: String, code: String },
+    /// The channel participates in the ceremony but nothing is waiting.
+    /// The ordinary state: a linked channel demands an assertion only while
+    /// linking, and only when the server's phased rollout selects it.
+    Idle,
+    /// This channel type has no passkey gate. Nothing was inspected.
+    NotApplicable,
+}
+
+/// Why a submitted assertion was not accepted.
+///
+/// The variants are the distinctions a caller must act on, not every way the
+/// underlying write can fail.
+#[derive(Debug)]
+pub enum SubmitError {
+    /// Nothing is waiting for an assertion on this alias, so there is no
+    /// challenge for the payload to answer.
+    NoPendingRequest,
+    /// The payload cannot satisfy the server; carries the specific reason.
+    Invalid(String),
+    /// This channel type has no passkey gate. Nothing was written.
+    NotApplicable,
+    /// The assertion could not be handed over.
+    Io(String),
+}
+
+impl std::fmt::Display for SubmitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoPendingRequest => write!(
+                f,
+                "this channel is not waiting for a passkey assertion; \
+                 nothing was written"
+            ),
+            Self::Invalid(reason) => write!(f, "{reason}"),
+            Self::NotApplicable => {
+                write!(f, "this channel type has no passkey gate")
+            }
+            Self::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for SubmitError {}
+
+/// Why a fresh-link code acknowledgement was not accepted.
+#[derive(Debug)]
+pub enum ConfirmError {
+    /// Nothing is currently waiting for a verification-code acknowledgement.
+    NoPendingConfirmation,
+    /// The supplied attempt id belongs to another ceremony.
+    AttemptMismatch,
+    /// This channel type has no passkey gate.
+    NotApplicable,
+    /// The acknowledgement could not be handed over.
+    Io(String),
+}
+
+impl std::fmt::Display for ConfirmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoPendingConfirmation => {
+                write!(f, "this channel is not waiting for passkey confirmation")
+            }
+            Self::AttemptMismatch => write!(f, "confirmation attempt_id does not match"),
+            Self::NotApplicable => write!(f, "this channel type has no passkey gate"),
+            Self::Io(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfirmError {}
+
+/// Report whether `alias` is currently blocked on a passkey assertion, and
+/// republish the challenge if so.
+///
+/// Callers resolve their channel type key to [`QrPairingChannel`] once via
+/// [`crate::listing::qr_pairing_channel`], the same typed key
+/// [`crate::login_relink::relink`] dispatches on, so no string key reaches
+/// this function.
+///
+/// Errors are I/O failures from reading an existing challenge (permissions,
+/// etc.); an absent challenge is [`PasskeyState::Idle`], never an error.
+pub fn pending(
+    channel: QrPairingChannel,
+    config: &Config,
+    alias: &str,
+) -> anyhow::Result<PasskeyState> {
+    // Read at use-time in the feature-gated arms below; the binding keeps
+    // the signature stable when no QR-pairing channel feature is compiled.
+    let (_config, _alias) = (config, alias);
+    match channel {
+        #[cfg(feature = "channel-wechat")]
+        QrPairingChannel::WeChat => Ok(PasskeyState::NotApplicable),
+        #[cfg(feature = "whatsapp-web")]
+        QrPairingChannel::WhatsAppWeb => {
+            let Some(session_path) = configured_session_path(_config, _alias) else {
+                // The alias carries no session path, so the run loop never
+                // had a location to publish a challenge to.
+                return Ok(PasskeyState::Idle);
+            };
+            if let Some(confirmation) =
+                crate::whatsapp_web::WhatsAppWebChannel::pending_passkey_confirmation(
+                    &session_path,
+                )?
+            {
+                return Ok(PasskeyState::ConfirmationPending {
+                    attempt_id: confirmation.attempt_id,
+                    code: confirmation.code,
+                });
+            }
+            match crate::whatsapp_web::WhatsAppWebChannel::pending_passkey_request(&session_path)? {
+                Some(options) => Ok(PasskeyState::Pending { options }),
+                None => Ok(PasskeyState::Idle),
+            }
+        }
+    }
+}
+
+/// Hand a signed credential to the channel waiting for it.
+///
+/// `body` is the JSON `navigator.credentials.get()` returned, passed through
+/// byte-for-byte — the server verifies a signature over exactly those bytes,
+/// so anything that reshapes them invalidates the assertion.
+pub fn submit(
+    channel: QrPairingChannel,
+    config: &Config,
+    alias: &str,
+    body: Vec<u8>,
+) -> Result<(), SubmitError> {
+    let (_config, _alias, _body) = (config, alias, body);
+    match channel {
+        #[cfg(feature = "channel-wechat")]
+        QrPairingChannel::WeChat => Err(SubmitError::NotApplicable),
+        #[cfg(feature = "whatsapp-web")]
+        QrPairingChannel::WhatsAppWeb => {
+            let Some(session_path) = configured_session_path(_config, _alias) else {
+                return Err(SubmitError::NoPendingRequest);
+            };
+            crate::whatsapp_web::WhatsAppWebChannel::submit_passkey_assertion(&session_path, _body)
+                .map_err(|e| match e {
+                    crate::whatsapp_passkey::StageError::NoPendingRequest => {
+                        SubmitError::NoPendingRequest
+                    }
+                    crate::whatsapp_passkey::StageError::Invalid(reason) => {
+                        SubmitError::Invalid(reason)
+                    }
+                    crate::whatsapp_passkey::StageError::Io(io) => SubmitError::Io(io.to_string()),
+                })
+        }
+    }
+}
+
+/// Acknowledge the verification code for a fresh passkey link.
+pub fn confirm(
+    channel: QrPairingChannel,
+    config: &Config,
+    alias: &str,
+    attempt_id: &str,
+) -> Result<(), ConfirmError> {
+    let (_config, _alias, _attempt_id) = (config, alias, attempt_id);
+    match channel {
+        #[cfg(feature = "channel-wechat")]
+        QrPairingChannel::WeChat => Err(ConfirmError::NotApplicable),
+        #[cfg(feature = "whatsapp-web")]
+        QrPairingChannel::WhatsAppWeb => {
+            let Some(session_path) = configured_session_path(_config, _alias) else {
+                return Err(ConfirmError::NoPendingConfirmation);
+            };
+            crate::whatsapp_web::WhatsAppWebChannel::submit_passkey_confirmation(
+                &session_path,
+                _attempt_id,
+            )
+            .map_err(|error| match error {
+                crate::whatsapp_passkey::ConfirmationStageError::NoPendingConfirmation => {
+                    ConfirmError::NoPendingConfirmation
+                }
+                crate::whatsapp_passkey::ConfirmationStageError::AttemptMismatch => {
+                    ConfirmError::AttemptMismatch
+                }
+                crate::whatsapp_passkey::ConfirmationStageError::Io(io) => {
+                    ConfirmError::Io(io.to_string())
+                }
+            })
+        }
+    }
+}
+
+/// The `session_path` configured for a WhatsApp Web alias, if it has one.
+///
+/// Both entry points resolve it the same way and neither defaults it: the
+/// run loop only publishes challenges beside a configured session, so
+/// inventing a path here would point the endpoint at a file nothing writes.
+#[cfg(feature = "whatsapp-web")]
+fn configured_session_path(config: &Config, alias: &str) -> Option<String> {
+    config
+        .channels
+        .whatsapp
+        .get(alias)
+        .and_then(|whatsapp| whatsapp.session_path.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use super::{PasskeyState, pending};
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use crate::listing::QrPairingChannel;
+    #[cfg(any(feature = "channel-wechat", feature = "whatsapp-web"))]
+    use zeroclaw_config::schema::Config;
+
+    #[test]
+    fn channels_without_qr_pairing_never_reach_the_passkey_hook() {
+        // "Unsupported" is decided at key-resolution time, exactly as it is
+        // for relink, so no channel type can be probed by accident.
+        assert_eq!(crate::listing::qr_pairing_channel("discord"), None);
+        assert_eq!(
+            crate::listing::qr_pairing_channel("whatsapp"),
+            None,
+            "the Cloud API backend links by token and never sees a passkey gate"
+        );
+    }
+
+    #[cfg(feature = "channel-wechat")]
+    #[test]
+    fn wechat_has_no_passkey_gate() {
+        let config = Config::default();
+        assert_eq!(
+            pending(QrPairingChannel::WeChat, &config, "admin").unwrap(),
+            PasskeyState::NotApplicable
+        );
+        assert!(matches!(
+            super::submit(QrPairingChannel::WeChat, &config, "admin", b"{}".to_vec()),
+            Err(super::SubmitError::NotApplicable)
+        ));
+        assert!(matches!(
+            super::confirm(QrPairingChannel::WeChat, &config, "admin", "attempt"),
+            Err(super::ConfirmError::NotApplicable)
+        ));
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn whatsapp_config(session_path: &std::path::Path) -> Config {
+        let mut config = Config::default();
+        config.channels.whatsapp.insert(
+            "spare".to_string(),
+            zeroclaw_config::schema::WhatsAppConfig {
+                enabled: true,
+                session_path: Some(session_path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+        config
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn credential_json() -> Vec<u8> {
+        use base64::prelude::*;
+        serde_json::json!({
+            "id": BASE64_URL_SAFE_NO_PAD.encode(b"cred"),
+            "rawId": BASE64_URL_SAFE_NO_PAD.encode(b"cred"),
+            "type": "public-key",
+            "response": {
+                "clientDataJSON": "eyJ0IjoxfQ",
+                "authenticatorData": "YXV0aA",
+                "signature": "c2ln",
+                "userHandle": null,
+            }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn an_idle_channel_reports_no_challenge_without_creating_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let config = whatsapp_config(&session_path);
+
+        assert_eq!(
+            pending(QrPairingChannel::WhatsAppWeb, &config, "spare").unwrap(),
+            PasskeyState::Idle
+        );
+        assert!(
+            !std::path::Path::new(&crate::whatsapp_passkey::request_path(
+                &session_path.to_string_lossy()
+            ))
+            .exists(),
+            "probing must not create the request file"
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn a_published_challenge_is_served_verbatim_and_answered() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+        let config = whatsapp_config(&session_path);
+
+        // Submitting before the channel asks is refused: the authenticator
+        // discards any assertion predating its challenge, so accepting one
+        // would tell the operator they had answered when they had not.
+        assert!(matches!(
+            super::submit(
+                QrPairingChannel::WhatsAppWeb,
+                &config,
+                "spare",
+                credential_json()
+            ),
+            Err(super::SubmitError::NoPendingRequest)
+        ));
+
+        let options = r#"{"challenge":"AQID","rpId":"web.whatsapp.com"}"#;
+        std::fs::write(crate::whatsapp_passkey::request_path(&session), options).unwrap();
+
+        match pending(QrPairingChannel::WhatsAppWeb, &config, "spare").unwrap() {
+            PasskeyState::Pending { options: served } => assert_eq!(
+                served, options,
+                "the challenge must reach the browser byte-for-byte"
+            ),
+            other => panic!("expected Pending, got {other:?}"),
+        }
+
+        super::submit(
+            QrPairingChannel::WhatsAppWeb,
+            &config,
+            "spare",
+            credential_json(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(crate::whatsapp_passkey::assertion_path(&session)).unwrap(),
+            credential_json(),
+            "the credential must land unmodified where the authenticator polls"
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn a_payload_that_cannot_satisfy_the_server_is_refused_at_the_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+        let config = whatsapp_config(&session_path);
+        std::fs::write(
+            crate::whatsapp_passkey::request_path(&session),
+            r#"{"challenge":"AQID"}"#,
+        )
+        .unwrap();
+
+        let err = super::submit(
+            QrPairingChannel::WhatsAppWeb,
+            &config,
+            "spare",
+            b"not a credential".to_vec(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, super::SubmitError::Invalid(_)));
+
+        assert!(
+            !std::path::Path::new(&crate::whatsapp_passkey::assertion_path(&session)).exists(),
+            "a rejected payload must not be left for the run loop to choke on"
+        );
+        assert!(
+            std::path::Path::new(&crate::whatsapp_passkey::request_path(&session)).exists(),
+            "a rejected submission must leave the challenge open to retry"
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn a_pending_confirmation_is_served_and_acknowledged_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+        let config = whatsapp_config(&session_path);
+        let prompt = crate::whatsapp_passkey::PendingPasskeyConfirmation {
+            attempt_id: "current-attempt".to_string(),
+            code: "ABCD-EFGH".to_string(),
+        };
+        std::fs::write(
+            crate::whatsapp_passkey::confirmation_path(&session),
+            serde_json::to_vec(&prompt).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            pending(QrPairingChannel::WhatsAppWeb, &config, "spare").unwrap(),
+            PasskeyState::ConfirmationPending {
+                attempt_id: "current-attempt".to_string(),
+                code: "ABCD-EFGH".to_string(),
+            }
+        );
+        assert!(matches!(
+            super::confirm(
+                QrPairingChannel::WhatsAppWeb,
+                &config,
+                "spare",
+                "older-attempt"
+            ),
+            Err(super::ConfirmError::AttemptMismatch)
+        ));
+        assert!(
+            !std::path::Path::new(&crate::whatsapp_passkey::confirmation_ack_path(&session))
+                .exists()
+        );
+
+        super::confirm(
+            QrPairingChannel::WhatsAppWeb,
+            &config,
+            "spare",
+            "current-attempt",
+        )
+        .unwrap();
+        assert!(
+            std::path::Path::new(&crate::whatsapp_passkey::confirmation_ack_path(&session))
+                .is_file()
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn an_alias_without_a_session_path_is_idle_rather_than_guessed_at() {
+        let config = Config::default();
+        assert_eq!(
+            pending(QrPairingChannel::WhatsAppWeb, &config, "missing").unwrap(),
+            PasskeyState::Idle
+        );
+        assert!(matches!(
+            super::submit(
+                QrPairingChannel::WhatsAppWeb,
+                &config,
+                "missing",
+                credential_json()
+            ),
+            Err(super::SubmitError::NoPendingRequest)
+        ));
+    }
+}

--- a/crates/zeroclaw-channels/src/whatsapp_passkey.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_passkey.rs
@@ -31,8 +31,12 @@
 //! reachable only from inside the channel's own run loop — the gateway's
 //! `login_relink` hook is disk-only by design and never touches a running
 //! channel. Keeping the seam on disk avoids inventing cross-crate plumbing
-//! for a rare event, and leaves an HTTP endpoint a trivial future addition:
-//! it would write the same file.
+//! for a rare event.
+//!
+//! The gateway passkey endpoint ([`crate::login_passkey`]) is a caller of the
+//! same seam rather than a second one. It serves the pending state and stages
+//! operator responses through the helpers in this module, so HTTP and manual
+//! handoffs are indistinguishable to the run loop.
 //!
 //! The assertion is a one-time signature over the server's challenge and
 //! carries no private key. The acknowledgement carries only a random attempt
@@ -148,6 +152,122 @@ async fn publish_private(path: &str, contents: &[u8]) -> std::io::Result<()> {
     drop(file);
 
     tokio::fs::rename(&tmp, path).await
+}
+
+/// Synchronous counterpart of [`publish_private`] for blocking gateway hooks.
+fn publish_private_sync(path: &str, contents: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let staging = format!("{path}.partial");
+    // Removing first makes `create_new` both recoverable after a crash and
+    // symlink-safe: a planted link is unlinked rather than followed.
+    let _ = std::fs::remove_file(&staging);
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(&staging)?;
+    file.write_all(contents)?;
+    file.sync_all()?;
+    drop(file);
+
+    std::fs::rename(&staging, path).map_err(|error| {
+        let _ = std::fs::remove_file(&staging);
+        error
+    })
+}
+
+/// Why an operator-supplied assertion could not be staged.
+#[derive(Debug)]
+pub enum StageError {
+    /// No challenge is currently published for this session.
+    NoPendingRequest,
+    /// The payload cannot satisfy the server; carries the specific reason.
+    Invalid(String),
+    /// The assertion could not be written to disk.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for StageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoPendingRequest => write!(
+                f,
+                "no passkey assertion is currently being waited for on this session"
+            ),
+            Self::Invalid(reason) => write!(f, "{reason}"),
+            Self::Io(error) => write!(f, "could not write the assertion: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for StageError {}
+
+/// Why a verification-code acknowledgement could not be staged.
+#[derive(Debug)]
+pub enum ConfirmationStageError {
+    /// No fresh-link code is currently waiting for operator confirmation.
+    NoPendingConfirmation,
+    /// The acknowledgement belongs to a different ceremony attempt.
+    AttemptMismatch,
+    /// The acknowledgement could not be written to disk.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ConfirmationStageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoPendingConfirmation => {
+                write!(f, "no passkey verification code is currently waiting")
+            }
+            Self::AttemptMismatch => write!(f, "confirmation attempt_id does not match"),
+            Self::Io(error) => write!(f, "could not write the confirmation: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfirmationStageError {}
+
+/// The assertion challenge currently published for `session_path`, if any.
+pub fn pending_request(session_path: &str) -> std::io::Result<Option<String>> {
+    match std::fs::read_to_string(request_path(session_path)) {
+        Ok(options) => Ok(Some(options)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Validate and atomically stage a browser assertion for the waiting channel.
+pub fn stage_assertion(session_path: &str, body: Vec<u8>) -> Result<(), StageError> {
+    if !std::path::Path::new(&request_path(session_path)).exists() {
+        return Err(StageError::NoPendingRequest);
+    }
+
+    parse_assertion(body.clone()).map_err(|e| StageError::Invalid(e.to_string()))?;
+    publish_private_sync(&assertion_path(session_path), &body).map_err(StageError::Io)
+}
+
+/// Atomically stage an acknowledgement for the current fresh-link code.
+pub fn stage_confirmation_ack(
+    session_path: &str,
+    attempt_id: &str,
+) -> Result<(), ConfirmationStageError> {
+    let pending = pending_confirmation(session_path)
+        .map_err(ConfirmationStageError::Io)?
+        .ok_or(ConfirmationStageError::NoPendingConfirmation)?;
+    if pending.attempt_id != attempt_id {
+        return Err(ConfirmationStageError::AttemptMismatch);
+    }
+
+    let body = serde_json::to_vec(&serde_json::json!({ "attempt_id": attempt_id }))
+        .map_err(|e| ConfirmationStageError::Io(std::io::Error::other(e)))?;
+    publish_private_sync(&confirmation_ack_path(session_path), &body)
+        .map_err(ConfirmationStageError::Io)
 }
 
 /// Read the pending verification-code prompt for `session_path`, if any.
@@ -596,6 +716,63 @@ mod tests {
         publish_private(&target, b"fresh").await.unwrap();
 
         assert_eq!(tokio::fs::read(&target).await.unwrap(), b"fresh".to_vec());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn assertion_staging_does_not_follow_a_planted_partial_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("session.db").to_string_lossy().to_string();
+        std::fs::write(request_path(&session), r#"{"challenge":"AQID"}"#).unwrap();
+
+        let target = tmp.path().join("must-not-change");
+        std::fs::write(&target, b"original").unwrap();
+        symlink(&target, format!("{}.partial", assertion_path(&session))).unwrap();
+
+        let raw_id = BASE64_URL_SAFE_NO_PAD.encode(b"cred");
+        stage_assertion(&session, credential_json(&raw_id, "c2ln")).unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"original");
+        assert!(std::path::Path::new(&assertion_path(&session)).is_file());
+    }
+
+    #[test]
+    fn confirmation_acknowledgement_is_bound_to_the_pending_attempt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("session.db").to_string_lossy().to_string();
+        let prompt = PendingPasskeyConfirmation {
+            attempt_id: "current-attempt".to_string(),
+            code: "ABCD-EFGH".to_string(),
+        };
+        std::fs::write(
+            confirmation_path(&session),
+            serde_json::to_vec(&prompt).unwrap(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            stage_confirmation_ack(&session, "older-attempt"),
+            Err(ConfirmationStageError::AttemptMismatch)
+        ));
+        assert!(!std::path::Path::new(&confirmation_ack_path(&session)).exists());
+
+        stage_confirmation_ack(&session, "current-attempt").unwrap();
+        let ack: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(confirmation_ack_path(&session)).unwrap())
+                .unwrap();
+        assert_eq!(ack["attempt_id"], "current-attempt");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(confirmation_ack_path(&session))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/whatsapp_passkey.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_passkey.rs
@@ -1,4 +1,4 @@
-//! File-brokered WebAuthn assertions for WhatsApp Web's SHORTCAKE passkey
+//! File-brokered operator handoff for WhatsApp Web's SHORTCAKE passkey
 //! companion-linking gate.
 //!
 //! WhatsApp began requiring a WebAuthn assertion during device linking in a
@@ -8,8 +8,8 @@
 //! on the host can produce one on its own. `whatsapp-rust` abstracts exactly
 //! that one step behind [`PasskeyAuthenticator`] and ships no default.
 //!
-//! This module supplies one whose transport is the filesystem, next to the
-//! session database the channel already owns:
+//! This module supplies that authenticator and the fresh-link verification
+//! handoff. Both use files next to the session database the channel owns:
 //!
 //! 1. When the server demands an assertion, the request options are written
 //!    to `<session>.passkey-request.json`.
@@ -18,7 +18,13 @@
 //!    browser only signs for an rpId matching the page origin — and saves the
 //!    resulting credential JSON to `<session>.passkey-assertion.json`.
 //! 3. This authenticator picks it up and hands it back to the library, which
-//!    resumes the normal pair-success path.
+//!    resumes the protocol.
+//! 4. A fresh link publishes WhatsApp's verification code and a one-shot
+//!    attempt id to `<session>.passkey-confirmation.json`.
+//! 5. After matching the code on the primary phone, the operator writes that
+//!    attempt id to `<session>.passkey-confirmed.json`; only then does ZeroClaw
+//!    send the final confirmation. Re-links prove continuity and upstream
+//!    auto-confirms them without this second handoff.
 //!
 //! The file is deliberately the interface rather than an HTTP handler. The
 //! ceremony is rare, operator-driven and one-shot, and the live client is
@@ -28,17 +34,19 @@
 //! for a rare event, and leaves an HTTP endpoint a trivial future addition:
 //! it would write the same file.
 //!
-//! Only the assertion crosses this boundary. It is a one-time signature over
-//! the server's challenge and carries no private key, so a stale or captured
-//! file cannot be replayed against a different challenge.
+//! The assertion is a one-time signature over the server's challenge and
+//! carries no private key. The acknowledgement carries only a random attempt
+//! id bound to the current code prompt. Neither file is reusable against a
+//! different ceremony.
 //!
-//! The request is published atomically (temp file plus rename) and, on Unix,
-//! created owner-only. Both matter because the reader is a poller rather than
-//! a process that knows when the write finished: without the rename it could
-//! read a truncated document, and without the mode the challenge would sit at
-//! the prevailing umask. The assertion is written by whoever runs the ceremony,
-//! so its permissions are theirs to set; this module consumes and deletes it as
-//! soon as it is read.
+//! The request and confirmation prompt are published atomically (temp file plus
+//! rename) and, on Unix, created owner-only. Both matter because the reader is
+//! a poller rather than a process that knows when the write finished: without
+//! the rename it could read a truncated document, and without the mode the
+//! challenge would sit at the prevailing umask. The assertion and
+//! acknowledgement are written by whoever runs the ceremony, so their
+//! permissions are theirs to set; this module consumes and deletes them as soon
+//! as they are read.
 
 #![cfg(feature = "whatsapp-web")]
 
@@ -49,7 +57,7 @@ use async_trait::async_trait;
 use base64::prelude::*;
 use whatsapp_rust::passkey::{Assertion, AssertionRequest, PasskeyAuthenticator, PasskeyError};
 
-/// How long to wait for the operator to drop the assertion file.
+/// How long to wait for each operator-mediated ceremony step.
 ///
 /// Generous on purpose: a human has to run a browser ceremony, and the
 /// server re-issues its request if this attempt lapses. The server's own
@@ -71,6 +79,33 @@ pub fn request_path(session_path: &str) -> String {
 #[must_use]
 pub fn assertion_path(session_path: &str) -> String {
     format!("{session_path}.passkey-assertion.json")
+}
+
+/// Path carrying the verification code for a fresh link.
+#[must_use]
+pub fn confirmation_path(session_path: &str) -> String {
+    format!("{session_path}.passkey-confirmation.json")
+}
+
+/// Path where the operator acknowledges the current verification code.
+#[must_use]
+pub fn confirmation_ack_path(session_path: &str) -> String {
+    format!("{session_path}.passkey-confirmed.json")
+}
+
+/// The fresh-link verification state published for the operator.
+///
+/// `attempt_id` binds the acknowledgement to this exact ceremony. The display
+/// code is short and can repeat, so it is not sufficient as a replay guard.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct PendingPasskeyConfirmation {
+    pub attempt_id: String,
+    pub code: String,
+}
+
+#[derive(serde::Deserialize)]
+struct PasskeyConfirmationAck {
+    attempt_id: String,
 }
 
 /// Publish `contents` at `path` atomically, and owner-only where the platform
@@ -113,6 +148,121 @@ async fn publish_private(path: &str, contents: &[u8]) -> std::io::Result<()> {
     drop(file);
 
     tokio::fs::rename(&tmp, path).await
+}
+
+/// Read the pending verification-code prompt for `session_path`, if any.
+///
+/// The prompt is published atomically, so a parse error is a real corrupt or
+/// incompatible file rather than an in-progress write.
+pub fn pending_confirmation(
+    session_path: &str,
+) -> std::io::Result<Option<PendingPasskeyConfirmation>> {
+    match std::fs::read(confirmation_path(session_path)) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map(Some).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid passkey confirmation state: {e}"),
+            )
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// File-backed operator acknowledgement for the fresh-link verification code.
+pub struct FilePasskeyConfirmation {
+    session_path: String,
+    wait: Duration,
+}
+
+impl FilePasskeyConfirmation {
+    #[must_use]
+    pub fn new(session_path: impl Into<String>) -> Self {
+        Self {
+            session_path: session_path.into(),
+            wait: DEFAULT_WAIT,
+        }
+    }
+
+    /// Override the operator wait. Tests use a short deadline.
+    #[must_use]
+    pub fn with_wait(mut self, wait: Duration) -> Self {
+        self.wait = wait;
+        self
+    }
+
+    /// Publish `code` and wait for an acknowledgement bound to this attempt.
+    pub async fn wait_for_acknowledgement(&self, code: &str) -> Result<(), PasskeyError> {
+        let prompt_file = confirmation_path(&self.session_path);
+        let ack_file = confirmation_ack_path(&self.session_path);
+        let attempt_id = uuid::Uuid::new_v4().to_string();
+        let prompt = PendingPasskeyConfirmation {
+            attempt_id: attempt_id.clone(),
+            code: code.to_string(),
+        };
+        let prompt_bytes = serde_json::to_vec(&prompt).map_err(|e| {
+            PasskeyError::Backend(format!("could not serialize passkey confirmation: {e}"))
+        })?;
+
+        // Any acknowledgement predating this prompt belongs to an earlier
+        // ceremony. Clear both names before publishing the new attempt.
+        let _ = tokio::fs::remove_file(&ack_file).await;
+        let _ = tokio::fs::remove_file(&prompt_file).await;
+        publish_private(&prompt_file, &prompt_bytes)
+            .await
+            .map_err(|e| PasskeyError::Backend(format!("could not write {prompt_file}: {e}")))?;
+
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+            &format!(
+                "WhatsApp requires confirmation of the passkey verification code. \
+                 Prompt written to {prompt_file}. After matching the code on the \
+                 primary phone, write JSON containing its attempt_id to {ack_file} \
+                 within {}s.",
+                self.wait.as_secs()
+            )
+        );
+
+        let deadline = tokio::time::Instant::now() + self.wait;
+        loop {
+            match tokio::fs::read(&ack_file).await {
+                Ok(bytes)
+                    if !bytes.is_empty()
+                        && serde_json::from_slice::<PasskeyConfirmationAck>(&bytes)
+                            .is_ok_and(|ack| ack.attempt_id == attempt_id) =>
+                {
+                    self.cleanup_attempt(&prompt_file, &ack_file, &attempt_id)
+                        .await;
+                    return Ok(());
+                }
+                _ => {}
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                self.cleanup_attempt(&prompt_file, &ack_file, &attempt_id)
+                    .await;
+                return Err(PasskeyError::Cancelled);
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    /// Remove only the state owned by this attempt. A later ceremony may have
+    /// replaced it while an older waiter was winding down.
+    async fn cleanup_attempt(&self, prompt_file: &str, ack_file: &str, attempt_id: &str) {
+        let owns_prompt = tokio::fs::read(prompt_file)
+            .await
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<PendingPasskeyConfirmation>(&bytes).ok())
+            .is_some_and(|prompt| prompt.attempt_id == attempt_id);
+        if owns_prompt {
+            let _ = tokio::fs::remove_file(prompt_file).await;
+            let _ = tokio::fs::remove_file(ack_file).await;
+        }
+    }
 }
 
 /// A [`PasskeyAuthenticator`] that brokers the ceremony through two files
@@ -286,6 +436,14 @@ mod tests {
             assertion_path("/data/wa.db"),
             "/data/wa.db.passkey-assertion.json"
         );
+        assert_eq!(
+            confirmation_path("/data/wa.db"),
+            "/data/wa.db.passkey-confirmation.json"
+        );
+        assert_eq!(
+            confirmation_ack_path("/data/wa.db"),
+            "/data/wa.db.passkey-confirmed.json"
+        );
     }
 
     #[test]
@@ -438,6 +596,67 @@ mod tests {
         publish_private(&target, b"fresh").await.unwrap();
 
         assert_eq!(tokio::fs::read(&target).await.unwrap(), b"fresh".to_vec());
+    }
+
+    #[tokio::test]
+    async fn fresh_confirmation_waits_for_a_matching_attempt_acknowledgement() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("session.db").to_string_lossy().to_string();
+        let broker = FilePasskeyConfirmation::new(&session).with_wait(Duration::from_secs(3));
+        let prompt_file = confirmation_path(&session);
+        let ack_file = confirmation_ack_path(&session);
+
+        let operator = async {
+            for _ in 0..100 {
+                if tokio::fs::try_exists(&prompt_file).await.unwrap_or(false) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            let prompt = pending_confirmation(&session)
+                .unwrap()
+                .expect("the confirmation prompt must be published");
+            assert_eq!(prompt.code, "ABCD-EFGH");
+            tokio::fs::write(
+                &ack_file,
+                serde_json::json!({ "attempt_id": prompt.attempt_id })
+                    .to_string()
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+        };
+
+        let (result, ()) = tokio::join!(broker.wait_for_acknowledgement("ABCD-EFGH"), operator);
+        result.unwrap();
+        assert!(!tokio::fs::try_exists(&prompt_file).await.unwrap());
+        assert!(!tokio::fs::try_exists(&ack_file).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn stale_acknowledgement_cannot_confirm_a_later_attempt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("session.db").to_string_lossy().to_string();
+        let broker = FilePasskeyConfirmation::new(&session).with_wait(Duration::from_millis(200));
+        let prompt_file = confirmation_path(&session);
+        let ack_file = confirmation_ack_path(&session);
+
+        let operator = async {
+            for _ in 0..50 {
+                if tokio::fs::try_exists(&prompt_file).await.unwrap_or(false) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            tokio::fs::write(&ack_file, br#"{"attempt_id":"from-an-older-attempt"}"#)
+                .await
+                .unwrap();
+        };
+
+        let (result, ()) = tokio::join!(broker.wait_for_acknowledgement("ABCD-EFGH"), operator);
+        assert!(matches!(result, Err(PasskeyError::Cancelled)));
+        assert!(!tokio::fs::try_exists(&prompt_file).await.unwrap());
+        assert!(!tokio::fs::try_exists(&ack_file).await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/whatsapp_passkey.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_passkey.rs
@@ -176,9 +176,8 @@ fn publish_private_sync(path: &str, contents: &[u8]) -> std::io::Result<()> {
     file.sync_all()?;
     drop(file);
 
-    std::fs::rename(&staging, path).map_err(|error| {
+    std::fs::rename(&staging, path).inspect_err(|_| {
         let _ = std::fs::remove_file(&staging);
-        error
     })
 }
 

--- a/crates/zeroclaw-channels/src/whatsapp_passkey.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_passkey.rs
@@ -1,0 +1,370 @@
+//! File-brokered WebAuthn assertions for WhatsApp Web's SHORTCAKE passkey
+//! companion-linking gate.
+//!
+//! WhatsApp began requiring a WebAuthn assertion during device linking in a
+//! server-side rollout from 2026-06-30. The assertion must be signed by a
+//! passkey already registered to the account, and its private key normally
+//! lives non-extractable in a platform authenticator, so no process running
+//! on the host can produce one on its own. `whatsapp-rust` abstracts exactly
+//! that one step behind [`PasskeyAuthenticator`] and ships no default.
+//!
+//! This module supplies one whose transport is the filesystem, next to the
+//! session database the channel already owns:
+//!
+//! 1. When the server demands an assertion, the request options are written
+//!    to `<session>.passkey-request.json`.
+//! 2. The operator performs the ceremony where a real authenticator lives —
+//!    the practical route is a logged-in `web.whatsapp.com` tab, because a
+//!    browser only signs for an rpId matching the page origin — and saves the
+//!    resulting credential JSON to `<session>.passkey-assertion.json`.
+//! 3. This authenticator picks it up and hands it back to the library, which
+//!    resumes the normal pair-success path.
+//!
+//! The file is deliberately the interface rather than an HTTP handler. The
+//! ceremony is rare, operator-driven and one-shot, and the live client is
+//! reachable only from inside the channel's own run loop — the gateway's
+//! `login_relink` hook is disk-only by design and never touches a running
+//! channel. Keeping the seam on disk avoids inventing cross-crate plumbing
+//! for a rare event, and leaves an HTTP endpoint a trivial future addition:
+//! it would write the same file.
+//!
+//! Only the assertion crosses this boundary. It is a one-time signature over
+//! the server's challenge and carries no private key, so a stale or captured
+//! file cannot be replayed against a different challenge.
+
+#![cfg(feature = "whatsapp-web")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::prelude::*;
+use whatsapp_rust::passkey::{Assertion, AssertionRequest, PasskeyAuthenticator, PasskeyError};
+
+/// How long to wait for the operator to drop the assertion file.
+///
+/// Generous on purpose: a human has to run a browser ceremony, and the
+/// server re-issues its request if this attempt lapses. The server's own
+/// `timeout_ms` is deliberately NOT used as the ceiling — it is typically
+/// around a minute, which is shorter than the manual step realistically
+/// takes, and giving up early would just burn the attempt.
+const DEFAULT_WAIT: Duration = Duration::from_secs(300);
+
+/// How often to look for the assertion file while waiting.
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Path the request options are written to, derived from the session path.
+#[must_use]
+pub fn request_path(session_path: &str) -> String {
+    format!("{session_path}.passkey-request.json")
+}
+
+/// Path the operator drops the signed assertion at.
+#[must_use]
+pub fn assertion_path(session_path: &str) -> String {
+    format!("{session_path}.passkey-assertion.json")
+}
+
+/// A [`PasskeyAuthenticator`] that brokers the ceremony through two files
+/// beside the session database.
+pub struct FilePasskeyAuthenticator {
+    session_path: String,
+    wait: Duration,
+}
+
+impl FilePasskeyAuthenticator {
+    #[must_use]
+    pub fn new(session_path: impl Into<String>) -> Self {
+        Self {
+            session_path: session_path.into(),
+            wait: DEFAULT_WAIT,
+        }
+    }
+
+    /// Override how long to wait for the operator. Used by tests to keep the
+    /// timeout path fast.
+    #[must_use]
+    pub fn with_wait(mut self, wait: Duration) -> Self {
+        self.wait = wait;
+        self
+    }
+
+    #[must_use]
+    pub fn into_arc(self) -> Arc<dyn PasskeyAuthenticator> {
+        Arc::new(self)
+    }
+}
+
+/// Build an [`Assertion`] from the credential JSON a WebAuthn `get()` returns.
+///
+/// The operator saves exactly what the browser produced, so the credential id
+/// is recovered from the JSON itself rather than asked for separately — one
+/// less field to transcribe wrongly. `rawId` is preferred over `id` because
+/// both carry the same base64url value and `rawId` is the canonical binary
+/// form; either is accepted since hand-assembled payloads often omit one.
+pub fn parse_assertion(bytes: Vec<u8>) -> Result<Assertion, PasskeyError> {
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| PasskeyError::InvalidOptions(format!("assertion is not valid JSON: {e}")))?;
+
+    let raw_id = value
+        .get("rawId")
+        .or_else(|| value.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            PasskeyError::InvalidOptions(
+                "assertion is missing a string `rawId` (or `id`) credential identifier".into(),
+            )
+        })?;
+
+    let credential_id = BASE64_URL_SAFE_NO_PAD
+        .decode(raw_id.trim_end_matches('='))
+        .map_err(|e| PasskeyError::InvalidOptions(format!("rawId is not base64url: {e}")))?;
+
+    if credential_id.is_empty() {
+        return Err(PasskeyError::InvalidOptions(
+            "assertion rawId decoded to zero bytes, which is never a credential id".into(),
+        ));
+    }
+
+    // A response block without a signature cannot satisfy the server, and
+    // failing here names the problem instead of surfacing an opaque rejection
+    // from WhatsApp minutes later.
+    if value
+        .get("response")
+        .and_then(|r| r.get("signature"))
+        .and_then(|s| s.as_str())
+        .is_none_or(str::is_empty)
+    {
+        return Err(PasskeyError::InvalidOptions(
+            "assertion is missing `response.signature`; save the full credential JSON returned by navigator.credentials.get()".into(),
+        ));
+    }
+
+    Ok(Assertion {
+        assertion_json: bytes,
+        credential_id,
+    })
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl PasskeyAuthenticator for FilePasskeyAuthenticator {
+    async fn get_assertion(&self, request: &AssertionRequest) -> Result<Assertion, PasskeyError> {
+        let request_file = request_path(&self.session_path);
+        let assertion_file = assertion_path(&self.session_path);
+
+        // Clear any assertion left by a previous attempt before advertising a
+        // new challenge. A stale file answers the WRONG challenge, so the
+        // server would reject it and burn this attempt for no reason.
+        let _ = tokio::fs::remove_file(&assertion_file).await;
+
+        tokio::fs::write(&request_file, request.raw_options_json.as_bytes())
+            .await
+            .map_err(|e| PasskeyError::Backend(format!("could not write {request_file}: {e}")))?;
+
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+            &format!(
+                "WhatsApp requires a passkey assertion to link this device. \
+                 Request options written to {request_file}. Run the WebAuthn \
+                 ceremony in a logged-in web.whatsapp.com tab and save the \
+                 resulting credential JSON to {assertion_file} within {}s.",
+                self.wait.as_secs()
+            )
+        );
+
+        let deadline = tokio::time::Instant::now() + self.wait;
+        loop {
+            match tokio::fs::read(&assertion_file).await {
+                Ok(bytes) if !bytes.is_empty() => {
+                    // Consume it either way: on success it is spent, and on a
+                    // malformed payload leaving it in place would make the
+                    // next attempt re-read the same bad file forever.
+                    let _ = tokio::fs::remove_file(&assertion_file).await;
+                    let _ = tokio::fs::remove_file(&request_file).await;
+                    let assertion = parse_assertion(bytes)?;
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                        "WhatsApp passkey assertion accepted; resuming device linking"
+                    );
+                    return Ok(assertion);
+                }
+                // Absent, or present but still being written: keep waiting.
+                _ => {}
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                let _ = tokio::fs::remove_file(&request_file).await;
+                return Err(PasskeyError::Cancelled);
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credential_json(raw_id: &str, signature: &str) -> Vec<u8> {
+        serde_json::json!({
+            "id": raw_id,
+            "rawId": raw_id,
+            "type": "public-key",
+            "response": {
+                "clientDataJSON": "eyJ0IjoxfQ",
+                "authenticatorData": "YXV0aA",
+                "signature": signature,
+                "userHandle": null,
+            }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn paths_sit_beside_the_session_database() {
+        assert_eq!(
+            request_path("/data/wa.db"),
+            "/data/wa.db.passkey-request.json"
+        );
+        assert_eq!(
+            assertion_path("/data/wa.db"),
+            "/data/wa.db.passkey-assertion.json"
+        );
+    }
+
+    #[test]
+    fn parses_a_browser_credential_and_recovers_the_id() {
+        let raw_id = BASE64_URL_SAFE_NO_PAD.encode(b"credential-1");
+        let bytes = credential_json(&raw_id, "c2ln");
+
+        let assertion = parse_assertion(bytes.clone()).unwrap();
+        assert_eq!(assertion.credential_id, b"credential-1".to_vec());
+        assert_eq!(
+            assertion.assertion_json, bytes,
+            "the credential JSON must reach the server byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn rejects_payloads_that_cannot_satisfy_the_server() {
+        // Not JSON at all.
+        assert!(parse_assertion(b"not json".to_vec()).is_err());
+
+        // No credential identifier.
+        let no_id = serde_json::json!({ "response": { "signature": "c2ln" } })
+            .to_string()
+            .into_bytes();
+        assert!(parse_assertion(no_id).is_err());
+
+        // Identifier present but not base64url.
+        let bad_b64 = credential_json("not valid base64!!", "c2ln");
+        assert!(parse_assertion(bad_b64).is_err());
+
+        // An empty rawId decodes to zero bytes, which is never a credential.
+        let empty_id = credential_json("", "c2ln");
+        assert!(parse_assertion(empty_id).is_err());
+
+        // Well-formed envelope with nothing to verify.
+        let no_signature = credential_json(&BASE64_URL_SAFE_NO_PAD.encode(b"cred"), "");
+        assert!(parse_assertion(no_signature).is_err());
+    }
+
+    #[tokio::test]
+    async fn waiting_publishes_the_request_and_consumes_the_assertion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("session.db").to_string_lossy().to_string();
+
+        let raw_id = BASE64_URL_SAFE_NO_PAD.encode(b"cred");
+        let assertion_file = assertion_path(&session);
+        let expected_request = request_path(&session);
+
+        let auth = FilePasskeyAuthenticator::new(&session).with_wait(Duration::from_secs(10));
+        let request = AssertionRequest {
+            challenge: vec![1, 2, 3],
+            rp_id: Some("web.whatsapp.com".into()),
+            allow_credentials: vec![],
+            user_verification: whatsapp_rust::passkey::UserVerification::Preferred,
+            timeout_ms: Some(60_000),
+            raw_options_json: r#"{"challenge":"AQID"}"#.into(),
+        };
+
+        // Drive the wait and the operator concurrently without spawning: the
+        // authenticator only resolves once the second future drops the file,
+        // which is exactly the interleaving being tested.
+        let operator = async {
+            for _ in 0..50 {
+                if tokio::fs::try_exists(&expected_request)
+                    .await
+                    .unwrap_or(false)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            let published = tokio::fs::read_to_string(&expected_request).await.unwrap();
+            assert!(
+                published.contains("challenge"),
+                "the server's request options must be published verbatim"
+            );
+            tokio::fs::write(&assertion_file, credential_json(&raw_id, "c2ln"))
+                .await
+                .unwrap();
+        };
+
+        let (assertion, ()) = tokio::join!(auth.get_assertion(&request), operator);
+        let assertion = assertion.unwrap();
+
+        assert_eq!(assertion.credential_id, b"cred".to_vec());
+        assert!(
+            !tokio::fs::try_exists(&assertion_file).await.unwrap(),
+            "a spent assertion must be consumed, not left to be replayed"
+        );
+        assert!(
+            !tokio::fs::try_exists(&expected_request).await.unwrap(),
+            "the request file must be cleaned up once answered"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stale_assertion_is_discarded_before_publishing_a_new_challenge() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("session.db").to_string_lossy().to_string();
+
+        // Left over from a previous attempt: it answers a challenge that is
+        // no longer live, so it must never be handed to the server.
+        tokio::fs::write(
+            assertion_path(&session),
+            credential_json(&BASE64_URL_SAFE_NO_PAD.encode(b"stale"), "c2ln"),
+        )
+        .await
+        .unwrap();
+
+        let auth = FilePasskeyAuthenticator::new(&session).with_wait(Duration::from_millis(200));
+        let request = AssertionRequest {
+            challenge: vec![9],
+            rp_id: None,
+            allow_credentials: vec![],
+            user_verification: whatsapp_rust::passkey::UserVerification::Preferred,
+            timeout_ms: None,
+            raw_options_json: r#"{"challenge":"CQ"}"#.into(),
+        };
+
+        let result = auth.get_assertion(&request).await;
+        assert!(
+            matches!(result, Err(PasskeyError::Cancelled)),
+            "the stale file must be cleared and the wait must time out instead"
+        );
+        assert!(
+            !tokio::fs::try_exists(&request_path(&session))
+                .await
+                .unwrap(),
+            "a lapsed attempt must not leave its request file behind"
+        );
+    }
+}

--- a/crates/zeroclaw-channels/src/whatsapp_passkey.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_passkey.rs
@@ -31,6 +31,14 @@
 //! Only the assertion crosses this boundary. It is a one-time signature over
 //! the server's challenge and carries no private key, so a stale or captured
 //! file cannot be replayed against a different challenge.
+//!
+//! The request is published atomically (temp file plus rename) and, on Unix,
+//! created owner-only. Both matter because the reader is a poller rather than
+//! a process that knows when the write finished: without the rename it could
+//! read a truncated document, and without the mode the challenge would sit at
+//! the prevailing umask. The assertion is written by whoever runs the ceremony,
+//! so its permissions are theirs to set; this module consumes and deletes it as
+//! soon as it is read.
 
 #![cfg(feature = "whatsapp-web")]
 
@@ -63,6 +71,48 @@ pub fn request_path(session_path: &str) -> String {
 #[must_use]
 pub fn assertion_path(session_path: &str) -> String {
     format!("{session_path}.passkey-assertion.json")
+}
+
+/// Publish `contents` at `path` atomically, and owner-only where the platform
+/// supports it.
+///
+/// Both properties matter because the file is picked up by a poller — the
+/// operator, or the gateway hook in the follow-up — rather than read once by a
+/// process that knows when the write finished:
+///
+/// * **Atomic.** A plain write leaves a window where a reader sees a truncated
+///   JSON document. Writing to a sibling temp file and renaming is atomic
+///   within a directory on POSIX, so a reader observes either the previous
+///   contents or the complete new ones, never a partial document.
+/// * **Owner-only.** The mode is applied at creation rather than after the
+///   write, so the file is never briefly readable at the prevailing umask. The
+///   temp file is created with `create_new`, so a pre-existing path (a stale
+///   temp, or something planted) is an error rather than something to clobber
+///   or follow.
+async fn publish_private(path: &str, contents: &[u8]) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt as _;
+
+    let tmp = format!("{path}.tmp");
+    // A previous run that died between create and rename would otherwise make
+    // `create_new` fail forever.
+    let _ = tokio::fs::remove_file(&tmp).await;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    // tokio's OpenOptions exposes `mode` inherently on Unix, so no extension
+    // trait is needed. Set at creation, not after: a later `set_permissions`
+    // would leave a window where the challenge is readable at the umask.
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(&tmp).await?;
+    file.write_all(contents).await?;
+    // Flush before the rename so the published name never points at a file
+    // whose contents have not reached disk.
+    file.sync_all().await?;
+    drop(file);
+
+    tokio::fs::rename(&tmp, path).await
 }
 
 /// A [`PasskeyAuthenticator`] that brokers the ceremony through two files
@@ -158,7 +208,7 @@ impl PasskeyAuthenticator for FilePasskeyAuthenticator {
         // server would reject it and burn this attempt for no reason.
         let _ = tokio::fs::remove_file(&assertion_file).await;
 
-        tokio::fs::write(&request_file, request.raw_options_json.as_bytes())
+        publish_private(&request_file, request.raw_options_json.as_bytes())
             .await
             .map_err(|e| PasskeyError::Backend(format!("could not write {request_file}: {e}")))?;
 
@@ -329,6 +379,65 @@ mod tests {
             !tokio::fs::try_exists(&expected_request).await.unwrap(),
             "the request file must be cleaned up once answered"
         );
+    }
+
+    #[tokio::test]
+    async fn a_published_request_is_owner_only_and_leaves_no_temp_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir
+            .path()
+            .join("session.db.passkey-request.json")
+            .to_string_lossy()
+            .into_owned();
+
+        publish_private(&target, br#"{"challenge":"AQID"}"#)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tokio::fs::read(&target).await.unwrap(),
+            br#"{"challenge":"AQID"}"#.to_vec(),
+            "the published file must carry the exact bytes"
+        );
+        assert!(
+            !tokio::fs::try_exists(format!("{target}.tmp"))
+                .await
+                .unwrap(),
+            "the rename must consume the temp file, not leave it beside the real one"
+        );
+
+        // The request is published for a poller to read, so it must never be
+        // observable at the prevailing umask.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = tokio::fs::metadata(&target)
+                .await
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600, "request file must be owner-only");
+        }
+    }
+
+    #[tokio::test]
+    async fn publishing_over_a_stale_temp_file_still_succeeds() {
+        // A run that died between create and rename leaves a temp behind.
+        // Without clearing it, `create_new` would fail on every later attempt
+        // and the channel could never publish another challenge.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir
+            .path()
+            .join("session.db.passkey-request.json")
+            .to_string_lossy()
+            .into_owned();
+        tokio::fs::write(format!("{target}.tmp"), b"leftover")
+            .await
+            .unwrap();
+
+        publish_private(&target, b"fresh").await.unwrap();
+
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"fresh".to_vec());
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/whatsapp_storage.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_storage.rs
@@ -344,6 +344,29 @@ impl RusqliteStore {
                 PRIMARY KEY (chat_jid, message_id, device_id)
             );
 
+            -- MessageContextInfo.messageSecret keyed by the outbound message
+            -- it belongs to. Needed to decrypt add-ons (reactions, edits,
+            -- poll votes, msmsg bot replies) that reference one of our own
+            -- sent messages. `expires_at` is an absolute unix-seconds
+            -- retention deadline (0 = never); `message_ts` is the parent
+            -- message's event time (0 = unknown), used to enforce the
+            -- edit-processing window.
+            CREATE TABLE IF NOT EXISTS msg_secrets (
+                chat TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                msg_id TEXT NOT NULL,
+                secret BLOB NOT NULL,
+                expires_at INTEGER NOT NULL DEFAULT 0,
+                message_ts INTEGER NOT NULL DEFAULT 0,
+                device_id INTEGER NOT NULL,
+                PRIMARY KEY (chat, sender, msg_id, device_id)
+            );
+
+            -- device_id first so the prune's `device_id = ? AND expires_at <= ?`
+            -- range scan stays localized to one account in a shared DB.
+            CREATE INDEX IF NOT EXISTS idx_msg_secrets_expires
+                ON msg_secrets (device_id, expires_at);
+
             -- Base keys for collision detection
             CREATE TABLE IF NOT EXISTS base_keys (
                 address TEXT NOT NULL,
@@ -540,6 +563,27 @@ impl SignalStore for RusqliteStore {
             "DELETE FROM prekeys WHERE id = ?1 AND device_id = ?2",
             params![id, self.device_id],
         ))
+    }
+
+    /// Flag the pre-keys in `ids` as uploaded to the server.
+    ///
+    /// UPDATE-only by contract: a key consumed (and deleted) between the
+    /// upload snapshot and this call must stay deleted, so an upsert here
+    /// would resurrect a spent key and hand it out twice.
+    async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> wacore::store::error::Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.conn.lock();
+        for id in ids {
+            to_store_err!(execute: conn.execute(
+                "UPDATE prekeys SET uploaded = 1 WHERE id = ?1 AND device_id = ?2",
+                params![id, self.device_id],
+            ))?;
+        }
+
+        Ok(())
     }
 
     // --- Signed PreKey Operations ---
@@ -763,6 +807,19 @@ impl AppSyncStore for RusqliteStore {
         Ok(())
     }
 
+    /// Drop every mutation MAC for one collection.
+    ///
+    /// Called on snapshot re-sync so the MAC store is rebuilt from the
+    /// snapshot and stays consistent with the ltHash baseline; a leftover
+    /// entry would corrupt the next patch's ltHash.
+    async fn clear_mutation_macs(&self, name: &str) -> wacore::store::error::Result<()> {
+        let conn = self.conn.lock();
+        to_store_err!(execute: conn.execute(
+            "DELETE FROM app_state_mutation_macs WHERE name = ?1 AND device_id = ?2",
+            params![name, self.device_id],
+        ))
+    }
+
     /// Get the most recently stored app state sync key ID.
     /// Added in wacore 0.6: used to seed app-state sync requests with the
     /// freshest key identifier we hold rather than scanning the table on each
@@ -783,6 +840,111 @@ impl AppSyncStore for RusqliteStore {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(wacore::store::error::StoreError::Database(Box::new(e))),
         }
+    }
+}
+
+#[cfg(feature = "whatsapp-web")]
+#[async_trait]
+impl MsgSecretStore for RusqliteStore {
+    /// Batched upsert. On key conflict the merge is deterministic and matches
+    /// `wacore::store::traits::merge_msg_secret_expiry` /
+    /// `merge_msg_secret_message_ts`: the later deadline wins with `0`
+    /// ("never") beating any finite one, so a redelivery or edit re-persist
+    /// can never shorten a retention window; and the later non-zero parent
+    /// timestamp wins, so an unknown `0` never clobbers a known one.
+    async fn put_msg_secrets(
+        &self,
+        entries: Vec<MsgSecretEntry>,
+    ) -> wacore::store::error::Result<usize> {
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let mut conn = self.conn.lock();
+        let tx = to_store_err!(conn.transaction())?;
+
+        let mut stored = 0usize;
+        for entry in &entries {
+            // Plain variant, not `execute:` — that one discards the row
+            // count, and the trait contract returns how many were stored.
+            stored += to_store_err!(tx.execute(
+                "INSERT INTO msg_secrets
+                     (chat, sender, msg_id, secret, expires_at, message_ts, device_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(chat, sender, msg_id, device_id) DO UPDATE SET
+                     secret = excluded.secret,
+                     expires_at = CASE
+                         WHEN msg_secrets.expires_at = 0 OR excluded.expires_at = 0 THEN 0
+                         ELSE MAX(msg_secrets.expires_at, excluded.expires_at)
+                     END,
+                     message_ts = MAX(msg_secrets.message_ts, excluded.message_ts)",
+                params![
+                    entry.chat,
+                    entry.sender,
+                    entry.msg_id,
+                    entry.secret,
+                    entry.expires_at,
+                    entry.message_ts,
+                    self.device_id,
+                ],
+            ))?;
+        }
+
+        to_store_err!(tx.commit())?;
+        Ok(stored)
+    }
+
+    async fn get_msg_secret(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> wacore::store::error::Result<Option<Vec<u8>>> {
+        Ok(self
+            .get_msg_secret_with_ts(chat, sender, msg_id)
+            .await?
+            .map(|(secret, _)| secret))
+    }
+
+    /// Overridden rather than left to the trait default: this backend does
+    /// persist `message_ts`, so the receive path gets the real parent event
+    /// time instead of the default's `0`, and can enforce the edit window.
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> wacore::store::error::Result<Option<(Vec<u8>, i64)>> {
+        let conn = self.conn.lock();
+        let result = conn.query_row(
+            "SELECT secret, message_ts FROM msg_secrets
+             WHERE chat = ?1 AND sender = ?2 AND msg_id = ?3 AND device_id = ?4",
+            params![chat, sender, msg_id, self.device_id],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
+        );
+
+        match result {
+            Ok(found) => Ok(Some(found)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(wacore::store::error::StoreError::Database(Box::new(e))),
+        }
+    }
+
+    /// Prune rows whose deadline has passed. `expires_at = 0` means "never",
+    /// so those rows are kept regardless of the cutoff.
+    async fn delete_expired_msg_secrets(
+        &self,
+        cutoff_timestamp: i64,
+    ) -> wacore::store::error::Result<u32> {
+        let conn = self.conn.lock();
+        // Plain variant, not `execute:` — the caller throttles its cleanup
+        // sweep on how many rows this actually removed.
+        let deleted = to_store_err!(conn.execute(
+            "DELETE FROM msg_secrets
+             WHERE expires_at != 0 AND expires_at <= ?1 AND device_id = ?2",
+            params![cutoff_timestamp, self.device_id],
+        ))?;
+        Ok(deleted as u32)
     }
 }
 
@@ -1433,10 +1595,10 @@ impl DeviceStoreTrait for RusqliteStore {
                 adv_secret.copy_from_slice(&adv_secret_bytes);
 
                 let account = if let Some(bytes) = account_bytes {
-                    Some(
+                    Some(std::sync::Arc::new(
                         waproto::whatsapp::AdvSignedDeviceIdentity::decode(&*bytes)
                             .map_err(to_rusqlite_err)?,
-                    )
+                    ))
                 } else {
                     None
                 };
@@ -1532,6 +1694,148 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = RusqliteStore::new(tmp.path()).unwrap();
         assert_eq!(store.device_id, 1);
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn msg_secret(msg_id: &str, expires_at: i64, message_ts: i64) -> MsgSecretEntry {
+        MsgSecretEntry {
+            chat: "chat@s.whatsapp.net".to_string(),
+            sender: "sender@s.whatsapp.net".to_string(),
+            msg_id: msg_id.to_string(),
+            secret: vec![7u8; 32],
+            expires_at,
+            message_ts,
+        }
+    }
+
+    /// A redelivery or edit re-persist must never shorten a retention window,
+    /// and `0` ("never") must beat any finite deadline in either direction.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn msg_secret_upsert_never_shortens_the_retention_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 1_000, 0)])
+            .await
+            .unwrap();
+
+        // An earlier deadline loses to the one already stored.
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 500, 0)])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.delete_expired_msg_secrets(600).await.unwrap(),
+            0,
+            "a 500 deadline must not have replaced the stored 1000"
+        );
+
+        // 0 means never, so it wins over the stored finite deadline.
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 0, 0)])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.delete_expired_msg_secrets(i64::MAX).await.unwrap(),
+            0,
+            "a never-expires row must survive any cutoff"
+        );
+    }
+
+    /// The parent message's event time is immutable; a later write that does
+    /// not know it (`0`) must not erase the value already stored.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn msg_secret_upsert_keeps_a_known_parent_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 0, 1_700_000_000)])
+            .await
+            .unwrap();
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 0, 0)])
+            .await
+            .unwrap();
+
+        let (secret, message_ts) = store
+            .get_msg_secret_with_ts("chat@s.whatsapp.net", "sender@s.whatsapp.net", "ID")
+            .await
+            .unwrap()
+            .expect("secret must still be present");
+        assert_eq!(secret, vec![7u8; 32]);
+        assert_eq!(
+            message_ts, 1_700_000_000,
+            "an unknown (0) parent time must not clobber a known one"
+        );
+    }
+
+    /// Only deadlines that have actually passed are pruned; `0` never expires.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn expired_msg_secrets_prune_only_passed_deadlines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store
+            .put_msg_secrets(vec![
+                msg_secret("NEVER", 0, 0),
+                msg_secret("PAST", 1_000, 0),
+                msg_secret("FUTURE", 9_000, 0),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(store.delete_expired_msg_secrets(5_000).await.unwrap(), 1);
+
+        let chat = "chat@s.whatsapp.net";
+        let sender = "sender@s.whatsapp.net";
+        assert!(
+            store
+                .get_msg_secret(chat, sender, "NEVER")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .get_msg_secret(chat, sender, "FUTURE")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .get_msg_secret(chat, sender, "PAST")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// `mark_prekeys_uploaded` is UPDATE-only by contract: a key consumed
+    /// between the upload snapshot and the callback must stay deleted, or it
+    /// would be handed out to a second peer.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn mark_prekeys_uploaded_never_resurrects_a_deleted_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store.store_prekey(1, &[1u8; 32], false).await.unwrap();
+        store.store_prekey(2, &[2u8; 32], false).await.unwrap();
+        store.remove_prekey(2).await.unwrap();
+
+        store.mark_prekeys_uploaded(&[1, 2]).await.unwrap();
+
+        assert!(store.load_prekey(1).await.unwrap().is_some());
+        assert!(
+            store.load_prekey(2).await.unwrap().is_none(),
+            "a consumed pre-key must not be resurrected by the uploaded flag"
+        );
     }
 
     #[cfg(feature = "whatsapp-web")]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -5334,7 +5334,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store.clone())
+            .with_backend_arc(store.clone())
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -5463,7 +5463,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store.clone())
+            .with_backend_arc(store.clone())
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -719,7 +719,7 @@ impl WhatsAppWebChannel {
                 .await
                 .ok()
                 .flatten()
-                .map(|entry| entry.phone_number)
+                .map(|entry| entry.phone_number.to_string())
         } else {
             None
         };
@@ -1746,13 +1746,12 @@ impl WhatsAppWebChannel {
         #[allow(clippy::cast_possible_truncation)]
         let estimated_seconds = std::cmp::max(1, (upload.file_length / 4000) as u32);
 
-        // whatsapp-rust 0.6: UploadResponse cryptographic fields became
-        // `[u8; 32]` for type safety. Pull the Vec<u8> copies before
-        // consuming the strings so the partial-move on `upload.direct_path`
-        // doesn't bite.
-        let media_key = upload.media_key_vec();
-        let file_enc_sha256 = upload.file_enc_sha256_vec();
-        let file_sha256 = upload.file_sha256_vec();
+        // whatsapp-rust 0.6: UploadResponse cryptographic fields are `[u8; 32]`
+        // for type safety. Copy them out before consuming the strings so the
+        // partial-move on `upload.direct_path` doesn't bite.
+        let media_key = upload.media_key.to_vec();
+        let file_enc_sha256 = upload.file_enc_sha256.to_vec();
+        let file_sha256 = upload.file_sha256.to_vec();
         let voice_msg = waproto::whatsapp::Message {
             audio_message: Some(Box::new(waproto::whatsapp::message::AudioMessage {
                 url: Some(upload.url),
@@ -1815,9 +1814,9 @@ impl WhatsAppWebChannel {
             .await
             .map_err(|e| anyhow::Error::msg(format!("WhatsApp media upload failed: {e}")))?;
 
-        let media_key = upload.media_key_vec();
-        let file_enc_sha256 = upload.file_enc_sha256_vec();
-        let file_sha256 = upload.file_sha256_vec();
+        let media_key = upload.media_key.to_vec();
+        let file_enc_sha256 = upload.file_enc_sha256.to_vec();
+        let file_sha256 = upload.file_sha256.to_vec();
         let outgoing = match marker.kind {
             WhatsAppMediaKind::Image => waproto::whatsapp::Message {
                 image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
@@ -2730,7 +2729,7 @@ impl Channel for WhatsAppWebChannel {
             };
 
             let mut builder = Bot::builder()
-                .with_backend(backend)
+                .with_backend_arc(backend)
                 .with_transport_factory(transport_factory)
                 .with_http_client(http_client)
                 .with_runtime(TokioRuntime)
@@ -2773,8 +2772,7 @@ impl Channel for WhatsAppWebChannel {
                                 WhatsAppWebChannel::reset_retry(&retry_count);
                                 let device = client
                                     .persistence_manager()
-                                    .get_device_snapshot()
-                                    .await;
+                                    .get_device_snapshot();
                                 // Resolve bot identity from the device store
                                 if mention_only {
                                     if let Some(ref pn) = device.pn
@@ -2833,6 +2831,61 @@ impl Channel for WhatsAppWebChannel {
                                 eprintln!("pair code: {code}");
                                 eprintln!();
                             }
+                            // WhatsApp's SHORTCAKE passkey gate (server-side
+                            // rollout from 2026-06-30). Linking now demands a
+                            // WebAuthn assertion signed by a passkey already
+                            // registered to the account. Without a registered
+                            // `PasskeyAuthenticator` the library cannot answer
+                            // it, so the QR loop would otherwise spin forever
+                            // with nothing in the logs. Surface it instead.
+                            Event::PairPasskeyRequest(_) => {
+                                crate::login_events::LoginEvent::Failed {
+                                    reason: "whatsapp_passkey_required",
+                                }
+                                .emit(
+                                    "whatsapp",
+                                    alias.as_ref(),
+                                    "WhatsApp requires a passkey to link this device; ZeroClaw cannot complete the WebAuthn step on its own",
+                                );
+                                ::zeroclaw_log::record!(
+                                    ERROR,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                                    "WhatsApp Web linking requires a passkey (SHORTCAKE); no authenticator is configured, so this link attempt cannot complete"
+                                );
+                            }
+                            Event::PairPasskeyConfirmation(confirmation) => {
+                                ::zeroclaw_log::record!(
+                                    INFO,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                                    "WhatsApp Web passkey verification code received"
+                                );
+                                eprintln!();
+                                eprintln!(
+                                    "WhatsApp passkey verification code: {}",
+                                    confirmation.code
+                                );
+                                eprintln!();
+                            }
+                            Event::PairPasskeyError(err) => {
+                                crate::login_events::LoginEvent::Failed {
+                                    reason: err.error.as_str(),
+                                }
+                                .emit(
+                                    "whatsapp",
+                                    alias.as_ref(),
+                                    "WhatsApp Web passkey linking failed",
+                                );
+                                ::zeroclaw_log::record!(
+                                    ERROR,
+                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                                    &format!(
+                                        "WhatsApp Web passkey linking failed: {} (continuation: {})",
+                                        err.error, err.continuation
+                                    )
+                                );
+                            }
                             Event::PairingQrCode { code, .. } => {
                                 crate::login_events::LoginEvent::Qr {
                                     payload: code.as_str(),
@@ -2888,11 +2941,14 @@ impl Channel for WhatsAppWebChannel {
                 );
             }
 
-            let mut bot = builder.build().await?;
+            let bot = builder.build().await?;
             *self.client.lock() = Some(bot.client());
 
-            // Run the bot
-            let bot_handle = bot.run().await?;
+            // Start the bot in the background. `Bot::run` now consumes the bot
+            // and drives the loop to completion in-place; `spawn` is the
+            // handle-returning form this channel needs so it can await a
+            // logout signal and shut the bot down on its own terms.
+            let bot_handle = bot.spawn();
 
             // Store the bot handle for later shutdown
             *self.bot_handle.lock() = Some(bot_handle);
@@ -2923,11 +2979,11 @@ impl Channel for WhatsAppWebChannel {
                 let _ = handle.await;
             }
 
-            // Drop bot/device so the SQLite connection is closed
-            // before we remove session files (releases WAL/SHM locks).
-            // `backend` was moved into the builder, so dropping `bot`
-            // releases the last Arc reference to the storage backend.
-            drop(bot);
+            // Drop the device so the SQLite connection is closed before we
+            // remove session files (releases WAL/SHM locks). `backend` was
+            // moved into the builder and then into the spawned task, so the
+            // awaited handle above is what releases the storage backend's
+            // last Arc reference — there is no local `bot` left to drop.
             drop(device);
 
             if should_reconnect {
@@ -3953,7 +4009,7 @@ mod tests {
 
         let cache = Arc::new(TestCacheStore::default());
         let bot = Bot::builder()
-            .with_backend(store.clone())
+            .with_backend_arc(store.clone())
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -1348,6 +1348,61 @@ impl WhatsAppWebChannel {
         Ok(removed)
     }
 
+    /// Channel-owned passkey hook: the challenge this session is currently
+    /// waiting on, if any.
+    ///
+    /// Resolves the same expanded path the run loop hands the authenticator,
+    /// so the endpoint and the waiting channel always agree on which files
+    /// they mean. Read-only; never creates anything.
+    pub fn pending_passkey_request(session_path: &str) -> std::io::Result<Option<String>> {
+        if session_path.is_empty() {
+            return Ok(None);
+        }
+        super::whatsapp_passkey::pending_request(&Self::expand_session_path(session_path))
+    }
+
+    /// Channel-owned passkey hook: hand a signed credential to the waiting
+    /// authenticator.
+    ///
+    /// The counterpart to [`Self::pending_passkey_request`], resolving the
+    /// same expanded path. An empty `session_path` cannot be waiting on
+    /// anything, so it reports no pending request rather than writing to a
+    /// relative path in the daemon's working directory.
+    pub fn submit_passkey_assertion(
+        session_path: &str,
+        body: Vec<u8>,
+    ) -> Result<(), super::whatsapp_passkey::StageError> {
+        if session_path.is_empty() {
+            return Err(super::whatsapp_passkey::StageError::NoPendingRequest);
+        }
+        super::whatsapp_passkey::stage_assertion(&Self::expand_session_path(session_path), body)
+    }
+
+    /// Channel-owned passkey hook: the fresh-link verification code currently
+    /// waiting for explicit operator acknowledgement, if any.
+    pub fn pending_passkey_confirmation(
+        session_path: &str,
+    ) -> std::io::Result<Option<super::whatsapp_passkey::PendingPasskeyConfirmation>> {
+        if session_path.is_empty() {
+            return Ok(None);
+        }
+        super::whatsapp_passkey::pending_confirmation(&Self::expand_session_path(session_path))
+    }
+
+    /// Channel-owned passkey hook: acknowledge the current fresh-link code.
+    pub fn submit_passkey_confirmation(
+        session_path: &str,
+        attempt_id: &str,
+    ) -> Result<(), super::whatsapp_passkey::ConfirmationStageError> {
+        if session_path.is_empty() {
+            return Err(super::whatsapp_passkey::ConfirmationStageError::NoPendingConfirmation);
+        }
+        super::whatsapp_passkey::stage_confirmation_ack(
+            &Self::expand_session_path(session_path),
+            attempt_id,
+        )
+    }
+
     /// Attempt to download and transcribe a WhatsApp voice note.
     /// Returns `None` if transcription is disabled, download fails, or
     /// transcription fails (all logged as warnings).

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -401,6 +401,23 @@ struct SenderAllowlistResolution {
     allowed_phone: Option<String>,
 }
 
+/// What a WhatsApp passkey (SHORTCAKE) linking event means for the operator.
+///
+/// A borrowed view computed on demand from the upstream event by
+/// [`WhatsAppWebChannel::passkey_notice`]; the event stays the source of truth.
+#[cfg(feature = "whatsapp-web")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PasskeyNotice<'a> {
+    /// The server demanded a WebAuthn assertion. Nothing in this process can
+    /// produce one without a registered authenticator, so the link stalls here.
+    Required,
+    /// A verification code the operator must confirm on the primary phone.
+    Confirm { code: &'a str },
+    /// Upstream reported the passkey link attempt failed. `continuation`
+    /// distinguishes a retryable continuation from a terminal failure.
+    Failed { error: &'a str, continuation: bool },
+}
+
 #[cfg(feature = "whatsapp-web")]
 #[derive(Clone)]
 struct WhatsAppInboundContext {
@@ -1156,6 +1173,27 @@ impl WhatsAppWebChannel {
     #[cfg(feature = "whatsapp-web")]
     fn is_jid(recipient: &str) -> bool {
         recipient.trim().contains('@')
+    }
+
+    /// Classify a passkey linking event into what the operator must be told.
+    ///
+    /// Split out from the event loop so the mapping is testable without a
+    /// live socket — the handler arm only renders what this returns. Returns
+    /// `None` for every non-passkey event.
+    #[cfg(feature = "whatsapp-web")]
+    fn passkey_notice(event: &wacore::types::events::Event) -> Option<PasskeyNotice<'_>> {
+        use wacore::types::events::Event;
+        match event {
+            Event::PairPasskeyRequest(_) => Some(PasskeyNotice::Required),
+            Event::PairPasskeyConfirmation(confirmation) => Some(PasskeyNotice::Confirm {
+                code: confirmation.code.as_str(),
+            }),
+            Event::PairPasskeyError(err) => Some(PasskeyNotice::Failed {
+                error: err.error.as_str(),
+                continuation: err.continuation,
+            }),
+            _ => None,
+        }
     }
 
     /// Render a WhatsApp pairing QR payload into terminal-friendly text.
@@ -2838,53 +2876,56 @@ impl Channel for WhatsAppWebChannel {
                             // `PasskeyAuthenticator` the library cannot answer
                             // it, so the QR loop would otherwise spin forever
                             // with nothing in the logs. Surface it instead.
-                            Event::PairPasskeyRequest(_) => {
-                                crate::login_events::LoginEvent::Failed {
-                                    reason: "whatsapp_passkey_required",
+                            passkey_event @ (Event::PairPasskeyRequest(_)
+                            | Event::PairPasskeyConfirmation(_)
+                            | Event::PairPasskeyError(_)) => {
+                                match Self::passkey_notice(passkey_event) {
+                                    Some(PasskeyNotice::Required) => {
+                                        crate::login_events::LoginEvent::Failed {
+                                            reason: "whatsapp_passkey_required",
+                                        }
+                                        .emit(
+                                            "whatsapp",
+                                            alias.as_ref(),
+                                            "WhatsApp requires a passkey to link this device; ZeroClaw cannot complete the WebAuthn step on its own",
+                                        );
+                                        ::zeroclaw_log::record!(
+                                            ERROR,
+                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                                                .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                                            "WhatsApp Web linking requires a passkey (SHORTCAKE); no authenticator is configured, so this link attempt cannot complete"
+                                        );
+                                    }
+                                    Some(PasskeyNotice::Confirm { code }) => {
+                                        ::zeroclaw_log::record!(
+                                            INFO,
+                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                                            "WhatsApp Web passkey verification code received"
+                                        );
+                                        eprintln!();
+                                        eprintln!("WhatsApp passkey verification code: {code}");
+                                        eprintln!();
+                                    }
+                                    Some(PasskeyNotice::Failed { error, continuation }) => {
+                                        crate::login_events::LoginEvent::Failed { reason: error }
+                                            .emit(
+                                                "whatsapp",
+                                                alias.as_ref(),
+                                                "WhatsApp Web passkey linking failed",
+                                            );
+                                        ::zeroclaw_log::record!(
+                                            ERROR,
+                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                                                .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                                            &format!(
+                                                "WhatsApp Web passkey linking failed: {error} (continuation: {continuation})"
+                                            )
+                                        );
+                                    }
+                                    // Unreachable: the arm pattern admits only
+                                    // the three passkey variants above.
+                                    None => {}
                                 }
-                                .emit(
-                                    "whatsapp",
-                                    alias.as_ref(),
-                                    "WhatsApp requires a passkey to link this device; ZeroClaw cannot complete the WebAuthn step on its own",
-                                );
-                                ::zeroclaw_log::record!(
-                                    ERROR,
-                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
-                                    "WhatsApp Web linking requires a passkey (SHORTCAKE); no authenticator is configured, so this link attempt cannot complete"
-                                );
-                            }
-                            Event::PairPasskeyConfirmation(confirmation) => {
-                                ::zeroclaw_log::record!(
-                                    INFO,
-                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-                                    "WhatsApp Web passkey verification code received"
-                                );
-                                eprintln!();
-                                eprintln!(
-                                    "WhatsApp passkey verification code: {}",
-                                    confirmation.code
-                                );
-                                eprintln!();
-                            }
-                            Event::PairPasskeyError(err) => {
-                                crate::login_events::LoginEvent::Failed {
-                                    reason: err.error.as_str(),
-                                }
-                                .emit(
-                                    "whatsapp",
-                                    alias.as_ref(),
-                                    "WhatsApp Web passkey linking failed",
-                                );
-                                ::zeroclaw_log::record!(
-                                    ERROR,
-                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
-                                    &format!(
-                                        "WhatsApp Web passkey linking failed: {} (continuation: {})",
-                                        err.error, err.continuation
-                                    )
-                                );
                             }
                             Event::PairingQrCode { code, .. } => {
                                 crate::login_events::LoginEvent::Qr {
@@ -4143,6 +4184,66 @@ mod tests {
         assert_eq!(
             WhatsAppWebChannel::compute_retry_delay(0),
             WhatsAppWebChannel::BASE_DELAY_SECS
+        );
+    }
+
+    /// The regression this whole change exists for: before the pin bump these
+    /// three variants did not exist, so the server's passkey demand fell into
+    /// the handler's `_ => {}` arm and the operator saw an endless QR loop with
+    /// nothing in the logs. Each must now classify into an operator notice.
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn passkey_events_are_surfaced_not_swallowed() {
+        use wacore::types::events::{
+            Event, PairPasskeyConfirmation, PairPasskeyError, PairPasskeyRequest,
+        };
+
+        let request = Event::PairPasskeyRequest(PairPasskeyRequest {
+            request_options_json: r#"{"challenge":"abc"}"#.to_string(),
+        });
+        assert_eq!(
+            WhatsAppWebChannel::passkey_notice(&request),
+            Some(PasskeyNotice::Required),
+            "a passkey request must reach the operator, not the catch-all arm"
+        );
+
+        let confirmation = Event::PairPasskeyConfirmation(PairPasskeyConfirmation {
+            code: "1234-5678".to_string(),
+            skip_handoff_ux: false,
+        });
+        assert_eq!(
+            WhatsAppWebChannel::passkey_notice(&confirmation),
+            Some(PasskeyNotice::Confirm { code: "1234-5678" }),
+            "the verification code must be surfaced verbatim to be typed on the phone"
+        );
+
+        let failure = Event::PairPasskeyError(PairPasskeyError {
+            error: "assertion rejected".to_string(),
+            continuation: true,
+        });
+        assert_eq!(
+            WhatsAppWebChannel::passkey_notice(&failure),
+            Some(PasskeyNotice::Failed {
+                error: "assertion rejected",
+                continuation: true,
+            }),
+            "the upstream error and its continuation flag must both survive"
+        );
+    }
+
+    /// The classifier must stay scoped to passkey events: a non-passkey event
+    /// returning `Some` would mean the handler arm hijacks unrelated traffic.
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn non_passkey_events_produce_no_passkey_notice() {
+        use wacore::types::events::Event;
+
+        assert_eq!(
+            WhatsAppWebChannel::passkey_notice(&Event::PairingQrCode {
+                code: "qr-payload".to_string(),
+                timeout: std::time::Duration::from_secs(60),
+            }),
+            None
         );
     }
 

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2881,19 +2881,26 @@ impl Channel for WhatsAppWebChannel {
                             | Event::PairPasskeyError(_)) => {
                                 match Self::passkey_notice(passkey_event) {
                                     Some(PasskeyNotice::Required) => {
-                                        crate::login_events::LoginEvent::Failed {
-                                            reason: "whatsapp_passkey_required",
+                                        // Not a failure: the registered
+                                        // authenticator is now waiting for the
+                                        // operator to drop an assertion file,
+                                        // and it logs the exact paths itself.
+                                        crate::login_events::LoginEvent::Qr {
+                                            payload: "",
+                                            image_url: None,
+                                            attempt: None,
+                                            max_attempts: None,
                                         }
                                         .emit(
                                             "whatsapp",
                                             alias.as_ref(),
-                                            "WhatsApp requires a passkey to link this device; ZeroClaw cannot complete the WebAuthn step on its own",
+                                            "WhatsApp requires a passkey assertion to link this device — awaiting the operator's WebAuthn ceremony",
                                         );
                                         ::zeroclaw_log::record!(
-                                            ERROR,
-                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
-                                                .with_outcome(::zeroclaw_log::EventOutcome::Failure),
-                                            "WhatsApp Web linking requires a passkey (SHORTCAKE); no authenticator is configured, so this link attempt cannot complete"
+                                            WARN,
+                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                                            "WhatsApp Web linking requires a passkey (SHORTCAKE); the file broker is waiting for a signed assertion"
                                         );
                                     }
                                     Some(PasskeyNotice::Confirm { code }) => {
@@ -2983,7 +2990,25 @@ impl Channel for WhatsAppWebChannel {
             }
 
             let bot = builder.build().await?;
-            *self.client.lock() = Some(bot.client());
+            let client = bot.client();
+
+            // Answer WhatsApp's SHORTCAKE passkey gate. With an authenticator
+            // registered the library drives the assertion step itself (and
+            // auto-confirms a re-link, where the handoff proof already proves
+            // continuity); without one it can only emit the events the handler
+            // above surfaces, and linking stalls. The broker waits on a file
+            // beside this session, so nothing here blocks the run loop until
+            // the server actually demands an assertion.
+            client
+                .set_passkey_authenticator(
+                    crate::whatsapp_passkey::FilePasskeyAuthenticator::new(
+                        expanded_session_path.clone(),
+                    )
+                    .into_arc(),
+                )
+                .await;
+
+            *self.client.lock() = Some(client);
 
             // Start the bot in the background. `Bot::run` now consumes the bot
             // and drives the loop to completion in-place; `spawn` is the

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -412,7 +412,11 @@ enum PasskeyNotice<'a> {
     /// produce one without a registered authenticator, so the link stalls here.
     Required,
     /// A verification code the operator must confirm on the primary phone.
-    Confirm { code: &'a str },
+    /// A re-link carries a continuity proof and upstream confirms it itself.
+    Confirm {
+        code: &'a str,
+        skip_handoff_ux: bool,
+    },
     /// Upstream reported the passkey link attempt failed. `continuation`
     /// distinguishes a retryable continuation from a terminal failure.
     Failed { error: &'a str, continuation: bool },
@@ -1187,6 +1191,7 @@ impl WhatsAppWebChannel {
             Event::PairPasskeyRequest(_) => Some(PasskeyNotice::Required),
             Event::PairPasskeyConfirmation(confirmation) => Some(PasskeyNotice::Confirm {
                 code: confirmation.code.as_str(),
+                skip_handoff_ux: confirmation.skip_handoff_ux,
             }),
             Event::PairPasskeyError(err) => Some(PasskeyNotice::Failed {
                 error: err.error.as_str(),
@@ -2746,6 +2751,7 @@ impl Channel for WhatsAppWebChannel {
             let bot_phone_clone = self.bot_phone.clone();
             let bot_lid_clone = self.bot_lid.clone();
             let persist_clone = self.persist.clone();
+            let passkey_session_path = expanded_session_path.clone();
             let inbound_context = WhatsAppInboundContext {
                 tx: tx.clone(),
                 alias: Arc::clone(&alias),
@@ -2788,6 +2794,7 @@ impl Channel for WhatsAppWebChannel {
                     let bot_lid_inner = bot_lid_clone.clone();
                     let persist_inner = persist_clone.clone();
                     let inbound_context = inbound_context.clone();
+                    let passkey_session_path = passkey_session_path.clone();
                     async move {
                         // whatsapp-rust 0.6: event handlers receive `Arc<Event>`
                         // per so we match against `&*event` to get a
@@ -2885,17 +2892,6 @@ impl Channel for WhatsAppWebChannel {
                                         // authenticator is now waiting for the
                                         // operator to drop an assertion file,
                                         // and it logs the exact paths itself.
-                                        crate::login_events::LoginEvent::Qr {
-                                            payload: "",
-                                            image_url: None,
-                                            attempt: None,
-                                            max_attempts: None,
-                                        }
-                                        .emit(
-                                            "whatsapp",
-                                            alias.as_ref(),
-                                            "WhatsApp requires a passkey assertion to link this device — awaiting the operator's WebAuthn ceremony",
-                                        );
                                         ::zeroclaw_log::record!(
                                             WARN,
                                             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -2903,15 +2899,87 @@ impl Channel for WhatsAppWebChannel {
                                             "WhatsApp Web linking requires a passkey (SHORTCAKE); the file broker is waiting for a signed assertion"
                                         );
                                     }
-                                    Some(PasskeyNotice::Confirm { code }) => {
-                                        ::zeroclaw_log::record!(
-                                            INFO,
-                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
-                                            "WhatsApp Web passkey verification code received"
-                                        );
-                                        eprintln!();
-                                        eprintln!("WhatsApp passkey verification code: {code}");
-                                        eprintln!();
+                                    Some(PasskeyNotice::Confirm {
+                                        code,
+                                        skip_handoff_ux,
+                                    }) => {
+                                        if skip_handoff_ux {
+                                            // Upstream already proved continuity
+                                            // from the prior ADV secret and will
+                                            // auto-confirm after this event returns.
+                                            ::zeroclaw_log::record!(
+                                                INFO,
+                                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                                                "WhatsApp Web passkey re-link continuity verified; upstream will auto-confirm"
+                                            );
+                                        } else {
+                                            ::zeroclaw_log::record!(
+                                                INFO,
+                                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                                                "WhatsApp Web passkey verification code received"
+                                            );
+                                            eprintln!();
+                                            eprintln!("WhatsApp passkey verification code: {code}");
+                                            eprintln!();
+
+                                            let confirmation = crate::whatsapp_passkey::FilePasskeyConfirmation::new(passkey_session_path);
+                                            let confirmation_code = code.to_string();
+                                            let confirmation_client = Arc::clone(&client);
+                                            let confirmation_alias = Arc::clone(&alias);
+                                            zeroclaw_spawn::spawn!(async move {
+                                                match confirmation
+                                                    .wait_for_acknowledgement(&confirmation_code)
+                                                    .await
+                                                {
+                                                    Ok(()) => {
+                                                        match confirmation_client
+                                                            .send_passkey_confirmation()
+                                                            .await
+                                                        {
+                                                            Ok(()) => ::zeroclaw_log::record!(
+                                                                INFO,
+                                                                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                                                                "WhatsApp Web passkey verification code confirmed; finishing device linking"
+                                                            ),
+                                                            Err(error) => {
+                                                                let reason = error.to_string();
+                                                                crate::login_events::LoginEvent::Failed {
+                                                                    reason: &reason,
+                                                                }
+                                                                .emit(
+                                                                    "whatsapp",
+                                                                    confirmation_alias.as_ref(),
+                                                                    "WhatsApp Web passkey confirmation failed",
+                                                                );
+                                                                ::zeroclaw_log::record!(
+                                                                    ERROR,
+                                                                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                                                                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                                                                    &format!("failed to confirm WhatsApp Web passkey code: {error}")
+                                                                );
+                                                            }
+                                                        }
+                                                    }
+                                                    Err(error) => {
+                                                        let reason = error.to_string();
+                                                        crate::login_events::LoginEvent::Failed {
+                                                            reason: &reason,
+                                                        }
+                                                        .emit(
+                                                            "whatsapp",
+                                                            confirmation_alias.as_ref(),
+                                                            "WhatsApp Web passkey confirmation was not acknowledged",
+                                                        );
+                                                        ::zeroclaw_log::record!(
+                                                            WARN,
+                                                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                                                            &format!("WhatsApp Web passkey confirmation ended without acknowledgement: {error}")
+                                                        );
+                                                    }
+                                                }
+                                            });
+                                        }
                                     }
                                     Some(PasskeyNotice::Failed { error, continuation }) => {
                                         crate::login_events::LoginEvent::Failed { reason: error }
@@ -4238,8 +4306,24 @@ mod tests {
         });
         assert_eq!(
             WhatsAppWebChannel::passkey_notice(&confirmation),
-            Some(PasskeyNotice::Confirm { code: "1234-5678" }),
+            Some(PasskeyNotice::Confirm {
+                code: "1234-5678",
+                skip_handoff_ux: false,
+            }),
             "the verification code must be surfaced verbatim to be typed on the phone"
+        );
+
+        let relink = Event::PairPasskeyConfirmation(PairPasskeyConfirmation {
+            code: "ABCD-EFGH".to_string(),
+            skip_handoff_ux: true,
+        });
+        assert_eq!(
+            WhatsAppWebChannel::passkey_notice(&relink),
+            Some(PasskeyNotice::Confirm {
+                code: "ABCD-EFGH",
+                skip_handoff_ux: true,
+            }),
+            "the classifier must preserve upstream's re-link auto-confirm signal"
         );
 
         let failure = Event::PairPasskeyError(PairPasskeyError {

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -3,9 +3,10 @@
 
 use super::AppState;
 use axum::{
+    body::Bytes,
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode, header},
-    response::{IntoResponse, Json},
+    response::{IntoResponse, Json, Response},
 };
 use serde::{Deserialize, Serialize};
 use zeroclaw_config::schema::{ChannelAliasInfo, Config};
@@ -1363,6 +1364,430 @@ pub async fn handle_api_channel_relink(
             Json(serde_json::json!({
                 "channel": channel,
                 "error": format!("failed to clear persisted login: {e}"),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// Largest credential body the passkey endpoint will read.
+///
+/// A WebAuthn assertion is on the order of a kilobyte; this is generous
+/// enough that no real credential is refused while keeping an unauthenticated
+/// misfire or a pasted-wrong-file from being buffered.
+const PASSKEY_ASSERTION_MAX_BYTES: usize = 64 * 1024;
+
+/// Largest verification-code acknowledgement body accepted by the endpoint.
+const PASSKEY_CONFIRMATION_MAX_BYTES: usize = 4 * 1024;
+
+#[derive(serde::Deserialize)]
+struct PasskeyConfirmationSubmission {
+    attempt_id: String,
+}
+
+/// Why a composite channel name has no passkey target.
+///
+/// Kept as a small value that each handler renders, rather than a prebuilt
+/// `Response`: an `axum` response is large enough that returning one in a
+/// `Result` trips `clippy::result_large_err`, and both handlers render these
+/// two cases identically anyway.
+enum PasskeyTargetError {
+    /// No `[channels.<type>.<alias>]` block matches the requested name.
+    Unknown,
+    /// The channel type has no QR-pairing session — so it can never see a
+    /// passkey gate — or its feature is not compiled into this binary.
+    Unsupported { channel_type: String },
+}
+
+impl PasskeyTargetError {
+    /// Render as the response to return verbatim. Both arms are explicit
+    /// no-ops: nothing was inspected and nothing was written.
+    fn render(self, channel: &str) -> Response {
+        match self {
+            Self::Unknown => (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": format!("unknown channel {channel} — use the composite name from GET /api/channels"),
+                })),
+            )
+                .into_response(),
+            Self::Unsupported { channel_type } => (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "channel": channel,
+                    "outcome": "unsupported",
+                    "error": format!(
+                        "channel type {channel_type} has no passkey ceremony (it does not use \
+                         QR-pairing sessions) or the feature is not compiled into this binary; \
+                         nothing was changed",
+                    ),
+                })),
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// Resolve a composite `<type>.<alias>` channel name to the alias and the
+/// typed QR-pairing key the passkey hooks dispatch on.
+fn resolve_passkey_channel(
+    config: &Config,
+    channel: &str,
+) -> Result<
+    (
+        ChannelAliasInfo,
+        zeroclaw_channels::listing::QrPairingChannel,
+    ),
+    PasskeyTargetError,
+> {
+    let info = config
+        .channels_by_alias()
+        .into_iter()
+        .find(|info| format!("{}.{}", info.channel_type, info.alias) == channel)
+        .ok_or(PasskeyTargetError::Unknown)?;
+
+    let compiled_key = compiled_readiness_key_for_alias(config, &info);
+    let qr_channel =
+        zeroclaw_channels::listing::qr_pairing_channel(compiled_key).ok_or_else(|| {
+            PasskeyTargetError::Unsupported {
+                channel_type: info.channel_type.clone(),
+            }
+        })?;
+
+    Ok((info, qr_channel))
+}
+
+/// GET /api/channels/{channel}/passkey — the passkey challenge a channel is
+/// currently blocked on, if any.
+///
+/// WhatsApp Web interrupts device linking to demand a WebAuthn assertion
+/// signed by a passkey registered to the account. Nothing on the host can
+/// produce one, so the channel publishes the server's challenge and waits;
+/// this endpoint serves that challenge to whoever is running the browser
+/// ceremony, and `POST` to the same path answers it. Dispatches to the
+/// channel-owned hook ([`zeroclaw_channels::login_passkey::pending`]); the
+/// gateway performs no file operations of its own and holds no knowledge of
+/// channel session layouts.
+///
+/// Responses (all authenticated via the standard bearer guard):
+///
+/// - `200` with `"outcome": "pending"` — the channel is waiting.
+///   `"options"` carries the server's WebAuthn request options for
+///   `navigator.credentials.get()`; `"options_raw"` appears instead on the
+///   rare payload that is not parseable JSON, so an operator is never
+///   blocked by a shape the gateway did not expect.
+/// - `200` with `"outcome": "idle"` — the channel is not waiting for one.
+///   The ordinary state: an assertion is demanded only during linking, and
+///   only when the server's phased rollout selects the account.
+/// - `409` with `"outcome": "unsupported"` — the channel type has no passkey
+///   ceremony or its feature is not compiled in. **Nothing was inspected.**
+/// - `404` — no `[channels.<type>.<alias>]` block matches `{channel}`.
+pub async fn handle_api_channel_passkey(
+    State(state): State<AppState>,
+    Path(channel): Path<String>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let config = state.config.read().clone();
+    let (info, qr_channel) = match resolve_passkey_channel(&config, &channel) {
+        Ok(resolved) => resolved,
+        Err(e) => return e.render(&channel),
+    };
+
+    match zeroclaw_channels::login_passkey::pending(qr_channel, &config, &info.alias) {
+        Ok(zeroclaw_channels::login_passkey::PasskeyState::Pending { options }) => {
+            let mut body = serde_json::json!({
+                "channel": channel,
+                "outcome": "assertion_pending",
+                "note": "sign these options with navigator.credentials.get() in a logged-in \
+                         web.whatsapp.com tab, then POST the resulting credential JSON back \
+                         to this same path",
+            });
+            match serde_json::from_str::<serde_json::Value>(&options) {
+                Ok(parsed) => body["options"] = parsed,
+                // Serve it anyway rather than failing the operator's one-shot
+                // ceremony over a shape the library did not promise.
+                Err(_) => body["options_raw"] = serde_json::Value::String(options),
+            }
+            Json(body).into_response()
+        }
+        Ok(zeroclaw_channels::login_passkey::PasskeyState::ConfirmationPending {
+            attempt_id,
+            code,
+        }) => Json(serde_json::json!({
+            "channel": channel,
+            "outcome": "confirmation_pending",
+            "attempt_id": attempt_id,
+            "code": code,
+            "note": format!(
+                "compare this code with the primary phone, then POST the attempt_id \
+                 to /api/channels/{channel}/passkey/confirm"
+            ),
+        }))
+        .into_response(),
+        Ok(zeroclaw_channels::login_passkey::PasskeyState::Idle) => Json(serde_json::json!({
+            "channel": channel,
+            "outcome": "idle",
+            "note": "no passkey assertion is being waited for; one is demanded only while linking",
+        }))
+        .into_response(),
+        Ok(zeroclaw_channels::login_passkey::PasskeyState::NotApplicable) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "unsupported",
+                "error": format!(
+                    "channel type {} has no passkey ceremony; nothing was inspected",
+                    info.channel_type
+                ),
+            })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "channel": channel,
+                "error": format!("failed to read the pending passkey request: {e}"),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/channels/{channel}/passkey — answer the pending challenge.
+///
+/// The body is the JSON `navigator.credentials.get()` returned, forwarded to
+/// the channel byte-for-byte: the server verifies a signature over exactly
+/// those bytes, so the gateway never reshapes them. Dispatches to the
+/// channel-owned hook ([`zeroclaw_channels::login_passkey::submit`]).
+///
+/// This is the same handoff as saving the credential to the file beside the
+/// session database, with two differences that matter to an operator: the
+/// caller does not need to know the session layout, and a payload that could
+/// never satisfy the server is rejected here, while they are still watching,
+/// rather than failing inside the run loop minutes later.
+///
+/// Responses (all authenticated via the standard bearer guard):
+///
+/// - `200` with `"outcome": "accepted"` — handed to the waiting channel,
+///   which resumes linking within a second.
+/// - `400` — the payload cannot satisfy the server (`"error"` names why).
+///   The challenge stays open, so a corrected credential can be posted.
+/// - `409` with `"outcome": "no_pending_request"` — nothing is waiting.
+///   **Nothing was written:** the channel discards any assertion predating
+///   its challenge, so accepting one would report a success that did not
+///   happen.
+/// - `409` with `"outcome": "unsupported"` — as for `GET`.
+/// - `413` — body larger than 64 KiB.
+/// - `404` — no `[channels.<type>.<alias>]` block matches `{channel}`.
+pub async fn handle_api_channel_passkey_submit(
+    State(state): State<AppState>,
+    Path(channel): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    if body.len() > PASSKEY_ASSERTION_MAX_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "channel": channel,
+                "error": format!(
+                    "credential body is {} bytes; a WebAuthn assertion is about a kilobyte \
+                     and this endpoint accepts at most {PASSKEY_ASSERTION_MAX_BYTES}",
+                    body.len()
+                ),
+            })),
+        )
+            .into_response();
+    }
+
+    let config = state.config.read().clone();
+    let (info, qr_channel) = match resolve_passkey_channel(&config, &channel) {
+        Ok(resolved) => resolved,
+        Err(e) => return e.render(&channel),
+    };
+
+    let submitted_bytes = body.len();
+    match zeroclaw_channels::login_passkey::submit(qr_channel, &config, &info.alias, body.to_vec())
+    {
+        Ok(()) => {
+            // Size only — the credential itself never reaches the log.
+            ::zeroclaw_log::record!(
+                INFO,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_attrs(
+                        ::serde_json::json!({"channel": channel, "bytes": submitted_bytes})
+                    ),
+                "passkey assertion accepted for a linking channel"
+            );
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "accepted",
+                "note": "the channel picks this up within a second and resumes linking",
+            }))
+            .into_response()
+        }
+        Err(zeroclaw_channels::login_passkey::SubmitError::NoPendingRequest) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "no_pending_request",
+                "error": "this channel is not waiting for a passkey assertion; nothing was written",
+                "note": "GET this path to check for a pending challenge before answering it",
+            })),
+        )
+            .into_response(),
+        Err(zeroclaw_channels::login_passkey::SubmitError::Invalid(reason)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "invalid",
+                "error": reason,
+                "note": "the pending challenge is unchanged; post a corrected credential",
+            })),
+        )
+            .into_response(),
+        Err(zeroclaw_channels::login_passkey::SubmitError::NotApplicable) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "unsupported",
+                "error": format!(
+                    "channel type {} has no passkey ceremony; nothing was written",
+                    info.channel_type
+                ),
+            })),
+        )
+            .into_response(),
+        Err(zeroclaw_channels::login_passkey::SubmitError::Io(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "channel": channel,
+                "error": format!("failed to hand the assertion to the channel: {e}"),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /api/channels/{channel}/passkey/confirm — acknowledge the fresh-link
+/// verification code currently displayed on the primary phone.
+///
+/// The body is `{ "attempt_id": "..." }`, copied from `GET` on the parent
+/// passkey endpoint. The attempt id makes a delayed or replayed request fail
+/// closed instead of confirming a later ceremony whose short display code may
+/// happen to repeat.
+pub async fn handle_api_channel_passkey_confirm(
+    State(state): State<AppState>,
+    Path(channel): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    if body.len() > PASSKEY_CONFIRMATION_MAX_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "channel": channel,
+                "error": format!(
+                    "confirmation body is {} bytes; this endpoint accepts at most \
+                     {PASSKEY_CONFIRMATION_MAX_BYTES}",
+                    body.len()
+                ),
+            })),
+        )
+            .into_response();
+    }
+
+    let submission: PasskeyConfirmationSubmission = match serde_json::from_slice(&body) {
+        Ok(submission) => submission,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "channel": channel,
+                    "outcome": "invalid",
+                    "error": format!("invalid confirmation JSON: {error}"),
+                })),
+            )
+                .into_response();
+        }
+    };
+    if submission.attempt_id.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "invalid",
+                "error": "attempt_id cannot be empty",
+            })),
+        )
+            .into_response();
+    }
+
+    let config = state.config.read().clone();
+    let (info, qr_channel) = match resolve_passkey_channel(&config, &channel) {
+        Ok(resolved) => resolved,
+        Err(e) => return e.render(&channel),
+    };
+
+    match zeroclaw_channels::login_passkey::confirm(
+        qr_channel,
+        &config,
+        &info.alias,
+        &submission.attempt_id,
+    ) {
+        Ok(()) => Json(serde_json::json!({
+            "channel": channel,
+            "outcome": "accepted",
+            "note": "the channel will finish the fresh passkey link",
+        }))
+        .into_response(),
+        Err(zeroclaw_channels::login_passkey::ConfirmError::NoPendingConfirmation) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "no_pending_confirmation",
+                "error": "this channel is not waiting for passkey-code confirmation; nothing was written",
+            })),
+        )
+            .into_response(),
+        Err(zeroclaw_channels::login_passkey::ConfirmError::AttemptMismatch) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "attempt_mismatch",
+                "error": "attempt_id does not match the current passkey confirmation",
+            })),
+        )
+            .into_response(),
+        Err(zeroclaw_channels::login_passkey::ConfirmError::NotApplicable) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "channel": channel,
+                "outcome": "unsupported",
+                "error": format!(
+                    "channel type {} has no passkey ceremony; nothing was written",
+                    info.channel_type
+                ),
+            })),
+        )
+            .into_response(),
+        Err(zeroclaw_channels::login_passkey::ConfirmError::Io(error)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "channel": channel,
+                "error": format!("failed to hand confirmation to the channel: {error}"),
             })),
         )
             .into_response(),
@@ -2973,6 +3398,339 @@ pub(crate) mod tests {
             State(state),
             Path("telegram.default".to_string()),
             HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// The JSON shape `navigator.credentials.get()` returns. `Y3JlZA` is
+    /// base64url for `cred`; the endpoint recovers the credential id from it.
+    #[cfg(feature = "whatsapp-web")]
+    fn browser_credential() -> &'static str {
+        r#"{"id":"Y3JlZA","rawId":"Y3JlZA","type":"public-key","response":{"clientDataJSON":"eyJ0IjoxfQ","authenticatorData":"YXV0aA","signature":"c2ln","userHandle":null}}"#
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn config_with_whatsapp_session(
+        session_path: &std::path::Path,
+    ) -> zeroclaw_config::schema::Config {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.gateway.require_pairing = false;
+        config.channels.whatsapp.insert(
+            "spare".to_string(),
+            zeroclaw_config::schema::WhatsAppConfig {
+                enabled: true,
+                session_path: Some(session_path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+        config
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn api_channel_passkey_serves_the_challenge_then_accepts_the_answer() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+        let config = config_with_whatsapp_session(&session_path);
+
+        // Nothing is waiting yet: the ordinary state.
+        let response = handle_api_channel_passkey(
+            State(test_state(config.clone())),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["outcome"], "idle");
+
+        // The run loop publishes a challenge beside the session database.
+        let options = r#"{"challenge":"AQID","rpId":"web.whatsapp.com"}"#;
+        std::fs::write(
+            zeroclaw_channels::whatsapp_passkey::request_path(&session),
+            options,
+        )
+        .unwrap();
+
+        let response = handle_api_channel_passkey(
+            State(test_state(config.clone())),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "assertion_pending");
+        assert_eq!(
+            json["options"]["challenge"], "AQID",
+            "the browser ceremony consumes these options directly"
+        );
+        assert_eq!(json["options"]["rpId"], "web.whatsapp.com");
+
+        let response = handle_api_channel_passkey_submit(
+            State(test_state(config)),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(browser_credential().as_bytes()),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["outcome"], "accepted");
+
+        assert_eq!(
+            std::fs::read_to_string(zeroclaw_channels::whatsapp_passkey::assertion_path(
+                &session
+            ))
+            .unwrap(),
+            browser_credential(),
+            "the credential must reach the waiting authenticator byte-for-byte"
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn api_channel_passkey_submit_without_a_challenge_is_conflict_noop() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+
+        let response = handle_api_channel_passkey_submit(
+            State(test_state(config_with_whatsapp_session(&session_path))),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(browser_credential().as_bytes()),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response_json(response).await["outcome"],
+            "no_pending_request"
+        );
+        assert!(
+            !std::path::Path::new(&zeroclaw_channels::whatsapp_passkey::assertion_path(
+                &session
+            ))
+            .exists(),
+            "an unrequested assertion must not be staged; the channel would discard it \
+             and the operator would believe they had answered"
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn api_channel_passkey_serves_and_accepts_fresh_link_confirmation() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+        let config = config_with_whatsapp_session(&session_path);
+        let prompt = zeroclaw_channels::whatsapp_passkey::PendingPasskeyConfirmation {
+            attempt_id: "current-attempt".to_string(),
+            code: "ABCD-EFGH".to_string(),
+        };
+        std::fs::write(
+            zeroclaw_channels::whatsapp_passkey::confirmation_path(&session),
+            serde_json::to_vec(&prompt).unwrap(),
+        )
+        .unwrap();
+
+        let response = handle_api_channel_passkey(
+            State(test_state(config.clone())),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "confirmation_pending");
+        assert_eq!(json["attempt_id"], "current-attempt");
+        assert_eq!(json["code"], "ABCD-EFGH");
+
+        let response = handle_api_channel_passkey_confirm(
+            State(test_state(config.clone())),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(br#"{"attempt_id":"older-attempt"}"#),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response_json(response).await["outcome"], "attempt_mismatch");
+
+        let response = handle_api_channel_passkey_confirm(
+            State(test_state(config)),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(br#"{"attempt_id":"current-attempt"}"#),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["outcome"], "accepted");
+
+        let ack: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(zeroclaw_channels::whatsapp_passkey::confirmation_ack_path(
+                &session,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(ack["attempt_id"], "current-attempt");
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn api_channel_passkey_rejects_an_unusable_payload_and_keeps_the_challenge() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+        let session = session_path.to_string_lossy().into_owned();
+        let request_file = zeroclaw_channels::whatsapp_passkey::request_path(&session);
+        std::fs::write(&request_file, r#"{"challenge":"AQID"}"#).unwrap();
+
+        // A credential with no signature can never satisfy the server, and
+        // saying so now beats an opaque rejection from WhatsApp later.
+        let response = handle_api_channel_passkey_submit(
+            State(test_state(config_with_whatsapp_session(&session_path))),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(br#"{"rawId":"Y3JlZA","response":{}}"#),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "invalid");
+        assert!(
+            json["error"]
+                .as_str()
+                .expect("error string")
+                .contains("signature"),
+            "the error must name the missing field, not just say no"
+        );
+        assert!(
+            std::path::Path::new(&request_file).exists(),
+            "a rejected submission must leave the challenge open to retry"
+        );
+        assert!(
+            !std::path::Path::new(&zeroclaw_channels::whatsapp_passkey::assertion_path(
+                &session
+            ))
+            .exists()
+        );
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn api_channel_passkey_refuses_an_oversized_body() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join("spare.db");
+
+        let response = handle_api_channel_passkey_submit(
+            State(test_state(config_with_whatsapp_session(&session_path))),
+            Path("whatsapp.spare".to_string()),
+            HeaderMap::new(),
+            Bytes::from(vec![b'x'; PASSKEY_ASSERTION_MAX_BYTES + 1]),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn api_channel_passkey_unsupported_channel_is_explicit_conflict_noop() {
+        let config = config_with_telegram("default");
+
+        let response = handle_api_channel_passkey(
+            State(test_state(config.clone())),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(response_json(response).await["outcome"], "unsupported");
+
+        let response = handle_api_channel_passkey_submit(
+            State(test_state(config.clone())),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(b"{}"),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let json = response_json(response).await;
+        assert_eq!(json["outcome"], "unsupported");
+        assert!(
+            json["error"]
+                .as_str()
+                .expect("error string")
+                .contains("nothing was changed")
+        );
+
+        let response = handle_api_channel_passkey_confirm(
+            State(test_state(config)),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(br#"{"attempt_id":"attempt"}"#),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(response_json(response).await["outcome"], "unsupported");
+    }
+
+    #[tokio::test]
+    async fn api_channel_passkey_unknown_channel_is_not_found() {
+        let response = handle_api_channel_passkey(
+            State(test_state(zeroclaw_config::schema::Config::default())),
+            Path("whatsapp.ghost".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn api_channel_passkey_requires_bearer_auth_when_pairing_enabled() {
+        let state = AppState {
+            pairing: Arc::new(PairingGuard::new(true, &[])),
+            ..test_state(config_with_telegram("default"))
+        };
+
+        let response = handle_api_channel_passkey(
+            State(state.clone()),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        // The write path must be guarded too — it is the one that stages a
+        // credential for a channel to act on.
+        let response = handle_api_channel_passkey_submit(
+            State(state.clone()),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(b"{}"),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = handle_api_channel_passkey_confirm(
+            State(state),
+            Path("telegram.default".to_string()),
+            HeaderMap::new(),
+            Bytes::from_static(br#"{"attempt_id":"attempt"}"#),
         )
         .await
         .into_response();

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1849,6 +1849,14 @@ pub async fn run_gateway(
             "/api/channels/{channel}/relink",
             post(api::handle_api_channel_relink),
         )
+        .route(
+            "/api/channels/{channel}/passkey",
+            get(api::handle_api_channel_passkey).post(api::handle_api_channel_passkey_submit),
+        )
+        .route(
+            "/api/channels/{channel}/passkey/confirm",
+            post(api::handle_api_channel_passkey_confirm),
+        )
         .route("/api/health", get(api::handle_api_health))
         .route("/api/tuis", get(api::handle_api_tuis))
         .route("/api/sessions", get(api::handle_api_sessions_list))


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Depends on #10084. Do not merge first.** This draft branch contains the
  complete core stack plus two endpoint commits; review the delta above
  #10084.
- **What changed and why:** Add authenticated HTTP access to both operator
  phases of WhatsApp's passkey ceremony:
  - `GET /api/channels/{channel}/passkey` reports `idle`,
    `assertion_pending`, or `confirmation_pending`.
  - `POST /api/channels/{channel}/passkey` validates and stages the browser
    assertion.
  - `POST /api/channels/{channel}/passkey/confirm` acknowledges the fresh-link
    display code using its one-shot attempt ID.
- **Scope boundary:** Convenience layer only. #10084's channel-owned file
  broker remains the source of truth and works without the gateway. This PR
  does not hold a live WhatsApp client, produce WebAuthn assertions, or
  auto-confirm a fresh link.
- **Blast radius:** Two authenticated gateway write paths and one read path,
  all reachable only for QR-pairing channel aliases compiled with
  `whatsapp-web`. No CORS is added.
- **Linked issue(s):** Depends on #10084, Refs #8627
- **Labels:** `dependencies`, `channel`, `gateway`, `channel:core`,
  `channel:whatsapp`, `risk:medium`, `size:L`

The gateway does not perform file operations or derive session paths itself.
It resolves the canonical channel alias and dispatches through
`login_passkey`; the WhatsApp channel expands the configured session path and
calls the same broker helpers used by the manual flow.

The endpoint adds two protections that hand-writing the files cannot provide:

- Invalid assertion envelopes and stale confirmation attempt IDs are rejected
  while the caller is still watching, without consuming the pending state.
- Assertions and acknowledgements are written to owner-only staging files,
  synced, and atomically renamed. Stale staging files and planted symlinks are
  unlinked before `create_new`, so an authenticated request cannot follow a
  predictable `.partial` symlink.

The fresh-link code is never auto-confirmed when the assertion is accepted.
The operator must compare the Crockford-base32 code with the primary phone and
submit the current attempt ID. Re-links retain upstream's continuity-proof
auto-confirmation and never enter this endpoint phase.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` — this adds authenticated HTTP writes
  carrying passkey ceremony material.
- **Interface(s) exercised:** `web`, `channel`
- **Setup / preconditions:** Build `zeroclaw-gateway` and
  `zeroclaw-channels` with `whatsapp-web`. No WhatsApp account is needed for
  deterministic route and file-boundary tests.
- **Steps to run:**

  ```sh
  cargo test -p zeroclaw-channels -p zeroclaw-gateway \
    --features whatsapp-web passkey
  ```

- **Expected on this branch (after):** 19 channel passkey tests and 8 gateway
  route tests pass. The route serves both phases, refuses stale attempts,
  requires bearer auth, bounds bodies, and never follows a planted staging
  symlink.
- **Prior behavior on `master` (before):** These routes and channel-owned
  dispatch hooks do not exist.

### How I tested

```sh
$ cargo test -p zeroclaw-channels -p zeroclaw-gateway \
    --features whatsapp-web passkey
test result: ok. 19 passed; 0 failed
test result: ok. 8 passed; 0 failed

$ cargo test -p zeroclaw-channels -p zeroclaw-gateway \
    --features whatsapp-web
test result: ok. 1662 passed; 0 failed; 1 ignored
test result: ok. 446 passed; 0 failed
test result: ok. 9 passed; 0 failed

$ cargo fmt --all -- --check
# clean

$ cargo clippy -p zeroclaw-channels -p zeroclaw-gateway \
    --features whatsapp-web --all-targets -- -D warnings
# clean

$ scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **CI checks relied on and why they cover this change:** Fresh required CI is
  running on head `0fe1da560`. `Lint` compiles both feature-gated crates;
  Security and gateway tests cover the new authenticated surface.
- **Known CI coverage gap, if any:** No available account has received the live
  SHORTCAKE gate, so the complete server/browser ceremony remains unexercised.
- **Commands run and tail output:** Included above.
- **Beyond CI, what did you manually verify?** The endpoint previously resolved
  a live configured alias and returned `idle`; ordinary ungated WhatsApp
  linking completed on hardware. The new confirmation phase is synthetic-only.
- **If any command was intentionally skipped, why:** A live test requires an
  account selected by Meta's phased rollout.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: The endpoint carries a
  challenge-bound WebAuthn assertion and a one-shot confirmation attempt ID.
  Every route uses the standard bearer guard; request bodies are bounded; no
  CORS is added; credential bytes are never logged. Writes use `create_new`,
  mode `0600` on Unix, `sync_all`, and atomic rename. The channel consumes each
  response once.

## Compatibility (required)

- Backward compatible? `Yes` — new endpoints only; manual files remain valid.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`:
  N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the endpoint squash commit. #10084's
  manual file broker remains available.
- **Feature flags or config toggles:** The path is compiled only with
  `whatsapp-web`; gateway bearer pairing remains the runtime access control.
- **Observable failure symptoms:** `GET` remains `idle` while broker files
  exist; assertion POST returns `accepted` but the file is never consumed; or
  confirmation POST succeeds without the link reaching `Connected`.
