### PR TITLE
fix(channels): keep Google STT API keys out of URLs

### DIFF
--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
-use reqwest::multipart::{Form, Part};
+use reqwest::{
+    header::HeaderValue,
+    multipart::{Form, Part},
+};
 
 use zeroclaw_config::providers::{TranscriptionProviderEntry, TranscriptionProviders};
 use zeroclaw_config::schema::{Config, TranscriptionConfig};
@@ -12,6 +15,9 @@ const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
 
 /// Request timeout for transcription API calls (seconds).
 const TRANSCRIPTION_TIMEOUT_SECS: u64 = 120;
+
+const GOOGLE_STT_ENDPOINT: &str = "https://speech.googleapis.com/v1/speech:recognize";
+const GOOGLE_API_KEY_HEADER: &str = "x-goog-api-key";
 
 // ── Audio utilities ─────────────────────────────────────────────
 
@@ -648,6 +654,24 @@ impl GoogleSttProvider {
                 .unwrap_or_else(|| "en-US".to_string()),
         })
     }
+
+    fn sensitive_api_key_header(&self) -> Result<HeaderValue> {
+        let mut value = HeaderValue::from_str(&self.api_key).map_err(|_| {
+            anyhow::Error::msg("Google STT API key contains invalid header characters")
+        })?;
+        value.set_sensitive(true);
+        Ok(value)
+    }
+
+    fn build_request(&self, request_body: &serde_json::Value) -> Result<reqwest::RequestBuilder> {
+        Ok(
+            zeroclaw_config::schema::build_runtime_proxy_client("transcription.google")
+                .post(GOOGLE_STT_ENDPOINT)
+                .header(GOOGLE_API_KEY_HEADER, self.sensitive_api_key_header()?)
+                .json(request_body)
+                .timeout(std::time::Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS)),
+        )
+    }
 }
 
 #[async_trait]
@@ -666,8 +690,6 @@ impl TranscriptionProvider for GoogleSttProvider {
 
     async fn transcribe(&self, audio_data: &[u8], file_name: &str) -> Result<String> {
         let (normalized_name, _) = validate_audio(audio_data, file_name)?;
-
-        let client = zeroclaw_config::schema::build_runtime_proxy_client("transcription.google");
 
         let encoding = match normalized_name
             .rsplit_once('.')
@@ -697,15 +719,8 @@ impl TranscriptionProvider for GoogleSttProvider {
             }
         });
 
-        let url = format!(
-            "https://speech.googleapis.com/v1/speech:recognize?key={}",
-            self.api_key
-        );
-
-        let resp = client
-            .post(&url)
-            .json(&request_body)
-            .timeout(std::time::Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS))
+        let resp = self
+            .build_request(&request_body)?
             .send()
             .await
             .context("Failed to send transcription request to Google STT")?;
@@ -1715,6 +1730,61 @@ mod tests {
         )
         .unwrap();
         assert_eq!(google.language_code, "en-US");
