### PR TITLE
fix(providers): redact Anthropic credential fragments

### DIFF
--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -3605,9 +3605,27 @@ data: {\"type\":\"message_stop\"}\n\n";
             );
             assert!(attrs.get("credential_head").is_none());
             assert!(attrs.get("credential_tail").is_none());
+            let former_head: String = credential.chars().take(8).collect();
+            let former_tail: String = credential
+                .chars()
+                .rev()
+                .take(4)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
+            let serialized = event.to_string();
             assert!(
-                !event.to_string().contains(credential),
+                !serialized.contains(credential),
                 "authentication event must not contain credential material"
+            );
+            assert!(
+                !serialized.contains(&former_head),
+                "authentication event must not contain the credential prefix"
+            );
+            assert!(
+                !serialized.contains(&former_tail),
+                "authentication event must not contain the credential suffix"
             );
         }
 

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -514,16 +514,7 @@ impl AnthropicModelProvider {
     ) -> reqwest::RequestBuilder {
         let is_setup = Self::is_setup_token(credential);
         let len = credential.len();
-        let head: String = credential.chars().take(8).collect();
-        let tail: String = credential
-            .chars()
-            .rev()
-            .take(4)
-            .collect::<String>()
-            .chars()
-            .rev()
-            .collect();
-        ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"header": if is_setup { "Authorization" } else { "x-api-key" }, "credential_len": len, "credential_head": head, "credential_tail": tail})), "Anthropic auth header applied");
+        ::zeroclaw_log::record!(DEBUG, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_attrs(::serde_json::json!({"header": if is_setup { "Authorization" } else { "x-api-key" }, "credential_len": len})), "Anthropic auth header applied");
         if is_setup {
             request
                 .header("Authorization", format!("Bearer {credential}"))
@@ -3551,6 +3542,76 @@ data: {\"type\":\"message_stop\"}\n\n";
         );
         assert!(request.headers().get("authorization").is_none());
         assert!(request.headers().get("anthropic-beta").is_none());
+    }
+
+    #[test]
+    fn apply_auth_log_omits_credentials_for_regular_and_setup_tokens() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let model_provider = AnthropicModelProvider::builder("test").build();
+        for (credential, expected_header) in [
+            ("sk-ant-api-key-secret", "x-api-key"),
+            ("sk-ant-oat01-setup-token-secret", "Authorization"),
+        ] {
+            model_provider
+                .apply_auth(
+                    model_provider
+                        .http_client()
+                        .get("https://api.anthropic.com/v1/models"),
+                    credential,
+                )
+                .build()
+                .expect("request should build");
+
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            let event = 'search: loop {
+                while let Ok(event) = rx.try_recv() {
+                    let matches_message = event.get("message").and_then(|value| value.as_str())
+                        == Some("Anthropic auth header applied");
+                    let matches_source = event
+                        .get("attributes")
+                        .and_then(|attributes| attributes.get("_file"))
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|file| file.ends_with("zeroclaw-providers/src/anthropic.rs"));
+                    let matches_auth = event.get("attributes").is_some_and(|attributes| {
+                        attributes.get("header").and_then(|value| value.as_str())
+                            == Some(expected_header)
+                            && attributes
+                                .get("credential_len")
+                                .and_then(|value| value.as_u64())
+                                == Some(credential.len() as u64)
+                    });
+                    if matches_message && matches_source && matches_auth {
+                        break 'search event;
+                    }
+                }
+
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "apply_auth should emit the expected canonical log event"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            };
+
+            let attrs = event.get("attributes").expect("attributes present");
+            assert_eq!(attrs["header"].as_str(), Some(expected_header));
+            assert_eq!(
+                attrs["credential_len"].as_u64(),
+                Some(credential.len() as u64)
+            );
+            assert!(attrs.get("credential_head").is_none());
+            assert!(attrs.get("credential_tail").is_none());
+            assert!(
+                !event.to_string().contains(credential),
+                "authentication event must not contain credential material"
+            );
+        }
+
+        zeroclaw_log::clear_broadcast_hook();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Stop writing `credential_head` and `credential_tail` to the Anthropic authentication debug event.
  - Keep non-secret diagnostic context: the selected authentication header and credential length.
  - Capture the canonical structured event for both ordinary API keys and Anthropic setup tokens, asserting that neither full placeholder token nor the old eight-character prefix and four-character suffix appear.
- **Scope boundary:** Does not change authentication headers, credential selection, rotation, network requests, configuration, or any provider behavior beyond this debug event's attributes.
- **Blast radius:** Anthropic provider debug logging and its focused regression coverage only.
- **Linked issue(s):** Fixes #9976.
- **Labels:** `bug`, `provider`, `provider:anthropic`, `domain:security`, `priority:p1`, `risk:high`, `size:S`

### What this does, simply

When ZeroClaw authenticated with Anthropic at debug level, one log event included the beginning and end of the credential. Short credentials could be reconstructed entirely from those two fragments. The event now records only which header was selected and the credential length, so operators can still diagnose the authentication mode without placing credential characters in logs. This deliberately fixes the log sink only; it does not alter how ZeroClaw sends or rotates credentials.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The behavior is an internal structured log event; the deterministic regression captures the canonical event for both authentication modes without requiring a real credential, account, or external request.

### How I tested

- **CI checks relied on and why they cover this change:** The exact-head `CI Required Gate` passed for the published commit. The local test exercises the exact event emitted by `AnthropicModelProvider::apply_auth` for ordinary API keys and setup tokens.
- **Known CI coverage gap, if any:** No behavior-specific gap identified. This PR does not change request construction or provider communication.
- **Commands run and tail output:**
  - `zc-cargo fmt --all -- --check` — completed with no diagnostic output.
  - `zc-cargo test -p zeroclaw-providers apply_auth_` — 3 passed, 0 failed.
  - `bash scripts/ci/comment_hygiene_gate.sh` — `Comment hygiene gate passed.`
  - `git diff --check` — completed with no output.
- **Beyond CI, what did you manually verify?** Inspected the emitted structured event for representative ordinary-key and setup-token placeholders. It retains only the expected header and length metadata, has neither fragment field, and serializes neither complete placeholder nor the former eight-character prefix or four-character suffix. No real credentials or external Anthropic request were used.
- **If any command was intentionally skipped, why:** Broader provider validation is deferred to required CI because the implementation changes one log event and the focused tests cover both authentication paths that emit it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`Yes`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: The debug event no longer stores credential-derived prefix or suffix fields. It retains only the selected header type and credential length; tests use non-secret placeholders and assert the complete placeholder plus the former prefix and suffix are absent from the captured event.

## Compatibility (required)

- Backward compatible? (`No` for consumers parsing the removed debug-event attributes; provider runtime behavior is unchanged.)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- Existing log consumers must stop relying on `credential_head` or `credential_tail`. No configuration, environment, CLI, or request migration is required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge commit>`. This restores the former attributes but also restores the credential-fragment exposure that this PR removes.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A reverted or regressed build emits `credential_head` or `credential_tail` on the `Anthropic auth header applied` debug event. The `apply_auth_log_omits_credentials_for_regular_and_setup_tokens` regression fails before such a build is accepted.
