### PR TITLE
fix(config): make config and provider paths fallible

### DIFF
--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -614,8 +614,14 @@ pub fn validate_alias_key(key: &str) -> Result<(), String> {
             key.len()
         ));
     }
-    let first = key.chars().next().unwrap();
-    let last = key.chars().next_back().unwrap();
+    let first = key
+        .chars()
+        .next()
+        .ok_or_else(|| "alias must not be empty".to_string())?;
+    let last = key
+        .chars()
+        .next_back()
+        .ok_or_else(|| "alias must not be empty".to_string())?;
     if !matches!(first, 'a'..='z' | '0'..='9') {
         return Err(format!(
             "alias '{key}' must start with a lowercase letter or digit"

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -791,7 +791,7 @@ type MigrationStep = fn(toml::Value) -> Result<toml::Value>;
 
 const MIGRATION_STEPS: &[MigrationStep] = &[
     // V0 → V1: padding so slot 0 is never indexed. V0 does not exist.
-    |_| unreachable!("MIGRATION_STEPS[0] is a 1-indexing pad and is never invoked"),
+    Ok,
     // V1 → V2
     |value| {
         let v1: V1Config = value

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1022,8 +1022,9 @@ fn split_unquoted_segments(command: &str) -> Vec<String> {
                         current.push(ch);
                         // Detect `<<` (heredoc) but not `<<<` (here-string).
                         if chars.peek() == Some(&'<') {
-                            let second = chars.next().unwrap();
-                            current.push(second);
+                            if let Some(second) = chars.next() {
+                                current.push(second);
+                            }
                             if chars.peek() != Some(&'<') {
                                 reading_heredoc_word = true;
                             }
@@ -1171,7 +1172,7 @@ fn contains_unsafe_output_redirect_for_shell(command: &str, dialect: ShellDialec
             r"\d*>[ ]?/dev/({})(\s|[;&|)]|$)",
             safe_device_redirect_names_pattern()
         ))
-        .unwrap()
+        .expect("static safe-device redirect regex must compile")
     });
 
     let safe = re.replace_all(command, "$2").to_string();

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -19536,7 +19536,7 @@ impl Config {
             (true, true) => "http_request and web_fetch",
             (true, false) => "http_request",
             (false, true) => "web_fetch",
-            (false, false) => unreachable!(),
+            (false, false) => return,
         };
         warnings.push(crate::validation_warnings::ValidationWarning::new(
             "proxy_conflicts_with_dns_pinned_tools",

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -1174,15 +1174,11 @@ impl AnthropicModelProvider {
                     // finished list for the same thing: `dedupe_tool_results_by_id`
                     // only sees duplicates that already share a message, and this
                     // is what puts them there.
-                    if native_messages
-                        .last()
-                        .is_some_and(|m| m.role == tool_msg.role)
+                    if let Some(last) = native_messages
+                        .last_mut()
+                        .filter(|message| message.role == tool_msg.role)
                     {
-                        native_messages
-                            .last_mut()
-                            .unwrap()
-                            .content
-                            .extend(tool_msg.content);
+                        last.content.extend(tool_msg.content);
                     } else {
                         native_messages.push(tool_msg);
                     }
@@ -1308,12 +1304,11 @@ impl AnthropicModelProvider {
                     // Merge into previous user message if present (e.g.
                     // when a user message immediately follows tool results
                     // which are also role "user" in Anthropic's format).
-                    if native_messages.last().is_some_and(|m| m.role == "user") {
-                        native_messages
-                            .last_mut()
-                            .unwrap()
-                            .content
-                            .extend(content_blocks);
+                    if let Some(last) = native_messages
+                        .last_mut()
+                        .filter(|message| message.role == "user")
+                    {
+                        last.content.extend(content_blocks);
                     } else {
                         native_messages.push(NativeMessage {
                             role: "user".to_string(),

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -76,10 +76,12 @@ pub(crate) trait FamilyProviderFactory {
 }
 
 fn fixed_family_endpoint<T: FamilyProviderFactory>() -> &'static str {
-    match T::ENDPOINT {
-        ProviderEndpoint::Fixed(url) => url,
-        _ => unreachable!("fixed endpoint helper used for a non-fixed provider family"),
-    }
+    // INVARIANT: this helper is called only by factory implementations whose
+    // associated endpoint is declared `Fixed`; registry tests enumerate the
+    // canonical families and enforce that classification.
+    T::ENDPOINT
+        .fixed_url()
+        .expect("fixed endpoint helper requires a fixed provider family")
 }
 
 /// Spec trait for OpenAI-compatible families. Implementing this gives a

--- a/crates/zeroclaw-providers/src/gemini.rs
+++ b/crates/zeroclaw-providers/src/gemini.rs
@@ -1255,7 +1255,11 @@ impl GeminiModelProvider {
                             (token, proj)
                         }
                         GeminiAuth::ManagedOAuth => {
-                            let auth_service = self.auth_service.as_ref().unwrap();
+                            let Some(auth_service) = self.auth_service.as_ref() else {
+                                return Err(anyhow::Error::msg(
+                                    "Gemini managed OAuth requires an auth service",
+                                ));
+                            };
                             let token = auth_service
                                 .get_valid_gemini_access_token(
                                     self.auth_profile_override.as_deref(),
@@ -1281,7 +1285,11 @@ impl GeminiModelProvider {
                             let proj = self.resolve_oauth_project(&token).await?;
                             (token, proj)
                         }
-                        _ => unreachable!(),
+                        _ => {
+                            return Err(anyhow::Error::msg(
+                                "Gemini retry reached a non-refreshable authentication mode",
+                            ));
+                        }
                     };
                     oauth_token = Some(new_token);
                     project = Some(new_project);

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -448,7 +448,7 @@ pub fn strip_media_markers(text: &str) -> String {
             r"(?i)\[(?:{}):[^\]]*\]",
             MEDIA_MARKER_KINDS.join("|")
         ))
-        .unwrap()
+        .expect("static media-marker regex must compile")
     });
     RE.replace_all(text, "[media attachment]").into_owned()
 }
@@ -460,7 +460,7 @@ static AUDIO_MARKER_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock:
         r"(?i)\[(?:{}):([^\]]*)\]",
         AUDIO_MARKER_KINDS.join("|")
     ))
-    .unwrap()
+    .expect("static audio-marker regex must compile")
 });
 
 /// Replace audio markers (`[AUDIO:...]`, `[VOICE:...]`) whose payload is a


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Removes all 13 panic/invariant findings from config and provider code. Alias validation, migration padding, shell parsing, proxy warnings, provider message merging, Gemini OAuth retry, and media-marker regex construction now remain total or return contextual errors.
- **What changed and why:** Retains the fixed-provider endpoint relationship as an explicit registry-tested invariant with a named `expect`, instead of an unqualified unreachable branch.
- **Scope boundary:** Config schema, migrations, provider endpoints, authentication precedence, request payloads, and successful message conversion are unchanged. This PR does not alter runtime retry policy or add provider families.
- **Blast radius:** Config alias/migration/policy/validation helpers and Anthropic/Gemini/multimodal/factory provider construction. Changed behavior is limited to malformed or internally inconsistent states.
- **Linked issue(s):** Related #10118.
- **Labels:** `config`, `provider`, `distinguished contributor`, `provider:anthropic`, `provider:gemini`, `security:policy`, `domain:code-quality`, `risk:medium`, `size:XS`, `type:refactor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — complete config and provider suites cover the changed validation and construction boundaries.

### How I tested

```sh
$ cargo fmt --all -- --check
# exit 0

$ cargo clippy --locked -p zeroclaw-config -p zeroclaw-providers --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 50s

$ cargo test --locked -p zeroclaw-config -p zeroclaw-providers --lib -- --test-threads=1
test result: ok. 1312 passed; 0 failed; 0 ignored  # config
test result: ok. 1317 passed; 0 failed; 0 ignored  # providers

$ anti-slop --changed-since upstream/master
anti-slop: checked 8 Rust files; no violations

$ anti-slop --summary src crates apps xtask tools tests benches firmware
189  require-invariant-comment-for-panics
 64  require-safety-comment-for-unsafe
 41  no-dead-code-allow
```

The independent branch removes all 13 config/provider panic-invariant findings.

- **CI checks relied on and why they cover this change:** Exact-head GitHub `Format`, `Lint`, `Test`, `Build x86_64-unknown-linux-gnu`, `Security`, `MSRV (declared floor)`, and `CI Required Gate` checks passed. Local all-target Clippy and 2,629 focused passing tests cover every changed config/provider module.
- **Known CI coverage gap, if any:** Live provider APIs were not contacted; no successful network path changed.
- **Beyond CI, what did you manually verify?** Confirmed migration indexing remains aligned, fixed endpoint families retain their canonical URLs, and Gemini's new error branches activate only when its managed-auth invariants are already broken.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Live provider smoke tests require external credentials and are unrelated to these defensive paths.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 7b767508c72f9ad1a5a3aba9777b608c441d39a0`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Config migration/version drift, provider factory URLs changing, Gemini OAuth retries failing despite a configured auth service, or Anthropic message ordering changing.
