### PR TITLE
fix(runtime): keep agent dispatch panic-free

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -539,8 +539,9 @@ pub fn native_tool_specs_present_for_turn(
     Ok(activated.tool_names().iter().any(|name| !is_excluded(name)))
 }
 
-static IMAGE_DATA_URI_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[IMAGE:data:[^\]]*\]").unwrap());
+static IMAGE_DATA_URI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[IMAGE:data:[^\]]*\]").expect("static image data URI regex must compile")
+});
 
 fn elide_image_data(content: &str) -> String {
     IMAGE_DATA_URI_REGEX

--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -330,12 +330,20 @@ async fn safety_net_streaming_event_sequence_for_tool_turn() {
         pos_tool_call < pos_tool_result,
         "ToolCall must precede its ToolResult"
     );
-    let (call_id, result_id) = match (&events[pos_tool_call], &events[pos_tool_result]) {
-        (TurnEvent::ToolCall { id: c, .. }, TurnEvent::ToolResult { id: r, .. }) => {
-            (c.clone(), r.clone())
-        }
-        _ => unreachable!(),
-    };
+    let call_id = events
+        .iter()
+        .find_map(|event| match event {
+            TurnEvent::ToolCall { id, .. } => Some(id.clone()),
+            _ => None,
+        })
+        .expect("a ToolCall event must carry an id");
+    let result_id = events
+        .iter()
+        .find_map(|event| match event {
+            TurnEvent::ToolResult { id, .. } => Some(id.clone()),
+            _ => None,
+        })
+        .expect("a ToolResult event must carry an id");
     assert_eq!(call_id, "tc-1");
     assert_eq!(
         call_id, result_id,

--- a/crates/zeroclaw-runtime/src/agent/turn/parse_response.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/parse_response.rs
@@ -49,19 +49,22 @@ pub(crate) fn build_native_assistant_history(
         serde_json::Value::String(text.trim().to_string())
     };
 
-    let mut obj = serde_json::json!({
-        "content": content,
-        "tool_calls": calls_json,
-    });
+    let mut obj = serde_json::Map::from_iter([
+        ("content".to_string(), content),
+        (
+            "tool_calls".to_string(),
+            serde_json::Value::Array(calls_json),
+        ),
+    ]);
 
     if let Some(rc) = reasoning_content {
-        obj.as_object_mut().unwrap().insert(
+        obj.insert(
             "reasoning_content".to_string(),
             serde_json::Value::String(rc.to_string()),
         );
     }
 
-    obj.to_string()
+    serde_json::Value::Object(obj).to_string()
 }
 
 pub(crate) fn resolve_display_text(

--- a/crates/zeroclaw-runtime/src/agent/turn/redact.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/redact.rs
@@ -6,7 +6,8 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 static SENSITIVE_KV_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)(authorization|token|api[_-]?key|password|secret|user[_-]?key|bearer|credential|set[_-]?cookie|cookie)["']?\s*[:=]\s*(?:"([^"]{8,})"|'([^']{8,})'|([a-zA-Z0-9_\-\./+=]{8,}))"#).unwrap()
+    Regex::new(r#"(?i)(authorization|token|api[_-]?key|password|secret|user[_-]?key|bearer|credential|set[_-]?cookie|cookie)["']?\s*[:=]\s*(?:"([^"]{8,})"|'([^']{8,})'|([a-zA-Z0-9_\-\./+=]{8,}))"#)
+        .expect("static sensitive key-value regex must compile")
 });
 
 pub fn scrub_credentials(input: &str) -> String {
@@ -53,7 +54,8 @@ pub fn scrub_credentials(input: &str) -> String {
 }
 
 static SENSITIVE_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)(authorization|token|api[_-]?key|password|secret|user[_-]?key|bearer|credential|set[_-]?cookie|cookie)"#).unwrap()
+    Regex::new(r#"(?i)(authorization|token|api[_-]?key|password|secret|user[_-]?key|bearer|credential|set[_-]?cookie|cookie)"#)
+        .expect("static sensitive-key regex must compile")
 });
 
 /// Structured-aware credential scrub for a JSON value bound for a human-facing

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -4689,7 +4689,7 @@ fn response_id_key(id: &Value) -> Option<String> {
         Value::String(id) => Some(id.clone()),
         Value::Number(id) => Some(id.to_string()),
         Value::Null => None,
-        _ => unreachable!("validated JSON-RPC ID"),
+        _ => None,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1865,9 +1865,20 @@ pub fn skills_to_tools_with_context_and_runtime(
                         tools.push(t);
                     }
                 }
-                // `is_registered_skill_tool_kind` above admits only the kinds
-                // dispatched here, so any other kind was already skipped.
-                other => unreachable!("registered skill kind '{other}' not dispatched"),
+                // Keep this fail-closed if the admission list and dispatcher
+                // ever drift apart: an unsupported tool is safer skipped than
+                // allowed to abort agent startup.
+                other => {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                        &format!(
+                            "Registered skill tool kind '{other}' for {}.{} has no dispatcher, skipping",
+                            skill.name, tool.name
+                        )
+                    );
+                }
             }
         }
     }

