### PR TITLE
perf(release): stop compiling release tools from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Test monthly outdated result classification
         run: bash scripts/ci/monthly_outdated_result.test.sh
 
+      - name: Test release tool installer mappings
+        run: bash scripts/ci/install_release_tool.test.sh
+
       - name: Guard release attestation contract
         run: python3 scripts/ci/release_attestation_contract_test.py
 

--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install cross (MUSL targets)
         if: matrix.use_cross
-        run: cargo install cross --version 0.2.5 --locked
+        run: bash scripts/ci/install_release_tool.sh cross
 
       - name: Setup Android NDK
         if: matrix.ndk

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -293,7 +293,7 @@ jobs:
 
       - name: Install cross (MUSL targets)
         if: matrix.use_cross
-        run: cargo install cross --version 0.2.5 --locked
+        run: bash scripts/ci/install_release_tool.sh cross
 
       - name: Setup Android NDK
         if: matrix.ndk
@@ -407,7 +407,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli --locked
+        run: bash scripts/ci/install_release_tool.sh tauri-cli
 
       - name: Sync Tauri version with Cargo.toml
         shell: bash
@@ -604,7 +604,7 @@ jobs:
           prefix-key: linux-tauri
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli --locked
+        run: bash scripts/ci/install_release_tool.sh tauri-cli
 
       - name: Sync Tauri version with Cargo.toml
         shell: bash
@@ -653,7 +653,8 @@ jobs:
           prefix-key: windows-tauri
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli --locked
+        shell: bash
+        run: bash scripts/ci/install_release_tool.sh tauri-cli
 
       - name: Sync Tauri version with Cargo.toml
         shell: bash

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -140,6 +140,11 @@ First triage step for a new issue: check if the reported outdated crates have se
 
 Manual trigger for building release binaries across the full target matrix: Linux x86_64/aarch64 GNU and MUSL plus armv7 and arm hard-float, macOS Intel/ARM, Windows x86_64, and `aarch64-linux-android` (built with the NDK). Use this to verify a branch compiles cleanly on non-Linux targets before tagging.
 
+MUSL legs install `cross` through `scripts/ci/install_release_tool.sh`, which
+downloads the exact pinned upstream release asset and verifies its SHA-256
+before installing it. The required Repository Structure job tests the supported
+runner-to-asset mapping without making network calls.
+
 ### Cross-Platform Clippy (`cross-platform-clippy.yml`)
 
 Manual and weekly scheduled advisory lint coverage on macOS aarch64 and Windows x86_64 targets. It mirrors the required PR lint command with `--target` set for each platform, but intentionally does not run on PRs and is not part of `CI Required Gate`.
@@ -156,6 +161,13 @@ both SBOM formats are checksummed and attested before the release is created.
 Cosign remains limited to GHCR image signing.
 
 See the [Release Runbook](./release-runbook.md) for the full procedure.
+
+Release-only build tools do not compile from source on every run. The workflow
+installs pinned upstream `cross` and Tauri CLI release binaries through
+`scripts/ci/install_release_tool.sh`; that script verifies a repository-owned
+SHA-256 for each runner-specific archive before placing the binary in Cargo's
+bin directory. Updating either tool requires updating its version, asset name,
+and checksum together, then running `scripts/ci/install_release_tool.test.sh`.
 
 ### Package Publishers
 

