### PR TITLE
docs(hardware): clarify experimental Android release binary

### DIFF
--- a/docs/book/src/hardware/android-setup.md
+++ b/docs/book/src/hardware/android-setup.md
@@ -1,18 +1,18 @@
 # Android Setup
 
-ZeroClaw provides prebuilt binaries for Android devices.
+ZeroClaw can publish an experimental prebuilt binary for Android devices.
 
 ## Supported Architectures
 
-ZeroClaw publishes a prebuilt `aarch64-linux-android` binary for modern 64-bit
-Android devices. The full set of prebuilt release targets (derived from the
-release workflow) is:
+The stable prebuilt release targets (derived from the release workflow) are:
 
 {{#include ../_snippets/hardware-release-targets.md}}
 
-Only `aarch64-linux-android` targets Android directly. 32-bit Android
-(`armv7-linux-androideabi`) is not currently published as a prebuilt binary;
-on a 32-bit device, build from source (see below).
+`aarch64-linux-android` is the only Android target. Its release binary is
+experimental: it is attached when that build succeeds, but it is not
+guaranteed for every release. If it is absent, build from source (see below).
+32-bit Android (`armv7-linux-androideabi`) is not currently published as a
+prebuilt binary.
 
 ## Installation via Termux
 
@@ -33,15 +33,22 @@ Download from [F-Droid](https://f-droid.org/packages/com.termux/) (recommended) 
 ```sh
 # Check your architecture
 uname -m
-# aarch64 = 64-bit (prebuilt binary available)
+# aarch64 = 64-bit (experimental prebuilt binary may be available)
 # armv7l/armv8l = 32-bit (build from source — no prebuilt binary)
 
-# Download the prebuilt 64-bit (aarch64) binary
-curl -LO https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-aarch64-linux-android.tar.gz
-tar xzf zeroclaw-aarch64-linux-android.tar.gz
+# Optionally download the experimental 64-bit (aarch64) binary.
+# A 404 means this release did not build it; use the source build below instead.
+if curl -fLO https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-aarch64-linux-android.tar.gz; then
+  tar xzf zeroclaw-aarch64-linux-android.tar.gz
+else
+  echo "No Android binary is available for this release. Build from source below."
+fi
 ```
 
 </div>
+
+Continue to the next step only after the archive extracts successfully. Otherwise,
+skip to [Building from Source](#building-from-source).
 
 ### 3. Install and Run
 

--- a/docs/book/src/hardware/android-setup.md
+++ b/docs/book/src/hardware/android-setup.md
@@ -41,14 +41,14 @@ uname -m
 if curl -fLO https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-aarch64-linux-android.tar.gz; then
   tar xzf zeroclaw-aarch64-linux-android.tar.gz
 else
-  echo "No Android binary is available for this release. Build from source below."
+  echo "Download failed. If GitHub reported 404, build from source below. Otherwise, check the error and retry."
 fi
 ```
 
 </div>
 
 Continue to the next step only after the archive extracts successfully. Otherwise,
-skip to [Building from Source](#building-from-source).
+build from source when the asset is missing, or resolve the download error and retry.
 
 ### 3. Install and Run
 

--- a/xtask/src/cmd/mdbook/hardware.rs
+++ b/xtask/src/cmd/mdbook/hardware.rs
@@ -137,12 +137,11 @@ fn release_targets(root: &Path) -> Result<Vec<String>> {
 
     for line in workflow.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("- os:") {
-            if let Some((target, experimental)) = matrix_entry.take()
-                && !experimental
-            {
-                targets.push(target);
-            }
+        if trimmed.starts_with("- os:")
+            && let Some((target, experimental)) = matrix_entry.take()
+            && !experimental
+        {
+            targets.push(target);
         }
         if let Some(target) = trimmed.strip_prefix("target:") {
             matrix_entry = Some((target.trim().to_string(), false));

--- a/xtask/src/cmd/mdbook/hardware.rs
+++ b/xtask/src/cmd/mdbook/hardware.rs
@@ -132,15 +132,36 @@ fn release_targets(root: &Path) -> Result<Vec<String>> {
              source for the prebuilt-binary target matrix."
         ))
     })?;
-    let mut targets: Vec<String> = workflow
-        .lines()
-        .filter_map(|l| l.trim().strip_prefix("target:"))
-        .map(|t| t.trim().to_string())
-        .collect();
+    let mut targets = Vec::new();
+    let mut matrix_entry: Option<(String, bool)> = None;
+
+    for line in workflow.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("- os:") {
+            if let Some((target, experimental)) = matrix_entry.take()
+                && !experimental
+            {
+                targets.push(target);
+            }
+        }
+        if let Some(target) = trimmed.strip_prefix("target:") {
+            matrix_entry = Some((target.trim().to_string(), false));
+        } else if trimmed == "experimental: true"
+            && let Some((_, experimental)) = matrix_entry.as_mut()
+        {
+            *experimental = true;
+        }
+    }
+    if let Some((target, experimental)) = matrix_entry
+        && !experimental
+    {
+        targets.push(target);
+    }
+
     targets.sort_unstable();
     targets.dedup();
     if targets.is_empty() {
-        anyhow::bail!("no `target:` entries parsed from {RELEASE_WORKFLOW}");
+        anyhow::bail!("no stable release targets parsed from {RELEASE_WORKFLOW}");
     }
     Ok(targets)
 }
@@ -224,5 +245,17 @@ mod tests {
                 "Pi target list leaked non-Pi target containing {excluded:?}: {snippet}"
             );
         }
+    }
+
+    #[test]
+    fn stable_release_targets_exclude_experimental_matrix_legs() {
+        let root = crate::util::repo_root();
+        let targets = release_targets(&root).expect("stable release targets must render");
+
+        assert!(targets.contains(&"aarch64-unknown-linux-gnu".to_string()));
+        assert!(
+            !targets.contains(&"aarch64-linux-android".to_string()),
+            "experimental Android must not be presented as a stable prebuilt target: {targets:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The Android setup guide now describes aarch64-linux-android release binaries as experimental rather than guaranteed.
  - The optional download step handles a missing latest-release asset and directs users to the existing source-build instructions.
  - The mdBook hardware snippet now excludes release-matrix entries marked experimental: true, so its stable-target list agrees with release availability.
- **Scope boundary:** Does not change the Android build matrix, release artifact policy, `install.sh`, or self-update behavior.
- **Blast radius:** Android installation documentation and the generated stable hardware target list.
- **Linked issue(s):** Related PR #10112.
- **Labels:** `docs`, `risk:low`, `size:S`, `type:docs`.

### What this does, simply

Some ZeroClaw releases do not include the experimental Android download. The guide previously presented that download as though it were always available, so users could follow the instructions only to find that the file did not exist.

This PR makes the guide match the actual release behavior: use the Android download when it is published, or follow the existing source-build path when it is not. It also keeps the experimental Android target out of the generated list of stable downloads. It does not change how releases are built or how the installer works.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a documentation and generated-reference repair.

### How I tested

- **CI checks relied on and why they cover this change:** `Detect changed paths` selected `Docs Style` for changed Markdown. `Docs Style`, `Lint`, and `CI Required Gate` passed on the current head. The focused test and CI-shaped workspace Clippy command below are local validation.
- **Known CI coverage gap, if any:** The release workflow only runs for dispatches or tags. It was not run because this PR does not change release behavior.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
cargo test -p xtask stable_release_targets_exclude_experimental_matrix_legs
cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
cargo run -p xtask --bin mdbook -- hardware
bash scripts/ci/docs_quality_gate.sh
bash scripts/ci/docs_links_gate.sh
bash scripts/ci/comment_hygiene_gate.sh
```

Relevant output tails:

```text
test cmd::mdbook::hardware::tests::stable_release_targets_exclude_experimental_matrix_legs ... ok
test result: ok. 1 passed; 0 failed
Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.21s
==> Generated hardware reference snippets from registry + catalog
```

- `cargo fmt --all -- --check`: passed.
- Focused `xtask` test: 1 passed, 0 failed.
- CI-shaped workspace Clippy: passed locally after the parser condition was simplified to satisfy `-D warnings`.
- Hardware generation: completed and omitted `aarch64-linux-android` from the stable snippet.
- Docs quality gate: 0 Markdown errors before the parser-only Clippy cleanup; a later local rerun was blocked by npm-cache ownership, and current PR CI passed `Docs Style`.
- Docs links gate: local targets passed; optional HTTP validation was skipped because `lychee` is not installed.
- Comment hygiene gate: passed.
- The docs links and comment-hygiene results were recorded before the parser-only Clippy cleanup; that cleanup did not change Markdown or generated targets.

- **Beyond CI, what did you manually verify?** The regenerated stable target snippet excludes `aarch64-linux-android`; the Android guide explains that a missing asset requires the existing source-build path.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No Android release dispatch or tag run; this PR does not alter that workflow's behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk documentation repair. Roll back with `git revert <sha>` if needed.
