### PR TITLE
fix(release): cache the Windows release build

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -272,8 +272,11 @@ jobs:
         with:
           toolchain: 1.96.1
           targets: ${{ matrix.target }}
+      # Cache every target, including Windows. CI's Windows Clippy job caches the
+      # same x86_64-pc-windows-msvc target with this exact action, so there is no
+      # Windows-specific reason to recompile the release build from scratch each
+      # time. The per-(os, target) prefix keeps each leg's cache isolated.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        if: runner.os != 'Windows'
         with:
           prefix-key: ${{ matrix.os }}-${{ matrix.target }}
 


### PR DESCRIPTION
## Summary

- **What changed and why:** The release build's `rust-cache` step was guarded with `if: runner.os != 'Windows'`, so the `x86_64-pc-windows-msvc` leg recompiled from scratch on **every release** while every other target restored its cache. The guard was a stale carry-over from an earlier workflow refactor (`df4e11bd1`, "rename workflow files"), with no Windows-specific rationale in its history.
- **Fix:** remove the guard so Windows caches like the other targets, using its own `prefix-key: ${{ matrix.os }}-${{ matrix.target }}` (each leg's cache stays isolated).
- **Why it's safe:** CI's `windows-clippy-tools` job (ci.yml) already caches the same `x86_64-pc-windows-msvc` target with this exact `Swatinem/rust-cache@v2.9.2` and **no** guard — proving Windows caching works. Worst case here is a cache miss, which is the current behavior; there is no correctness impact (it is a build cache).
- **Found by:** the CI/release-process review (related #7108).
- **Scope boundary:** removes one `if:` line and adds an explanatory comment in `release-stable-manual.yml`. No matrix, build, or artifact change.
- **Allowlist impact:** none — `Swatinem/rust-cache` is already used (and allowlisted); no new `uses:` source.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes (release-only)` — this workflow runs on `workflow_dispatch` / a `v*` tag, not on PR CI. On the next release, the Windows build leg restores/saves a cache under `windows-latest-x86_64-pc-windows-msvc-*` instead of a cold compile; subsequent releases show the reduced Windows build time.
- **Interface(s) exercised:** release CI only.

### How I tested

```sh
$ actionlint .github/workflows/release-stable-manual.yml   # exit 0
$ ruby -ryaml -e 'YAML.load_file(".github/workflows/release-stable-manual.yml")'   # YAML OK
```

- Confirmed the `if: runner.os != 'Windows'` guard is removed and the `prefix-key` (which isolates each leg's cache) is unchanged.
- Cross-checked against CI: the `windows-clippy-tools` job caches the same Windows target with the same action and version and no guard, so the Windows-exclusion here was an oversight, not a workaround.
- **If any command was intentionally skipped, why:** `cargo *` / PR CI — release-only workflow, no Rust/source change.

### Known coverage gap

The release workflow only runs on dispatch/tag, so the actual cache hit/miss lands on the next release. The change only adds caching to an existing build step.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` new ones (the cache action already runs on every other target).
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A — enables an existing build cache for one more matrix leg.

## Compatibility (required)

- Backward compatible? `Yes` — the cache is additive; a miss reproduces the current cold-compile behavior, a hit is strictly faster.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>` restores the `if: runner.os != 'Windows'` guard.
- **Feature flags or config toggles:** none.
- **Observable failure symptoms:** a Windows release build behaves unexpectedly due to a stale cache (mitigated by the per-`(os, target)` prefix key and by `rust-cache`'s lockfile/rustc-versioned keying, same as every other leg).