--- a/crates/zeroclaw-runtime/src/skills/reference.rs
+++ b/crates/zeroclaw-runtime/src/skills/reference.rs
@@ -72,7 +72,9 @@ pub fn resolve(
     }
 
     if config.skill_bundles.len() == 1 {
-        let bundle_alias = config.skill_bundles.keys().next().unwrap().clone();
+        let Some(bundle_alias) = config.skill_bundles.keys().next().cloned() else {
+            return Err(SkillRefError::NoBundles);
+        };
         return Ok(SkillRef::new_unchecked(bundle_alias, name.to_string()));
     }
 

--- a/crates/zeroclaw-runtime/src/sop/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/sop/dispatch.rs
@@ -710,10 +710,15 @@ async fn dispatch_sop_event_filtered(
                             reason,
                         });
                     }
-                    // `has_retryable_defer` was false, so no `Defer` remains here.
-                    SopAdmission::Defer { .. } => unreachable!(
-                        "a retryable Defer would have returned via the has_retryable_defer branch"
-                    ),
+                    // `has_retryable_defer` was computed from this same vector,
+                    // but keep the fallback safe if this loop is refactored:
+                    // surface backpressure so the durable delivery is retried.
+                    SopAdmission::Defer { reason } => {
+                        results.push(DispatchResult::Deferred {
+                            sop_name: sop_name.clone(),
+                            reason,
+                        });
+                    }
                 }
             }
 

