### PR TITLE
ci(perf): path-gate four non-Rust jobs so pure-Rust PRs skip them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,9 +725,70 @@ jobs:
       - name: Run cargo audit (RustSec advisory database)
         run: cargo audit
 
+  # Detect which non-Rust job families a PR actually touches, so a pure-Rust
+  # PR does not spin runners it cannot affect. Cheap and always-on; forces every
+  # family true on push / merge_group so master cache-warming and the required
+  # gate keep exercising the full set. A path-skipped job leaves `CI Required
+  # Gate` green (it only trips on failure/cancelled), and this detector is never
+  # skipped, so a job that should run never is.
+  path-changes:
+    name: Detect changed paths
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      nix: ${{ steps.filter.outputs.nix }}
+      nix_hash: ${{ steps.filter.outputs.nix_hash }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Non-PR events (push to master, merge_group) always run every gated
+          # job: warms caches and keeps the required gate exercising the full set.
+          case "${{ github.event_name }}" in
+            pull_request) ;;
+            *)
+              {
+                echo "docs=true"
+                echo "nix=true"
+                echo "nix_hash=true"
+                echo "web=true"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          changed="$(mktemp)"
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD > "$changed"
+
+          emit() {
+            local name="$1" pattern="$2"
+            if grep -Eq "$pattern" "$changed"; then
+              echo "${name}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "${name}=false" >> "$GITHUB_OUTPUT"
+            fi
+          }
+
+          # Any change to this workflow re-runs all gated families.
+          wf='^\.github/workflows/ci\.yml$'
+          emit docs     "\.mdx?$|^docs/|^\.markdownlint-cli2\.yaml$|^scripts/ci/docs_(quality_gate|links_gate)\.sh$|${wf}"
+          emit nix      "\.nix$|^flake\.(nix|lock)$|^nix/|${wf}"
+          emit nix_hash "(^|/)Cargo\.(toml|lock)$|^nix/hashes\.json$|^scripts/ci/list_git_dep_keys\.py$|${wf}"
+          emit web      "^web/|^\.nvmrc$|${wf}"
+
   nix-eval:
     name: Nix Module Eval
-    needs: [fmt]
+    needs: [path-changes]
+    if: needs.path-changes.outputs.nix == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -741,7 +802,8 @@ jobs:
 
   nix-hash-drift:
     name: Nix Hash Drift
-    needs: [fmt]
+    needs: [path-changes]
+    if: needs.path-changes.outputs.nix_hash == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -782,7 +844,8 @@ jobs:
 
   docs-style:
     name: Docs Style
-    needs: [fmt]
+    needs: [path-changes]
+    if: needs.path-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -862,7 +925,8 @@ jobs:
 
   web-permission-tests:
     name: Web Permission Tests
-    needs: [fmt]
+    needs: [path-changes]
+    if: needs.path-changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -889,7 +953,7 @@ jobs:
   gate:
     name: CI Required Gate
     if: always()
-    needs: [fmt, repo-structure, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-plugin-backends, msrv, check-32bit, bench, test, parallel-runtime-test-changes, parallel-runtime-test, test-landlock, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
+    needs: [fmt, repo-structure, path-changes, lint, windows-clippy-tools-changes, windows-clippy-tools, build, check, check-plugin-backends, msrv, check-32bit, bench, test, parallel-runtime-test-changes, parallel-runtime-test, test-landlock, security, nix-eval, nix-hash-drift, docs-style, installer-drift, zerocode-rpc-boundary, web-permission-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check results


### PR DESCRIPTION
## Summary

- **What changed and why:** Adds a single always-on `path-changes` detector job that classifies a PR's changed files into four families (`docs`, `nix`, `nix_hash`, `web`) and gates four **non-Rust, file-scoped** jobs on the matching family: `docs-style`, `nix-eval`, `nix-hash-drift`, `web-permission-tests`. A pure-Rust PR no longer spins these four GitHub-hosted runners it cannot affect.
- **Motivation:** CI critical-path / per-PR scope reduction (see #7108). These four jobs validate only specific file families (markdown/docs, Nix expressions, `nix/hashes.json` vs `Cargo.lock` git-deps, and `web/` TS logic) and cannot be affected by a Rust-only change.
- **Pattern:** follows the repo's existing change-detector idiom (`windows-clippy-tools-changes`, `parallel-runtime-test-changes`) — one **consolidated** detector with four boolean outputs rather than four separate detector jobs.
- **On `push` / `merge_group`:** every family is forced `true`, so master cache-warming and the required gate keep exercising the full set. Pruning only happens on PR runs.
- **Scope boundary:** one detector job + four `needs:`/`if:` gates + adding `path-changes` to `gate.needs`. No change to any Rust correctness gate.
- **Allowlist impact:** none — the detector reuses `actions/checkout` (already allowlisted); no new `uses:` source.
- **Related:** #7108.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` — because this PR edits `.github/workflows/ci.yml`, the detector's workflow-file rule forces all four families `true`, so all four gated jobs run on this PR (exercises the "everything runs" direction and the new detector). The skip direction is exercised whenever a later Rust-only PR shows these four jobs `skipped` while the required gate stays green.
- **Interface(s) exercised:** CI infrastructure only.

### How I tested

```sh
$ actionlint .github/workflows/ci.yml    # clean (exit 0)
$ ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml")'   # YAML OK
```

- **Detector regex unit test (local):** ran each of the four patterns against representative paths.
  - `crates/**/*.rs` (pure Rust) → docs=F nix=F nix_hash=F web=F (all four skip) ✓
  - `docs/**/*.md`, `README.md`, `.markdownlint-cli2.yaml` → docs ✓
  - `flake.nix`, `nix/**` → nix ✓
  - `Cargo.lock`, `crates/**/Cargo.toml`, `nix/hashes.json` → nix_hash ✓
  - `web/**`, `.nvmrc` → web ✓
  - `.github/workflows/ci.yml` → all four ✓ (no false-skips)
- **Required-gate safety:** `CI Required Gate` (`if: always()`) trips only on `failure`/`cancelled`. A path-skipped job resolves to `skipped` (leaves the gate green — no false block), and the detector is always-on and never skipped, so a job that *should* run is never skipped (no false pass). A per-job detector is used rather than workflow-level `paths:` precisely so the required gate always runs and reports.
- **`web-permission-tests` scope check:** verified its steps run entirely inside `web/` (`npm ci` + jiti/node tests over `web/src/**`) and read no Rust source, so `web/**` + `.nvmrc` is complete for what it validates.

- **If any command was intentionally skipped, why:** `cargo *` — no Rust/source change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A — pure CI-orchestration change; the detector only reads the PR's changed-file list via `git diff --name-only`.

## Compatibility (required)

- Backward compatible? `Yes` — no behavior change on `push`/`merge_group` (all families forced true); only PR runs prune.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` restores the four jobs to `needs: [fmt]` unconditionally. No state to migrate; the detector is purely additive.
- **Feature flags or config toggles:** none.
- **Observable failure symptoms:** a job that should have run is skipped (would surface as an unexpected regression landing on `master`, where all families run anyway), or the detector misclassifies a path.