--- a/scripts/ci/install_release_tool.sh
+++ b/scripts/ci/install_release_tool.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/ci/install_release_tool.sh <cross|tauri-cli> [--print-manifest]
+
+Installs a SHA-256-pinned release binary into Cargo's bin directory. The
+--print-manifest mode resolves the runner-specific asset without downloading it
+and is used by install_release_tool.test.sh.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+normalize_os() {
+  local raw="${ZEROCLAW_RELEASE_TOOL_OS:-${RUNNER_OS:-}}"
+  if [[ -z "$raw" ]]; then
+    raw="$(uname -s)"
+  fi
+
+  case "$raw" in
+    Linux*) echo "linux" ;;
+    Darwin|macOS) echo "macos" ;;
+    Windows|MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+    *) die "unsupported operating system: $raw" ;;
+  esac
+}
+
+normalize_arch() {
+  local raw="${ZEROCLAW_RELEASE_TOOL_ARCH:-${RUNNER_ARCH:-}}"
+  if [[ -z "$raw" ]]; then
+    raw="$(uname -m)"
+  fi
+
+  case "$raw" in
+    X64|x86_64|amd64) echo "x86_64" ;;
+    ARM64|aarch64|arm64) echo "aarch64" ;;
+    *) die "unsupported architecture: $raw" ;;
+  esac
+}
+
+sha256_file() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{ print $1 }'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$path" | awk '{ print $NF }'
+  else
+    die "sha256sum, shasum, or openssl is required to verify release tools"
+  fi
+}
+
+extract_archive() {
+  local archive="$1"
+  local destination="$2"
+
+  case "$archive" in
+    *.tar.gz|*.tgz)
+      tar -xzf "$archive" -C "$destination"
+      ;;
+    *.zip)
+      if command -v unzip >/dev/null 2>&1; then
+        unzip -q "$archive" -d "$destination"
+      elif command -v 7z >/dev/null 2>&1; then
+        7z x -y "-o${destination}" "$archive" >/dev/null
+      else
+        die "unzip or 7z is required to extract $archive"
+      fi
+      ;;
+    *) die "unsupported archive format: $archive" ;;
+  esac
+}
+
+tool="${1:-}"
+mode="${2:-}"
+if [[ -z "$tool" ]] || [[ "$mode" != "" && "$mode" != "--print-manifest" ]] || [[ $# -gt 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+os="$(normalize_os)"
+arch="$(normalize_arch)"
+
+case "$tool" in
+  cross)
+    version="0.2.5"
+    tag="v${version}"
+    repository="cross-rs/cross"
+    primary_binary="cross"
+    binaries=("cross" "cross-util")
+    case "${os}/${arch}" in
+      linux/x86_64)
+        asset="cross-x86_64-unknown-linux-gnu.tar.gz"
+        sha256="642375d1bcf3bd88272c32ba90e999f3d983050adf45e66bd2d3887e8e838bad"
+        ;;
+      *) die "cross ${version} is not pinned for ${os}/${arch}" ;;
+    esac
+    ;;
+  tauri-cli)
+    version="2.11.4"
+    tag="tauri-cli-v${version}"
+    repository="tauri-apps/tauri"
+    case "${os}/${arch}" in
+      linux/x86_64)
+        asset="cargo-tauri-x86_64-unknown-linux-gnu.tgz"
+        primary_binary="cargo-tauri"
+        binaries=("cargo-tauri")
+        sha256="6864602a34292aa6f2ad40ae019eebe5c1064d6c623fe20696a8a8974067e60b"
+        ;;
+      macos/x86_64)
+        asset="cargo-tauri-x86_64-apple-darwin.zip"
+        primary_binary="cargo-tauri"
+        binaries=("cargo-tauri")
+        sha256="f10dfcc103ccb79248ca27cb9aff7b8a65499d1b0df79fe0465e8aa0a8e7cbef"
+        ;;
+      macos/aarch64)
+        asset="cargo-tauri-aarch64-apple-darwin.zip"
+        primary_binary="cargo-tauri"
+        binaries=("cargo-tauri")
+        sha256="82bdcb9ae7f407882321680ae50750f11623fae22445f8b00b096e10f815d604"
+        ;;
+      windows/x86_64)
+        asset="cargo-tauri-x86_64-pc-windows-msvc.zip"
+        primary_binary="cargo-tauri.exe"
+        binaries=("cargo-tauri.exe")
+        sha256="0743e30a661a35d63339b24cf63828f97ba5389a1d7f13b368a542794dd0a3f3"
+        ;;
+      *) die "tauri-cli ${version} is not pinned for ${os}/${arch}" ;;
+    esac
+    ;;
+  *)
+    usage >&2
+    die "unknown release tool: $tool"
+    ;;
+esac
+
+url="https://github.com/${repository}/releases/download/${tag}/${asset}"
+
+if [[ "$mode" == "--print-manifest" ]]; then
+  binaries_csv="$(IFS=,; echo "${binaries[*]}")"
+  printf 'tool=%s\nversion=%s\nos=%s\narch=%s\nasset=%s\nprimary_binary=%s\nbinaries=%s\nsha256=%s\nurl=%s\n' \
+    "$tool" "$version" "$os" "$arch" "$asset" "$primary_binary" "$binaries_csv" "$sha256" "$url"
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+archive="${tmp_dir}/${asset}"
+extract_dir="${tmp_dir}/extract"
+mkdir -p "$extract_dir"
+
+echo "Downloading ${tool} ${version} for ${os}/${arch}"
+curl --fail --location --silent --show-error \
+  --connect-timeout 15 --max-time 120 --retry 3 --retry-all-errors \
+  --proto '=https' --tlsv1.2 \
+  "$url" -o "$archive"
+
+actual_sha256="$(sha256_file "$archive")"
+if [[ "$actual_sha256" != "$sha256" ]]; then
+  die "checksum mismatch for $asset (expected $sha256, got $actual_sha256)"
+fi
+
+extract_archive "$archive" "$extract_dir"
+
+cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
+if command -v cygpath >/dev/null 2>&1; then
+  cargo_home="$(cygpath -u "$cargo_home")"
+fi
+install_dir="${cargo_home}/bin"
+mkdir -p "$install_dir"
+for binary in "${binaries[@]}"; do
+  source_binary="${extract_dir}/${binary}"
+  [[ -f "$source_binary" ]] || die "$binary was not present in $asset"
+  cp "$source_binary" "${install_dir}/${binary}"
+  chmod +x "${install_dir}/${binary}"
+done
+
+"${install_dir}/${primary_binary}" --version