+    }
+
+    #[test]
+    fn google_stt_request_uses_sensitive_header_without_url_credential() {
+        let provider = GoogleSttProvider {
+            alias: "default".to_string(),
+            api_key: "api-key-123".to_string(),
+            language_code: "en-US".to_string(),
+        };
+        let body = serde_json::json!({
+            "config": { "languageCode": "en-US" },
+            "audio": { "content": "dGVzdA==" },
+        });
+
+        let request = provider.build_request(&body).unwrap().build().unwrap();
+
+        assert_eq!(request.url().as_str(), GOOGLE_STT_ENDPOINT);
+        assert!(!request.url().as_str().contains("api-key-123"));
+        assert!(!request.url().query_pairs().any(|(name, _)| name == "key"));
+
+        let header = request
+            .headers()
+            .get(GOOGLE_API_KEY_HEADER)
+            .expect("Google API key header");
+        assert_eq!(header.to_str().unwrap(), "api-key-123");
+        assert!(header.is_sensitive());
+
+        let payload = request
+            .body()
+            .and_then(reqwest::Body::as_bytes)
+            .expect("JSON request body should be buffered");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(payload).unwrap(),
+            body
+        );
+    }
+
+    #[test]
+    fn google_stt_request_rejects_malformed_header_without_echoing_key() {
+        let api_key = "api-key-123\r\nleaked";
+        let provider = GoogleSttProvider {
+            alias: "default".to_string(),
+            api_key: api_key.to_string(),
+            language_code: "en-US".to_string(),
+        };
+
+        let err = match provider.build_request(&serde_json::json!({})) {
+            Ok(_) => panic!("malformed Google STT API key should be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.to_string(),
+            "Google STT API key contains invalid header characters"
+        );
+        assert!(!err.to_string().contains(api_key));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Removes Google Speech-to-Text API keys from recognition request URLs so URL-oriented proxy logs, diagnostics, and monitoring records do not capture the credential.
  - Sends the key through Google's `x-goog-api-key` header and marks the header value sensitive.
  - Rejects malformed header values with credential-free error text and adds request-level regressions for the security properties.
- **Scope boundary:** This PR does not change credential storage, configuration, provider selection, audio encoding, request payloads, timeouts, response parsing, or other transcription providers.
- **Blast radius:** Google Speech-to-Text v1 recognition requests authenticated with an API key. Existing runtime proxy selection and all non-Google transcription paths are unchanged.
- **Linked issue(s):** Related #9973. The adjacent exact proxy-selector mismatch remains separate in #10106.
- **Labels:** `bug`, `channel`, `domain:security`, `follow-up`, `priority:p1`, `risk:high`, `size:S`, `distinguished contributor`

### What this does, simply

ZeroClaw used to put the Google Speech-to-Text API key in the request URL. URLs are often saved in logs and diagnostics, which could expose the key.

This change removes the key from the URL and sends it in Google's dedicated authentication header instead. ZeroClaw also marks the header as sensitive and rejects values that cannot safely be used in a header.

Nothing else about transcription changes.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. A live vendor check requires a real Google project credential; request-level regressions cover credential placement without sending one.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on exact head `436b147d34`. `Test`, `Lint`, `Check (default features, all targets)`, and `MSRV (declared floor)` cover the changed channels crate and workspace integration; `Security` and `Semgrep` cover the credential-transport surface.
- **Known CI coverage gap, if any:** No live Google Speech-to-Text request verifies vendor acceptance with a real project credential. Google documents `x-goog-api-key` as the header form of its API-key system parameter.
- **Commands run and tail output:**

  ```text
  cargo test -p zeroclaw-channels google_stt_request_
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1425 filtered out

  cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo]

  rustfmt --edition 2024 --check crates/zeroclaw-channels/src/transcription.rs
  # no output; exit 0

  git diff --check
  # no output; exit 0

  bash scripts/ci/comment_hygiene_gate.sh
  Comment hygiene gate passed.
  ```

- **Beyond CI, what did you manually verify?** Inspected the built request to confirm the credential is absent from the URL, present only in a sensitive `x-goog-api-key` header, and omitted from malformed-header errors. I also verified that the JSON body, timeout, runtime proxy client, and response path remain unchanged. No live Google request was made.
- **Visual interface changed?** N/A. This PR changes HTTP credential transport only.
- **If any command was intentionally skipped, why:** A live Google Speech-to-Text call was skipped to avoid requiring or exposing a real credential.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any **Yes**, describe the risk and mitigation: The Google STT API key moves from a URL query parameter to Google's dedicated header. The header is marked sensitive, malformed values are rejected before dispatch, fixed error text does not echo the key, and request tests verify that URLs remain credential-free.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: Not applicable.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged commit>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Google STT transcription requests return authentication failures such as HTTP 401 or 403 while other transcription providers continue to work.
