### PR TITLE
refactor(native): audit unsafe platform boundaries

### DIFF
--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -178,6 +178,9 @@ fn set_dock_icon() {
     let data = NSData::with_bytes(icon_bytes);
     if let Some(image) = NSImage::initWithData(NSImage::alloc(), &data) {
         let app = NSApplication::sharedApplication(mtm);
+        // SAFETY: `mtm` proves this code is running on the AppKit main thread,
+        // and both `app` and `image` are live Objective-C objects for the
+        // duration of the message send.
         unsafe { app.setApplicationIconImage(Some(&image)) };
     }
 }

--- a/apps/tauri/src/macos/permissions.rs
+++ b/apps/tauri/src/macos/permissions.rs
@@ -6,6 +6,9 @@ use std::process::Command;
 
 // ── Accessibility ──────────────────────────────────────────────────────────
 
+// SAFETY: these declarations match the parameter-free Boolean signatures in
+// Apple's ApplicationServices accessibility API. The framework is linked by
+// name on macOS, the only target that compiles this module.
 #[link(name = "ApplicationServices", kind = "framework")]
 unsafe extern "C" {
     fn AXIsProcessTrusted() -> bool;
@@ -20,6 +23,9 @@ pub fn check_accessibility() -> &'static str {
 
 // ── Screen Recording ───────────────────────────────────────────────────────
 
+// SAFETY: these declarations match the parameter-free Boolean signatures in
+// Apple's CoreGraphics screen-capture permission API. The framework is linked
+// by name on macOS, the only target that compiles this module.
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {
     fn CGPreflightScreenCaptureAccess() -> bool;
@@ -119,6 +125,9 @@ print(result)
     }
 }
 
