### PR TITLE
fix(zerocode): keep runtime interactions panic-free

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -5927,8 +5927,9 @@ impl ChatState {
         } else if !extend {
             self.browse_anchor = None;
         }
-        self.browse_cursor = Some(cur.saturating_sub(n));
-        self.scroll_entry_into_view(self.browse_cursor.unwrap());
+        let next = cur.saturating_sub(n);
+        self.browse_cursor = Some(next);
+        self.scroll_entry_into_view(next);
         self.pinned_to_bottom = false;
         self.mark_dirty_full();
     }
@@ -5947,8 +5948,9 @@ impl ChatState {
         } else if !extend {
             self.browse_anchor = None;
         }
-        self.browse_cursor = Some((cur + n).min(len - 1));
-        self.scroll_entry_into_view(self.browse_cursor.unwrap());
+        let next = cur.saturating_add(n).min(len - 1);
+        self.browse_cursor = Some(next);
+        self.scroll_entry_into_view(next);
         self.pinned_to_bottom =
             self.scroll_offset >= self.last_total_rows.saturating_sub(self.last_inner_height);
         self.mark_dirty_full();

--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -406,6 +406,20 @@ pub enum ConnectionState {
     Disconnected { reason: String },
 }
 
+fn replace_connection_state(state: &Mutex<ConnectionState>, next: ConnectionState) {
+    match state.lock() {
+        Ok(mut state) => *state = next,
+        Err(poisoned) => *poisoned.into_inner() = next,
+    }
+}
+
+fn clone_connection_state(state: &Mutex<ConnectionState>) -> ConnectionState {
+    match state.lock() {
+        Ok(state) => state.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
 /// The TUI and daemon are built from the same package version and do not
 /// promise cross-version wire compatibility.
 #[derive(Debug)]
@@ -683,15 +697,21 @@ impl RpcClient {
                 buf.clear();
                 match reader.read_line(&mut buf).await {
                     Ok(0) => {
-                        *conn_state_for_reader.lock().unwrap() = ConnectionState::Disconnected {
-                            reason: "EOF (daemon closed connection)".to_string(),
-                        };
+                        replace_connection_state(
+                            &conn_state_for_reader,
+                            ConnectionState::Disconnected {
+                                reason: "EOF (daemon closed connection)".to_string(),
+                            },
+                        );
                         break;
                     }
                     Err(e) => {
-                        *conn_state_for_reader.lock().unwrap() = ConnectionState::Disconnected {
-                            reason: e.to_string(),
-                        };
+                        replace_connection_state(
+                            &conn_state_for_reader,
+                            ConnectionState::Disconnected {
+                                reason: e.to_string(),
+                            },
+                        );
                         break;
                     }
                     Ok(_) => {}
@@ -839,22 +859,30 @@ impl RpcClient {
                         let reason = frame
                             .map(|f| f.reason.to_string())
                             .unwrap_or_else(|| "server closed connection".to_string());
-                        *conn_state_for_reader.lock().unwrap() =
-                            ConnectionState::Disconnected { reason };
+                        replace_connection_state(
+                            &conn_state_for_reader,
+                            ConnectionState::Disconnected { reason },
+                        );
                         break;
                     }
                     Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => continue,
                     Some(Ok(Message::Binary(_))) => continue,
                     Some(Err(e)) => {
-                        *conn_state_for_reader.lock().unwrap() = ConnectionState::Disconnected {
-                            reason: e.to_string(),
-                        };
+                        replace_connection_state(
+                            &conn_state_for_reader,
+                            ConnectionState::Disconnected {
+                                reason: e.to_string(),
+                            },
+                        );
                         break;
                     }
                     None => {
-                        *conn_state_for_reader.lock().unwrap() = ConnectionState::Disconnected {
-                            reason: "EOF (WSS connection closed)".to_string(),
-                        };
+                        replace_connection_state(
+                            &conn_state_for_reader,
+                            ConnectionState::Disconnected {
+                                reason: "EOF (WSS connection closed)".to_string(),
+                            },
+                        );
                         break;
                     }
                 }
@@ -1006,7 +1034,7 @@ impl RpcClient {
 
     /// Current connection state. Cheap mutex read, safe to call on every frame.
     pub fn connection_state(&self) -> ConnectionState {
-        self.connection_state.lock().unwrap().clone()
+        clone_connection_state(&self.connection_state)
     }
 
     // ── Notifications ─────────────────────────────────────────────

--- a/apps/zerocode/src/i18n.rs
+++ b/apps/zerocode/src/i18n.rs
@@ -84,8 +84,12 @@ fn load_strings(locale: &str) -> HashMap<String, String> {
 fn format_ftl_messages(ftl_source: &str, locale: &str) -> HashMap<String, String> {
     let resource =
         FluentResource::try_new(ftl_source.to_string()).unwrap_or_else(|(resource, _)| resource);
-    let language_identifier: LanguageIdentifier =
-        locale.parse().unwrap_or_else(|_| "en".parse().unwrap());
+    let language_identifier: LanguageIdentifier = match locale.parse() {
+        Ok(identifier) => identifier,
+        Err(_) => "en"
+            .parse()
+            .expect("static English Fluent locale must parse"),
+    };
     let mut bundle = FluentBundle::new(vec![language_identifier]);
     bundle.set_use_isolating(false);
     let _ = bundle.add_resource(resource);
@@ -179,8 +183,12 @@ fn format_ftl_message(
 ) -> Option<String> {
     let resource =
         FluentResource::try_new(ftl_source.to_string()).unwrap_or_else(|(resource, _)| resource);
-    let language_identifier: LanguageIdentifier =
-        locale.parse().unwrap_or_else(|_| "en".parse().unwrap());
+    let language_identifier: LanguageIdentifier = match locale.parse() {
+        Ok(identifier) => identifier,
+        Err(_) => "en"
+            .parse()
+            .expect("static English Fluent locale must parse"),
+    };
     let mut bundle = FluentBundle::new(vec![language_identifier]);
     bundle.set_use_isolating(false);
     let _ = bundle.add_resource(resource);


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Removed all 10 production panic candidates from ZeroCode chat navigation, RPC connection-state handling, and Fluent locale fallback.
- **What changed and why:** Browse movement now carries the computed cursor directly and uses saturating addition; connection readers and the public state accessor recover a poisoned mutex; static English locale fallback uses a descriptive invariant message.
- **Scope boundary:** This slice does not include ZeroCode's build-script findings, which are handled independently by #10126. It does not change rendered UI, RPC wire shape, configuration, or keybindings.
- **Blast radius:** The ZeroCode TUI and build-time consumers `xtask` and `fill-translations`. Normal navigation and connection-state output are unchanged; malformed locale input continues to fall back to English without a bare unwrap, and poisoned connection state now recovers instead of aborting.
- **Linked issue(s):** Related #10118
- **Labels:** `distinguished contributor`, `domain:code-quality`, `risk:medium`, `zerocode`, `size:S`, `type:refactor`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — no visible UI state changed; the ZeroCode test targets cover navigation, RPC routing, connection lifecycle, and localization.

### How I tested

- **CI checks relied on and why they cover this change:** ZeroCode all-target clippy covers the changed library and binary paths; all-target tests exercise both targets and their connection subprocess fixture.
- **Known CI coverage gap, if any:** The repository code-graph helper had no SCIP index in this fresh worktree, so caller review used its crate-level dependent report, source inspection, clippy, and all-target tests.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# exit 0

anti-slop --changed-since upstream/master
# anti-slop: checked 3 Rust files; no violations

cargo clippy --locked -p zerocode --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 04s

cargo test --locked -p zerocode --all-targets
# lib: 191 passed; 0 failed
# binary: 736 passed; 0 failed; 1 ignored
```

- **Beyond CI, what did you manually verify?** Reviewed cursor movement for empty, upper-bound, and overflow behavior; confirmed the client preserves the same disconnected reasons after poisoned-lock recovery; and checked the ZeroCode anti-slop summary, which now reports only the nine independent build-script findings from #10126.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No relevant command was skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 8cf9beadb`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Browse selection moves to an unexpected entry, connection status stops updating after disconnect, or localized strings fail to render.
