### PR TITLE
docs(readme): restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ Built and maintained by the community — original creator [@theonlyhennygod](ht
 Thanks to the communities that incubated early work: **Harvard University**, **MIT**, **Sundai Club**, and every contributor pushing it forward.
 
 <p align="center">
-  <a href="https://www.star-history.com/#zeroclaw-labs/zeroclaw&type=date&legend=top-left">
+  <a href="https://star-history.dera.page/#zeroclaw-labs/zeroclaw&type=date&legend=top-left">
     <picture>
-     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=date&theme=dark&legend=top-left" />
-     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=date&legend=top-left" />
-     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=date&legend=top-left" />
+     <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=zeroclaw-labs/zeroclaw&type=date&theme=dark&legend=top-left" />
+     <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=zeroclaw-labs/zeroclaw&type=date&legend=top-left" />
+     <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=zeroclaw-labs/zeroclaw&type=date&legend=top-left" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Restores the README Star History chart after the prior `star-history.com` source stopped rendering.
  - Moves the chart page and theme-specific SVG sources to `star-history.dera.page`.
  - Preserves the existing `zeroclaw-labs/zeroclaw`, `type=date`, and `legend=top-left` chart parameters.
- **Scope boundary:** README chart source URLs only. No Rust code, configuration, API, CLI, dependency, or contributor-list change.
- **Blast radius:** The public GitHub README’s rendered chart and its third-party chart/image hosts.
- **Linked issue(s):** None; this is a self-contained README repair.
- **Labels:** `docs`, `needs-author-action`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — GitHub README rendering is the only changed user-facing surface; the exact rendered state is recorded below.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head `Docs Style`, link/structure checks, and the required CI gate are green for `d6d00a5c362620845bfa8e1ce4fde80049075731`; they cover README syntax, changed-link collection, and repository checks.
- **Known CI coverage gap, if any:** Required CI does not prove GitHub’s `<picture>` theme-source selection or third-party image rendering.
- **Commands run and tail output:** The exact-head CI record reports README markdown lint with `0 error(s)`, `docs_quality_gate.sh` exit 0, and `docs_links_gate.sh` exit 0. `lychee` was unavailable, so its optional external-link check was skipped.
- **Beyond CI, what did you manually verify?** On August 30, 2026, GitHub rendered the README at this exact revision in a 1280×720 system-dark browser. The Star History chart loaded beneath Credits with the repository series visible. The changed page and both SVG endpoints also returned HTTP 200, with both SVG endpoints reporting `image/svg+xml`.
- **Visual interface changed?** Yes.
- **Tested revision, interface, and terminal or viewport dimensions:** `d6d00a5c362620845bfa8e1ce4fde80049075731`; GitHub README Preview; 1280×720; system-dark appearance.
- **Screenshot evidence:**
<img width="1265" height="712" alt="image" src="https://github.com/user-attachments/assets/dcac49cf-bd58-4cd5-a65e-a47cab4c8f12" />
- **Action or changed state and observed result:** Opened `README.md` at the exact revision and scrolled to Credits; the Star History chart rendered normally below the section text.
- **If any command was intentionally skipped, why:** Rust build, Clippy, and test commands were not run because this change affects only README image/page URLs. No command was run to simulate a light browser theme, because that would not be valid evidence of GitHub’s actual light-mode renderer.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? Yes.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any `Yes`, describe the risk and mitigation: The README loads the chart from a third-party host; the URLs use HTTPS, retain the existing public repository identifier and chart parameters, and do not introduce credentials or user-supplied content.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.
