### PR TITLE
fix(core): keep platform paths panic-free

### DIFF
--- a/crates/zeroclaw-hardware/src/peripherals/uno_q_setup.rs
+++ b/crates/zeroclaw-hardware/src/peripherals/uno_q_setup.rs
@@ -44,12 +44,9 @@ fn deploy_remote(host: &str, bridge_dir: &std::path::Path) -> Result<()> {
     }
 
     let status = Command::new("scp")
-        .args([
-            "-r",
-            "--",
-            bridge_dir.to_str().unwrap(),
-            &format!("{}:~/ArduinoApps/", ssh_target),
-        ])
+        .args(["-r", "--"])
+        .arg(bridge_dir)
+        .arg(format!("{}:~/ArduinoApps/", ssh_target))
         .status()
         .context("scp failed")?;
     if !status.success() {
@@ -149,7 +146,8 @@ fn deploy_local(bridge_dir: Option<&std::path::Path>) -> Result<()> {
 
     println!("Starting Bridge app...");
     let status = Command::new("arduino-app-cli")
-        .args(["app", "start", dest_dir.to_str().unwrap()])
+        .args(["app", "start"])
+        .arg(&dest_dir)
         .status()
         .context("arduino-app-cli start failed")?;
     if !status.success() {

--- a/crates/zeroclaw-infra/src/session_queue.rs
+++ b/crates/zeroclaw-infra/src/session_queue.rs
@@ -97,7 +97,12 @@ impl SessionActorQueue {
                 .clone();
 
             #[cfg(test)]
-            if let Some(hook) = self.registration_hook.lock().unwrap().as_ref() {
+            let registration_hook = match self.registration_hook.lock() {
+                Ok(hook) => hook,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            #[cfg(test)]
+            if let Some(hook) = registration_hook.as_ref() {
                 hook();
             }
 

--- a/crates/zeroclaw-log/src/layer.rs
+++ b/crates/zeroclaw-log/src/layer.rs
@@ -180,21 +180,16 @@ where
 
         // Attach source location for jump-to-source from log viewers.
         if visitor.file.is_some() || visitor.line.is_some() {
-            let map = match &mut log_event.attributes {
-                Value::Object(m) => m,
-                _ => {
-                    log_event.attributes = Value::Object(JsonMap::new());
-                    match &mut log_event.attributes {
-                        Value::Object(m) => m,
-                        _ => unreachable!(),
-                    }
-                }
-            };
-            if let Some(f) = visitor.file {
-                map.entry("_file".to_string()).or_insert(Value::String(f));
+            if !log_event.attributes.is_object() {
+                log_event.attributes = Value::Object(JsonMap::new());
             }
-            if let Some(l) = visitor.line {
-                map.entry("_line".to_string()).or_insert(Value::from(l));
+            if let Some(map) = log_event.attributes.as_object_mut() {
+                if let Some(f) = visitor.file {
+                    map.entry("_file".to_string()).or_insert(Value::String(f));
+                }
+                if let Some(l) = visitor.line {
+                    map.entry("_line".to_string()).or_insert(Value::from(l));
+                }
             }
         }
 

--- a/firmware/nucleo/src/main.rs
+++ b/firmware/nucleo/src/main.rs
@@ -22,7 +22,10 @@ async fn main(_spawner: Spawner) {
     let mut config = Config::default();
     config.baudrate = 115_200;
 
-    let mut usart = Uart::new_blocking(p.USART2, p.PA3, p.PA2, config).unwrap();
+    let Ok(mut usart) = Uart::new_blocking(p.USART2, p.PA3, p.PA2, config) else {
+        defmt::error!("failed to initialize USART2");
+        return;
+    };
     let mut led = Output::new(p.PA5, Level::Low, Speed::Low);
 
     info!("ZeroClaw Nucleo firmware ready on USART2 (115200)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3746,7 +3746,7 @@ async fn async_main(command: clap::Command) -> Result<()> {
                 return Ok(());
             }
             Commands::Completions { .. } | Commands::MarkdownHelp | Commands::MarkdownSchema => {
-                unreachable!()
+                anyhow::bail!("documentation command was not handled before runtime dispatch")
             }
             _ => {
                 anyhow::bail!(
@@ -3775,7 +3775,9 @@ async fn async_main(command: clap::Command) -> Result<()> {
         Commands::Onboard { .. }
         | Commands::Completions { .. }
         | Commands::MarkdownHelp
-        | Commands::MarkdownSchema => unreachable!(),
+        | Commands::MarkdownSchema => {
+            anyhow::bail!("pre-runtime command was not handled before runtime dispatch")
+        }
 
         Commands::Quickstart {
             model_provider,
@@ -6887,7 +6889,7 @@ async fn sop_admin_request(cmd: SopCommands, config: &crate::config::Config) -> 
             .await
         }
         // List/Validate/Show are dispatched on the local synchronous path.
-        _ => unreachable!("local SOP verbs are handled by sop::handle_command"),
+        _ => anyhow::bail!("local SOP verb reached the gateway dispatch path"),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Removed the final eight repository panic candidates from root command dispatch, Arduino Uno Q deployment, the session queue test seam, log source attribution, and Nucleo USART initialization.
- **What changed and why:** Unexpected command-routing states now return contextual errors; process arguments accept native paths without UTF-8 conversion; poisoned test-hook state recovers; source metadata normalizes to an object without an impossible arm; and firmware initialization logs and exits cleanly when the UART cannot be created.
- **Scope boundary:** This slice does not change public CLI syntax, log schema, device protocols, session queue limits, or firmware behavior after successful USART initialization.
- **Blast radius:** The root `zeroclaw` binary, `zeroclaw-hardware`, `zeroclaw-infra`, `zeroclaw-log`, and Nucleo firmware. The low-level log and infrastructure crates have broad workspace dependents, so their full library suites and a broad multi-package clippy gate were run.
- **Linked issue(s):** Related #10118
- **Labels:** `core`, `distinguished contributor`, `observability:log`, `domain:code-quality`, `risk:medium`, `hardware`, `size:S`, `type:refactor`, `cli`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — these are error-path and invariant refactors covered by host tests, both root feature configurations, and the firmware cross-target build.

### How I tested

- **CI checks relied on and why they cover this change:** Broad all-target clippy covers the root and all affected workspace crates; focused library suites cover hardware, queueing, and log-layer behavior; the root binary suite covers default-feature dispatch; a no-default-features check covers the lean dispatch arm; and the Nucleo check uses its real ARM target.
- **Known CI coverage gap, if any:** The repository code-graph helper had no SCIP index in the fresh root or firmware workspaces, so caller review used crate-level dependent reports, source inspection, broad compilation, and focused/full tests.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# exit 0

anti-slop --changed-since upstream/master
# anti-slop: checked 5 Rust files; no violations

cargo clippy --locked -p zeroclaw -p zeroclaw-hardware -p zeroclaw-infra -p zeroclaw-log --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 58s

cargo test --locked -p zeroclaw-infra -p zeroclaw-log -p zeroclaw-hardware --lib
# hardware: 93 passed; 0 failed; 1 ignored
# infra: 202 passed; 0 failed
# log: 107 passed; 0 failed

cargo test --locked -p zeroclaw --bin zeroclaw -- --test-threads=1
# test result: ok. 361 passed; 0 failed

cargo check --locked -p zeroclaw --no-default-features
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 55s

cargo check --locked --manifest-path firmware/nucleo/Cargo.toml --target thumbv7em-none-eabihf
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 42.56s
```

- **Beyond CI, what did you manually verify?** Confirmed native `Path` arguments reach `scp` and `arduino-app-cli` without lossy conversion; checked that each formerly impossible command arm returns through the existing `Result` contract; and scanned all five changed files with zero remaining panic-rule findings.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No relevant command was skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 7080bcb61`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Documentation/SOP commands return unexpected dispatch errors, Uno Q deployment receives malformed paths, source locations disappear from logs, or Nucleo firmware exits during USART startup.