--- a/scripts/ci/install_release_tool.sh
+++ b/scripts/ci/install_release_tool.sh
@@ -143,7 +143,13 @@ esac
 url="https://github.com/${repository}/releases/download/${tag}/${asset}"
 
 if [[ "$mode" == "--print-manifest" ]]; then
-  binaries_csv="$(IFS=,; echo "${binaries[*]}")"
+  binaries_csv=""
+  for binary in "${binaries[@]}"; do
+    if [[ -n "$binaries_csv" ]]; then
+      binaries_csv+=","
+    fi
+    binaries_csv+="$binary"
+  done
   printf 'tool=%s\nversion=%s\nos=%s\narch=%s\nasset=%s\nprimary_binary=%s\nbinaries=%s\nsha256=%s\nurl=%s\n' \
     "$tool" "$version" "$os" "$arch" "$asset" "$primary_binary" "$binaries_csv" "$sha256" "$url"
   exit 0

--- a/scripts/ci/install_release_tool.test.sh
+++ b/scripts/ci/install_release_tool.test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${root_dir}/scripts/ci/install_release_tool.sh"
+
+assert_manifest() {
+  local tool="$1"
+  local os="$2"
+  local arch="$3"
+  local expected_version="$4"
+  local expected_asset="$5"
+  local expected_primary_binary="$6"
+  local expected_sha256="$7"
+  local expected_url="$8"
+  local expected_binaries="$9"
+  local manifest
+
+  manifest="$(
+    ZEROCLAW_RELEASE_TOOL_OS="$os" \
+      ZEROCLAW_RELEASE_TOOL_ARCH="$arch" \
+      bash "$installer" "$tool" --print-manifest
+  )"
+
+  grep -Fxq "tool=${tool}" <<<"$manifest"
+  grep -Fxq "version=${expected_version}" <<<"$manifest"
+  grep -Fxq "asset=${expected_asset}" <<<"$manifest"
+  grep -Fxq "primary_binary=${expected_primary_binary}" <<<"$manifest"
+  grep -Fxq "binaries=${expected_binaries}" <<<"$manifest"
+  grep -Fxq "sha256=${expected_sha256}" <<<"$manifest"
+  grep -Fxq "url=${expected_url}" <<<"$manifest"
+}
+
+assert_manifest \
+  cross Linux X64 \
+  0.2.5 \
+  cross-x86_64-unknown-linux-gnu.tar.gz \
+  cross \
+  642375d1bcf3bd88272c32ba90e999f3d983050adf45e66bd2d3887e8e838bad \
+  https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz \
+  cross,cross-util
+
+assert_manifest \
+  tauri-cli Linux X64 \
+  2.11.4 \
+  cargo-tauri-x86_64-unknown-linux-gnu.tgz \
+  cargo-tauri \
+  6864602a34292aa6f2ad40ae019eebe5c1064d6c623fe20696a8a8974067e60b \
+  https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.11.4/cargo-tauri-x86_64-unknown-linux-gnu.tgz \
+  cargo-tauri
+
+assert_manifest \
+  tauri-cli macOS X64 \
+  2.11.4 \
+  cargo-tauri-x86_64-apple-darwin.zip \
+  cargo-tauri \
+  f10dfcc103ccb79248ca27cb9aff7b8a65499d1b0df79fe0465e8aa0a8e7cbef \
+  https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.11.4/cargo-tauri-x86_64-apple-darwin.zip \
+  cargo-tauri
+
+assert_manifest \
+  tauri-cli macOS ARM64 \
+  2.11.4 \
+  cargo-tauri-aarch64-apple-darwin.zip \
+  cargo-tauri \
+  82bdcb9ae7f407882321680ae50750f11623fae22445f8b00b096e10f815d604 \
+  https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.11.4/cargo-tauri-aarch64-apple-darwin.zip \
+  cargo-tauri
+
+assert_manifest \
+  tauri-cli Windows X64 \
+  2.11.4 \
+  cargo-tauri-x86_64-pc-windows-msvc.zip \
+  cargo-tauri.exe \
+  0743e30a661a35d63339b24cf63828f97ba5389a1d7f13b368a542794dd0a3f3 \
+  https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.11.4/cargo-tauri-x86_64-pc-windows-msvc.zip \
+  cargo-tauri.exe
+
+if ZEROCLAW_RELEASE_TOOL_OS=Linux ZEROCLAW_RELEASE_TOOL_ARCH=ARM64 \
+  bash "$installer" cross --print-manifest >/dev/null 2>&1; then
+  echo "expected cross on Linux/ARM64 to fail closed" >&2
+  exit 1
+fi
+
+if bash "$installer" unknown-tool --print-manifest >/dev/null 2>&1; then
+  echo "expected an unknown release tool to fail closed" >&2
+  exit 1
+fi
+
+echo "release tool manifest tests passed"

