### PR TITLE
fix(config): accept exact transcription proxy selectors (#10106)

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -52,6 +52,11 @@ const SUPPORTED_PROXY_SERVICE_KEYS: &[&str] = &[
     "memory.embeddings",
     "tunnel.custom",
     "transcription.groq",
+    "transcription.openai",
+    "transcription.deepgram",
+    "transcription.assemblyai",
+    "transcription.google",
+    "transcription.local_whisper",
 ];
 
 const SUPPORTED_PROXY_SERVICE_SELECTORS: &[&str] = &[
@@ -32030,6 +32035,32 @@ api_token = "tok"
 
         let error = proxy.validate().unwrap_err().to_string();
         assert!(error.contains("proxy.scope='services'"));
+    }
+
+    #[test]
+    async fn proxy_config_accepts_transcription_service_selectors() {
+        let mut proxy = ProxyConfig {
+            enabled: true,
+            http_proxy: Some("http://127.0.0.1:7890".into()),
+            scope: ProxyScope::Services,
+            ..ProxyConfig::default()
+        };
+
+        for selector in [
+            "transcription.groq",
+            "transcription.openai",
+            "transcription.deepgram",
+            "transcription.assemblyai",
+            "transcription.google",
+            "transcription.local_whisper",
+            "transcription.*",
+        ] {
+            proxy.services = vec![selector.to_string()];
+            assert!(
+                proxy.validate().is_ok(),
+                "exact transcription selector `{selector}` should validate"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Allow exact `proxy.services` selectors for the six transcription backends already used by the runtime: Groq, OpenAI, Deepgram, AssemblyAI, Google, and local Whisper.
  - Keep the existing `transcription.*` wildcard selector and the existing validation semantics unchanged.
  - Add a regression test through `ProxyConfig::validate()` covering all six exact keys and the wildcard selector.
- **Scope boundary:** This changes only the service-selector allowlist and its validation coverage. It does not change transcription providers, proxy transport, credentials, endpoints, or environment-variable handling.
- **Blast radius:** Configurations using `proxy.scope = "services"` can now select the transcription service keys that the runtime already supports. Existing valid configurations and wildcard behavior are unchanged.
- **Linked issue(s):** Fixes #10106
- **Labels:** `bug`, `config`, `risk:medium`, `size:XS`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — no separate UI or manual workflow adds signal beyond the config validation boundary test.

### How I tested

- **CI checks relied on and why they cover this change:** The exact-head GitHub Quality Gate run 32625429847 passed, including the required gate, MSRV, lint, build, and test jobs that cover the changed configuration crate and workspace integration surface. Local Rust formatting, focused configuration-crate tests, and workspace Clippy provide additional boundary evidence.
- **Known CI coverage gap, if any:** None identified for this single-crate validation change.
- **Commands run and tail output:** These local commands were run on pre-rebase head `6cbddf0fdc4ef0ba2ca9cf4276a20f0568e9a8c7`. Current head `20e6d12b75793191c7b71b84d3d58a7d4460c855` has the same stable patch ID, and its required CI gate is green.

```text
$ cargo fmt --all -- --check
# passed with no output

$ git diff --check origin/master...HEAD
# passed with no output

$ cargo test --locked -p zeroclaw-config --all-targets --all-features
# 1,385 unit + 8 comment-writer + 90 migration + 5 mDNS + 9 PowerShell
# policy + 1 repro + 1 schema regression test; all passed

$ cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Finished `dev` profile; no warnings or errors

$ cargo test --locked -p zeroclaw-config --lib schema::tests::proxy_config_accepts_transcription_service_selectors -- --exact --nocapture
test schema::tests::proxy_config_accepts_transcription_service_selectors ... ok
test result: ok. 1 passed; 0 failed; 1383 filtered out
```

- **Before/after evidence:** Before this change, the exact selectors for OpenAI, Deepgram, AssemblyAI, Google, and local Whisper were rejected by the allowlist; after this change, the boundary test accepts them and still accepts `transcription.*`.
- **Beyond CI, what did you manually verify?** The allowlist matches the transcription service keys used by the runtime providers, and the test exercises the real `ProxyConfig::validate()` boundary for each exact key plus `transcription.*`; no network calls, credentials, or external services were used.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Full workspace preflight is run separately before the approval gate.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.

## Compatibility

- Backward compatible? Yes.
- Config / env / CLI surface changed? Yes — the existing `proxy.services` field keeps the same shape, but its accepted selector value domain now includes runtime transcription keys that were previously rejected by validation.
- Rust/MSRV/toolchain floor changed? No.
- **Upgrade steps for existing users:** N/A — no migration or config rewrite is required.

## Rollback

- **Fast rollback command/path:** `git revert 20e6d12b757`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Service-scoped proxy configurations using a transcription key could again fail validation with an unsupported-selector error; the regression test would fail if the allowlist is removed.
