### PR TITLE
fix(gateway): avoid panics in shared state

### DIFF
--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -2497,9 +2497,7 @@ pub async fn handle_options_prop(
         header::ALLOW,
         HeaderValue::from_static("GET, PUT, DELETE, OPTIONS"),
     );
-    response
-        .headers_mut()
-        .insert(header::ETAG, HeaderValue::from_str(etag).unwrap());
+    insert_etag(&mut response, etag);
     response
 }
 
@@ -2510,10 +2508,14 @@ fn schema_response(_label: &'static str) -> Response {
         header::ALLOW,
         HeaderValue::from_static("GET, PUT, PATCH, OPTIONS"),
     );
+    insert_etag(&mut response, etag);
     response
-        .headers_mut()
-        .insert(header::ETAG, HeaderValue::from_str(etag).unwrap());
-    response
+}
+
+fn insert_etag(response: &mut Response, etag: &str) {
+    if let Ok(value) = HeaderValue::from_str(etag) {
+        response.headers_mut().insert(header::ETAG, value);
+    }
 }
 
 fn cached_schema() -> (&'static serde_json::Value, &'static str) {
@@ -2562,6 +2564,13 @@ mod tests {
     use std::time::Duration;
     use zeroclaw_providers::ModelProvider;
     use zeroclaw_runtime::security::pairing::PairingGuard;
+
+    #[test]
+    fn invalid_etag_value_is_omitted_instead_of_panicking() {
+        let mut response = StatusCode::OK.into_response();
+        insert_etag(&mut response, "invalid\nheader");
+        assert!(!response.headers().contains_key(header::ETAG));
+    }
 
     // dirty_entry_for / CascadeReport::dirty_paths tests live in
     // zeroclaw_config::alias_refs — single source of truth (the gateway and CLI

--- a/crates/zeroclaw-gateway/src/sse.rs
+++ b/crates/zeroclaw-gateway/src/sse.rs
@@ -33,7 +33,10 @@ impl EventBuffer {
 
     /// Push an event into the buffer, evicting the oldest if at capacity.
     pub fn push(&self, event: serde_json::Value) {
-        let mut buf = self.inner.lock().unwrap();
+        let mut buf = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         if buf.len() == self.capacity {
             buf.pop_front();
         }
@@ -42,7 +45,11 @@ impl EventBuffer {
 
     /// Return a snapshot of all buffered events (oldest first).
     pub fn snapshot(&self) -> Vec<serde_json::Value> {
-        self.inner.lock().unwrap().iter().cloned().collect()
+        let buf = match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        buf.iter().cloned().collect()
     }
 }
 
@@ -374,6 +381,25 @@ mod tests {
     // The broadcast hook is process-wide; serialize hook-touching tests
     // within this test binary so they don't observe each other's state.
     static HOOK_TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    #[test]
+    fn event_buffer_recovers_after_a_poisoned_writer() {
+        let buffer = Arc::new(EventBuffer::new(4));
+        let poisoned = buffer.clone();
+        let result = std::thread::spawn(move || {
+            let mut guard = poisoned.inner.lock().expect("fresh buffer must lock");
+            guard.push_back(serde_json::json!({"sequence": 1}));
+            panic!("poison event buffer");
+        })
+        .join();
+        assert!(result.is_err());
+
+        buffer.push(serde_json::json!({"sequence": 2}));
+        let snapshot = buffer.snapshot();
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot[0]["sequence"], 1);
+        assert_eq!(snapshot[1]["sequence"], 2);
+    }
 
     fn make_broadcast() -> (
         Arc<BroadcastObserver>,

--- a/crates/zeroclaw-gateway/src/version.rs
+++ b/crates/zeroclaw-gateway/src/version.rs
@@ -21,7 +21,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use zeroclaw_runtime::i18n::get_required_cli_string;
@@ -30,6 +30,13 @@ use zeroclaw_runtime::i18n::get_required_cli_string;
 const CHECK_CACHE_TTL: Duration = Duration::from_secs(3600);
 /// Upper bound on the `zeroclaw update --check` subprocess.
 const CHECK_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
 
 // ── Restart classification (advisory) ────────────────────────────
 
@@ -238,7 +245,7 @@ pub async fn handle_version_check(
 
     let use_cache = !q.force && q.version.is_none();
     if use_cache {
-        if let Some((ts, cached)) = CHECK_CACHE.lock().unwrap().as_ref() {
+        if let Some((ts, cached)) = lock_recover(&CHECK_CACHE).as_ref() {
             if ts.elapsed() < CHECK_CACHE_TTL {
                 return Json(VersionCheckResponse::from(cached)).into_response();
             }
@@ -248,7 +255,7 @@ pub async fn handle_version_check(
     match run_cli_check(q.version.as_deref()).await {
         Ok(info) => {
             if use_cache {
-                *CHECK_CACHE.lock().unwrap() = Some((Instant::now(), info.clone()));
+                *lock_recover(&CHECK_CACHE) = Some((Instant::now(), info.clone()));
             }
             Json(VersionCheckResponse::from(&info)).into_response()
         }
@@ -407,9 +414,9 @@ pub async fn handle_version_upgrade(
     }
 
     // One upgrade at a time.
-    let mut slot = UPGRADE.lock().unwrap();
+    let mut slot = lock_recover(&UPGRADE);
     if let Some(existing) = slot.as_ref() {
-        if !existing.lock().unwrap().state.is_terminal() {
+        if !lock_recover(existing).state.is_terminal() {
             return json_error(StatusCode::CONFLICT, "an upgrade is already in progress");
         }
     }
@@ -502,7 +509,7 @@ pub async fn handle_version_upgrade_status(
         return e.into_response();
     }
 
-    let slot = UPGRADE.lock().unwrap();
+    let slot = lock_recover(&UPGRADE);
     let Some(progress) = slot.as_ref() else {
         return Json(UpgradeStatusResponse {
             handoff_id: None,
@@ -517,7 +524,7 @@ pub async fn handle_version_upgrade_status(
         })
         .into_response();
     };
-    let p = progress.lock().unwrap();
+    let p = lock_recover(progress);
     if let Some(id) = q.handoff_id.as_deref() {
         if id != p.handoff_id {
             return json_error(StatusCode::NOT_FOUND, "unknown handoff_id");
@@ -538,11 +545,11 @@ pub async fn handle_version_upgrade_status(
 }
 
 fn set_state(progress: &Arc<Mutex<UpgradeProgress>>, state: UpgradeState) {
-    progress.lock().unwrap().state = state;
+    lock_recover(progress).state = state;
 }
 
 fn fail(progress: &Arc<Mutex<UpgradeProgress>>, msg: String) {
-    let mut p = progress.lock().unwrap();
+    let mut p = lock_recover(progress);
     p.state = UpgradeState::Failed;
     p.error = Some(msg);
 }
@@ -586,7 +593,7 @@ async fn pump_lines<R: AsyncRead + Unpin>(reader: R, progress: Arc<Mutex<Upgrade
     let mut lines = BufReader::new(reader).lines();
     while let Ok(Some(raw)) = lines.next_line().await {
         let line = strip_ansi(&raw);
-        let mut p = progress.lock().unwrap();
+        let mut p = lock_recover(&progress);
         if let Some(phase) = parse_phase(&line) {
             p.phase = phase;
         }
@@ -691,7 +698,7 @@ async fn run_upgrade(
 
     if !status.success() {
         let tail = {
-            let p = progress.lock().unwrap();
+            let p = lock_recover(&progress);
             p.log_tail
                 .iter()
                 .rev()
@@ -774,6 +781,20 @@ fn trigger_graceful_shutdown() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lock_recover_preserves_state_after_poisoning() {
+        let state = Arc::new(Mutex::new(1_u8));
+        let poisoned = state.clone();
+        let result = std::thread::spawn(move || {
+            let mut guard = poisoned.lock().expect("fresh mutex must lock");
+            *guard = 2;
+            panic!("poison test mutex");
+        })
+        .join();
+        assert!(result.is_err());
+        assert_eq!(*lock_recover(&state), 2);
+    }
 
     #[test]
     fn restart_mode_as_str_is_stable() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Removes 14 gateway panic candidates. Version-check cache, upgrade state, and SSE history now recover the guarded value after mutex poisoning instead of cascading a prior task panic into every later request.
- **What changed and why:** Invalid schema ETag values are omitted rather than unwrapped. The normal ETag remains the same quoted hexadecimal digest; a malformed internal value can no longer terminate the request path.
- **Scope boundary:** This PR does not change version-check/upgrade state transitions, cache TTLs, SSE retention, authentication, schema content, or non-gateway panic sites.
- **Blast radius:** Gateway version, upgrade-status, SSE history, and config schema/OPTIONS responses. Recovery behavior activates only after a mutex has already been poisoned or an internally generated ETag is malformed.
- **Linked issue(s):** Related #10118.
- **Labels:** `gateway`, `distinguished contributor`, `domain:code-quality`, `risk:medium`, `size:S`, `type:refactor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the failure modes are exercised directly with poisoned locks and an invalid header value.

### How I tested

```sh
$ cargo fmt --all -- --check
# exit 0

$ cargo clippy --locked -p zeroclaw-gateway --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 46s

$ cargo test --locked -p zeroclaw-gateway --lib
test result: ok. 439 passed; 0 failed; 0 ignored

$ anti-slop --changed-since upstream/master
anti-slop: checked 3 Rust files; no violations

$ anti-slop --summary src crates apps xtask tools tests benches firmware
188  require-invariant-comment-for-panics
 64  require-safety-comment-for-unsafe
 41  no-dead-code-allow
```

The independent branch removes all 14 gateway panic/invariant findings. New regressions prove that version state and the SSE buffer remain usable after poisoning, and that a malformed ETag is omitted without panic.

- **CI checks relied on and why they cover this change:** Exact-head hosted CI is green, including `CI Required Gate`, `Test`, `Lint`, `Check (all features)`, and the gateway-relevant platform and build lanes. These checks cover the gateway targets and the request, upgrade-state, SSE-buffer, and schema-response paths changed here.
- **Known CI coverage gap, if any:** None beyond hosted platform coverage.
- **Beyond CI, what did you manually verify?** Confirmed the recovery helper preserves the value held at the poisoning point and all normal response shapes remain unchanged.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert eaa19ef72bf8ca82e212b8a2fe9a4c93a8e4295f`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Version-check/upgrade requests returning stale or inconsistent state after a prior handler panic, missing ETag headers on otherwise valid schema responses, or SSE history not retaining/replaying events.

