### PR TITLE
fix(robot-kit): remove panic-prone platform assumptions

### DIFF
--- a/crates/robot-kit/src/listen.rs
+++ b/crates/robot-kit/src/listen.rs
@@ -38,20 +38,15 @@ impl ListenTool {
         let device = &self.config.audio.mic_device;
 
         // Record using arecord (standard on Linux/Pi)
+        let duration = duration_secs.to_string();
         let output = tokio::process::Command::new("arecord")
             .args([
-                "-D",
-                device,
-                "-f",
-                "S16_LE", // 16-bit signed little-endian
-                "-r",
-                "16000", // 16kHz (Whisper expects this)
-                "-c",
-                "1", // Mono
-                "-d",
-                &duration_secs.to_string(),
-                filename.to_str().unwrap(),
+                "-D", device, "-f", "S16_LE", // 16-bit signed little-endian
+                "-r", "16000", // 16kHz (Whisper expects this)
+                "-c", "1", // Mono
+                "-d", &duration,
             ])
+            .arg(&filename)
             .output()
             .await?;
 
@@ -82,14 +77,11 @@ impl ListenTool {
 
         // Run whisper.cpp
         let output = tokio::process::Command::new(whisper_path)
-            .args([
-                "-m",
-                model_path.to_str().unwrap(),
-                "-f",
-                audio_path.to_str().unwrap(),
-                "--no-timestamps",
-                "-otxt", // Output as text
-            ])
+            .arg("-m")
+            .arg(&model_path)
+            .arg("-f")
+            .arg(audio_path)
+            .args(["--no-timestamps", "-otxt"])
             .output()
             .await?;
 

--- a/crates/robot-kit/src/look.rs
+++ b/crates/robot-kit/src/look.rs
@@ -50,8 +50,8 @@ impl LookTool {
                 "-frames:v",
                 "1",
                 "-y", // Overwrite
-                filename.to_str().unwrap(),
             ])
+            .arg(&filename)
             .output()
             .await?;
 
@@ -64,8 +64,8 @@ impl LookTool {
                     "--no-banner",
                     "-d",
                     device,
-                    filename.to_str().unwrap(),
                 ])
+                .arg(&filename)
                 .output()
                 .await?;
 

