### PR TITLE
feat(whatsapp-web): port to whatsapp-rust 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -351,7 +351,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -680,13 +680,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -837,7 +837,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -1103,6 +1103,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
+dependencies = [
+ "bon-macros",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
+dependencies = [
+ "darling 0.24.1",
+ "ident_case",
+ "prettyplease 0.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1159,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "buffa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92f2f5df67a9d5ccfc65237bfc954c56328aee40a04a9b92381ecba370be246"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "foldhash 0.1.5",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "smoothutf8",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "buffa-build"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee6b6b4a8d23f1f98a043f188f4d9d2ef8bee43191f42e93ac577f3c3b0f334"
+dependencies = [
+ "buffa",
+ "buffa-codegen",
+ "tempfile",
+]
+
+[[package]]
+name = "buffa-codegen"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4bea10ef85ea3d06a20412c67cb612527feb25f33367eab850139441fb5dd9"
+dependencies = [
+ "buffa",
+ "buffa-descriptor",
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "buffa-descriptor"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7dd79a6898e70dac8adae959c8ad2cae51ed96397935c91c996280cedcb55e"
+dependencies = [
+ "buffa",
+ "rustversion",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1193,9 +1272,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1316,7 +1395,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1612,7 +1691,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1622,7 +1701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd93fd2c1b27acd030440c9dbd9d14c1122aad622374fe05a670b67a4bc034be"
 dependencies = [
  "heapless",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1652,8 +1731,21 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
  "serde",
  "static_assertions",
+ "zmij",
 ]
 
 [[package]]
@@ -2306,9 +2398,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -2345,6 +2452,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2489,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2521,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2884,7 +3025,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -2993,25 +3134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,7 +3175,7 @@ dependencies = [
  "serde",
  "serde_plain",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3077,7 +3199,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3209,7 +3331,7 @@ checksum = "7737298823a6f9ca743e372e8cb03658d55354fbab843424f575706ba9563046"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3252,6 +3374,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -3336,7 +3464,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -3390,7 +3517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3528,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3538,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
@@ -3555,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -3589,32 +3716,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4025,7 +4152,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4075,6 +4202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -4266,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4281,7 +4409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -4292,7 +4420,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -4335,7 +4463,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -4352,7 +4480,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "log",
@@ -4361,7 +4489,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -4374,7 +4502,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -5018,7 +5146,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -5204,7 +5332,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5262,7 +5390,7 @@ checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5331,7 +5459,7 @@ dependencies = [
  "socket2 0.6.3",
  "tokio",
  "url",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5625,7 +5753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c34e6db65145740459f2ca56623b40cd4e6000ffae2a7d91515fa82aa935dbf"
 dependencies = [
  "matrix-pickle-derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5665,7 +5793,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "gloo-timers",
- "http 1.4.1",
+ "http 1.5.0",
  "imbl",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -5692,7 +5820,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5700,7 +5828,7 @@ dependencies = [
  "url",
  "urlencoding",
  "vodozemac",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "wiremock",
  "zeroize",
 ]
@@ -5721,7 +5849,7 @@ dependencies = [
  "eyeball-im",
  "futures-util",
  "growable-bloom-filter",
- "http 1.4.1",
+ "http 1.5.0",
  "matrix-sdk-common",
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
@@ -5730,7 +5858,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "unicode-normalization",
@@ -5751,7 +5879,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5791,7 +5919,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-stream",
@@ -5825,7 +5953,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -5855,7 +5983,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "vodozemac",
@@ -5880,7 +6008,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
@@ -5893,7 +6021,7 @@ dependencies = [
  "as_variant",
  "ctor 0.2.9",
  "getrandom 0.4.2",
- "http 1.4.1",
+ "http 1.5.0",
  "insta",
  "matrix-sdk-common",
  "matrix-sdk-test-macros",
@@ -5936,7 +6064,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5985,9 +6113,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -6159,7 +6287,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -6554,7 +6682,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
- "http 1.4.1",
+ "http 1.5.0",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -6949,7 +7077,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6960,7 +7088,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.1",
+ "http 1.5.0",
  "opentelemetry",
  "reqwest 0.13.1",
 ]
@@ -6971,14 +7099,14 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.1",
+ "http 1.5.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.13.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7005,7 +7133,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7057,7 +7185,7 @@ dependencies = [
  "rc2",
  "sha1 0.10.6",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "x509-parser 0.17.0",
 ]
 
@@ -7702,6 +7830,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "probe-rs"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7731,7 +7869,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "serialport",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "uf2-decode",
  "zerocopy",
@@ -7857,7 +7995,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7969,7 +8107,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -7991,7 +8129,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8150,7 +8288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.1",
- "compact_str",
+ "compact_str 0.9.1",
  "critical-section",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
@@ -8159,7 +8297,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.2",
@@ -8308,7 +8446,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8403,7 +8541,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -8433,7 +8571,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -8448,7 +8586,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -8476,7 +8614,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -8546,7 +8684,7 @@ dependencies = [
  "as_variant",
  "assign",
  "bytes",
- "http 1.4.1",
+ "http 1.5.0",
  "js_int",
  "js_option",
  "maplit",
@@ -8555,7 +8693,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "web-time",
 ]
@@ -8572,7 +8710,7 @@ dependencies = [
  "date_header",
  "form_urlencoded",
  "getrandom 0.4.2",
- "http 1.4.1",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "js_int",
  "konst",
@@ -8584,7 +8722,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tracing",
  "url",
@@ -8609,7 +8747,7 @@ dependencies = [
  "ruma-macros",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "web-time",
  "wildmatch",
@@ -8635,7 +8773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6cff00317675f487c4e7ccfb18875a14c5a14867b51d13f2a826053f03c432"
 dependencies = [
  "js_int",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8669,7 +8807,7 @@ dependencies = [
  "rustls-native-certs 0.8.3",
  "rustls-pemfile",
  "rustls-webpki 0.102.8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -9547,7 +9685,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -9570,6 +9708,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smoothutf8"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
+dependencies = [
+ "simdutf8",
 ]
 
 [[package]]
@@ -9815,6 +9962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9966,7 +10124,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http 1.4.1",
+ "http 1.5.0",
  "image",
  "jni 0.21.1",
  "libc",
@@ -9992,7 +10150,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tray-icon",
  "url",
@@ -10043,7 +10201,7 @@ dependencies = [
  "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "url",
  "uuid",
@@ -10089,7 +10247,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
@@ -10106,7 +10264,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -10120,7 +10278,7 @@ dependencies = [
  "cookie 0.18.1",
  "dpi",
  "gtk",
- "http 1.4.1",
+ "http 1.5.0",
  "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
@@ -10129,7 +10287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -10143,7 +10301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
- "http 1.4.1",
+ "http 1.5.0",
  "jni 0.21.1",
  "log",
  "objc2",
@@ -10175,7 +10333,7 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "http 1.4.1",
+ "http 1.5.0",
  "infer",
  "json-patch",
  "log",
@@ -10192,7 +10350,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
@@ -10329,11 +10487,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -10349,13 +10507,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -10447,9 +10605,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -10629,15 +10787,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "rand 0.10.1",
  "ring",
@@ -10813,7 +10971,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -10921,7 +11079,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -10969,14 +11127,14 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -10988,14 +11146,14 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -11011,26 +11169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.2",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -11096,7 +11234,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -11289,7 +11427,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -11299,7 +11437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.1",
+ "http 1.5.0",
  "httparse",
  "log",
 ]
@@ -11424,7 +11562,7 @@ dependencies = [
  "base64ct",
  "cbc 0.1.2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hkdf 0.12.4",
@@ -11437,8 +11575,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "subtle",
- "thiserror 2.0.18",
- "x25519-dalek",
+ "thiserror 2.0.20",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -11479,21 +11617,26 @@ dependencies = [
 
 [[package]]
 name = "wacore"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6139a98fece24956f1d6bf164c82c5daefb43834813d96a879b41e010707c2c2"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.3",
  "anyhow",
  "async-channel 2.5.0",
  "async-lock 3.4.2",
  "async-trait",
  "base64 0.22.1",
+ "bon",
+ "buffa",
+ "buffa-build",
  "bytes",
  "chrono",
+ "compact_str 0.10.0",
  "ctr 0.10.1",
  "event-listener 5.4.2",
- "flate2",
  "futures",
+ "hashbrown 0.17.1",
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",
@@ -11501,40 +11644,42 @@ dependencies = [
  "log",
  "md5",
  "portable-atomic",
- "prost",
  "rand 0.10.1",
  "serde",
  "serde-big-array",
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "smallvec",
+ "smoothutf8",
  "subtle",
- "thiserror 2.0.18",
- "typed-builder",
+ "thiserror 2.0.20",
  "wacore-appstate",
  "wacore-binary",
  "wacore-derive",
  "wacore-libsignal",
  "wacore-noise",
  "waproto",
+ "zeroize",
 ]
 
 [[package]]
 name = "wacore-appstate"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afb5372c68d1cda49b7e86a81a01302b7c71b78e8555178c7cf3be01f09ecc3"
 dependencies = [
  "anyhow",
- "bytemuck",
+ "buffa",
  "hex",
  "hkdf 0.13.0",
+ "hmac 0.13.0",
  "log",
- "prost",
  "serde",
  "serde-big-array",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wacore-binary",
  "wacore-libsignal",
  "waproto",
@@ -11542,75 +11687,79 @@ dependencies = [
 
 [[package]]
 name = "wacore-binary"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e56452f93ac1e6167a6ebafec23971fe1ca9332b27cc887520f4a6753956fde"
 dependencies = [
  "bytes",
- "compact_str",
- "flate2",
- "hashify",
+ "compact_str 0.10.0",
  "itoa",
  "serde",
  "serde_json",
+ "smallvec",
+ "smoothutf8",
  "stable_deref_trait",
  "yoke 0.8.2",
+ "zlib-rs",
 ]
 
 [[package]]
 name = "wacore-derive"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cba66b01df4bef777c3d131af434dea0f3c8a7da2e42d7fb74e11fd65fb094"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "wacore-libsignal"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf8e90eebdf77703305089c1dfe672dddf203e0238e8f47163f76e7f9d5c713"
 dependencies = [
- "aes 0.9.1",
- "arrayref",
+ "aes 0.9.3",
+ "async-lock 3.4.2",
  "async-trait",
+ "buffa",
  "bytes",
  "cbc 0.2.1",
  "chrono",
  "ctr 0.10.1",
- "curve25519-dalek",
- "derive_more 2.1.1",
- "displaydoc",
+ "curve25519-dalek 5.0.0",
  "ghash",
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "log",
- "prost",
+ "portable-atomic",
  "rand 0.10.1",
  "serde",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "subtle",
- "thiserror 2.0.18",
- "uuid",
+ "thiserror 2.0.20",
+ "wacore-derive",
  "waproto",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
 ]
 
 [[package]]
 name = "wacore-noise"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b03c1e5e4bbf20d2d875c96649aaff82d149f025ae3a1421a1b6a9c426114"
 dependencies = [
  "anyhow",
+ "buffa",
  "bytes",
  "hkdf 0.13.0",
  "log",
- "prost",
  "rand 0.10.1",
  "sha2 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wacore-binary",
  "wacore-libsignal",
  "waproto",
@@ -11630,7 +11779,7 @@ checksum = "6e2db2daf1dfbadf228fd8b3c22b96a359135fd673b3d2c203274ee6a0df9c77"
 dependencies = [
  "anyhow",
  "form_urlencoded",
- "http 1.4.1",
+ "http 1.5.0",
  "serde",
  "waki-macros",
  "wit-bindgen 0.34.0",
@@ -11668,11 +11817,17 @@ dependencies = [
 
 [[package]]
 name = "waproto"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd19a927d4781e92382a478d234f74baeacb4822ceeb45c665bb9cb321622c35"
 dependencies = [
- "prost",
+ "buffa",
+ "buffa-build",
+ "buffa-descriptor",
+ "bytes",
+ "heck 0.5.0",
  "serde",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -12073,7 +12228,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon 0.13.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -12171,7 +12326,7 @@ dependencies = [
  "io-lifetimes 3.0.1",
  "rand 0.10.1",
  "rustix 1.1.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -12189,7 +12344,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -12200,7 +12355,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -12328,14 +12483,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12371,7 +12526,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows",
  "windows-core",
 ]
@@ -12450,59 +12605,65 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb354c32641cfe832bf5c5767a016762234c5efd1b4ce979e2b3e32175d96bc"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-lock 3.4.2",
  "async-trait",
  "base64 0.22.1",
+ "buffa",
  "bytes",
  "chrono",
- "env_logger",
  "event-listener 5.4.2",
  "futures",
+ "getrandom 0.4.2",
+ "hashbrown 0.17.1",
  "hex",
  "itoa",
  "log",
  "portable-atomic",
- "prost",
  "rand 0.10.1",
  "scopeguard",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "smallvec",
+ "thiserror 2.0.20",
  "tokio",
  "wacore",
  "wacore-binary",
  "waproto",
+ "zeroize",
 ]
 
 [[package]]
 name = "whatsapp-rust-tokio-transport"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02ae442f8a6e747c777225ce1808f2ce5311963cf2dccb17a1f304c749f01832"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http 1.5.0",
  "log",
  "rustls",
  "tokio",
  "tokio-rustls",
  "tokio-websockets",
  "wacore",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=cbcdd2a6b931d804f3c2693554dce75e654834e3#cbcdd2a6b931d804f3c2693554dce75e654834e3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebb64db9f84faa5eddb851ba7f44566363523bbdb88d5772fcc7d168e177797"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13074,7 +13235,7 @@ dependencies = [
  "base64 0.22.1",
  "deadpool 0.12.3",
  "futures",
- "http 1.4.1",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -13156,7 +13317,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata 0.219.2",
  "wit-bindgen-core 0.34.0",
@@ -13172,7 +13333,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata 0.244.0",
  "wit-bindgen-core 0.51.0",
@@ -13186,7 +13347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c967731fc5d50244d7241ecfc9302a8929db508eea3c601fbc5371b196ba38a5"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13201,7 +13362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13330,7 +13491,7 @@ dependencies = [
  "dunce",
  "gdkx11",
  "gtk",
- "http 1.4.1",
+ "http 1.5.0",
  "javascriptcore-rs",
  "jni 0.21.1",
  "libc",
@@ -13347,7 +13508,7 @@ dependencies = [
  "sha2 0.10.9",
  "soup3",
  "tao-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -13394,9 +13555,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -13442,7 +13614,7 @@ dependencies = [
  "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -13684,7 +13856,7 @@ dependencies = [
  "serde_json",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -13749,12 +13921,11 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
- "serde-big-array",
  "serde_json",
  "sha2 0.10.9",
  "shellexpand",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-executor-trait",
  "tokio-reactor-trait",
@@ -13768,7 +13939,7 @@ dependencies = [
  "wacore",
  "wacore-binary",
  "waproto",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "whatsapp-rust",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
@@ -13819,7 +13990,7 @@ dependencies = [
  "sha2 0.10.9",
  "shellexpand",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
@@ -13829,7 +14000,7 @@ dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
  "url",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "windows",
  "zeroclaw-api",
  "zeroclaw-infra",
@@ -13957,7 +14128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-serial",
  "toml 1.1.2+spec-1.1.0",
@@ -14078,7 +14249,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "toml 1.1.2+spec-1.1.0",
@@ -14086,7 +14257,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "zeroclaw-api",
  "zeroclaw-config",
  "zeroclaw-infra",
@@ -14121,7 +14292,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -14197,7 +14368,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -14208,7 +14379,7 @@ dependencies = [
  "tower-http",
  "urlencoding",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "which",
  "windows",
  "wiremock",
@@ -14346,7 +14517,7 @@ dependencies = [
  "sha2 0.10.9",
  "sys-locale",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -14356,7 +14527,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "urlencoding",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
  "which",
  "wiremock",
  "zeroclaw-api",
@@ -14449,18 +14620,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14562,9 +14733,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -129,21 +129,22 @@ nanohtml2text = "0.2"
 rand = "0.10"
 webpki-roots = "1.0.6"
 
-# WhatsApp Web (optional). Pinned to oxidezap/whatsapp-rust @ cbcdd2a
-# until upstream ships 0.6.1 to crates.io.
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false, features = [
+# WhatsApp Web (optional). Registry releases from oxidezap/whatsapp-rust.
+# Moving from the old fork pin to 0.7.0 includes the upstream protobuf-codegen
+# migration, so the storage and event adapters are ported in the same change.
+# Registry dependencies also make zeroclaw-channels publishable to crates.io.
+whatsapp-rust = { version = "0.7.0", optional = true, default-features = false, features = [
   "tokio-runtime",
 ] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
-serde-big-array = { version = "0.5", optional = true }
+wacore = { version = "0.7.0", optional = true, default-features = false }
+wacore-binary = { version = "0.7.0", optional = true, default-features = false }
+waproto = { version = "0.7.0", optional = true, default-features = false }
 
 cpal = { version = "0.18.1", optional = true }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "cbcdd2a6b931d804f3c2693554dce75e654834e3", optional = true, default-features = false }
+whatsapp-rust-ureq-http-client = { version = "0.7.0", optional = true }
+whatsapp-rust-tokio-transport = { version = "0.7.0", optional = true, default-features = false }
 qrcode = { version = "0.14", optional = true }
-# `bytes` is required for the `Bytes` return types in wacore 0.6 storage
+# `bytes` is required for the `Bytes` return types in wacore storage
 # traits (SignalStore::get_session / load_prekey). Feature-gated to
 # whatsapp-web alongside the rest of the WA Web stack.
 bytes = { version = "1", optional = true }
@@ -226,10 +227,8 @@ channel-line = ["dep:axum"]
 channel-nostr = ["dep:nostr-sdk"]
 whatsapp-web = [
   "dep:bytes",
-  "dep:prost",
   "dep:qrcode",
   "dep:rusqlite",
-  "dep:serde-big-array",
   "dep:wacore",
   "dep:wacore-binary",
   "dep:waproto",

--- a/crates/zeroclaw-channels/src/whatsapp_storage.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_storage.rs
@@ -14,8 +14,6 @@ use std::sync::Arc;
 #[cfg(feature = "whatsapp-web")]
 use bytes::Bytes;
 #[cfg(feature = "whatsapp-web")]
-use prost::Message;
-#[cfg(feature = "whatsapp-web")]
 use wacore::appstate::hash::HashState;
 #[cfg(feature = "whatsapp-web")]
 use wacore::appstate::processor::AppStateMutationMAC;
@@ -27,6 +25,10 @@ use wacore::store::traits::DeviceInfo;
 use wacore::store::traits::DeviceStore as DeviceStoreTrait;
 #[cfg(feature = "whatsapp-web")]
 use wacore::store::traits::*;
+#[cfg(feature = "whatsapp-web")]
+// waproto 0.7 generates buffa messages, not prost; `encode_to_vec`/`decode`
+// come from buffa's `Message` trait, re-exported by waproto.
+use waproto::buffa::Message;
 
 #[cfg(feature = "whatsapp-web")]
 #[derive(Clone)]
@@ -159,7 +161,7 @@ impl RusqliteStore {
             table_exists && !has_raw_id
         };
 
-        let device_06_migrations: Vec<(&'static str, &'static str)> = {
+        let device_migrations: Vec<(&'static str, &'static str)> = {
             let mut existing: std::collections::HashSet<String> = std::collections::HashSet::new();
             let mut stmt = conn.prepare("PRAGMA table_info(device)")?;
             let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
@@ -168,14 +170,21 @@ impl RusqliteStore {
             }
             const ALL: &[(&str, &str)] = &[
                 ("next_pre_key_id", "INTEGER NOT NULL DEFAULT 0"),
+                ("first_unupload_pre_key_id", "INTEGER NOT NULL DEFAULT 0"),
                 ("server_has_prekeys", "INTEGER NOT NULL DEFAULT 0"),
                 ("nct_salt", "BLOB"),
                 ("server_cert_chain", "BLOB"),
                 ("login_counter", "INTEGER NOT NULL DEFAULT 0"),
+                ("lid_migrated", "INTEGER NOT NULL DEFAULT 0"),
+                (
+                    "last_signed_pre_key_rotation_ms",
+                    "INTEGER NOT NULL DEFAULT 0",
+                ),
+                ("read_receipts_disabled", "INTEGER NOT NULL DEFAULT 0"),
             ];
             // If the table doesn't exist yet (existing is empty), the
-            // CREATE TABLE inside the transaction will define all five
-            // columns, so we want an empty migration list. The same
+            // CREATE TABLE inside the transaction will define every column,
+            // so we want an empty migration list. The same
             // empty-set check that `needs_raw_id` relies on applies here.
             if existing.is_empty() {
                 Vec::new()
@@ -211,10 +220,14 @@ impl RusqliteStore {
                 edge_routing_info BLOB,
                 props_hash TEXT,
                 next_pre_key_id INTEGER NOT NULL DEFAULT 0,
+                first_unupload_pre_key_id INTEGER NOT NULL DEFAULT 0,
                 server_has_prekeys INTEGER NOT NULL DEFAULT 0,
                 nct_salt BLOB,
                 server_cert_chain BLOB,
-                login_counter INTEGER NOT NULL DEFAULT 0
+                login_counter INTEGER NOT NULL DEFAULT 0,
+                lid_migrated INTEGER NOT NULL DEFAULT 0,
+                last_signed_pre_key_rotation_ms INTEGER NOT NULL DEFAULT 0,
+                read_receipts_disabled INTEGER NOT NULL DEFAULT 0
             );
 
             -- Signal identity keys
@@ -344,6 +357,29 @@ impl RusqliteStore {
                 PRIMARY KEY (chat_jid, message_id, device_id)
             );
 
+            -- MessageContextInfo.messageSecret keyed by the outbound message
+            -- it belongs to. Needed to decrypt add-ons (reactions, edits,
+            -- poll votes, msmsg bot replies) that reference one of our own
+            -- sent messages. `expires_at` is an absolute unix-seconds
+            -- retention deadline (0 = never); `message_ts` is the parent
+            -- message's event time (0 = unknown), used to enforce the
+            -- edit-processing window.
+            CREATE TABLE IF NOT EXISTS msg_secrets (
+                chat TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                msg_id TEXT NOT NULL,
+                secret BLOB NOT NULL,
+                expires_at INTEGER NOT NULL DEFAULT 0,
+                message_ts INTEGER NOT NULL DEFAULT 0,
+                device_id INTEGER NOT NULL,
+                PRIMARY KEY (chat, sender, msg_id, device_id)
+            );
+
+            -- device_id first so the prune's `device_id = ? AND expires_at <= ?`
+            -- range scan stays localized to one account in a shared DB.
+            CREATE INDEX IF NOT EXISTS idx_msg_secrets_expires
+                ON msg_secrets (device_id, expires_at);
+
             -- Base keys for collision detection
             CREATE TABLE IF NOT EXISTS base_keys (
                 address TEXT NOT NULL,
@@ -390,7 +426,7 @@ impl RusqliteStore {
             ))?;
         }
 
-        for (col, ty) in &device_06_migrations {
+        for (col, ty) in &device_migrations {
             to_store_err!(execute: tx.execute(
                 &format!("ALTER TABLE device ADD COLUMN {col} {ty}"),
                 [],
@@ -540,6 +576,26 @@ impl SignalStore for RusqliteStore {
             "DELETE FROM prekeys WHERE id = ?1 AND device_id = ?2",
             params![id, self.device_id],
         ))
+    }
+
+    /// Flag the pre-keys in `ids` as uploaded to the server.
+    ///
+    /// UPDATE-only by contract: a key consumed (and deleted) between the
+    /// upload snapshot and this call must stay deleted, so an upsert here
+    /// would resurrect a spent key and hand it out twice.
+    async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> wacore::store::error::Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.conn.lock();
+        for id in ids {
+            to_store_err!(execute: conn.execute(
+                "UPDATE prekeys SET uploaded = 1 WHERE id = ?1 AND device_id = ?2",
+                params![id, self.device_id],
+            ))?;
+        }
+        Ok(())
     }
 
     // --- Signed PreKey Operations ---
@@ -763,6 +819,19 @@ impl AppSyncStore for RusqliteStore {
         Ok(())
     }
 
+    /// Drop every mutation MAC for one collection.
+    ///
+    /// Called on snapshot re-sync so the MAC store is rebuilt from the
+    /// snapshot and stays consistent with the ltHash baseline; a leftover
+    /// entry would corrupt the next patch's ltHash.
+    async fn clear_mutation_macs(&self, name: &str) -> wacore::store::error::Result<()> {
+        let conn = self.conn.lock();
+        to_store_err!(execute: conn.execute(
+            "DELETE FROM app_state_mutation_macs WHERE name = ?1 AND device_id = ?2",
+            params![name, self.device_id],
+        ))
+    }
+
     /// Get the most recently stored app state sync key ID.
     /// Added in wacore 0.6: used to seed app-state sync requests with the
     /// freshest key identifier we hold rather than scanning the table on each
@@ -783,6 +852,111 @@ impl AppSyncStore for RusqliteStore {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(wacore::store::error::StoreError::Database(Box::new(e))),
         }
+    }
+}
+
+#[cfg(feature = "whatsapp-web")]
+#[async_trait]
+impl MsgSecretStore for RusqliteStore {
+    /// Batched upsert. On key conflict the merge is deterministic and matches
+    /// `wacore::store::traits::merge_msg_secret_expiry` /
+    /// `merge_msg_secret_message_ts`: the later deadline wins with `0`
+    /// ("never") beating any finite one, so a redelivery or edit re-persist
+    /// can never shorten a retention window; and the later non-zero parent
+    /// timestamp wins, so an unknown `0` never clobbers a known one.
+    async fn put_msg_secrets(
+        &self,
+        entries: Vec<MsgSecretEntry>,
+    ) -> wacore::store::error::Result<usize> {
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let mut conn = self.conn.lock();
+        let tx = to_store_err!(conn.transaction())?;
+
+        let mut stored = 0usize;
+        for entry in &entries {
+            // Plain variant, not `execute:` — that one discards the row
+            // count, and the trait contract returns how many were stored.
+            stored += to_store_err!(tx.execute(
+                "INSERT INTO msg_secrets
+                     (chat, sender, msg_id, secret, expires_at, message_ts, device_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(chat, sender, msg_id, device_id) DO UPDATE SET
+                     secret = excluded.secret,
+                     expires_at = CASE
+                         WHEN msg_secrets.expires_at = 0 OR excluded.expires_at = 0 THEN 0
+                         ELSE MAX(msg_secrets.expires_at, excluded.expires_at)
+                     END,
+                     message_ts = MAX(msg_secrets.message_ts, excluded.message_ts)",
+                params![
+                    entry.chat,
+                    entry.sender,
+                    entry.msg_id,
+                    entry.secret,
+                    entry.expires_at,
+                    entry.message_ts,
+                    self.device_id,
+                ],
+            ))?;
+        }
+
+        to_store_err!(tx.commit())?;
+        Ok(stored)
+    }
+
+    async fn get_msg_secret(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> wacore::store::error::Result<Option<Vec<u8>>> {
+        Ok(self
+            .get_msg_secret_with_ts(chat, sender, msg_id)
+            .await?
+            .map(|(secret, _)| secret))
+    }
+
+    /// Overridden rather than left to the trait default: this backend does
+    /// persist `message_ts`, so the receive path gets the real parent event
+    /// time instead of the default's `0`, and can enforce the edit window.
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> wacore::store::error::Result<Option<(Vec<u8>, i64)>> {
+        let conn = self.conn.lock();
+        let result = conn.query_row(
+            "SELECT secret, message_ts FROM msg_secrets
+             WHERE chat = ?1 AND sender = ?2 AND msg_id = ?3 AND device_id = ?4",
+            params![chat, sender, msg_id, self.device_id],
+            |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
+        );
+
+        match result {
+            Ok(found) => Ok(Some(found)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(wacore::store::error::StoreError::Database(Box::new(e))),
+        }
+    }
+
+    /// Prune rows whose deadline has passed. `expires_at = 0` means "never",
+    /// so those rows are kept regardless of the cutoff.
+    async fn delete_expired_msg_secrets(
+        &self,
+        cutoff_timestamp: i64,
+    ) -> wacore::store::error::Result<u32> {
+        let conn = self.conn.lock();
+        // Plain variant, not `execute:` — the caller throttles its cleanup
+        // sweep on how many rows this actually removed.
+        let deleted = to_store_err!(conn.execute(
+            "DELETE FROM msg_secrets
+             WHERE expires_at != 0 AND expires_at <= ?1 AND device_id = ?2",
+            params![cutoff_timestamp, self.device_id],
+        ))?;
+        Ok(deleted as u32)
     }
 }
 
@@ -1162,6 +1336,54 @@ impl ProtocolStore for RusqliteStore {
         ))
     }
 
+    /// Advance only the sender-side bucket, atomically preserving a received
+    /// token written by the concurrent privacy-notification path.
+    async fn touch_tc_token_sender_timestamp(
+        &self,
+        jid: &str,
+        sender_timestamp: i64,
+    ) -> wacore::store::error::Result<()> {
+        let conn = self.conn.lock();
+        let now = chrono::Utc::now().timestamp();
+        to_store_err!(execute: conn.execute(
+            "INSERT INTO tc_tokens
+                 (jid, token, token_timestamp, sender_timestamp, device_id, updated_at)
+             VALUES (?1, X'', ?2, ?2, ?3, ?4)
+             ON CONFLICT(jid, device_id) DO UPDATE SET
+                 sender_timestamp = CASE
+                     WHEN tc_tokens.sender_timestamp IS NULL
+                         THEN excluded.sender_timestamp
+                     ELSE MAX(tc_tokens.sender_timestamp, excluded.sender_timestamp)
+                 END,
+                 updated_at = excluded.updated_at",
+            params![jid, sender_timestamp, self.device_id, now],
+        ))
+    }
+
+    /// Store the newer received token in one statement while leaving the
+    /// sender-side bucket untouched.
+    async fn store_received_tc_token(
+        &self,
+        jid: &str,
+        token: &[u8],
+        token_timestamp: i64,
+    ) -> wacore::store::error::Result<()> {
+        let conn = self.conn.lock();
+        let now = chrono::Utc::now().timestamp();
+        to_store_err!(execute: conn.execute(
+            "INSERT INTO tc_tokens
+                 (jid, token, token_timestamp, sender_timestamp, device_id, updated_at)
+             VALUES (?1, ?2, ?3, NULL, ?4, ?5)
+             ON CONFLICT(jid, device_id) DO UPDATE SET
+                 token = excluded.token,
+                 token_timestamp = excluded.token_timestamp,
+                 updated_at = excluded.updated_at
+             WHERE length(tc_tokens.token) = 0
+                OR excluded.token_timestamp >= tc_tokens.token_timestamp",
+            params![jid, token, token_timestamp, self.device_id, now],
+        ))
+    }
+
     async fn delete_tc_token(&self, jid: &str) -> wacore::store::error::Result<()> {
         let conn = self.conn.lock();
         to_store_err!(execute: conn.execute(
@@ -1189,13 +1411,21 @@ impl ProtocolStore for RusqliteStore {
 
     async fn delete_expired_tc_tokens(
         &self,
-        cutoff_timestamp: i64,
+        token_cutoff: i64,
+        sender_cutoff: i64,
     ) -> wacore::store::error::Result<u32> {
         let conn = self.conn.lock();
+        // Both halves must be dead before the row goes. Recent sender state is
+        // never dropped just because the received token expired, so the two
+        // cutoffs are ANDed rather than either one deleting the row alone. An
+        // empty token counts as absent, as does a NULL sender bucket.
         let deleted = conn
             .execute(
-                "DELETE FROM tc_tokens WHERE token_timestamp < ?1 AND device_id = ?2",
-                params![cutoff_timestamp, self.device_id],
+                "DELETE FROM tc_tokens
+                  WHERE device_id = ?3
+                    AND (token_timestamp < ?1 OR length(token) = 0)
+                    AND (sender_timestamp IS NULL OR sender_timestamp < ?2)",
+                params![token_cutoff, sender_cutoff, self.device_id],
             )
             .map_err(|e| {
                 wacore::store::error::StoreError::Database(
@@ -1324,7 +1554,7 @@ impl DeviceStoreTrait for RusqliteStore {
 
         // Safety: device account data is stored to DB only; to_store_err! converts
         // rusqlite errors without logging parameter values.
-        let account = device.account.as_ref().map(|a| a.encode_to_vec());
+        let account = device.account.as_ref().map(|a| a.as_ref().encode_to_vec());
 
         let server_cert_chain_blob = device
             .server_cert_chain
@@ -1340,12 +1570,14 @@ impl DeviceStoreTrait for RusqliteStore {
                 adv_secret_key, account, push_name, app_version_primary,
                 app_version_secondary, app_version_tertiary, app_version_last_fetched_ms,
                 edge_routing_info, props_hash,
-                next_pre_key_id, server_has_prekeys, nct_salt,
-                server_cert_chain, login_counter
+                next_pre_key_id, first_unupload_pre_key_id,
+                server_has_prekeys, nct_salt, server_cert_chain,
+                login_counter, lid_migrated,
+                last_signed_pre_key_rotation_ms, read_receipts_disabled
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18,
-                ?19, ?20, ?21, ?22, ?23
+                ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27
             )",
             params![
                 self.device_id,
@@ -1367,10 +1599,14 @@ impl DeviceStoreTrait for RusqliteStore {
                 device.edge_routing_info.clone(),
                 device.props_hash.clone(),
                 device.next_pre_key_id,
+                device.first_unupload_pre_key_id,
                 device.server_has_prekeys as i64,
                 device.nct_salt.clone(),
                 server_cert_chain_blob,
                 device.login_counter,
+                device.lid_migrated as i64,
+                device.last_signed_pre_key_rotation_ms,
+                device.read_receipts_disabled as i64,
             ],
         ))
     }
@@ -1446,10 +1682,13 @@ impl DeviceStoreTrait for RusqliteStore {
                 let account_bytes: Option<Vec<u8>> = row.get("account")?;
 
                 let account = if let Some(bytes) = account_bytes {
-                    Some(
-                        waproto::whatsapp::AdvSignedDeviceIdentity::decode(&*bytes)
+                    // buffa's `decode` wants `&mut impl Buf`; `decode_from_slice`
+                    // is the convenience form. 0.7 also stores the account behind
+                    // an `Arc` on `Device`.
+                    Some(std::sync::Arc::new(
+                        waproto::whatsapp::ADVSignedDeviceIdentity::decode_from_slice(&bytes)
                             .map_err(to_rusqlite_err)?,
-                    )
+                    ))
                 } else {
                     None
                 };
@@ -1462,6 +1701,8 @@ impl DeviceStoreTrait for RusqliteStore {
                     }
                 };
                 let server_has_prekeys_int: i64 = row.get("server_has_prekeys")?;
+                let lid_migrated_int: i64 = row.get("lid_migrated")?;
+                let read_receipts_disabled_int: i64 = row.get("read_receipts_disabled")?;
 
                 Ok(CoreDevice {
                     lid: lid_str.and_then(|s| s.parse().ok()),
@@ -1482,10 +1723,14 @@ impl DeviceStoreTrait for RusqliteStore {
                     edge_routing_info: row.get("edge_routing_info")?,
                     props_hash: row.get("props_hash")?,
                     next_pre_key_id: row.get("next_pre_key_id")?,
+                    first_unupload_pre_key_id: row.get("first_unupload_pre_key_id")?,
                     server_has_prekeys: server_has_prekeys_int != 0,
                     nct_salt: row.get("nct_salt")?,
                     server_cert_chain,
                     login_counter: row.get("login_counter")?,
+                    lid_migrated: lid_migrated_int != 0,
+                    last_signed_pre_key_rotation_ms: row.get("last_signed_pre_key_rotation_ms")?,
+                    read_receipts_disabled: read_receipts_disabled_int != 0,
                     ..Default::default()
                 })
             },
@@ -1558,6 +1803,150 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = RusqliteStore::new(tmp.path()).unwrap();
         assert_eq!(store.device_id, 1);
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    fn msg_secret(msg_id: &str, expires_at: i64, message_ts: i64) -> MsgSecretEntry {
+        // 0.7 narrows these: the JID/id fields are `Arc<str>` and the secret is
+        // a fixed `[u8; MESSAGE_SECRET_SIZE]` rather than a `Vec<u8>`.
+        MsgSecretEntry {
+            chat: "chat@s.whatsapp.net".into(),
+            sender: "sender@s.whatsapp.net".into(),
+            msg_id: msg_id.into(),
+            secret: [7u8; 32],
+            expires_at,
+            message_ts,
+        }
+    }
+
+    /// A redelivery or edit re-persist must never shorten a retention window,
+    /// and `0` ("never") must beat any finite deadline in either direction.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn msg_secret_upsert_never_shortens_the_retention_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 1_000, 0)])
+            .await
+            .unwrap();
+
+        // An earlier deadline loses to the one already stored.
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 500, 0)])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.delete_expired_msg_secrets(600).await.unwrap(),
+            0,
+            "a 500 deadline must not have replaced the stored 1000"
+        );
+
+        // 0 means never, so it wins over the stored finite deadline.
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 0, 0)])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.delete_expired_msg_secrets(i64::MAX).await.unwrap(),
+            0,
+            "a never-expires row must survive any cutoff"
+        );
+    }
+
+    /// The parent message's event time is immutable; a later write that does
+    /// not know it (`0`) must not erase the value already stored.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn msg_secret_upsert_keeps_a_known_parent_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 0, 1_700_000_000)])
+            .await
+            .unwrap();
+        store
+            .put_msg_secrets(vec![msg_secret("ID", 0, 0)])
+            .await
+            .unwrap();
+
+        let (secret, message_ts) = store
+            .get_msg_secret_with_ts("chat@s.whatsapp.net", "sender@s.whatsapp.net", "ID")
+            .await
+            .unwrap()
+            .expect("secret must still be present");
+        assert_eq!(secret, vec![7u8; 32]);
+        assert_eq!(
+            message_ts, 1_700_000_000,
+            "an unknown (0) parent time must not clobber a known one"
+        );
+    }
+
+    /// Only deadlines that have actually passed are pruned; `0` never expires.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn expired_msg_secrets_prune_only_passed_deadlines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store
+            .put_msg_secrets(vec![
+                msg_secret("NEVER", 0, 0),
+                msg_secret("PAST", 1_000, 0),
+                msg_secret("FUTURE", 9_000, 0),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(store.delete_expired_msg_secrets(5_000).await.unwrap(), 1);
+
+        let chat = "chat@s.whatsapp.net";
+        let sender = "sender@s.whatsapp.net";
+        assert!(
+            store
+                .get_msg_secret(chat, sender, "NEVER")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .get_msg_secret(chat, sender, "FUTURE")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .get_msg_secret(chat, sender, "PAST")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// `mark_prekeys_uploaded` is UPDATE-only by contract: a key consumed
+    /// between the upload snapshot and the callback must stay deleted, or it
+    /// would be handed out to a second peer.
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn mark_prekeys_uploaded_never_resurrects_a_deleted_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RusqliteStore::new(tmp.path().join("session.db")).unwrap();
+
+        store.store_prekey(1, &[1u8; 32], false).await.unwrap();
+        store.store_prekey(2, &[2u8; 32], false).await.unwrap();
+        store.remove_prekey(2).await.unwrap();
+
+        store.mark_prekeys_uploaded(&[1, 2]).await.unwrap();
+
+        assert!(store.load_prekey(1).await.unwrap().is_some());
+        assert!(
+            store.load_prekey(2).await.unwrap().is_none(),
+            "a consumed pre-key must not be resurrected by the uploaded flag"
+        );
     }
 
     #[cfg(feature = "whatsapp-web")]
@@ -1698,7 +2087,7 @@ mod tests {
 
     #[cfg(feature = "whatsapp-web")]
     #[tokio::test]
-    async fn mutation_macs_round_trip_raw_bytes() {
+    async fn mutation_macs_round_trip_raw_bytes_and_clear_stays_scoped() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = RusqliteStore::new(tmp.path()).unwrap();
 
@@ -1721,13 +2110,69 @@ mod tests {
         let got = AppSyncStore::get_mutation_mac(&store, "critical_block", &index_mac)
             .await
             .unwrap();
-        assert_eq!(got, Some(value_mac));
+        assert_eq!(got, Some(value_mac.clone()));
 
         // Unknown index → None.
         let missing = AppSyncStore::get_mutation_mac(&store, "critical_block", &[1, 2, 3])
             .await
             .unwrap();
         assert_eq!(missing, None);
+
+        let other_index = vec![0x44, 0x55];
+        let other_mac = AppStateMutationMAC {
+            index_mac: other_index.clone(),
+            value_mac: vec![0x66, 0x77],
+        };
+        AppSyncStore::put_mutation_macs(
+            &store,
+            "regular_high",
+            1,
+            std::slice::from_ref(&other_mac),
+        )
+        .await
+        .unwrap();
+
+        let other_device = RusqliteStore {
+            device_id: 2,
+            ..store.clone()
+        };
+        AppSyncStore::put_mutation_macs(
+            &other_device,
+            "critical_block",
+            1,
+            std::slice::from_ref(&mac),
+        )
+        .await
+        .unwrap();
+
+        AppSyncStore::clear_mutation_macs(&store, "critical_block")
+            .await
+            .unwrap();
+        assert_eq!(
+            AppSyncStore::get_mutation_mac(&store, "critical_block", &index_mac)
+                .await
+                .unwrap(),
+            None,
+            "the named collection must be cleared for this device"
+        );
+        assert_eq!(
+            AppSyncStore::get_mutation_mac(&store, "regular_high", &other_index)
+                .await
+                .unwrap(),
+            Some(other_mac.value_mac),
+            "another collection on this device must survive"
+        );
+        assert_eq!(
+            AppSyncStore::get_mutation_mac(&other_device, "critical_block", &index_mac)
+                .await
+                .unwrap(),
+            Some(value_mac.clone()),
+            "the same collection on another device must survive"
+        );
+
+        AppSyncStore::put_mutation_macs(&store, "critical_block", 2, &[mac])
+            .await
+            .unwrap();
 
         // Delete removes the entry.
         AppSyncStore::delete_mutation_macs(
@@ -1777,7 +2222,7 @@ mod tests {
 
     #[cfg(feature = "whatsapp-web")]
     #[tokio::test]
-    async fn delete_expired_tc_tokens_returns_deleted_row_count() {
+    async fn delete_expired_tc_tokens_requires_both_halves_to_be_dead() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = RusqliteStore::new(tmp.path()).unwrap();
 
@@ -1791,6 +2236,21 @@ mod tests {
             token_timestamp: 1000,
             sender_timestamp: Some(1000),
         };
+        let expired_token_live_sender = TcTokenEntry {
+            token: vec![7, 8, 9],
+            token_timestamp: 10,
+            sender_timestamp: Some(1000),
+        };
+        let empty_token_expired_sender = TcTokenEntry {
+            token: Vec::new(),
+            token_timestamp: 1000,
+            sender_timestamp: Some(10),
+        };
+        let live_token_expired_sender = TcTokenEntry {
+            token: vec![10, 11, 12],
+            token_timestamp: 1000,
+            sender_timestamp: Some(10),
+        };
 
         ProtocolStore::put_tc_token(&store, "15550000001", &expired)
             .await
@@ -1798,11 +2258,20 @@ mod tests {
         ProtocolStore::put_tc_token(&store, "15550000002", &fresh)
             .await
             .unwrap();
-
-        let deleted = ProtocolStore::delete_expired_tc_tokens(&store, 100)
+        ProtocolStore::put_tc_token(&store, "15550000003", &expired_token_live_sender)
             .await
             .unwrap();
-        assert_eq!(deleted, 1);
+        ProtocolStore::put_tc_token(&store, "15550000004", &empty_token_expired_sender)
+            .await
+            .unwrap();
+        ProtocolStore::put_tc_token(&store, "15550000005", &live_token_expired_sender)
+            .await
+            .unwrap();
+
+        let deleted = ProtocolStore::delete_expired_tc_tokens(&store, 100, 100)
+            .await
+            .unwrap();
+        assert_eq!(deleted, 2);
         assert!(
             ProtocolStore::get_tc_token(&store, "15550000001")
                 .await
@@ -1815,11 +2284,72 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+        assert!(
+            ProtocolStore::get_tc_token(&store, "15550000003")
+                .await
+                .unwrap()
+                .is_some(),
+            "a live sender bucket must preserve an expired received token row"
+        );
+        assert!(
+            ProtocolStore::get_tc_token(&store, "15550000004")
+                .await
+                .unwrap()
+                .is_none(),
+            "an empty token with an expired sender bucket has no live state"
+        );
+        assert!(
+            ProtocolStore::get_tc_token(&store, "15550000005")
+                .await
+                .unwrap()
+                .is_some(),
+            "a live received token must preserve an expired sender bucket row"
+        );
     }
 
     #[cfg(feature = "whatsapp-web")]
     #[tokio::test]
-    async fn device_save_load_round_trips_wacore_06_fields() {
+    async fn tc_token_writers_atomically_preserve_each_others_fields() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let store = RusqliteStore::new(tmp.path()).unwrap();
+        const JID: &str = "15550000006";
+
+        ProtocolStore::touch_tc_token_sender_timestamp(&store, JID, 5_000)
+            .await
+            .unwrap();
+        ProtocolStore::store_received_tc_token(&store, JID, &[1, 2, 3], 4_000)
+            .await
+            .unwrap();
+        ProtocolStore::touch_tc_token_sender_timestamp(&store, JID, 3_000)
+            .await
+            .unwrap();
+        ProtocolStore::store_received_tc_token(&store, JID, &[9, 9, 9], 2_000)
+            .await
+            .unwrap();
+
+        let merged = ProtocolStore::get_tc_token(&store, JID)
+            .await
+            .unwrap()
+            .expect("both writer paths must converge on one row");
+        assert_eq!(merged.token, vec![1, 2, 3]);
+        assert_eq!(merged.token_timestamp, 4_000);
+        assert_eq!(merged.sender_timestamp, Some(5_000));
+
+        ProtocolStore::store_received_tc_token(&store, JID, &[4, 5, 6], 6_000)
+            .await
+            .unwrap();
+        let newer = ProtocolStore::get_tc_token(&store, JID)
+            .await
+            .unwrap()
+            .expect("the merged row must remain present");
+        assert_eq!(newer.token, vec![4, 5, 6]);
+        assert_eq!(newer.token_timestamp, 6_000);
+        assert_eq!(newer.sender_timestamp, Some(5_000));
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn device_save_load_round_trips_all_persisted_wacore_07_fields() {
         use wacore::store::Device as CoreDevice;
         use wacore::store::device::{CachedNoiseCert, CachedServerCertChain};
         use wacore::store::traits::DeviceStore as DeviceStoreTrait;
@@ -1827,12 +2357,13 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let path = tmp.path().to_path_buf();
 
-        // First boot: populate the 5 wacore-0.6 device fields with
-        // non-default values and persist.
+        // First boot: populate every post-0.5 persisted device field with a
+        // non-default value and persist it.
         {
             let store = RusqliteStore::new(&path).unwrap();
             let mut device = CoreDevice::new();
             device.next_pre_key_id = 42;
+            device.first_unupload_pre_key_id = 17;
             device.server_has_prekeys = true;
             device.nct_salt = Some(vec![0xDE, 0xAD, 0xBE, 0xEF]);
             device.server_cert_chain = Some(CachedServerCertChain {
@@ -1848,6 +2379,9 @@ mod tests {
                 },
             });
             device.login_counter = 7;
+            device.lid_migrated = true;
+            device.last_signed_pre_key_rotation_ms = 1_750_000_000_000;
+            device.read_receipts_disabled = true;
             DeviceStoreTrait::save(&store, &device).await.unwrap();
         }
 
@@ -1860,6 +2394,7 @@ mod tests {
             .expect("device row should exist after save");
 
         assert_eq!(loaded.next_pre_key_id, 42);
+        assert_eq!(loaded.first_unupload_pre_key_id, 17);
         assert!(loaded.server_has_prekeys);
         assert_eq!(
             loaded.nct_salt.as_deref(),
@@ -1874,6 +2409,9 @@ mod tests {
         assert_eq!(cert.intermediate.not_before, 1_700_000_000);
         assert_eq!(cert.leaf.not_after, 1_800_000_000);
         assert_eq!(loaded.login_counter, 7);
+        assert!(loaded.lid_migrated);
+        assert_eq!(loaded.last_signed_pre_key_rotation_ms, 1_750_000_000_000);
+        assert!(loaded.read_receipts_disabled);
     }
 
     #[cfg(feature = "whatsapp-web")]
@@ -1915,12 +2453,16 @@ mod tests {
             .unwrap();
         }
 
-        // Opening the store must add the 5 wacore-0.6 columns idempotently;
-        // a subsequent save+load round-trip must succeed.
+        // Opening the store must add every post-0.5 column idempotently; a
+        // subsequent save+load round-trip must succeed.
         let store = RusqliteStore::new(&path).unwrap();
         let mut device = CoreDevice::new();
         device.next_pre_key_id = 99;
+        device.first_unupload_pre_key_id = 50;
         device.login_counter = 3;
+        device.lid_migrated = true;
+        device.last_signed_pre_key_rotation_ms = 1_750_000_000_000;
+        device.read_receipts_disabled = true;
         DeviceStoreTrait::save(&store, &device).await.unwrap();
 
         let loaded = DeviceStoreTrait::load(&store)
@@ -1928,7 +2470,11 @@ mod tests {
             .unwrap()
             .expect("device row should exist after save");
         assert_eq!(loaded.next_pre_key_id, 99);
+        assert_eq!(loaded.first_unupload_pre_key_id, 50);
         assert_eq!(loaded.login_counter, 3);
+        assert!(loaded.lid_migrated);
+        assert_eq!(loaded.last_signed_pre_key_rotation_ms, 1_750_000_000_000);
+        assert!(loaded.read_receipts_disabled);
 
         // Re-opening a second time must be a no-op (idempotent ALTER).
         drop(store);

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -398,8 +398,8 @@ pub struct WhatsAppWebChannel {
     /// does and the safer of the two readings of zero.
     approval_timeout_secs: u64,
     /// Bot handle for shutdown.
-    /// whatsapp-rust 0.6: `Bot::run()` now returns `BotHandle` (a Future + abort)
-    /// rather than a tokio JoinHandle directly (oxidezap/whatsapp-rust BotHandle wrapper).
+    /// Handle returned by `Bot::spawn` in whatsapp-rust 0.7 (a Future + abort)
+    /// rather than a tokio JoinHandle directly.
     bot_handle: Arc<Mutex<Option<whatsapp_rust::bot::BotHandle>>>,
     /// Client handle for sending messages and typing indicators
     client: Arc<Mutex<Option<Arc<whatsapp_rust::Client>>>>,
@@ -809,7 +809,7 @@ impl WhatsAppWebChannel {
                 .await
                 .ok()
                 .flatten()
-                .map(|entry| entry.phone_number)
+                .map(|entry| entry.phone_number.to_string())
         } else {
             None
         };
@@ -826,18 +826,39 @@ impl WhatsAppWebChannel {
         }
     }
 
+    /// Fan a delivered batch out to the per-message handler, in arrival order.
+    ///
+    /// whatsapp-rust 0.7 replaced `Event::Message(msg, info)` with
+    /// `Event::Messages(batch)`. Live traffic still arrives as a batch of one;
+    /// an offline drain delivers one batch per durable commit. Each message is
+    /// dispatched through its own call so that a per-message early return skips
+    /// only that message: inlining the loop into the handler body would turn
+    /// each of its early returns into "abandon the rest of the batch".
     #[cfg(feature = "whatsapp-web")]
     async fn handle_inbound_message_event(
         event: &wacore::types::events::Event,
         client: &whatsapp_rust::Client,
         context: &WhatsAppInboundContext,
     ) {
-        use wacore::proto_helpers::MessageExt;
-        use wacore_binary::jid::JidExt as _;
-
-        let wacore::types::events::Event::Message(msg, info) = event else {
+        let wacore::types::events::Event::Messages(batch) = event else {
             return;
         };
+
+        for inbound in batch.messages.iter() {
+            Self::handle_one_inbound_message(&inbound.message, &inbound.info, client, context)
+                .await;
+        }
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    async fn handle_one_inbound_message(
+        msg: &waproto::whatsapp::Message,
+        info: &wacore::types::message::MessageInfo,
+        client: &whatsapp_rust::Client,
+        context: &WhatsAppInboundContext,
+    ) {
+        use wacore::proto_helpers::MessageExt;
+        use wacore_binary::jid::JidExt as _;
 
         let sender_jid = info.source.sender.clone();
         let sender_alt = info.source.sender_alt.clone();
@@ -1117,7 +1138,7 @@ impl WhatsAppWebChannel {
             return;
         }
 
-        let voice_text = if let Some(ref audio) = msg.audio_message {
+        let voice_text = if let Some(audio) = msg.audio_message.as_option() {
             let is_ptt = audio.ptt == Some(true);
             let non_ptt_enabled = context
                 .transcription_config
@@ -1485,33 +1506,36 @@ impl WhatsAppWebChannel {
         use wacore::proto_helpers::MessageExt;
         let base = msg.get_base_message();
 
-        if let Some(ref ext) = base.extended_text_message
-            && let Some(ref ctx) = ext.context_info
+        // waproto 0.7 renders optional submessages as `MessageField` rather than
+        // `Option<Box<_>>`, so each arm reads through `as_option()`. Order is
+        // load-bearing: the first populated variant wins, as before.
+        if let Some(ext) = base.extended_text_message.as_option()
+            && let Some(ctx) = ext.context_info.as_option()
         {
             return Some(ctx);
         }
-        if let Some(ref img) = base.image_message
-            && let Some(ref ctx) = img.context_info
+        if let Some(img) = base.image_message.as_option()
+            && let Some(ctx) = img.context_info.as_option()
         {
             return Some(ctx);
         }
-        if let Some(ref vid) = base.video_message
-            && let Some(ref ctx) = vid.context_info
+        if let Some(vid) = base.video_message.as_option()
+            && let Some(ctx) = vid.context_info.as_option()
         {
             return Some(ctx);
         }
-        if let Some(ref doc) = base.document_message
-            && let Some(ref ctx) = doc.context_info
+        if let Some(doc) = base.document_message.as_option()
+            && let Some(ctx) = doc.context_info.as_option()
         {
             return Some(ctx);
         }
-        if let Some(ref aud) = base.audio_message
-            && let Some(ref ctx) = aud.context_info
+        if let Some(aud) = base.audio_message.as_option()
+            && let Some(ctx) = aud.context_info.as_option()
         {
             return Some(ctx);
         }
-        if let Some(ref stk) = base.sticker_message
-            && let Some(ref ctx) = stk.context_info
+        if let Some(stk) = base.sticker_message.as_option()
+            && let Some(ctx) = stk.context_info.as_option()
         {
             return Some(ctx);
         }
@@ -1523,7 +1547,7 @@ impl WhatsAppWebChannel {
     fn extract_quoted_message(
         msg: &waproto::whatsapp::Message,
     ) -> Option<&waproto::whatsapp::Message> {
-        Self::extract_context_info(msg).and_then(|ctx| ctx.quoted_message.as_deref())
+        Self::extract_context_info(msg).and_then(|ctx| ctx.quoted_message.as_option())
     }
 
     #[cfg(feature = "whatsapp-web")]
@@ -1594,7 +1618,7 @@ impl WhatsAppWebChannel {
 
         let base = msg.get_base_message();
 
-        if let Some(ref image) = base.image_message {
+        if let Some(image) = base.image_message.as_option() {
             let mime = image
                 .mimetype
                 .clone()
@@ -1605,7 +1629,7 @@ impl WhatsAppWebChannel {
             );
             Self::push_downloaded_attachment(
                 client,
-                image.as_ref() as &dyn Downloadable,
+                image as &dyn Downloadable,
                 file_name,
                 Some(mime),
                 attachments,
@@ -1613,7 +1637,7 @@ impl WhatsAppWebChannel {
             .await;
         }
 
-        if let Some(ref video) = base.video_message {
+        if let Some(video) = base.video_message.as_option() {
             let mime = video
                 .mimetype
                 .clone()
@@ -1624,7 +1648,7 @@ impl WhatsAppWebChannel {
             );
             Self::push_downloaded_attachment(
                 client,
-                video.as_ref() as &dyn Downloadable,
+                video as &dyn Downloadable,
                 file_name,
                 Some(mime),
                 attachments,
@@ -1632,7 +1656,7 @@ impl WhatsAppWebChannel {
             .await;
         }
 
-        if include_audio && let Some(ref audio) = base.audio_message {
+        if include_audio && let Some(audio) = base.audio_message.as_option() {
             let mime = audio
                 .mimetype
                 .clone()
@@ -1643,7 +1667,7 @@ impl WhatsAppWebChannel {
             );
             Self::push_downloaded_attachment(
                 client,
-                audio.as_ref() as &dyn Downloadable,
+                audio as &dyn Downloadable,
                 file_name,
                 Some(mime),
                 attachments,
@@ -1651,7 +1675,7 @@ impl WhatsAppWebChannel {
             .await;
         }
 
-        if let Some(ref sticker) = base.sticker_message {
+        if let Some(sticker) = base.sticker_message.as_option() {
             let mime = sticker
                 .mimetype
                 .clone()
@@ -1662,7 +1686,7 @@ impl WhatsAppWebChannel {
             );
             Self::push_downloaded_attachment(
                 client,
-                sticker.as_ref() as &dyn Downloadable,
+                sticker as &dyn Downloadable,
                 file_name,
                 Some(mime),
                 attachments,
@@ -1680,19 +1704,19 @@ impl WhatsAppWebChannel {
         use wacore::proto_helpers::MessageExt;
         let base = msg.get_base_message();
 
-        if base.sticker_message.is_some() {
+        if base.sticker_message.is_set() {
             return "[Sticker]".to_string();
         }
-        if base.image_message.is_some() {
+        if base.image_message.is_set() {
             return "[Image]".to_string();
         }
-        if base.video_message.is_some() {
+        if base.video_message.is_set() {
             return "[Video]".to_string();
         }
-        if base.document_message.is_some() {
+        if base.document_message.is_set() {
             return "[Document]".to_string();
         }
-        if let Some(ref loc) = base.location_message {
+        if let Some(loc) = base.location_message.as_option() {
             // Live locations are silently ignored — they stream
             // periodic updates and have no meaningful static content.
             if loc.is_live == Some(true) {
@@ -1827,15 +1851,14 @@ impl WhatsAppWebChannel {
         #[allow(clippy::cast_possible_truncation)]
         let estimated_seconds = std::cmp::max(1, (upload.file_length / 4000) as u32);
 
-        // whatsapp-rust 0.6: UploadResponse cryptographic fields became
-        // `[u8; 32]` for type safety. Pull the Vec<u8> copies before
-        // consuming the strings so the partial-move on `upload.direct_path`
-        // doesn't bite.
-        let media_key = upload.media_key_vec();
-        let file_enc_sha256 = upload.file_enc_sha256_vec();
-        let file_sha256 = upload.file_sha256_vec();
+        // UploadResponse cryptographic fields are `[u8; 32]`, and the
+        // `_vec()` helpers are gone. Copy them out before consuming the
+        // strings so the partial-move on `upload.direct_path` doesn't bite.
+        let media_key = upload.media_key.to_vec();
+        let file_enc_sha256 = upload.file_enc_sha256.to_vec();
+        let file_sha256 = upload.file_sha256.to_vec();
         let voice_msg = waproto::whatsapp::Message {
-            audio_message: Some(Box::new(waproto::whatsapp::message::AudioMessage {
+            audio_message: waproto::whatsapp::message::AudioMessage {
                 url: Some(upload.url),
                 direct_path: Some(upload.direct_path),
                 media_key: Some(media_key),
@@ -1846,7 +1869,8 @@ impl WhatsAppWebChannel {
                 ptt: Some(true),
                 seconds: Some(estimated_seconds),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
 
@@ -1896,12 +1920,12 @@ impl WhatsAppWebChannel {
             .await
             .map_err(|e| anyhow::Error::msg(format!("WhatsApp media upload failed: {e}")))?;
 
-        let media_key = upload.media_key_vec();
-        let file_enc_sha256 = upload.file_enc_sha256_vec();
-        let file_sha256 = upload.file_sha256_vec();
+        let media_key = upload.media_key.to_vec();
+        let file_enc_sha256 = upload.file_enc_sha256.to_vec();
+        let file_sha256 = upload.file_sha256.to_vec();
         let outgoing = match marker.kind {
             WhatsAppMediaKind::Image => waproto::whatsapp::Message {
-                image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
+                image_message: waproto::whatsapp::message::ImageMessage {
                     url: Some(upload.url),
                     direct_path: Some(upload.direct_path),
                     media_key: Some(media_key),
@@ -1910,11 +1934,12 @@ impl WhatsAppWebChannel {
                     file_length: Some(upload.file_length),
                     mimetype: Some(mime),
                     ..Default::default()
-                })),
+                }
+                .into(),
                 ..Default::default()
             },
             WhatsAppMediaKind::Video => waproto::whatsapp::Message {
-                video_message: Some(Box::new(waproto::whatsapp::message::VideoMessage {
+                video_message: waproto::whatsapp::message::VideoMessage {
                     url: Some(upload.url),
                     direct_path: Some(upload.direct_path),
                     media_key: Some(media_key),
@@ -1923,14 +1948,15 @@ impl WhatsAppWebChannel {
                     file_length: Some(upload.file_length),
                     mimetype: Some(mime),
                     ..Default::default()
-                })),
+                }
+                .into(),
                 ..Default::default()
             },
             WhatsAppMediaKind::Audio | WhatsAppMediaKind::Voice => {
                 #[allow(clippy::cast_possible_truncation)]
                 let estimated_seconds = std::cmp::max(1, (upload.file_length / 4000) as u32);
                 waproto::whatsapp::Message {
-                    audio_message: Some(Box::new(waproto::whatsapp::message::AudioMessage {
+                    audio_message: waproto::whatsapp::message::AudioMessage {
                         url: Some(upload.url),
                         direct_path: Some(upload.direct_path),
                         media_key: Some(media_key),
@@ -1941,7 +1967,8 @@ impl WhatsAppWebChannel {
                         ptt: Some(matches!(marker.kind, WhatsAppMediaKind::Voice)),
                         seconds: Some(estimated_seconds),
                         ..Default::default()
-                    })),
+                    }
+                    .into(),
                     ..Default::default()
                 }
             }
@@ -1952,7 +1979,7 @@ impl WhatsAppWebChannel {
                     .unwrap_or("attachment")
                     .to_string();
                 waproto::whatsapp::Message {
-                    document_message: Some(Box::new(waproto::whatsapp::message::DocumentMessage {
+                    document_message: waproto::whatsapp::message::DocumentMessage {
                         url: Some(upload.url),
                         direct_path: Some(upload.direct_path),
                         media_key: Some(media_key),
@@ -1963,7 +1990,8 @@ impl WhatsAppWebChannel {
                         file_name: Some(file_name.clone()),
                         title: Some(file_name),
                         ..Default::default()
-                    })),
+                    }
+                    .into(),
                     ..Default::default()
                 }
             }
@@ -1984,13 +2012,14 @@ impl WhatsAppWebChannel {
         loc: &WhatsAppLocation,
     ) -> Result<()> {
         let outgoing = waproto::whatsapp::Message {
-            location_message: Some(Box::new(waproto::whatsapp::message::LocationMessage {
+            location_message: waproto::whatsapp::message::LocationMessage {
                 degrees_latitude: Some(loc.lat),
                 degrees_longitude: Some(loc.lng),
                 name: loc.name.clone(),
                 address: loc.address.clone(),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
         Box::pin(client.send_message(to.clone(), outgoing))
@@ -2951,7 +2980,7 @@ impl Channel for WhatsAppWebChannel {
             let configured_push_name = self.push_name.clone();
 
             let mut builder = Bot::builder()
-                .with_backend(backend)
+                .with_backend_arc(backend)
                 .with_transport_factory(transport_factory)
                 .with_http_client(http_client)
                 .with_runtime(TokioRuntime)
@@ -2974,11 +3003,11 @@ impl Channel for WhatsAppWebChannel {
                     let inbound_context = inbound_context.clone();
                     let configured_push_name = configured_push_name.clone();
                     async move {
-                        // whatsapp-rust 0.6: event handlers receive `Arc<Event>`
-                        // per so we match against `&*event` to get a
-                        // `&Event` reference and bind variant fields by ref.
+                        // Event handlers receive `Arc<Event>`, so match on
+                        // `&*event` to get a `&Event` and bind variant fields
+                        // by reference.
                         match &*event {
-                            Event::Message(_, _) => {
+                            Event::Messages(_) => {
                                 Self::handle_inbound_message_event(
                                     event.as_ref(),
                                     &client,
@@ -2993,10 +3022,8 @@ impl Channel for WhatsAppWebChannel {
                                     "WhatsApp Web connected successfully",
                                 );
                                 WhatsAppWebChannel::reset_retry(&retry_count);
-                                let device = client
-                                    .persistence_manager()
-                                    .get_device_snapshot()
-                                    .await;
+                                // 0.7 returns the snapshot directly, not a future.
+                                let device = client.persistence_manager().get_device_snapshot();
                                 // Resolve bot identity from the device store
                                 if mention_only {
                                     if let Some(ref pn) = device.pn
@@ -3063,7 +3090,8 @@ impl Channel for WhatsAppWebChannel {
                             Event::StreamError(stream_error) => {
                                 ::zeroclaw_log::record!(ERROR, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail).with_outcome(::zeroclaw_log::EventOutcome::Failure), &format!("stream error: {:?}", stream_error));
                             }
-                            Event::PairingCode { code, .. } => {
+                            Event::PairingCode(pairing) => {
+                                let code = &pairing.code;
                                 crate::login_events::LoginEvent::PairCode { code: code.as_str() }
                                     .emit(
                                     "whatsapp",
@@ -3074,7 +3102,8 @@ impl Channel for WhatsAppWebChannel {
                                 eprintln!("pair code: {code}");
                                 eprintln!();
                             }
-                            Event::PairingQrCode { code, .. } => {
+                            Event::PairingQrCode(qr) => {
+                                let code = &qr.code;
                                 crate::login_events::LoginEvent::Qr {
                                     payload: code.as_str(),
                                     image_url: None,
@@ -3115,11 +3144,38 @@ impl Channel for WhatsAppWebChannel {
                     ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
                     "pair-code flow enabled for configured phone number"
                 );
-                builder = builder.with_pair_code(PairCodeOptions {
+                let options = PairCodeOptions {
                     phone_number: phone.clone(),
                     custom_code: self.pair_code.clone(),
                     ..Default::default()
-                });
+                };
+                let refresh_options = options.clone();
+                let failure_alias = Arc::clone(&alias);
+                builder = builder
+                    .with_pair_code(options)
+                    .on_pair_code_refresh(move |_force_manual, client| {
+                        let options = refresh_options.clone();
+                        async move {
+                            // The 0.7 flow retires the old code before emitting
+                            // this event; the consumer must explicitly request
+                            // its replacement. Any failure emits the dedicated
+                            // PairingCodeError event handled below.
+                            let _ = client.pair_with_code(options).await;
+                        }
+                    })
+                    .on_pair_code_error(move |_error, _client| {
+                        let alias = Arc::clone(&failure_alias);
+                        async move {
+                            crate::login_events::LoginEvent::Failed {
+                                reason: "pair-code request failed",
+                            }
+                            .emit(
+                                "whatsapp",
+                                alias.as_ref(),
+                                "WhatsApp Web pair-code request failed; retry or use the QR flow",
+                            );
+                        }
+                    });
             } else if self.pair_code.is_some() {
                 ::zeroclaw_log::record!(
                     WARN,
@@ -3129,11 +3185,12 @@ impl Channel for WhatsAppWebChannel {
                 );
             }
 
-            let mut bot = builder.build().await?;
+            let bot = builder.build().await?;
             *self.client.lock() = Some(bot.client());
 
-            // Run the bot
-            let bot_handle = bot.run().await?;
+            // `run` consumes and drives the bot in place in 0.7; `spawn`
+            // returns the abortable handle this channel owns.
+            let bot_handle = bot.spawn();
 
             // Store the bot handle for later shutdown
             *self.bot_handle.lock() = Some(bot_handle);
@@ -3158,17 +3215,25 @@ impl Channel for WhatsAppWebChannel {
             *self.client.lock() = None;
             let handle = self.bot_handle.lock().take();
             if let Some(handle) = handle {
-                handle.abort();
-                // Await the aborted task so background I/O finishes before
-                // we delete session files.
-                let _ = handle.await;
+                // 0.7's graceful shutdown flushes the device snapshot,
+                // receipts, and message secrets before the run loop exits.
+                // If it exceeds the bound, dropping the shutdown future drops
+                // BotHandle, whose AbortHandle is the documented fallback.
+                if tokio::time::timeout(std::time::Duration::from_secs(30), handle.shutdown())
+                    .await
+                    .is_err()
+                {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail,)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                        "graceful WhatsApp Web shutdown timed out; bot task aborted"
+                    );
+                }
             }
 
-            // Drop bot/device so the SQLite connection is closed
-            // before we remove session files (releases WAL/SHM locks).
-            // `backend` was moved into the builder, so dropping `bot`
-            // releases the last Arc reference to the storage backend.
-            drop(bot);
+            // Drop the separate device reference before removing SQLite
+            // session files after a confirmed logout.
             drop(device);
 
             if should_reconnect {
@@ -3517,6 +3582,44 @@ mod tests {
     use super::*;
     #[cfg(feature = "whatsapp-web")]
     use wacore_binary::jid::Jid;
+
+    /// Wrap one message in the single-entry batch that 0.7 delivers for live
+    /// traffic, so tests keep expressing "one inbound message" directly.
+    #[cfg(feature = "whatsapp-web")]
+    fn single_message_event(
+        message: std::sync::Arc<waproto::whatsapp::Message>,
+        info: std::sync::Arc<wacore::types::message::MessageInfo>,
+    ) -> wacore::types::events::Event {
+        message_batch_event(vec![(message, info)])
+    }
+
+    /// Build the real multi-message event shape delivered by offline drains.
+    #[cfg(feature = "whatsapp-web")]
+    fn message_batch_event(
+        messages: Vec<(
+            std::sync::Arc<waproto::whatsapp::Message>,
+            std::sync::Arc<wacore::types::message::MessageInfo>,
+        )>,
+    ) -> wacore::types::events::Event {
+        use wacore::types::events::{BatchOrigin, InboundMessage, MessageBatch};
+        // Both types are #[non_exhaustive]; bon builders are the supported
+        // construction path. `hook_committed` defaults to false.
+        let inbound = messages
+            .into_iter()
+            .map(|(message, info)| {
+                InboundMessage::builder()
+                    .message(message)
+                    .info(info)
+                    .build()
+            })
+            .collect::<Vec<_>>();
+        wacore::types::events::Event::Messages(
+            MessageBatch::builder()
+                .messages(std::sync::Arc::from(inbound))
+                .origin(BatchOrigin::Live)
+                .build(),
+        )
+    }
 
     #[test]
     #[cfg(feature = "whatsapp-web")]
@@ -4382,7 +4485,6 @@ mod tests {
     async fn whatsapp_client_persistent_lid_mapping_drives_allowlist() {
         use wacore::store::CacheStore;
         use wacore::store::traits::{LidPnMappingEntry, ProtocolStore};
-        use wacore::types::events::Event;
         use wacore::types::message::{MessageInfo, MessageSource};
         use whatsapp_rust::bot::Bot;
         use whatsapp_rust::{CacheConfig, CacheStores, TokioRuntime};
@@ -4414,7 +4516,7 @@ mod tests {
 
         let cache = Arc::new(TestCacheStore::default());
         let bot = Bot::builder()
-            .with_backend(store.clone())
+            .with_backend_arc(store.clone())
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -4472,7 +4574,7 @@ mod tests {
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
         };
         let message_event = |lid: &str| {
-            Event::Message(
+            single_message_event(
                 Arc::new(waproto::whatsapp::Message {
                     conversation: Some("persistent LID mapping".to_string()),
                     ..Default::default()
@@ -4534,7 +4636,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "whatsapp-web")]
     async fn inbound_path_enforces_chat_policy_under_both_modes() {
-        use wacore::types::events::Event;
         use wacore::types::message::{MessageInfo, MessageSource};
         use whatsapp_rust::TokioRuntime;
         use whatsapp_rust::bot::Bot;
@@ -4549,7 +4650,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store)
+            .with_backend_arc(store)
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -4573,7 +4674,7 @@ mod tests {
             } else {
                 sender_jid.clone()
             };
-            Event::Message(
+            single_message_event(
                 Arc::new(waproto::whatsapp::Message {
                     conversation: Some("policy probe".to_string()),
                     ..Default::default()
@@ -4667,6 +4768,103 @@ mod tests {
         }
     }
 
+    /// Rejecting one entry in an offline-drain batch must not abandon later
+    /// entries, and the accepted messages must preserve their arrival order.
+    #[tokio::test]
+    #[cfg(feature = "whatsapp-web")]
+    async fn inbound_batch_isolates_early_returns_and_preserves_order() {
+        use wacore::types::message::{MessageInfo, MessageSource};
+        use whatsapp_rust::TokioRuntime;
+        use whatsapp_rust::bot::Bot;
+        use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
+        use whatsapp_rust_ureq_http_client::UreqHttpClient;
+        use zeroclaw_config::schema::{WhatsAppChatPolicy as Policy, WhatsAppWebMode as Mode};
+
+        const ALLOWED: &str = "15551234567";
+        const DENIED: &str = "15559999999";
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
+        let bot = Bot::builder()
+            .with_backend_arc(store)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(UreqHttpClient::new())
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .unwrap();
+        let client = bot.client();
+
+        let inbound = |sender: &str, id: &str, content: &str| {
+            let jid = Jid::pn(sender);
+            (
+                Arc::new(waproto::whatsapp::Message {
+                    conversation: Some(content.to_string()),
+                    ..Default::default()
+                }),
+                Arc::new(MessageInfo {
+                    source: MessageSource {
+                        chat: jid.clone(),
+                        sender: jid,
+                        is_from_me: false,
+                        is_group: false,
+                        ..Default::default()
+                    },
+                    id: id.to_string(),
+                    r#type: "text".to_string(),
+                    push_name: "Batch Probe".to_string(),
+                    timestamp: chrono::Utc::now(),
+                    ..Default::default()
+                }),
+            )
+        };
+        let batch = message_batch_event(vec![
+            inbound(DENIED, "batch-denied", "must not dispatch"),
+            inbound(ALLOWED, "batch-second", "second"),
+            inbound(ALLOWED, "batch-third", "third"),
+        ]);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        let context = WhatsAppInboundContext {
+            tx,
+            alias: Arc::new("batch-order".to_string()),
+            peer_resolver: Arc::new(|| vec![format!("+{ALLOWED}")]),
+            allowed_groups_resolver: Arc::new(Vec::new),
+            mode: Mode::Business,
+            dm_policy: Policy::Allowlist,
+            group_policy: Policy::Allowlist,
+            self_chat_mode: false,
+            mention_only: false,
+            passive_group_context: false,
+            bot_phone: Arc::new(Mutex::new(None)),
+            bot_lid: Arc::new(Mutex::new(None)),
+            dm_mention_patterns: Arc::new(Vec::new()),
+            group_mention_patterns: Arc::new(Vec::new()),
+            transcription_config: None,
+            transcription_manager: None,
+            voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        };
+
+        WhatsAppWebChannel::handle_inbound_message_event(&batch, &client, &context).await;
+
+        let second = rx
+            .recv()
+            .await
+            .expect("the second batch entry must dispatch");
+        let third = rx
+            .recv()
+            .await
+            .expect("the third batch entry must dispatch");
+        assert_eq!(
+            (second.content.as_str(), third.content.as_str()),
+            ("second", "third")
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "the refused first entry must not dispatch or duplicate later entries"
+        );
+    }
+
     /// The self-chat exception composes with the policy, and stays personal-only.
     ///
     /// Driven through `handle_inbound_message_event` so the `operator_self_chat`
@@ -4674,7 +4872,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "whatsapp-web")]
     async fn inbound_path_keeps_self_chat_bypass_personal_only() {
-        use wacore::types::events::Event;
         use wacore::types::message::{MessageInfo, MessageSource};
         use whatsapp_rust::TokioRuntime;
         use whatsapp_rust::bot::Bot;
@@ -4689,7 +4886,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store)
+            .with_backend_arc(store)
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -4704,7 +4901,7 @@ mod tests {
             let jid: Jid = format!("{OPERATOR}@s.whatsapp.net")
                 .parse()
                 .expect("operator jid parses");
-            Event::Message(
+            single_message_event(
                 Arc::new(waproto::whatsapp::Message {
                     conversation: Some("note to self".to_string()),
                     ..Default::default()
@@ -4931,20 +5128,20 @@ mod tests {
         mentioned_jids: &[&str],
     ) -> waproto::whatsapp::Message {
         waproto::whatsapp::Message {
-            extended_text_message: Some(Box::new(
-                waproto::whatsapp::message::ExtendedTextMessage {
-                    text: Some("expand the previous response".to_string()),
-                    context_info: Some(Box::new(waproto::whatsapp::ContextInfo {
-                        participant: Some(participant.to_string()),
-                        mentioned_jid: mentioned_jids
-                            .iter()
-                            .map(|jid| (*jid).to_string())
-                            .collect(),
-                        ..Default::default()
-                    })),
+            extended_text_message: waproto::whatsapp::message::ExtendedTextMessage {
+                text: Some("expand the previous response".to_string()),
+                context_info: waproto::whatsapp::ContextInfo {
+                    participant: Some(participant.to_string()),
+                    mentioned_jid: mentioned_jids
+                        .iter()
+                        .map(|jid| (*jid).to_string())
+                        .collect(),
                     ..Default::default()
-                },
-            )),
+                }
+                .into(),
+                ..Default::default()
+            }
+            .into(),
             ..Default::default()
         }
     }
@@ -4955,15 +5152,17 @@ mod tests {
         quoted_message: Option<waproto::whatsapp::Message>,
     ) -> waproto::whatsapp::Message {
         waproto::whatsapp::Message {
-            sticker_message: Some(Box::new(waproto::whatsapp::message::StickerMessage {
+            sticker_message: waproto::whatsapp::message::StickerMessage {
                 mimetype: Some("image/webp".to_string()),
-                context_info: Some(Box::new(waproto::whatsapp::ContextInfo {
+                context_info: waproto::whatsapp::ContextInfo {
                     participant: Some(participant.to_string()),
-                    quoted_message: quoted_message.map(Box::new),
+                    quoted_message: quoted_message.into(),
                     ..Default::default()
-                })),
+                }
+                .into(),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         }
     }
@@ -4971,17 +5170,19 @@ mod tests {
     #[cfg(feature = "whatsapp-web")]
     fn image_mention(mentioned_jids: &[&str]) -> waproto::whatsapp::Message {
         waproto::whatsapp::Message {
-            image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
+            image_message: waproto::whatsapp::message::ImageMessage {
                 mimetype: Some("image/jpeg".to_string()),
-                context_info: Some(Box::new(waproto::whatsapp::ContextInfo {
+                context_info: waproto::whatsapp::ContextInfo {
                     mentioned_jid: mentioned_jids
                         .iter()
                         .map(|jid| (*jid).to_string())
                         .collect(),
                     ..Default::default()
-                })),
+                }
+                .into(),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         }
     }
@@ -5183,16 +5384,17 @@ mod tests {
     #[cfg(feature = "whatsapp-web")]
     fn extract_quoted_message_reads_media_context_info() {
         let quoted = waproto::whatsapp::Message {
-            image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
+            image_message: waproto::whatsapp::message::ImageMessage {
                 mimetype: Some("image/png".to_string()),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
         let msg = sticker_reply("200@lid", Some(quoted));
         let quoted = WhatsAppWebChannel::extract_quoted_message(&msg)
             .expect("sticker reply should expose the quoted message");
-        assert!(quoted.image_message.is_some());
+        assert!(quoted.image_message.is_set());
     }
 
     #[test]
@@ -5223,12 +5425,13 @@ mod tests {
     #[cfg(feature = "whatsapp-web")]
     fn media_fallback_content_parses_static_location() {
         let msg = waproto::whatsapp::Message {
-            location_message: Some(Box::new(waproto::whatsapp::message::LocationMessage {
+            location_message: waproto::whatsapp::message::LocationMessage {
                 degrees_latitude: Some(40.7128),
                 degrees_longitude: Some(-74.0060),
                 name: Some("NYC".into()),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
         assert_eq!(
@@ -5241,12 +5444,13 @@ mod tests {
     #[cfg(feature = "whatsapp-web")]
     fn media_fallback_content_skips_live_location() {
         let msg = waproto::whatsapp::Message {
-            location_message: Some(Box::new(waproto::whatsapp::message::LocationMessage {
+            location_message: waproto::whatsapp::message::LocationMessage {
                 degrees_latitude: Some(40.7128),
                 degrees_longitude: Some(-74.0060),
                 is_live: Some(true),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
         assert_eq!(
@@ -5260,11 +5464,12 @@ mod tests {
     fn media_fallback_content_skips_missing_coordinates() {
         // Missing longitude — should silently drop, not fabricate 0,0
         let msg = waproto::whatsapp::Message {
-            location_message: Some(Box::new(waproto::whatsapp::message::LocationMessage {
+            location_message: waproto::whatsapp::message::LocationMessage {
                 degrees_latitude: Some(40.7128),
                 degrees_longitude: None,
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
         assert_eq!(
@@ -5273,11 +5478,12 @@ mod tests {
         );
         // Missing latitude
         let msg = waproto::whatsapp::Message {
-            location_message: Some(Box::new(waproto::whatsapp::message::LocationMessage {
+            location_message: waproto::whatsapp::message::LocationMessage {
                 degrees_latitude: None,
                 degrees_longitude: Some(-74.0060),
                 ..Default::default()
-            })),
+            }
+            .into(),
             ..Default::default()
         };
         assert_eq!(
@@ -5902,7 +6108,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "whatsapp-web")]
     async fn approval_reply_is_intercepted_by_the_inbound_handler() {
-        use wacore::types::events::Event;
         use wacore::types::message::{MessageInfo, MessageSource};
         use whatsapp_rust::TokioRuntime;
         use whatsapp_rust::bot::Bot;
@@ -5916,7 +6121,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store.clone())
+            .with_backend_arc(store.clone())
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -5959,7 +6164,7 @@ mod tests {
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
         };
 
-        let reply_event = Event::Message(
+        let reply_event = single_message_event(
             Arc::new(waproto::whatsapp::Message {
                 conversation: Some(format!("{token} yes")),
                 ..Default::default()
@@ -6031,7 +6236,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "whatsapp-web")]
     async fn every_decision_round_trips_from_the_send_seam_through_interception() {
-        use wacore::types::events::Event;
         use wacore::types::message::{MessageInfo, MessageSource};
         use whatsapp_rust::TokioRuntime;
         use whatsapp_rust::bot::Bot;
@@ -6045,7 +6249,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store.clone())
+            .with_backend_arc(store.clone())
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -6122,7 +6326,7 @@ mod tests {
                     .recv()
                     .await
                     .expect("the send hook must publish the token before the wait");
-                let reply_event = Event::Message(
+                let reply_event = single_message_event(
                     Arc::new(waproto::whatsapp::Message {
                         conversation: Some(format!("{token} {word}")),
                         ..Default::default()
@@ -6703,7 +6907,6 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "whatsapp-web")]
     async fn inbound_path_admits_a_personal_self_chat_approval_reply() {
-        use wacore::types::events::Event;
         use wacore::types::message::{MessageInfo, MessageSource};
         use whatsapp_rust::TokioRuntime;
         use whatsapp_rust::bot::Bot;
@@ -6716,7 +6919,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = Arc::new(crate::whatsapp_storage::RusqliteStore::new(tmp.path()).unwrap());
         let bot = Bot::builder()
-            .with_backend(store)
+            .with_backend_arc(store)
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(UreqHttpClient::new())
             .with_runtime(TokioRuntime)
@@ -6731,7 +6934,7 @@ mod tests {
             let jid: Jid = format!("{OPERATOR}@s.whatsapp.net")
                 .parse()
                 .expect("jid parses");
-            Event::Message(
+            single_message_event(
                 Arc::new(waproto::whatsapp::Message {
                     conversation: Some(format!("{token} yes")),
                     ..Default::default()

--- a/deny.toml
+++ b/deny.toml
@@ -148,6 +148,11 @@ name = "strum_macros"
 version = "=0.27.2"
 
 [[bans.skip]]
+name = "syn"
+version = "=2.0.117"
+reason = "whatsapp-rust 0.7 requires async-trait >=0.1.91 (syn 3); existing proc macros still require syn 2"
+
+[[bans.skip]]
 name = "thiserror"
 version = "=1.0.69"
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replace six git-pinned WhatsApp Web dependencies with their crates.io `0.7.0` releases so `zeroclaw-channels` can be published.
  - Port protobuf fields to buffa `MessageField`, single-message events to ordered batches, and bot ownership to the 0.7 lifecycle.
  - Complete the SQLite storage contract: message-secret retention, atomic trusted-contact merges, mutation-MAC resets, pre-key upload state, and every persisted 0.7 device field.
  - Preserve current chat-policy behavior while adding bounded graceful shutdown and the pair-code refresh required by 0.7.
  - Permit only the required exact `syn` 2/3 dependency split in `cargo-deny`.
- **Scope boundary:** This does not include #10084's passkey broker or confirmation flow, change the WhatsApp Cloud API backend, add a gateway passkey route, or add the crates.io publisher. It is the independently buildable registry port only.
- **Blast radius:** WhatsApp Web dependency resolution, protobuf field access, inbound batch dispatch, persistent device/message-secret storage, trusted-contact concurrency, media payload construction, pairing refresh, bot shutdown, and WhatsApp test fixtures. Other channels and configuration surfaces are unchanged.
- **Linked issue(s):** Related #9381, Related #9459, Unblocks #10158
- **Labels:** `dependencies`, `channel`, `distinguished contributor`, `channel:whatsapp`, `risk:medium`, `size:L`, `type:dependencies`

### Why this is a port

`whatsapp-rust` 0.7 moved generated protobufs from prost to buffa, replaced single-message events with message batches, changed bot ownership, added explicit pair-code refresh, and expanded its storage/device traits. The adapter changes preserve the existing ZeroClaw configuration and migrate the existing session database while satisfying those contracts.

The registry dependency is also a release prerequisite: crates.io rejects git dependencies even when they are optional. The 0.6.0 registry fallback was tested and rejected because it lacks the protocol-critical `Device::login_counter` field. This branch compiles and tests directly against the published 0.7.0 crates.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` — this feature is optional, and its persistent-store, event-batching, and shutdown paths need explicit coverage.
- **Interface(s) exercised:** `channel` (WhatsApp Web)
- **Setup / preconditions:** No WhatsApp account is required for the automated suite. Local mock-server tests require loopback port access.
- **Steps to run:**

  ```sh
  cargo test --locked -p zeroclaw-channels --lib --features whatsapp-web
  cargo clippy --locked -p zeroclaw-channels --all-targets \
    --features whatsapp-web -- -D warnings
  ```

- **Expected on this branch (after):** The complete channels suite passes against registry `whatsapp-rust` 0.7.0, including restart persistence, atomic trusted-contact updates, multi-message ordering, policy, approval, media, pairing, and current-master regressions.
- **Prior behavior on `master` (before):** The channel uses six git dependencies at 0.6-era APIs and cannot be packaged for crates.io.

### How I tested

- **CI checks relied on and why they cover this change:** Final hosted Quality Gate [run 33900495068](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33900495068) passed on exact head cfec4f57d, including CI Required Gate, Security, full tests, Lint, Linux build, all-features, MSRV, cross-platform checks, parallel-runtime repetition, and installer drift.
- **Known CI coverage gap, if any:** No live WhatsApp account smoke was run. That would require unlinking an operator session and still would not guarantee selection into Meta's phased passkey rollout.
- **Commands run and tail output:**

  ```text
  $ cargo fmt --all -- --check
  # clean

  $ cargo clippy --locked -p zeroclaw-channels --all-targets \
      --features whatsapp-web -- -D warnings
  Finished dev profile

  $ cargo test --locked -p zeroclaw-channels --lib \
      --features whatsapp-web
  test result: ok. 1779 passed; 0 failed; 2 ignored

  $ cargo test -p zeroclaw-channels --lib \
      --features whatsapp-web whatsapp_storage::tests::
  test result: ok. 15 passed; 0 failed

  $ cargo clippy --locked --workspace --exclude zeroclaw-desktop \
      --all-targets --features ci-all -- -D warnings
  Finished dev profile

  $ cargo deny check
  advisories ok, bans ok, licenses ok, sources ok
  ```

- **Beyond CI, what did you manually verify?** The manifest and lockfile contain all six WhatsApp crates at registry version 0.7.0 and no `oxidezap/whatsapp-rust` git source. Existing 18-column session databases migrate idempotently; all new 0.7 device fields survive restart; trusted-contact writes converge without losing either writer's field; a refused first batch item does not suppress or reorder later items; graceful shutdown uses 0.7's flush path with a bounded abort fallback; and #9382's fail-closed group-policy behavior remains intact. The branch contains no passkey implementation from #10084.
- **Visual interface changed?** `N/A` — no rendered UI or user-facing text changed.
- **If any command was intentionally skipped, why:** A live account smoke was skipped for the destructive/session-cohort reason above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes` — when 0.7 emits `PairingCodeRefresh`, the channel reissues the existing pair-code request to the same WhatsApp service. The old flow is retired first, and failures surface through the login lifecycle.
- Secrets / tokens / credentials handling changed? `Yes` — the existing session SQLite database now persists the 0.7 message-secret and device-state fields required by the protocol. Values are device-scoped, retention-tested, and never logged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: Pair-code refresh is server-triggered and reuses in-memory configuration without adding a destination or credential store. New cryptographic/session fields stay inside the existing SQLite trust boundary; fixed-width values fail closed on malformed data, and migrations/round trips are covered directly.

## Compatibility (required)

- Backward compatible? `Yes` for ZeroClaw configuration and persisted sessions; older databases are migrated idempotently on open.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the squash commit to restore the pinned 0.6-era fork and prost-generated field API. The additional SQLite table/columns are backward-compatible and ignored by the old adapter.
- **Feature flags or config toggles:** The dependency/runtime path remains entirely behind `whatsapp-web`.
- **Observable failure symptoms:** The WhatsApp feature fails to compile, pairing codes stop refreshing, inbound batches lose entries after a rejected message, existing sessions lose device state after restart, or media send/receive reports protobuf errors.