--- a/xtask/src/generate/spec.rs
+++ b/xtask/src/generate/spec.rs
@@ -1617,6 +1617,17 @@ mod tests {
                 .unwrap();
         assert!(release.contains("features --selection dist --target \"${{ matrix.target }}\""));
         assert!(!release.contains("excluded_features"));
+        let cross_install = "- name: Install cross (MUSL targets)\n        if: matrix.use_cross\n        run: bash scripts/ci/install_release_tool.sh cross";
+        assert!(release.contains(cross_install));
+        assert!(!release.contains("cargo install cross"));
+        assert_eq!(
+            release
+                .matches("run: bash scripts/ci/install_release_tool.sh tauri-cli")
+                .count(),
+            3,
+            "all three desktop release jobs must use the pinned installer"
+        );
+        assert!(!release.contains("cargo install tauri-cli"));
 
         let manual = std::fs::read_to_string(
             root().join(".github/workflows/cross-platform-build-manual.yml"),
@@ -1641,9 +1652,8 @@ mod tests {
                 "- os: ubuntu-latest\n            target: {target}\n            use_cross: true"
             )));
         }
-        assert!(manual.contains(
-            "- name: Install cross (MUSL targets)\n        if: matrix.use_cross\n        run: cargo install cross --version 0.2.5 --locked"
-        ));
+        assert!(manual.contains(cross_install));
+        assert!(!manual.contains("cargo install cross"));
         assert!(manual.contains(
             "if [ \"${{ matrix.use_cross || 'false' }}\" = \"true\" ]; then\n              echo \"BUILD_CMD=cross build\""
         ));


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replace two `cargo install cross` builds and three independent `cargo install tauri-cli` builds with one repository-owned installer for pinned upstream release binaries.
  - Pin `cross` 0.2.5 and Tauri CLI 2.11.4 by exact asset name and SHA-256 for Linux x86_64, Windows x86_64, Intel macOS, and ARM64 macOS. Unsupported runner/platform pairs, missing binaries, and checksum mismatches fail closed before a release build starts.
  - Reuse the installer in Release Stable and Cross-Platform Build, test the complete runner-to-asset manifest in the required Repository Structure job, and document the update/trust contract for maintainers.
- **Scope boundary:** Does not change the release target matrix, Cargo feature selection, build commands, produced artifacts, signing/publishing permissions, or package destinations. Adds no third-party Action and requires no Actions allowlist change.
- **Blast radius:** Release Stable desktop and MUSL tool bootstrap plus the manual Cross-Platform Build MUSL legs. A bad pin stops that job during tool installation; it cannot silently fall back to an unverified binary or alter a published artifact.
- **Linked issue(s):** Related #7108.
- **Labels:** `ci`, `docs`, `scripts`, `type:ci`, `risk:high`, `size:M`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the offline manifest test covers every supported runner mapping, and the focused installer smoke below exercises the real download/checksum/extract/install boundary without requiring a release dispatch.

### How I tested