--- a/crates/zeroclaw-runtime/src/sop/engine.rs
+++ b/crates/zeroclaw-runtime/src/sop/engine.rs
@@ -4408,7 +4408,10 @@ impl SopEngine {
             self.dispatch_deterministic_step(&run_id, &sop, 1, last_output)
         } else {
             {
-                let run = self.active_runs.get_mut(&run_id).unwrap();
+                let Some(run) = self.active_runs.get_mut(&run_id) else {
+                    self.release_claim_on_park(&run_id);
+                    bail!("Active run not found: {run_id}");
+                };
                 run.current_step = state.last_completed_step;
             }
             self.resolve_sop_step(&sop, state.last_completed_step)

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1339,18 +1339,14 @@ pub fn all_tools_with_runtime(
     tool_arcs.push(Arc::new(git_forge_tool));
 
     // Channel room-management tool — always registered; owns its own late-bound channel map.
-    let channel_room_handle: Option<PerToolChannelHandle> =
-        Some(Arc::new(RwLock::new(HashMap::new())));
-    let channel_room_tool = ChannelRoomTool::new(
-        security.clone(),
-        channel_room_handle.as_ref().cloned().unwrap(),
-    );
+    let channel_room_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
+    let channel_room_tool =
+        ChannelRoomTool::new(security.clone(), Arc::clone(&channel_room_handle));
     tool_arcs.push(Arc::new(channel_room_tool));
 
     // Interactive ask_user tool — always registered; owns its own late-bound channel map.
-    let ask_user_handle: Option<PerToolChannelHandle> = Some(Arc::new(RwLock::new(HashMap::new())));
-    let ask_user_tool =
-        AskUserTool::new(security.clone(), ask_user_handle.as_ref().cloned().unwrap());
+    let ask_user_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
+    let ask_user_tool = AskUserTool::new(security.clone(), Arc::clone(&ask_user_handle));
     tool_arcs.push(Arc::new(ask_user_tool));
 
     {
@@ -1363,17 +1359,17 @@ pub fn all_tools_with_runtime(
         };
         tool_arcs.push(Arc::new(SendViaTool::new(
             security.clone(),
-            ask_user_handle.as_ref().cloned().unwrap(),
+            Arc::clone(&ask_user_handle),
             agent_peer_groups,
         )));
     }
 
     // Human escalation tool — always registered; owns its own late-bound channel map.
-    let escalate_handle: Option<PerToolChannelHandle> = Some(Arc::new(RwLock::new(HashMap::new())));
+    let escalate_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
     let escalate_tool = EscalateToHumanTool::new(
         security.clone(),
         root_config.escalation.alert_channels.clone(),
-        escalate_handle.as_ref().cloned().unwrap(),
+        Arc::clone(&escalate_handle),
     );
     tool_arcs.push(Arc::new(escalate_tool));
 
@@ -1410,11 +1406,11 @@ pub fn all_tools_with_runtime(
                     unfiltered_tool_arcs: tool_arcs.clone(),
                     tools: boxed_registry_from_arcs(tool_arcs),
                     delegate_handle: None,
-                    ask_user_handle,
-                    channel_room_handle,
+                    ask_user_handle: Some(ask_user_handle),
+                    channel_room_handle: Some(channel_room_handle),
                     reaction_handle,
                     poll_handle: Some(poll_handle),
-                    escalate_handle,
+                    escalate_handle: Some(escalate_handle),
                 };
             }
 
@@ -1684,11 +1680,11 @@ pub fn all_tools_with_runtime(
         unfiltered_tool_arcs: tool_arcs.clone(),
         tools: boxed_registry_from_arcs(tool_arcs),
         delegate_handle,
-        ask_user_handle,
-        channel_room_handle,
+        ask_user_handle: Some(ask_user_handle),
+        channel_room_handle: Some(channel_room_handle),
         reaction_handle,
         poll_handle: Some(poll_handle),
-        escalate_handle,
+        escalate_handle: Some(escalate_handle),
     }
 }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1339,14 +1339,15 @@ pub fn all_tools_with_runtime(
     tool_arcs.push(Arc::new(git_forge_tool));
 
     // Channel room-management tool — always registered; owns its own late-bound channel map.
-    let channel_room_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
-    let channel_room_tool =
-        ChannelRoomTool::new(security.clone(), Arc::clone(&channel_room_handle));
+    let channel_room_tool_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
+    let channel_room_handle = Some(Arc::clone(&channel_room_tool_handle));
+    let channel_room_tool = ChannelRoomTool::new(security.clone(), channel_room_tool_handle);
     tool_arcs.push(Arc::new(channel_room_tool));
 
     // Interactive ask_user tool — always registered; owns its own late-bound channel map.
-    let ask_user_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
-    let ask_user_tool = AskUserTool::new(security.clone(), Arc::clone(&ask_user_handle));
+    let ask_user_tool_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
+    let ask_user_handle = Some(Arc::clone(&ask_user_tool_handle));
+    let ask_user_tool = AskUserTool::new(security.clone(), Arc::clone(&ask_user_tool_handle));
     tool_arcs.push(Arc::new(ask_user_tool));
 
     {
@@ -1359,17 +1360,18 @@ pub fn all_tools_with_runtime(
         };
         tool_arcs.push(Arc::new(SendViaTool::new(
             security.clone(),
-            Arc::clone(&ask_user_handle),
+            ask_user_tool_handle,
             agent_peer_groups,
         )));
     }
 
     // Human escalation tool — always registered; owns its own late-bound channel map.
-    let escalate_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
+    let escalate_tool_handle: PerToolChannelHandle = Arc::new(RwLock::new(HashMap::new()));
+    let escalate_handle = Some(Arc::clone(&escalate_tool_handle));
     let escalate_tool = EscalateToHumanTool::new(
         security.clone(),
         root_config.escalation.alert_channels.clone(),
-        Arc::clone(&escalate_handle),
+        escalate_tool_handle,
     );
     tool_arcs.push(Arc::new(escalate_tool));
 
@@ -1406,11 +1408,11 @@ pub fn all_tools_with_runtime(
                     unfiltered_tool_arcs: tool_arcs.clone(),
                     tools: boxed_registry_from_arcs(tool_arcs),
                     delegate_handle: None,
-                    ask_user_handle: Some(ask_user_handle),
-                    channel_room_handle: Some(channel_room_handle),
+                    ask_user_handle,
+                    channel_room_handle,
                     reaction_handle,
                     poll_handle: Some(poll_handle),
-                    escalate_handle: Some(escalate_handle),
+                    escalate_handle,
                 };
             }
 
