### PR TITLE
fix(ci): suppress maintainer mentions in fork advisory issues

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -77,7 +77,9 @@ jobs:
             printf 'Review `deny.toml` for the current ignore list. If this advisory is a known\n'
             printf 'acceptable risk, add an entry with a `reason` field. If it requires a\n'
             printf 'dependency update, open a tracking issue and link it here.\n\n'
-            printf 'cc @JordanTheJet @Audacity88\n'
+            if [[ "$GITHUB_REPOSITORY" == "zeroclaw-labs/zeroclaw" ]]; then
+              printf 'cc @JordanTheJet @Audacity88\n'
+            fi
           } > /tmp/issue-body.md
 
           issue_url=$(gh issue create \


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Restrict the daily advisory issue's maintainer `cc` line to `zeroclaw-labs/zeroclaw`, preventing fork-local workflow runs from notifying ZeroClaw's upstream maintainers.
- **Scope boundary:** This does not disable advisory scans or issue creation in forks, and it does not change duplicate detection, labels, scheduling, or failure propagation.
- **Blast radius:** Only the issue body generated by `.github/workflows/daily-audit.yml` is affected. Upstream issue bodies retain the existing maintainer mentions; fork issue bodies omit them.
- **Linked issue(s):** Related to [Hadi777-apk/zeroclaw#4](https://github.com/Hadi777-apk/zeroclaw/issues/4).
- **Labels:** `type:ci`, `risk:low`, `size:XS`, `ci`

### What this does, simply

Forks can enable ZeroClaw's inherited advisory workflow, which creates issues in that fork when a dependency advisory is detected. Those fork-local issues previously copied ZeroClaw's upstream maintainer mentions verbatim. This keeps the useful fork scan and issue while adding the mentions only when the workflow is running in the upstream repository.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the changed behavior is a small repository-identity branch exercised directly against the embedded workflow shell.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head required CI passed, including Format, Repository Structure, Lint, Test, Security, and `CI Required Gate`. Focused local checks cover the changed shell branch directly.
- **Known CI coverage gap, if any:** No hosted end-to-end run created real advisory issues in both the canonical repository and a fork.
- **Commands run and tail output:**

  ```text
  actionlint -ignore SC2016 .github/workflows/daily-audit.yml
  # exit 0

  bash scripts/ci/comment_hygiene_gate.sh .github/workflows/daily-audit.yml
  Comment hygiene gate passed.

  git diff --check
  # exit 0
  ```

- **Beyond CI, what did you manually verify?** Executed the embedded issue-body shell with `GITHUB_REPOSITORY=zeroclaw-labs/zeroclaw` and `GITHUB_REPOSITORY=Hadi777-apk/zeroclaw`. The canonical body retained `cc @JordanTheJet @Audacity88`; the fork body omitted it.
- **If any command was intentionally skipped, why:** Cargo checks were skipped because this change only modifies a GitHub Actions workflow and does not touch Rust source or dependencies.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? Yes. The diff retains the workflow's existing public maintainer handles only for upstream notifications and prevents forks from propagating those mentions.
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: Public maintainer handles were already present in the workflow. The repository guard narrows where they are emitted.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: `git revert <sha>`.
