### PR TITLE
fix(release): stop the experimental Android leg from blocking releases

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -777,7 +777,12 @@ jobs:
             "zeroclaw-arm-unknown-linux-gnueabihf.tar.gz"
             "zeroclaw-aarch64-apple-darwin.tar.gz"
             "zeroclaw-x86_64-apple-darwin.tar.gz"
-            "zeroclaw-aarch64-linux-android.tar.gz"
+            # aarch64-linux-android is experimental (continue-on-error): it is
+            # attached to the release when it builds (matched by the zeroclaw-*
+            # artifact download above) but must not block publish when the
+            # allowed-to-fail leg fails. Treated like the desktop-linux/windows
+            # bundles. Promote it back into required_assets only when the
+            # Android build leg drops `experimental: true`.
             "zeroclaw-x86_64-pc-windows-msvc.zip"
             "ZeroClaw.dmg"
             "zeroclaw-${TAG}-sbom.spdx.json"


### PR DESCRIPTION
## Summary

- **What changed and why:** The `aarch64-linux-android` release build leg is `experimental` (`continue-on-error: ${{ matrix.experimental || false }}`, release-stable-manual.yml), so it is **allowed to fail** — but `zeroclaw-aarch64-linux-android.tar.gz` was listed in the `publish` job's `required_assets`. A failed (permitted) Android build therefore left the asset missing and hard-failed the "Verify required release assets" step, **blocking the entire release**. A nominally-optional target could kill a release.
- **Fix:** remove Android from `required_assets` so it is treated like the other `continue-on-error` legs (`desktop-linux`/`desktop-windows`) — still attached to the release when it builds (matched by the `pattern: zeroclaw-*` artifact download) but never blocking when the allowed-to-fail leg fails. An inline comment records how to promote it back once the leg drops `experimental: true`.
- **Found by:** the CI/release-process review (related #7108).
- **Scope boundary:** one entry removed from the `required_assets` array in `release-stable-manual.yml` + an explanatory comment. No change to the build matrix, the artifact download, or the attach logic.
- **Allowlist impact:** none — no `uses:` source added or changed.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes (release-only)` — this workflow runs on `workflow_dispatch` / a `v*` tag, not on PR CI. Behavior to confirm on the next release: when the Android leg fails, `publish` no longer fails "Verify required release assets" for the missing Android asset; when Android succeeds, the tarball is still downloaded via `pattern: zeroclaw-*` and attached.
- **Interface(s) exercised:** release CI only.

### How I tested

```sh
$ actionlint .github/workflows/release-stable-manual.yml   # exit 0
$ ruby -ryaml -e 'YAML.load_file(".github/workflows/release-stable-manual.yml")'   # YAML OK
```

- Verified the `required_assets` bash array still parses with the inline comment and drops from 13 → 12 entries.
- Confirmed Android is no longer referenced in `required_assets` (`grep -c` = 0) and is still matched by the always-present `pattern: zeroclaw-*` download step (so it is attached when built).
- `actionlint` is clean (exit 0); the only reported items are pre-existing `info`-level shellcheck notes at unrelated lines (831, 910), untouched by this change.
- **If any command was intentionally skipped, why:** `cargo *` / PR CI — this is a release-only workflow with no Rust/source change.

### Known coverage gap

The release workflow only runs on dispatch/tag, so full end-to-end validation lands on the next release. The change is a pure removal from a verification allowlist plus a comment, with no effect on the success path.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A — removes one entry from a release-asset verification list.

## Compatibility (required)

- Backward compatible? `Yes` — when Android builds, nothing changes (still attached); when it fails, the release now proceeds instead of hard-failing, which is the intended `experimental`/`continue-on-error` behavior.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` restores `zeroclaw-aarch64-linux-android.tar.gz` to `required_assets`. No state to migrate.
- **Feature flags or config toggles:** none.
- **Observable failure symptoms:** a release ships without the Android asset even though the leg succeeded (would indicate a download/attach regression unrelated to this verification-list change).