```sh
$ bash -n scripts/ci/install_release_tool.sh scripts/ci/install_release_tool.test.sh
$ shellcheck scripts/ci/install_release_tool.sh scripts/ci/install_release_tool.test.sh
$ bash scripts/ci/install_release_tool.test.sh
release tool manifest tests passed

$ ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p) }' \
    .github/workflows/ci.yml \
    .github/workflows/release-stable-manual.yml \
    .github/workflows/cross-platform-build-manual.yml

$ actionlint .github/workflows/ci.yml \
    .github/workflows/cross-platform-build-manual.yml
# exit 0

$ DOCS_FILES=docs/book/src/maintainers/ci-and-actions.md \
    BASE_SHA=$(git rev-parse upstream/master) \
    bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Summary: 0 error(s)
```

The current Release Stable workflow and `master` both report the same four pre-existing ShellCheck info findings (`SC2016` and `SC2094`) in unrelated attestation/checksum steps; this diff adds none.

Current-head follow-up on signed fix `d25cff03e`:

- The initial Test run exposed a stale architecture assertion for the old `cargo install cross` step. The contract now requires the pinned installer in both workflows, requires all three desktop Tauri call sites, and rejects the old source-install forms.
- GitHub Advanced Security flagged `IFS=,` in manifest formatting. The formatter now uses an explicit join loop with no `IFS` assignment; fresh `Semgrep` and `Semgrep OSS` checks pass.
- The first fresh run was cancelled in the pre-existing unbounded apt setup before Lint/Test executed. The authorized failed-job rerun on the same head completed successfully: all 42 reported checks pass, including `Test` and `CI Required Gate`.

End-to-end macOS ARM64 smoke with a temporary Cargo home:

```sh
$ CARGO_HOME="$tmp" bash scripts/ci/install_release_tool.sh tauri-cli
Downloading tauri-cli 2.11.4 for macos/aarch64
tauri-cli 2.11.4
$ file "$tmp/bin/cargo-tauri"
Mach-O 64-bit executable arm64
```

The Intel macOS asset also executes under Rosetta and reports `tauri-cli 2.11.4`. I downloaded all five official archives, matched the pinned SHA-256 values, and inspected their contents (`cross`, `cross-util`, `cargo-tauri`, or `cargo-tauri.exe` as applicable). Historical Release Stable run 30764737521 confirms the live desktop runner families used by the mapping: `ubuntu-22.04`, `windows-2025-vs2026`, and `macos-14-arm64`.

- **CI checks relied on and why they cover this change:** `Repository Structure` executes `install_release_tool.test.sh` on every Quality Gate run. Workflow syntax and the required aggregate remain covered by `CI Required Gate`.
- **Known CI coverage gap, if any:** PR CI does not dispatch Release Stable or the manual Cross-Platform Build. Linux `cross` and Windows Tauri execution therefore remain validated by archive inspection plus fail-closed manifest tests until the next trusted manual/release run exercises those exact binaries.
- **Commands run and tail output:** See above. Fresh PR CI on `d25cff03e`: 42 pass, 1 CodeQL check skipped; `Test`, both Semgrep checks, and `CI Required Gate` pass.
- **Beyond CI, what did you manually verify?** Verified the official GitHub release assets and SHA-256 pins, archive contents, ARM64 and Intel macOS binary execution, and the actual architectures from a prior release run. Confirmed `cargo install cross` currently installs both `cross` and `cross-util`; the replacement preserves both binaries.
- **Visual interface changed?** `N/A` — CI/release tooling only.
- **If any command was intentionally skipped, why:** Cargo workspace checks were skipped because no Rust source, manifest, feature set, or build command changed. A full release dispatch was not started because it can publish artifacts and requires protected environment approvals.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — tool installation moves from crates.io source resolution to exact release assets under `cross-rs/cross` and `tauri-apps/tauri` on GitHub. URLs, versions, asset names, and SHA-256 values are reviewed in-repository; downloads require HTTPS, use bounded retries/timeouts, and fail closed on any integrity or platform mismatch.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: The new binary-download boundary is limited to public official GitHub releases and pinned by repository-owned checksums. The installer extracts into a temporary directory, copies only named binaries into Cargo's bin directory, and runs the primary binary's version command before continuing.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — the platform override environment variables are test-only internals of the CI installer, not a product/operator surface.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this commit to restore the four `cargo install` call sites and remove the installer/test/doc additions.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Release/manual jobs stop at `Install cross` or `Install Tauri CLI` with `unsupported ...`, `checksum mismatch`, `was not present in ...`, download timeout, or a non-zero tool `--version`. No build or publish step runs after such a failure.
