### PR TITLE
fix(core): make replay and parser state recovery fallible

### DIFF
--- a/crates/zeroclaw-eval/src/observer.rs
+++ b/crates/zeroclaw-eval/src/observer.rs
@@ -1,6 +1,6 @@
 //! An [`Observer`] that records tool-call outcomes and token usage from a run.
 
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 use zeroclaw_api::observability_traits::{Observer, ObserverEvent, ObserverMetric};
 
 /// Captures `(tool_name, success)` for each dispatched tool call and accumulates
@@ -12,6 +12,13 @@ pub struct RecordingObserver {
     output_tokens: Mutex<u64>,
 }
 
+fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 impl RecordingObserver {
     pub fn new() -> Self {
         Self::default()
@@ -19,9 +26,7 @@ impl RecordingObserver {
 
     /// Names of tools that were dispatched, in call order.
     pub fn tool_names(&self) -> Vec<String> {
-        self.tool_calls
-            .lock()
-            .unwrap()
+        lock_recover(&self.tool_calls)
             .iter()
             .map(|(name, _)| name.clone())
             .collect()
@@ -29,14 +34,14 @@ impl RecordingObserver {
 
     /// True when every dispatched tool call reported success (vacuously true if none).
     pub fn all_tools_succeeded(&self) -> bool {
-        self.tool_calls.lock().unwrap().iter().all(|(_, ok)| *ok)
+        lock_recover(&self.tool_calls).iter().all(|(_, ok)| *ok)
     }
 
     /// Accumulated `(input_tokens, output_tokens)` reported by the provider.
     pub fn tokens(&self) -> (u64, u64) {
         (
-            *self.input_tokens.lock().unwrap(),
-            *self.output_tokens.lock().unwrap(),
+            *lock_recover(&self.input_tokens),
+            *lock_recover(&self.output_tokens),
         )
     }
 }
@@ -45,10 +50,7 @@ impl Observer for RecordingObserver {
     fn record_event(&self, event: &ObserverEvent) {
         match event {
             ObserverEvent::ToolCall { tool, success, .. } => {
-                self.tool_calls
-                    .lock()
-                    .unwrap()
-                    .push((tool.clone(), *success));
+                lock_recover(&self.tool_calls).push((tool.clone(), *success));
             }
             ObserverEvent::LlmResponse {
                 input_tokens,
@@ -56,10 +58,10 @@ impl Observer for RecordingObserver {
                 ..
             } => {
                 if let Some(i) = input_tokens {
-                    *self.input_tokens.lock().unwrap() += i;
+                    *lock_recover(&self.input_tokens) += i;
                 }
                 if let Some(o) = output_tokens {
-                    *self.output_tokens.lock().unwrap() += o;
+                    *lock_recover(&self.output_tokens) += o;
                 }
             }
             _ => {}

--- a/crates/zeroclaw-eval/src/replay.rs
+++ b/crates/zeroclaw-eval/src/replay.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use zeroclaw_api::attribution::{Attributable, ModelProviderKind, ProviderKind, Role};
 use zeroclaw_api::model_provider::{
     ChatRequest, ChatResponse, ModelProvider, TokenUsage, ToolCall,
@@ -17,6 +17,13 @@ use crate::case::{LlmTrace, TraceResponse};
 struct ReplayState {
     turns: Vec<VecDeque<TraceResponse>>,
     current: usize,
+}
+
+fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 pub struct TraceLlmProvider {
@@ -59,7 +66,7 @@ impl ReplayHandle {
     /// Assert the just-finished turn consumed all of its scripted steps, then advance
     /// the cursor to the next turn. Errors if any steps were left unconsumed.
     pub fn finish_turn(&self, turn_index: usize) -> anyhow::Result<()> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = lock_recover(&self.state);
         let leftover = state.turns.get(state.current).map_or(0, |q| q.len());
         if leftover > 0 {
             anyhow::bail!(
@@ -102,7 +109,7 @@ impl ModelProvider for TraceLlmProvider {
         _temperature: Option<f64>,
     ) -> anyhow::Result<ChatResponse> {
         let step = {
-            let mut state = self.state.lock().unwrap();
+            let mut state = lock_recover(&self.state);
             let current = state.current;
             match state.turns.get_mut(current).and_then(|q| q.pop_front()) {
                 Some(step) => step,

--- a/crates/zeroclaw-memory/src/snapshot.rs
+++ b/crates/zeroclaw-memory/src/snapshot.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use chrono::Local;
 use rusqlite::{Connection, params};
-use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -65,17 +64,19 @@ pub fn export_snapshot(workspace_dir: &Path) -> Result<usize> {
     output.push_str(SNAPSHOT_HEADER);
 
     let now = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-    write!(output, "**Last exported:** {now}\n\n").unwrap();
-    write!(output, "**Total core memories:** {}\n\n---\n\n", rows.len()).unwrap();
+    output.push_str(&format!("**Last exported:** {now}\n\n"));
+    output.push_str(&format!(
+        "**Total core memories:** {}\n\n---\n\n",
+        rows.len()
+    ));
 
     for (key, content, _category, created_at, updated_at) in &rows {
-        write!(output, "### 🔑 `{key}`\n\n").unwrap();
-        write!(output, "{content}\n\n").unwrap();
-        write!(
-            output,
+        output.push_str(&format!("### 🔑 `{key}`\n\n"));
+        output.push_str(content);
+        output.push_str("\n\n");
+        output.push_str(&format!(
             "*Created: {created_at} | Updated: {updated_at}*\n\n---\n\n"
-        )
-        .unwrap();
+        ));
     }
 
     let snapshot_path = snapshot_path(workspace_dir);

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -859,8 +859,14 @@ fn extract_xml_pairs(input: &str) -> Vec<(&str, &str)> {
     let mut results = Vec::new();
     let mut search_start = 0;
     while let Some(open_cap) = XML_OPEN_TAG_RE.captures(&input[search_start..]) {
-        let full_open = open_cap.get(0).unwrap();
-        let tag_name = open_cap.get(1).unwrap().as_str();
+        let Some(full_open) = open_cap.get(0) else {
+            break;
+        };
+        let Some(tag_name) = open_cap.get(1) else {
+            search_start += full_open.end();
+            continue;
+        };
+        let tag_name = tag_name.as_str();
         let open_end = search_start + full_open.end();
 
         let closing_tag = format!("</{tag_name}>");
@@ -2344,7 +2350,9 @@ pub fn parse_tool_calls(response: &str) -> (String, Vec<ParsedToolCall>) {
         let mut last_end = 0;
 
         for cap in MD_TOOL_CALL_RE.captures_iter(response) {
-            let full_match = cap.get(0).unwrap();
+            let Some(full_match) = cap.get(0) else {
+                continue;
+            };
             // Range-aware: a fence that OPENS before a refused span and runs
             // through it must be refused too, not just one that starts inside.
             if range_hits_rejected_span(&rejected_tools_spans, full_match.start(), full_match.end())
@@ -2390,7 +2398,9 @@ pub fn parse_tool_calls(response: &str) -> (String, Vec<ParsedToolCall>) {
         let mut last_end = 0;
 
         for cap in MD_TOOL_NAME_RE.captures_iter(response) {
-            let full_match = cap.get(0).unwrap();
+            let Some(full_match) = cap.get(0) else {
+                continue;
+            };
             // Range-aware: a fence that OPENS before a refused span and runs
             // through it must be refused too, not just one that starts inside.
             if range_hits_rejected_span(&rejected_tools_spans, full_match.start(), full_match.end())
@@ -2703,8 +2713,10 @@ pub fn build_native_assistant_history_from_parsed_calls(
         "tool_calls": calls_json,
     });
 
-    if let Some(rc) = reasoning_content {
-        obj.as_object_mut().unwrap().insert(
+    if let Some(rc) = reasoning_content
+        && let Some(obj) = obj.as_object_mut()
+    {
+        obj.insert(
             "reasoning_content".to_string(),
             serde_json::Value::String(rc.to_string()),
         );


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Removes all 19 panic/invariant findings from eval replay/observation, memory snapshots, and the tool-call parser. Eval mutexes recover their guarded state after poisoning; replay exhaustion continues to return its existing trace error.
- **What changed and why:** Snapshot Markdown uses infallible `String` construction instead of unwrapping formatter results. Parser capture and JSON-object assumptions are checked, with malformed shapes skipped or left unmodified rather than panicking.
- **Scope boundary:** Trace semantics, snapshot format, parser-supported protocols, tool-call aliases, and successful parse output are unchanged. This PR does not change runtime dispatch or provider behavior.
- **Blast radius:** Evaluation reporting/replay, core-memory snapshot export, and model-output tool-call parsing. Changed behavior applies only after lock poisoning or on malformed internal capture/object shapes.
- **Linked issue(s):** Related #10118.
- **Labels:** `memory`, `distinguished contributor`, `domain:code-quality`, `risk:medium`, `size:S`, `type:refactor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — full focused crate suites cover the replay, snapshot, and parser contracts.

### How I tested

```sh
$ cargo fmt --all -- --check
# exit 0

$ cargo clippy --locked -p zeroclaw-eval -p zeroclaw-memory -p zeroclaw-tool-call-parser --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 42s

$ cargo test --locked -p zeroclaw-eval -p zeroclaw-memory -p zeroclaw-tool-call-parser --lib
test result: ok. 36 passed; 0 failed; 0 ignored    # eval
test result: ok. 503 passed; 0 failed; 0 ignored   # memory
test result: ok. 189 passed; 0 failed; 1 ignored   # parser

$ anti-slop --changed-since upstream/master
anti-slop: checked 4 Rust files; no violations

$ anti-slop --summary src crates apps xtask tools tests benches firmware
183  require-invariant-comment-for-panics
 64  require-safety-comment-for-unsafe
 41  no-dead-code-allow
```

The independent branch removes all 19 eval/memory/parser panic-invariant findings.

- **CI checks relied on and why they cover this change:** Fresh hosted CI is green on the current head. The required gate plus Test, Lint, Format, build/check, MSRV, and Security checks cover the affected crates and supported build surfaces; local all-target Clippy plus all 728 focused passing tests cover every changed crate and format/parser boundary.
- **Known CI coverage gap, if any:** None beyond hosted platform coverage.
- **Beyond CI, what did you manually verify?** Compared representative snapshot output and confirmed the parser still advances safely when a defensive capture check fails.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert e701a0a63f1fcd8172d90990e1ddac94a238dcc5`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Eval trace cursors drifting, snapshot Markdown changing, or supported tool-call envelopes no longer producing the same parsed calls/text.