@@ -1680,11 +1682,11 @@ pub fn all_tools_with_runtime(
         unfiltered_tool_arcs: tool_arcs.clone(),
         tools: boxed_registry_from_arcs(tool_arcs),
         delegate_handle,
-        ask_user_handle: Some(ask_user_handle),
-        channel_room_handle: Some(channel_room_handle),
+        ask_user_handle,
+        channel_room_handle,
         reaction_handle,
         poll_handle: Some(poll_handle),
-        escalate_handle: Some(escalate_handle),
+        escalate_handle,
     }
 }
 

--- a/crates/zeroclaw-runtime/src/tools/model_switch.rs
+++ b/crates/zeroclaw-runtime/src/tools/model_switch.rs
@@ -146,7 +146,10 @@ impl Tool for ModelSwitchTool {
 impl ModelSwitchTool {
     fn handle_get(&self) -> anyhow::Result<ToolResult> {
         let switch_state = current_model_switch_state()?;
-        let pending = switch_state.lock().unwrap().clone();
+        let pending = match switch_state.lock() {
+            Ok(state) => state.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        };
 
         Ok(ToolResult {
             success: true,
@@ -213,7 +216,12 @@ impl ModelSwitchTool {
         }
 
         let switch_state = current_model_switch_state()?;
-        *switch_state.lock().unwrap() = Some((model_provider.clone(), model.to_string()));
+        match switch_state.lock() {
+            Ok(mut state) => *state = Some((model_provider.clone(), model.to_string())),
+            Err(poisoned) => {
+                *poisoned.into_inner() = Some((model_provider.clone(), model.to_string()));
+            }
+        }
 
         Ok(ToolResult {
             success: true,

--- a/crates/zeroclaw-runtime/src/tools/security_ops.rs
+++ b/crates/zeroclaw-runtime/src/tools/security_ops.rs
@@ -198,8 +198,8 @@ impl SecurityOpsTool {
             anyhow::Error::msg("Missing required 'scan_data' parameter")
         })?;
 
-        let json_str = if scan_data.is_string() {
-            scan_data.as_str().unwrap().to_string()
+        let json_str = if let Some(scan_data) = scan_data.as_str() {
+            scan_data.to_string()
         } else {
             serde_json::to_string(scan_data)?
         };


### PR DESCRIPTION
## Summary

- **Base branch:** master
- **What changed and why:** Converts all 17 panic candidates in runtime agent, turn, RPC dispatch, skills, SOP dispatch/engine, and tool-registry paths: 12 production `unwrap`/`unreachable!` sites become error returns or fail-closed fallbacks, and the 3 static regex compilations (plus 2 test-only sites) become `expect()` with a documented invariant, as AGENTS.md allows.
- **What changed and why:** Invalid JSON-RPC IDs remain uncorrelatable, unsupported skill-dispatch drift is logged and skipped, a late SOP `Defer` defers the whole AMQP delivery instead of starting siblings, the SOP resume path sets the current step under the lookup that already validated the run (no second fallible lookup), and a pending model switch is read through a poisoned guard on both the tool and the turn-loop side, with a regression test. Tool handles are constructed without unwrap while preserving optional return handles.
- **Scope boundary:** This independent slice does not include the 30 operational runtime findings handled by #10133. The Microsoft 365 client_credentials early-return block remains unchanged because #8310/#8754 removes it. The pre-existing resume-path lookup that errors after `reacquire_claim_on_resume` without releasing the claim is not changed here.
- **Blast radius:** zeroclaw-runtime and its workspace dependents. Normal successful paths preserve existing output; changes affect malformed, poisoned, or internally inconsistent states that previously aborted.
- **Linked issue(s):** Related #10118, #8310, and #8754; complementary to #10133.
- **Labels:** agent, runtime, skills, distinguished contributor, domain:code-quality, tool:security, follow-up, risk:medium, size:M, type:refactor

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the serialized runtime suite, the new poisoned-callback regression, and lint gates cover this panic-safety refactor.

### How I tested

- **Tested revision:** `4db84e994ac05aedef2597a3bfdca57114ccca1f`; the following local results are reported in [the author’s validation update](https://github.com/zeroclaw-labs/zeroclaw/pull/10134#issuecomment-5702655965).

~~~sh
cargo fmt --all -- --check
# exit 0

cargo check --locked -p zeroclaw-runtime --all-targets
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 11s
# exit 0

cargo clippy --locked -p zeroclaw-runtime --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 11s
# exit 0, no warnings

cargo test --locked -p zeroclaw-runtime --lib -- poisoned_model_switch model_switch sop::dispatch resume restore safety_net --test-threads=1
# test agent::agent::safety_net::poisoned_model_switch_callback_still_raises_model_switch_requested ... ok
# test result: ok. 135 passed; 0 failed; 0 ignored; 0 measured; 4309 filtered out; finished in 17.34s
~~~

- **CI checks relied on and why they cover this change:** Runtime Clippy covers every changed target, and the serialized runtime suite exercises agent, RPC, skills, SOP, and tool-registry paths without process-global test interference.
- **Merge note:** CI builds the PR merged with master, and master sealed `ResolvedIo.tools_registry` as `ScopedToolRegistry` (#9319, #10445), so the new regression compiled on the PR head alone but not in the merge. The branch now carries a merge of upstream/master (b9ca287335) and the test builds its empty registry through `ScopedToolRegistry::from_raw_for_test`; the local results above are from the merged tree.
- **Current CI status:** Required checks pass on `4db84e994ac05aedef2597a3bfdca57114ccca1f`. The [advisory Windows nextest job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35133155473/job/104919550847) fails in the shell-denial, peer-turn stack-overflow, and two Arduino tests; Windows testing is not fully green.
- **Known CI coverage gap, if any:** `anti-slop` is not installed in this worktree, so the third-round push relies on CI Lint for that check; the code-graph helper had no SCIP index, so caller review used source inspection, crate-wide Clippy, and the runtime suite.
- **Beyond CI, what did you manually verify?** Confirmed the cumulative PR diff no longer touches the Microsoft 365 early-return block; that the optional handle returned to callers is the same Arc passed to each live tool; that `has_retryable_defer` in SOP dispatch is computed from the same admissions vector, so the late `Defer` arm is unreachable today and now starts nothing if reached; and that the new regression fails on the previous head (`let Ok(guard) = callback.lock()` short-circuits on a poisoned callback) and passes on this one.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** `anti-slop --changed-since upstream/master` was not rerun for the third round because the binary is not available in this worktree; CI Lint covers it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback:** Revert the eventual squash-merge commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Missing runtime tools or skills, model switches not being consumed, JSON-RPC responses correlating incorrectly, or SOP deliveries retaining execution claims.