--- a/crates/robot-kit/src/safety.rs
+++ b/crates/robot-kit/src/safety.rs
@@ -156,8 +156,7 @@ impl SafetyMonitor {
         // Update last command time
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+            .map_or(0, |duration| duration.as_millis() as u64);
         self.state.last_command_ms.store(now_ms, Ordering::SeqCst);
 
         // Calculate speed limit based on proximity

--- a/crates/robot-kit/src/sense.rs
+++ b/crates/robot-kit/src/sense.rs
@@ -53,7 +53,7 @@ impl SenseTool {
     /// Mock LIDAR for testing
     async fn scan_mock(&self) -> Result<LidarScan> {
         // Simulate a room with walls
-        let mut ranges = vec![3.0; 360];
+        let mut ranges: Vec<f64> = vec![3.0; 360];
 
         // Wall in front at 2m
         for range in &mut ranges[350..360] {
@@ -71,7 +71,7 @@ impl SenseTool {
         let nearest = ranges
             .iter()
             .enumerate()
-            .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .min_by(|a, b| a.1.total_cmp(b.1))
             .map(|(i, &d)| (d, i as u16))
             .unwrap_or((999.0, 0));
 
@@ -114,7 +114,7 @@ impl SenseTool {
                 let nearest = ranges
                     .iter()
                     .enumerate()
-                    .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                    .min_by(|a, b| a.1.total_cmp(b.1))
                     .map(|(i, &d)| (d, i as u16))
                     .unwrap_or((999.0, 0));
 
@@ -155,7 +155,7 @@ impl SenseTool {
 
         // Parse ROS2 LaserScan message (simplified)
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let ranges = vec![999.0; 360];
+        let ranges: Vec<f64> = vec![999.0; 360];
 
         // Very simplified parsing - in production use rclrs
         if let Some(_ranges_line) = stdout.lines().find(|l| l.contains("ranges:")) {
@@ -166,7 +166,7 @@ impl SenseTool {
         let nearest = ranges
             .iter()
             .enumerate()
-            .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .min_by(|a, b| a.1.total_cmp(b.1))
             .map(|(i, &d)| (d, i as u16))
             .unwrap_or((999.0, 0));
 

--- a/crates/robot-kit/src/speak.rs
+++ b/crates/robot-kit/src/speak.rs
@@ -101,12 +101,10 @@ impl SpeakTool {
         // `--output_file`, so its own stdout/stderr are detached: they are never
         // surfaced to the caller and must not block on or pollute our stdio.
         let mut piper = Command::new(piper_path)
-            .args([
-                "--model",
-                model_path.to_str().unwrap(),
-                "--output_file",
-                output_path.to_str().unwrap(),
-            ])
+            .arg("--model")
+            .arg(&model_path)
+            .arg("--output_file")
+            .arg(&output_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -127,14 +125,14 @@ impl SpeakTool {
 
         // Play audio using aplay
         let mut aplay = Command::new("aplay");
-        aplay.args(["-D", speaker_device, output_path.to_str().unwrap()]);
+        aplay.args(["-D", speaker_device]).arg(&output_path);
         let play_result =
             run_audio_command_with_timeout(aplay, "aplay", AUDIO_PLAYBACK_TIMEOUT).await?;
 
         if !play_result.status.success() {
             // Fallback: try paplay (PulseAudio)
             let mut paplay = Command::new("paplay");
-            paplay.arg(output_path.to_str().unwrap());
+            paplay.arg(&output_path);
             let fallback =
                 run_audio_command_with_timeout(paplay, "paplay", AUDIO_PLAYBACK_TIMEOUT).await?;
 
@@ -163,7 +161,7 @@ impl SpeakTool {
 
         let speaker_device = &self.config.audio.speaker_device;
         let mut aplay = Command::new("aplay");
-        aplay.args(["-D", speaker_device, sound_file.to_str().unwrap()]);
+        aplay.args(["-D", speaker_device]).arg(&sound_file);
         let output = run_audio_command_with_timeout(aplay, "aplay", AUDIO_PLAYBACK_TIMEOUT).await?;
 
         if !output.status.success() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Removes all 14 robot-kit panic/invariant findings. Audio, camera, Whisper, and playback subprocesses now accept `Path`/`OsStr` arguments directly instead of requiring UTF-8 conversion.
- **What changed and why:** LiDAR nearest-distance selection uses total floating-point ordering, and a pre-epoch system clock now records a conservative zero timestamp rather than panicking.
- **Scope boundary:** Device commands, formats, timeouts, safety thresholds, configuration, and successful hardware behavior are unchanged. This PR does not address the separate Aardvark FFI or root hardware crates.
- **Blast radius:** Robot-kit listen, look, sense, speak, and movement safety helpers. The changed cases are non-UTF-8 paths, unordered floating-point inputs, and a system clock earlier than the Unix epoch.
- **Linked issue(s):** Related #10118.
- **Labels:** `domain:code-quality`, `type:refactor`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — command construction and sensor/safety helpers are covered by the crate suite without requiring physical hardware.

### How I tested

```sh
$ cargo fmt --all -- --check
# exit 0

$ cargo clippy --locked -p zeroclaw-robot-kit --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.87s  # warm rerun

$ cargo test --locked -p zeroclaw-robot-kit
test result: ok. 64 passed; 0 failed; 0 ignored

$ anti-slop --changed-since upstream/master
anti-slop: checked 5 Rust files; no violations

$ anti-slop --summary src crates apps xtask tools tests benches firmware
188  require-invariant-comment-for-panics
 64  require-safety-comment-for-unsafe
 41  no-dead-code-allow
```

The independent branch removes all 14 robot-kit panic/invariant findings.

- **CI checks relied on and why they cover this change:** Fresh hosted CI is pending. Local all-target Clippy and the complete robot-kit suite cover every changed module and command helper.
- **Known CI coverage gap, if any:** Physical camera, microphone, speaker, and LiDAR hardware were not exercised; their command and parsing contracts are unchanged.
- **Beyond CI, what did you manually verify?** Confirmed each subprocess receives the same argument sequence with paths passed losslessly, and total ordering preserves ordinary finite distance order.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Hardware-in-the-loop smoke tests require devices not present on this host.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 9091bef9d1914fe71081b545dd3e4a16f9ab8f38`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Robot subprocesses receiving malformed arguments, changed nearest-obstacle selection, or movement throttling using an incorrect command timestamp.