+// SAFETY: these declarations match the `IOHIDCheckAccess` and
+// `IOHIDRequestAccess` signatures in the macOS IOKit HID API; the request type
+// is the SDK-defined integer enum value passed by value.
 #[link(name = "IOKit", kind = "framework")]
 unsafe extern "C" {
     fn IOHIDCheckAccess(requestType: u32) -> u32;

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -1054,6 +1054,8 @@ mod connection_tests {
             std::thread::sleep(Duration::from_millis(10));
         };
 
+        // SAFETY: `owner.id()` is the live child PID returned by `spawn`; this
+        // test sends a standard signal and does not pass pointers across FFI.
         let signal_result = unsafe { libc::kill(owner.id() as libc::pid_t, libc::SIGTERM) };
         assert_eq!(
             signal_result,
@@ -1063,6 +1065,8 @@ mod connection_tests {
         );
         assert!(owner.wait().expect("wait signal owner").success());
 
+        // SAFETY: signal 0 performs a process-existence probe only; `daemon_pid`
+        // was parsed from the child helper's PID file and no pointers are used.
         let child_probe = unsafe { libc::kill(daemon_pid as libc::pid_t, 0) };
         assert_eq!(child_probe, -1, "spawned daemon pid {daemon_pid} survived");
         assert_eq!(

--- a/crates/aardvark-sys/src/lib.rs
+++ b/crates/aardvark-sys/src/lib.rs
@@ -19,10 +19,6 @@ const AA_I2C_NO_FLAGS: i32 = 0x00;
 /// Enable both onboard I2C pullup resistors (hardware v2+ only).
 const AA_I2C_PULLUP_BOTH: u8 = 0x03;
 
-fn initialized_device_count(reported: i32, capacity: usize) -> usize {
-    usize::try_from(reported).unwrap_or_default().min(capacity)
-}
-
 // ── Library loading ───────────────────────────────────────────────────────
 
 static AARDVARK_LIB: OnceLock<Option<Library>> = OnceLock::new();
@@ -56,18 +52,11 @@ fn lib() -> Option<&'static Library> {
                     continue;
                 }
                 tried_any = true;
-                // SAFETY: loading a native library runs code outside Rust's
-                // guarantees. These candidates are the configured or bundled
-                // Total Phase library, and the handle is retained for the
-                // process lifetime before any symbols are used.
                 match unsafe { Library::new(path) } {
                     Ok(lib) => {
                         // Verify the .so exports aa_c_version (Total Phase version gate).
                         // The .so exports c_aa_* symbols (not aa_*); aa_c_version is the
                         // one non-prefixed symbol used to confirm library identity.
-                        // SAFETY: the symbol name and no-argument `u32` ABI
-                        // match `aardvark.h`; this lookup is used only as an
-                        // identity/version gate while `lib` remains loaded.
                         let version_ok = unsafe {
                             lib.get::<unsafe extern "C" fn() -> u32>(b"aa_c_version\0").is_ok()
                         };
@@ -163,9 +152,6 @@ impl AardvarkHandle {
     /// Open a specific Aardvark adapter by port index.
     pub fn open_port(port: i32) -> Result<Self> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
-        // SAFETY: `c_aa_open` has the declared signature in `aardvark.h`, and
-        // `lib` is retained in the process-wide `OnceLock` for the call and
-        // the lifetime of every returned handle.
         let handle: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32) -> i32> = lib
                 .get(b"c_aa_open\0")
@@ -188,9 +174,6 @@ impl AardvarkHandle {
             return Vec::new();
         };
         let mut ports = [0u16; 16];
-        // SAFETY: the symbol signature matches `aardvark.h`; `ports` is a
-        // writable 16-element array and the same capacity is passed to C, so
-        // the vendor function cannot initialize beyond the allocation.
         let n: i32 = unsafe {
             let f: std::result::Result<Symbol<unsafe extern "C" fn(i32, *mut u16) -> i32>, _> =
                 lib.get(b"c_aa_find_devices\0");
@@ -202,15 +185,14 @@ impl AardvarkHandle {
                 }
             }
         };
-        let initialized = initialized_device_count(n, ports.len());
         eprintln!(
-            "[aardvark-sys] find_devices: c_aa_find_devices returned {n}, initialized ports={:?}",
-            &ports[..initialized]
+            "[aardvark-sys] find_devices: c_aa_find_devices returned {n}, ports={:?}",
+            &ports[..n.max(0) as usize]
         );
-        if initialized == 0 {
+        if n <= 0 {
             return Vec::new();
         }
-        let free: Vec<u16> = ports[..initialized]
+        let free: Vec<u16> = ports[..n as usize]
             .iter()
             .filter(|&&p| (p & AA_PORT_NOT_FREE) == 0)
             .copied()
@@ -224,9 +206,6 @@ impl AardvarkHandle {
     /// Enable I2C mode and set the bitrate (kHz).
     pub fn i2c_enable(&self, bitrate_khz: u32) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
-        // SAFETY: all three symbol signatures match `aardvark.h`; `self`
-        // keeps the positive, not-yet-closed adapter handle alive, and the
-        // calls pass only integer configuration values.
         unsafe {
             let configure: Symbol<unsafe extern "C" fn(i32, i32) -> i32> = lib
                 .get(b"c_aa_configure\0")
@@ -247,9 +226,6 @@ impl AardvarkHandle {
     /// Write `data` bytes to the I2C device at `addr`.
     pub fn i2c_write(&self, addr: u8, data: &[u8]) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
-        // SAFETY: the symbol signature matches `aardvark.h`, the adapter
-        // handle remains live through `&self`, and `data.as_ptr()` is valid
-        // for at least the `u16`-truncated byte count passed to the C API.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32, u16, i32, u16, *const u8) -> i32> = lib
                 .get(b"c_aa_i2c_write\0")
@@ -273,9 +249,6 @@ impl AardvarkHandle {
     pub fn i2c_read(&self, addr: u8, len: usize) -> Result<Vec<u8>> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
         let mut buf = vec![0u8; len];
-        // SAFETY: the symbol signature matches `aardvark.h`, the adapter
-        // handle remains live, and `buf.as_mut_ptr()` is writable for at
-        // least the `u16`-truncated byte count passed to the C API.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32, u16, i32, u16, *mut u8) -> i32> = lib
                 .get(b"c_aa_i2c_read\0")
@@ -307,20 +280,15 @@ impl AardvarkHandle {
         let Some(lib) = lib() else {
             return Vec::new();
         };
-        // SAFETY: this lookup uses the exact `aa_i2c_read` signature from
-        // `aardvark.h`, and the process-wide library handle remains loaded.
-        let symbol = unsafe {
-            lib.get::<unsafe extern "C" fn(i32, u16, i32, u16, *mut u8) -> i32>(b"c_aa_i2c_read\0")
-        };
-        let Ok(f) = symbol else {
+        let Ok(f): std::result::Result<
+            Symbol<unsafe extern "C" fn(i32, u16, i32, u16, *mut u8) -> i32>,
+            _,
+        > = (unsafe { lib.get(b"c_aa_i2c_read\0") }) else {
             return Vec::new();
         };
         let mut found = Vec::new();
         let mut buf = [0u8; 1];
         for addr in 0x08u16..=0x77 {
-            // SAFETY: `f` has the vendor-declared signature, the handle is
-            // live through `&self`, and `buf` is writable for the one byte
-            // requested by this probe.
             let ret = unsafe { f(self.handle, addr, AA_I2C_NO_FLAGS, 1, buf.as_mut_ptr()) };
             // ret > 0: bytes received → device ACKed
             // ret == 0: NACK → no device at this address
@@ -337,9 +305,6 @@ impl AardvarkHandle {
     /// Enable SPI mode and set the bitrate (kHz).
     pub fn spi_enable(&self, bitrate_khz: u32) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
-        // SAFETY: all three symbol signatures match `aardvark.h`; `self`
-        // keeps the positive adapter handle live, and only integer mode and
-        // bitrate values cross the FFI boundary.
         unsafe {
             let configure: Symbol<unsafe extern "C" fn(i32, i32) -> i32> = lib
                 .get(b"c_aa_configure\0")
@@ -364,9 +329,6 @@ impl AardvarkHandle {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
         let mut recv = vec![0u8; send.len()];
         // aa_spi_write(aardvark, out_num_bytes, data_out, in_num_bytes, data_in)
-        // SAFETY: the symbol signature matches `aardvark.h`; both slices stay
-        // alive for the call, and their pointers are valid for at least the
-        // `u16`-truncated lengths supplied to the vendor function.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32, u16, *const u8, u16, *mut u8) -> i32> = lib
                 .get(b"c_aa_spi_write\0")
@@ -393,9 +355,6 @@ impl AardvarkHandle {
     /// `value`: output state bitmask.
     pub fn gpio_set(&self, direction: u8, value: u8) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
-        // SAFETY: both symbol signatures match `aardvark.h`, the adapter
-        // handle remains live through `&self`, and the GPIO masks are passed
-        // by value with no raw pointers.
         unsafe {
             let dir_f: Symbol<unsafe extern "C" fn(i32, u8) -> i32> = lib
                 .get(b"c_aa_gpio_direction\0")
@@ -418,8 +377,6 @@ impl AardvarkHandle {
     /// Read the current GPIO pin states as a bitmask.
     pub fn gpio_get(&self) -> Result<u8> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
-        // SAFETY: `c_aa_gpio_get` has the declared `aardvark.h` signature and
-        // `self` keeps the positive adapter handle alive for the call.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32) -> i32> = lib
                 .get(b"c_aa_gpio_get\0")
@@ -437,9 +394,6 @@ impl AardvarkHandle {
 impl Drop for AardvarkHandle {
     fn drop(&mut self) {
         if let Some(lib) = lib() {
-            // SAFETY: the lookup uses the vendor-declared close signature;
-            // this handle was returned positive by `c_aa_open`, has not been
-            // closed elsewhere, and the library outlives this value.
             unsafe {
                 if let Ok(f) = lib.get::<unsafe extern "C" fn(i32) -> i32>(b"c_aa_close\0") {
                     f(self.handle);
@@ -452,13 +406,6 @@ impl Drop for AardvarkHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn device_count_is_bounded_by_the_initialized_output_buffer() {
-        assert_eq!(initialized_device_count(-1, 16), 0);
-        assert_eq!(initialized_device_count(3, 16), 3);
-        assert_eq!(initialized_device_count(17, 16), 16);
-    }
 
     #[test]
     fn find_devices_does_not_panic() {

--- a/crates/aardvark-sys/src/lib.rs
+++ b/crates/aardvark-sys/src/lib.rs
@@ -19,6 +19,10 @@ const AA_I2C_NO_FLAGS: i32 = 0x00;
 /// Enable both onboard I2C pullup resistors (hardware v2+ only).
 const AA_I2C_PULLUP_BOTH: u8 = 0x03;
 
+fn initialized_device_count(reported: i32, capacity: usize) -> usize {
+    usize::try_from(reported).unwrap_or_default().min(capacity)
+}
+
 // ── Library loading ───────────────────────────────────────────────────────
 
 static AARDVARK_LIB: OnceLock<Option<Library>> = OnceLock::new();
@@ -52,11 +56,18 @@ fn lib() -> Option<&'static Library> {
                     continue;
                 }
                 tried_any = true;
+                // SAFETY: loading a native library runs code outside Rust's
+                // guarantees. These candidates are the configured or bundled
+                // Total Phase library, and the handle is retained for the
+                // process lifetime before any symbols are used.
                 match unsafe { Library::new(path) } {
                     Ok(lib) => {
                         // Verify the .so exports aa_c_version (Total Phase version gate).
                         // The .so exports c_aa_* symbols (not aa_*); aa_c_version is the
                         // one non-prefixed symbol used to confirm library identity.
+                        // SAFETY: the symbol name and no-argument `u32` ABI
+                        // match `aardvark.h`; this lookup is used only as an
+                        // identity/version gate while `lib` remains loaded.
                         let version_ok = unsafe {
                             lib.get::<unsafe extern "C" fn() -> u32>(b"aa_c_version\0").is_ok()
                         };
@@ -152,6 +163,9 @@ impl AardvarkHandle {
     /// Open a specific Aardvark adapter by port index.
     pub fn open_port(port: i32) -> Result<Self> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
+        // SAFETY: `c_aa_open` has the declared signature in `aardvark.h`, and
+        // `lib` is retained in the process-wide `OnceLock` for the call and
+        // the lifetime of every returned handle.
         let handle: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32) -> i32> = lib
                 .get(b"c_aa_open\0")
@@ -174,6 +188,9 @@ impl AardvarkHandle {
             return Vec::new();
         };
         let mut ports = [0u16; 16];
+        // SAFETY: the symbol signature matches `aardvark.h`; `ports` is a
+        // writable 16-element array and the same capacity is passed to C, so
+        // the vendor function cannot initialize beyond the allocation.
         let n: i32 = unsafe {
             let f: std::result::Result<Symbol<unsafe extern "C" fn(i32, *mut u16) -> i32>, _> =
                 lib.get(b"c_aa_find_devices\0");
@@ -185,14 +202,15 @@ impl AardvarkHandle {
                 }
             }
         };
+        let initialized = initialized_device_count(n, ports.len());
         eprintln!(
-            "[aardvark-sys] find_devices: c_aa_find_devices returned {n}, ports={:?}",
-            &ports[..n.max(0) as usize]
+            "[aardvark-sys] find_devices: c_aa_find_devices returned {n}, initialized ports={:?}",
+            &ports[..initialized]
         );
-        if n <= 0 {
+        if initialized == 0 {
             return Vec::new();
         }
-        let free: Vec<u16> = ports[..n as usize]
+        let free: Vec<u16> = ports[..initialized]
             .iter()
             .filter(|&&p| (p & AA_PORT_NOT_FREE) == 0)
             .copied()
@@ -206,6 +224,9 @@ impl AardvarkHandle {
     /// Enable I2C mode and set the bitrate (kHz).
     pub fn i2c_enable(&self, bitrate_khz: u32) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
+        // SAFETY: all three symbol signatures match `aardvark.h`; `self`
+        // keeps the positive, not-yet-closed adapter handle alive, and the
+        // calls pass only integer configuration values.
         unsafe {
             let configure: Symbol<unsafe extern "C" fn(i32, i32) -> i32> = lib
                 .get(b"c_aa_configure\0")
@@ -226,6 +247,9 @@ impl AardvarkHandle {
     /// Write `data` bytes to the I2C device at `addr`.
     pub fn i2c_write(&self, addr: u8, data: &[u8]) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
+        // SAFETY: the symbol signature matches `aardvark.h`, the adapter
+        // handle remains live through `&self`, and `data.as_ptr()` is valid
+        // for at least the `u16`-truncated byte count passed to the C API.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32, u16, i32, u16, *const u8) -> i32> = lib
                 .get(b"c_aa_i2c_write\0")
@@ -249,6 +273,9 @@ impl AardvarkHandle {
     pub fn i2c_read(&self, addr: u8, len: usize) -> Result<Vec<u8>> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
         let mut buf = vec![0u8; len];
+        // SAFETY: the symbol signature matches `aardvark.h`, the adapter
+        // handle remains live, and `buf.as_mut_ptr()` is writable for at
+        // least the `u16`-truncated byte count passed to the C API.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32, u16, i32, u16, *mut u8) -> i32> = lib
                 .get(b"c_aa_i2c_read\0")
@@ -280,15 +307,20 @@ impl AardvarkHandle {
         let Some(lib) = lib() else {
             return Vec::new();
         };
-        let Ok(f): std::result::Result<
-            Symbol<unsafe extern "C" fn(i32, u16, i32, u16, *mut u8) -> i32>,
-            _,
-        > = (unsafe { lib.get(b"c_aa_i2c_read\0") }) else {
+        // SAFETY: this lookup uses the exact `aa_i2c_read` signature from
+        // `aardvark.h`, and the process-wide library handle remains loaded.
+        let symbol = unsafe {
+            lib.get::<unsafe extern "C" fn(i32, u16, i32, u16, *mut u8) -> i32>(b"c_aa_i2c_read\0")
+        };
+        let Ok(f) = symbol else {
             return Vec::new();
         };
         let mut found = Vec::new();
         let mut buf = [0u8; 1];
         for addr in 0x08u16..=0x77 {
+            // SAFETY: `f` has the vendor-declared signature, the handle is
+            // live through `&self`, and `buf` is writable for the one byte
+            // requested by this probe.
             let ret = unsafe { f(self.handle, addr, AA_I2C_NO_FLAGS, 1, buf.as_mut_ptr()) };
             // ret > 0: bytes received → device ACKed
             // ret == 0: NACK → no device at this address
@@ -305,6 +337,9 @@ impl AardvarkHandle {
     /// Enable SPI mode and set the bitrate (kHz).
     pub fn spi_enable(&self, bitrate_khz: u32) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
+        // SAFETY: all three symbol signatures match `aardvark.h`; `self`
+        // keeps the positive adapter handle live, and only integer mode and
+        // bitrate values cross the FFI boundary.
         unsafe {
             let configure: Symbol<unsafe extern "C" fn(i32, i32) -> i32> = lib
                 .get(b"c_aa_configure\0")
@@ -329,6 +364,9 @@ impl AardvarkHandle {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
         let mut recv = vec![0u8; send.len()];
         // aa_spi_write(aardvark, out_num_bytes, data_out, in_num_bytes, data_in)
+        // SAFETY: the symbol signature matches `aardvark.h`; both slices stay
+        // alive for the call, and their pointers are valid for at least the
+        // `u16`-truncated lengths supplied to the vendor function.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32, u16, *const u8, u16, *mut u8) -> i32> = lib
                 .get(b"c_aa_spi_write\0")
@@ -355,6 +393,9 @@ impl AardvarkHandle {
     /// `value`: output state bitmask.
     pub fn gpio_set(&self, direction: u8, value: u8) -> Result<()> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
+        // SAFETY: both symbol signatures match `aardvark.h`, the adapter
+        // handle remains live through `&self`, and the GPIO masks are passed
+        // by value with no raw pointers.
         unsafe {
             let dir_f: Symbol<unsafe extern "C" fn(i32, u8) -> i32> = lib
                 .get(b"c_aa_gpio_direction\0")
@@ -377,6 +418,8 @@ impl AardvarkHandle {
     /// Read the current GPIO pin states as a bitmask.
     pub fn gpio_get(&self) -> Result<u8> {
         let lib = lib().ok_or(AardvarkError::LibraryNotFound)?;
+        // SAFETY: `c_aa_gpio_get` has the declared `aardvark.h` signature and
+        // `self` keeps the positive adapter handle alive for the call.
         let ret: i32 = unsafe {
             let f: Symbol<unsafe extern "C" fn(i32) -> i32> = lib
                 .get(b"c_aa_gpio_get\0")
@@ -394,6 +437,9 @@ impl AardvarkHandle {
 impl Drop for AardvarkHandle {
     fn drop(&mut self) {
         if let Some(lib) = lib() {
+            // SAFETY: the lookup uses the vendor-declared close signature;
+            // this handle was returned positive by `c_aa_open`, has not been
+            // closed elsewhere, and the library outlives this value.
             unsafe {
                 if let Ok(f) = lib.get::<unsafe extern "C" fn(i32) -> i32>(b"c_aa_close\0") {
                     f(self.handle);
@@ -406,6 +452,13 @@ impl Drop for AardvarkHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn device_count_is_bounded_by_the_initialized_output_buffer() {
+        assert_eq!(initialized_device_count(-1, 16), 0);
+        assert_eq!(initialized_device_count(3, 16), 3);
+        assert_eq!(initialized_device_count(17, 16), 16);
+    }
 
     #[test]
     fn find_devices_does_not_panic() {

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -421,6 +421,9 @@ const EDGE_TTS_REAP_GRACE: std::time::Duration = std::time::Duration::from_secs(
 #[cfg(unix)]
 fn graceful_kill(child: &mut tokio::process::Child) {
     if let Some(pid) = child.id() {
+        // SAFETY: `pid` comes from this live child handle; `kill` receives no
+        // pointers, and failure (including a raced child exit) is deliberately
+        // handled as best-effort cleanup.
         let _ = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
     }
 }
@@ -1718,6 +1721,8 @@ mod tests {
 
     #[cfg(unix)]
     fn edge_tts_fixture_process_exists(pid: u32) -> std::io::Result<bool> {
+        // SAFETY: signal 0 only probes the PID recorded by the fixture; no
+        // pointers cross FFI and all documented error cases are handled below.
         if unsafe { libc::kill(pid as i32, 0) } == 0 {
             return Ok(true);
         }
@@ -2160,6 +2165,8 @@ mod tests {
             }
             std::thread::sleep(std::time::Duration::from_millis(25));
         }
+        // SAFETY: signal 0 is a non-mutating existence probe for the PID
+        // returned by `Child::id`; no pointers cross the FFI boundary.
         let still_alive = unsafe { libc::kill(child_pid as i32, 0) } == 0;
         assert!(
             !still_alive,

--- a/crates/zeroclaw-runtime/src/cli_input.rs
+++ b/crates/zeroclaw-runtime/src/cli_input.rs
@@ -30,6 +30,8 @@ impl Drop for TerminalUtf8EraseGuard {
         };
         // Best-effort restoration: this guard only tweaks terminal line
         // discipline for interactive CLI input, and drop must not panic.
+        // SAFETY: `original` was initialized by a successful `tcgetattr` on
+        // this same descriptor, and the guard retains both until restoration.
         unsafe {
             let _ = libc::tcsetattr(self.fd, libc::TCSANOW, original);
         }
@@ -51,11 +53,15 @@ mod imp {
 
     pub(super) fn ensure_terminal_utf8_erase_for_fd(fd: libc::c_int) -> TerminalUtf8EraseGuard {
         let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+        // SAFETY: `termios` points to writable, correctly aligned storage for
+        // one `libc::termios`; initialization is trusted only when rc is zero.
         let rc = unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) };
         if rc != 0 {
             return TerminalUtf8EraseGuard { fd, original: None };
         }
 
+        // SAFETY: the successful `tcgetattr` above initialized every byte of
+        // the `termios` output object.
         let original = unsafe { termios.assume_init() };
         if original.c_iflag & libc::IUTF8 != 0 {
             return TerminalUtf8EraseGuard { fd, original: None };
@@ -63,6 +69,8 @@ mod imp {
 
         let mut updated = original;
         updated.c_iflag |= libc::IUTF8;
+        // SAFETY: `updated` is a fully initialized `termios` value derived
+        // from this descriptor's state and remains live for the call.
         let rc = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &updated) };
         TerminalUtf8EraseGuard {
             fd,
@@ -481,6 +489,8 @@ mod tests {
     fn terminal_utf8_erase_guard_sets_and_restores_iutf8() {
         let mut master_fd = -1;
         let mut slave_fd = -1;
+        // SAFETY: both output pointers refer to live `c_int` storage; the
+        // optional name and termios/winsize inputs are intentionally null.
         let openpty_rc = unsafe {
             libc::openpty(
                 &mut master_fd,
@@ -492,6 +502,9 @@ mod tests {
         };
         assert_eq!(openpty_rc, 0, "openpty failed");
 
+        // SAFETY: `openpty` succeeded, so both descriptors are live. Each
+        // `MaybeUninit` output is read only after its `tcgetattr` succeeds,
+        // and both descriptors are closed exactly once at the end.
         unsafe {
             let mut original = std::mem::MaybeUninit::<libc::termios>::uninit();
             assert_eq!(libc::tcgetattr(slave_fd, original.as_mut_ptr()), 0);

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -987,6 +987,9 @@ pub async fn run(
     }
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    // SAFETY: glibc's parameter-free process allocator trim may release free
+    // arenas after all daemon tasks have been joined; no Rust pointers are
+    // retained across the call.
     unsafe {
         libc::malloc_trim(0);
     }
@@ -1061,10 +1064,11 @@ pub fn stderr_is_interactive_foreground() -> bool {
     if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
         return false;
     }
-    // SAFETY: these libc calls take no pointers. `tcgetpgrp` returns -1 when
-    // stderr has no controlling terminal; `getpgrp` cannot fail.
-    let foreground_pgrp = unsafe { libc::tcgetpgrp(libc::STDERR_FILENO) };
-    let own_pgrp = unsafe { libc::getpgrp() };
+    let (foreground_pgrp, own_pgrp) = {
+        // SAFETY: these libc calls take no pointers. `tcgetpgrp` returns -1
+        // when stderr has no controlling terminal; `getpgrp` cannot fail.
+        unsafe { (libc::tcgetpgrp(libc::STDERR_FILENO), libc::getpgrp()) }
+    };
     stderr_foreground_decision(foreground_pgrp, own_pgrp)
 }
 
@@ -3416,7 +3420,9 @@ mod tests {
         // Give the signal handler time to register
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Send SIGHUP to ourselves — should be ignored by the handler
+        // Send SIGHUP to ourselves — should be ignored by the handler.
+        // SAFETY: `raise` targets the current process with a valid signal
+        // constant and passes no pointers across FFI.
         unsafe { libc::raise(libc::SIGHUP) };
 
         // The future should NOT complete within a short window

--- a/crates/zeroclaw-runtime/src/rpc/local.rs
+++ b/crates/zeroclaw-runtime/src/rpc/local.rs
@@ -291,6 +291,8 @@ mod platform {
                 parent.display()
             )
         })?;
+        // SAFETY: `geteuid` is a parameter-free process query with no pointer
+        // arguments or memory ownership requirements.
         let euid = unsafe { libc::geteuid() };
         let mode = metadata.mode();
         if metadata.uid() != euid && metadata.uid() != 0 {
@@ -329,6 +331,8 @@ mod platform {
                 lock_path.display()
             );
         }
+        // SAFETY: `geteuid` is a parameter-free process query with no pointer
+        // arguments or memory ownership requirements.
         let euid = unsafe { libc::geteuid() };
         if metadata.uid() != euid {
             anyhow::bail!(

--- a/crates/zeroclaw-runtime/src/security/landlock.rs
+++ b/crates/zeroclaw-runtime/src/security/landlock.rs
@@ -267,6 +267,11 @@ impl Sandbox for LandlockSandbox {
         // `Drop for RulesetCreated` remain fork-safe — no heap allocation,
         // no lock acquisition, no async-signal-unsafe calls between fork()
         // and exec().
+        //
+        // SAFETY: the closure obeys `pre_exec`'s post-fork restrictions for
+        // the reasons above: its captured state is child-local, the audited
+        // landlock operations are fork-safe, and every error path is
+        // allocation-free.
         unsafe {
             cmd.pre_exec(move || {
                 if let Some(rs) = ruleset.take() {

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -48,6 +48,9 @@ impl Drop for ChildGroupGuard {
                 .with_attrs(::serde_json::json!({ "pgid": pgid, "signal": "SIGKILL" })),
             "shell tool reaping child process group"
         );
+        // SAFETY: `pgid` was published only after the spawned child created
+        // its own process group; a negative PID targets that group, and this
+        // best-effort signal call passes no pointers.
         unsafe {
             libc::kill(-pgid, libc::SIGKILL);
         }
@@ -150,8 +153,16 @@ fn decode_output(bytes: &[u8]) -> String {
     use windows::Win32::Globalization::GetACP;
     use windows::Win32::System::Console::GetConsoleOutputCP;
 
-    let cp = unsafe { GetConsoleOutputCP() };
-    let cp = if cp == 0 { unsafe { GetACP() } } else { cp };
+    // SAFETY: both Win32 functions are parameter-free code-page queries. A
+    // zero console code page selects the documented system ANSI fallback.
+    let cp = unsafe {
+        let console_cp = GetConsoleOutputCP();
+        if console_cp == 0 {
+            GetACP()
+        } else {
+            console_cp
+        }
+    };
 
     decode_output_with_code_page(bytes, cp)
 }

--- a/crates/zeroclaw-runtime/tests/landlock_workspace_boundary.rs
+++ b/crates/zeroclaw-runtime/tests/landlock_workspace_boundary.rs
@@ -33,6 +33,9 @@ fn landlock_abi_version() -> u32 {
     // highest supported ABI version instead of creating a ruleset.
     const LANDLOCK_CREATE_RULESET_VERSION: u32 = 1;
 
+    // SAFETY: this is the kernel-documented version-query form: a null attrs
+    // pointer with size zero, plus the VERSION flag. No memory is read or
+    // written through the null pointer.
     let ret = unsafe {
         libc::syscall(
             libc::SYS_landlock_create_ruleset,


### PR DESCRIPTION
## Summary

- **Base branch:** master
- **What changed and why:** Audits 25 native and platform unsafe sites and records the concrete pointer, descriptor, process, thread, or post-fork invariant at each surviving boundary. Related calls are consolidated where one invariant governs them.
- **Scope boundary:** Aardvark is unchanged in this PR because #9852/#9853 retire aardvark-sys and its transport. The remaining native, desktop, runtime, channel, and ZeroCode boundaries survive that removal. This PR does not add unsafe code or cover the 25 test/global-state sites handled by #10125.
- **Blast radius:** macOS desktop permission/icon calls, Unix terminal/process/IPC/Landlock paths, Windows console decoding, Edge TTS cleanup, and their focused tests. No runtime behavior change is intended.
- **Linked issue(s):** Related #10118, #9852, and #9853. Companion unsafe cleanup: #10125.
- **Labels:** channel, daemon, runtime, security, distinguished contributor, domain:code-quality, tool:shell, desktop, zerocode, risk:low, size:S, type:refactor, cli

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — compile-time checks and focused tests cover the retained boundaries.

### How I tested

~~~sh
cargo fmt --all -- --check
# exit 0

cargo clippy --locked -p aardvark-sys -p zeroclaw-runtime   -p zeroclaw-channels -p zerocode --all-targets -- -D warnings
# Finished dev profile in 7m 58s

cargo clippy --locked -p zeroclaw-desktop --all-targets -- -D warnings
# Finished dev profile in 1m 30s

cargo test --locked -p aardvark-sys
# 4 passed; 0 failed

cargo test --locked -p zeroclaw-runtime --lib endpoint_lock
# 6 passed; 0 failed

cargo test --locked -p zeroclaw-runtime --lib   daemon_startup_stderr_requires_current_process_group_ownership
# 1 passed; 0 failed

cargo test --locked -p zeroclaw-runtime --lib   sighup_does_not_shut_down_daemon
# 1 passed; 0 failed

cargo test --locked -p zeroclaw-channels --lib edge_tts
# 9 passed; 0 failed

cargo test --locked -p zerocode --bin zerocode   spawned_daemon_parent_only_sigterm_cleans_up_child
# 1 passed; 0 failed

anti-slop --changed-since upstream/master
# anti-slop: checked 10 Rust files; no violations

anti-slop --summary src crates apps xtask tools tests benches firmware
# 202 require-invariant-comment-for-panics
# 41 no-dead-code-allow
# 39 require-safety-comment-for-unsafe
~~~

The branch removes 25 unsafe findings. Of the 39 remaining, 14 are in retiring aardvark-sys (#9853) and 25 are the test/global-state sites handled by #10125. The endpoint-lock tests that bind Unix sockets were rerun outside the restricted sandbox after the sandbox denied socket creation; all six passed.

- **CI checks relied on and why they cover this change:** Local all-target Clippy covers every retained host target, including the separately excluded desktop crate. Hosted Linux and Windows lanes cover target-specific compilation unavailable on this macOS host.
- **Known CI coverage gap, if any:** A local x86_64-pc-windows-msvc cross-check stops in ring before compiling ZeroClaw because this host lacks MSVC C headers. Hosted Windows is authoritative.
- **Beyond CI, what did you manually verify?** Confirmed crates/aardvark-sys/src/lib.rs matches the branch base exactly and all ten retained files survive #9853.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Physical hardware testing is outside the retained scope.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: revert the eventual squash-merge commit.


