### PR TITLE
ci(docker): enforce non-root production image

### DIFF
--- a/.github/workflows/docker-image-pr.yml
+++ b/.github/workflows/docker-image-pr.yml
@@ -154,6 +154,15 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.cache-scope }}
           cache-to: type=gha,scope=${{ matrix.cache-scope }},mode=max,ignore-error=true
 
+      - name: Verify default production image runs as non-root
+        if: matrix.dockerfile == 'Dockerfile' && matrix.platform == 'linux/amd64'
+        run: |
+          actual_user=$(docker inspect --format='{{.Config.User}}' "${{ matrix.tag }}")
+          if [ "$actual_user" != "65534:65534" ]; then
+            echo "::error title=Unexpected container user::Expected 65534:65534, found ${actual_user:-<empty>}"
+            exit 1
+          fi
+
       - name: Smoke test Compose published gateway port
         if: matrix.gateway_smoke
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,7 +87,4 @@ docker run --read-only -v /path/to/workspace:/workspace zeroclaw gateway
 
 ### CI Enforcement
 
-The `docker` job in `.github/workflows/checks-on-pr.yml` automatically verifies:
-1. Container does not run as root (UID 0)
-2. Runtime stage uses `:nonroot` variant
-3. Explicit `USER` directive with numeric UID exists
+The `source-images` job in `.github/workflows/docker-image-pr.yml` builds the default production image and verifies that the resulting image is configured to run as `65534:65534`.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The existing Docker source-image workflow now checks the finished default production image and fails unless Docker reports its configured runtime user and group as `65534:65534`.
  - `SECURITY.md` now names that real workflow and check instead of a workflow that was deleted.
- **Scope boundary:** This does not change the image itself, container runtime behavior, other image variants, other architectures, Compose overrides, or release workflows.
- **Blast radius:** Docker-related pull-request CI for the default `Dockerfile` image on `linux/amd64`, plus the matching security documentation.
- **Linked issue(s):** Closes #10074
- **Labels:** `ci`, `docs`, `domain:security`, `risk:high`, `size:XS`, `type:ci`

### What this does, simply

ZeroClaw's default production image already runs as a non-root user, but the current source-image workflow did not inspect the finished image's configured user. A future Dockerfile change could accidentally make the container run as root while the security documentation still claimed an automatic check would catch it.

This PR adds that check to the workflow that already builds the real production image. After the default `linux/amd64` image is built, the workflow asks Docker which user and group the finished image will use. It fails unless the answer is exactly `65534:65534`.

### Why it matters

Running the container as non-root limits the damage available to a compromised process. Checking the completed image is stronger than searching Dockerfile text because it verifies the built image artifact, and a mismatch fails loudly before the rest of the smoke test continues.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the hosted Docker workflow is the useful verification boundary because it builds and inspects the real image.

### How I tested

- **CI checks relied on and why they cover this change:** `Docker Image PR Check / Source Image Build (no push)` builds and loads the default `linux/amd64` production image, then executes the new metadata assertion against that exact tag. That exact-head check must pass before reviewer sign-off.
- **Known CI coverage gap, if any:** The assertion intentionally does not inspect the arm64, Alpine, Debian, or `Containerfile` images.
- **Commands run and tail output:**

```text
$ actionlint .github/workflows/docker-image-pr.yml
(exit 0; no findings)

$ git diff --check
(exit 0; no findings)
```

- **Beyond CI, what did you manually verify?** By source inspection, I confirmed that the checked matrix row is the already loaded default `Dockerfile` / `linux/amd64` image, that the script rejects an empty or mismatched user, and that the production Dockerfile currently declares `USER 65534:65534`. I did not perform a separate local image build.
- **If any command was intentionally skipped, why:** A local multi-stage Docker build was skipped because the hosted workflow builds the same production artifact and is the authoritative evidence for this CI change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A
- **Security behavior:** The check reads only the built image's local metadata inside CI; it handles no user data, authorization decision, secret, or autonomously invoked runtime action. A missing image fails at `docker inspect`; an empty or mismatched configured user emits the custom error with the non-secret observed value and fails the job.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 8ef0910c05b99fa1dad37288ce961bc8f3293aa5`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The default-amd64 `Source Image Build (no push)` lane fails at `Verify default production image runs as non-root` with an `Unexpected container user` error that reports the observed value.
