### PR TITLE
test(runtime): anchor the rapid-resample cache test to its timing premise

### DIFF
--- a/crates/zeroclaw-runtime/src/process_stats.rs
+++ b/crates/zeroclaw-runtime/src/process_stats.rs
@@ -211,29 +211,82 @@ mod tests {
         if !sysinfo::IS_SUPPORTED_SYSTEM {
             return;
         }
-        // Prime a real reading so `last_cpu_percent` is populated.
-        let _ = sample();
-        std::thread::sleep(
-            sysinfo::MINIMUM_CPU_UPDATE_INTERVAL + std::time::Duration::from_millis(10),
-        );
-        let primed = sample();
-        assert!(primed.cpu_percent.is_some(), "primed sample has cpu%");
 
-        // Two back-to-back calls well under MINIMUM_CPU_UPDATE_INTERVAL —
-        // without rate limiting sysinfo would return 0 (or 100*ncpu on
-        // Linux). We should instead see the cached value from `primed`.
-        let a = sample();
-        let b = sample();
-        assert_eq!(
-            a.cpu_percent, primed.cpu_percent,
-            "rapid resample must reuse the last real reading, not a sysinfo artifact"
+        // The property under test is conditional: resamples that land inside
+        // MINIMUM_CPU_UPDATE_INTERVAL of the last real reading must reuse it.
+        // The condition is a timing premise this test cannot force on a
+        // loaded runner: under a parallel test run the thread can be
+        // descheduled between the samples for longer than the interval
+        // (making a fresh reading legitimate), and `STATE` is process-global,
+        // so a concurrent `sample()` from another test that crosses the
+        // interval boundary rotates the cache mid-sequence. Both showed up as
+        // one-in-many CI failures of the parallel runtime gate.
+        //
+        // So each attempt establishes the premise, samples, and only counts
+        // when the whole sequence provably fit inside the interval window
+        // anchored before the priming call: any refresh — ours or a
+        // concurrent caller's — can then only have happened at or after that
+        // anchor, so every later call in the window is sub-interval and must
+        // serve the cache. Attempts where the premise did not hold are
+        // retried rather than asserted. Exhausting all attempts still fails
+        // loudly: with rate limiting broken, `a`/`b` are independent sysinfo
+        // reads and will not equal `primed` five attempts running, so the
+        // regression this test exists for is still caught.
+        // Establish the process-global CPU baseline first: the very first
+        // `sample()` in the process returns `None` by contract, and this
+        // test must not depend on a sibling test having sampled already.
+        let _ = sample();
+
+        const ATTEMPTS: usize = 5;
+        let mut last_failure = String::new();
+        for attempt in 1..=ATTEMPTS {
+            // Ensure the next sample takes (or observes) a reading no older
+            // than `anchor`, then prime.
+            std::thread::sleep(
+                sysinfo::MINIMUM_CPU_UPDATE_INTERVAL + std::time::Duration::from_millis(10),
+            );
+            let anchor = Instant::now();
+            let primed = sample();
+            assert!(primed.cpu_percent.is_some(), "primed sample has cpu%");
+
+            // Back-to-back calls intended to land well under
+            // MINIMUM_CPU_UPDATE_INTERVAL — without rate limiting sysinfo
+            // would return 0 (or 100*ncpu on Linux) instead of the cache.
+            let a = sample();
+            let b = sample();
+            let elapsed = anchor.elapsed();
+
+            if elapsed >= sysinfo::MINIMUM_CPU_UPDATE_INTERVAL {
+                // Premise blown: the runner stalled us across the interval,
+                // so a fresh reading was legitimate. Not a verdict either way.
+                last_failure = format!(
+                    "attempt {attempt}: sequence took {elapsed:?}, \
+                     exceeding MINIMUM_CPU_UPDATE_INTERVAL"
+                );
+                continue;
+            }
+            if a.cpu_percent == primed.cpu_percent && b.cpu_percent == primed.cpu_percent {
+                // RSS is fine to update at any cadence — just check it stays
+                // plausible.
+                assert!(a.rss_bytes > 0);
+                assert!(b.rss_bytes > 0);
+                return;
+            }
+            // In-window mismatch. A concurrent sampler that crossed the
+            // interval boundary just before our anchor can still cause this
+            // once; its fresh reading resets the cache clock, so a retry
+            // gets a clean window. A real rate-limiting regression fails
+            // every attempt.
+            last_failure = format!(
+                "attempt {attempt}: rapid resample did not reuse the last real reading \
+                 (primed={:?} a={:?} b={:?}, elapsed {elapsed:?})",
+                primed.cpu_percent, a.cpu_percent, b.cpu_percent
+            );
+        }
+        panic!(
+            "rapid resample never reused the cached cpu% in {ATTEMPTS} attempts; \
+             last: {last_failure}"
         );
-        assert_eq!(
-            b.cpu_percent, primed.cpu_percent,
-            "second rapid resample also reuses cached value"
-        );
-        // RSS is fine to update at any cadence — just check it stays plausible.
-        assert!(a.rss_bytes > 0);
-        assert!(b.rss_bytes > 0);
     }
+
 }

--- a/crates/zeroclaw-runtime/src/process_stats.rs
+++ b/crates/zeroclaw-runtime/src/process_stats.rs
@@ -288,5 +288,4 @@ mod tests {
              last: {last_failure}"
         );
     }
-
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `process_stats::tests::rapid_resample_reuses_last_cpu_percent_instead_of_sysinfo_artifact` asserted a timing premise it cannot force on a loaded runner: that three consecutive `sample()` calls land inside sysinfo's `MINIMUM_CPU_UPDATE_INTERVAL`. Under the Parallel Runtime Test gate (`--test-threads=16`) the thread can be descheduled mid-sequence for longer than the interval — a fresh CPU reading is then correct behavior, and the test fails on it. `STATE` is also process-global, so any concurrent `sample()` caller crossing the interval boundary rotates the cache mid-sequence with the same effect. This flaked the required gate on an unrelated PR head (#10146) on 2026-08-19; the identical head passed on rerun with zero code change. Third documented flake class of this gate, after #10006 (fixed by #10036) and #9965.
  - Each attempt now anchors an `Instant` before priming and asserts cache reuse only when the whole sampled sequence provably fit inside the interval window — any refresh, ours or a concurrent caller's, can then only have happened at or after the anchor, so every later call in the window is sub-interval and must serve the cache. Premise-blown attempts retry, bounded at 5.
  - No silent-success skip: exhausting retries still panics with the last failure detail, and a genuine rate-limiting regression fails every attempt because three independent sysinfo reads do not compare equal.
  - The test also primes the process-global CPU baseline explicitly instead of depending on a sibling test having sampled first (the first `sample()` in a process returns `None` by contract).
- **Scope boundary:** test-only; no production code changes.
- **Blast radius:** one test in `crates/zeroclaw-runtime/src/process_stats.rs`.
- **Linked issue(s):** Closes #10161.

## Testing (required)

### How I tested

```text
cargo fmt --all -- --check                                              passed
cargo clippy --locked -p zeroclaw-runtime --lib -- -D warnings          clean
cargo test --locked -p zeroclaw-runtime --lib process_stats             5 passed
20x cargo test -p zeroclaw-runtime --lib process_stats --test-threads=16   0/20 failed
cargo test --locked -q -p zeroclaw-runtime --lib -- --test-threads=16   3767 passed; 0 failed; 3 ignored
```

**Failure-mode evidence** (each demonstrated locally, scaffolding removed, file restored checksum-verified):

- *Old test under a forced mid-sequence stall* (sleep past `MINIMUM_CPU_UPDATE_INTERVAL` between the rapid samples, simulating runner descheduling): fails with exactly the CI signature — `second rapid resample also reuses cached value; left: Some(4.997254) right: Some(0.1560659)`.
- *New test under the same stall made transient* (first attempt only): attempt 1 is discarded as premise-blown, attempt 2 passes — recovers instead of flaking.
- *Regression-detection power preserved*: with production rate limiting disabled (`cpu_stale` forced `true`), the new test fails all 5 attempts: `rapid resample never reused the cached cpu% in 5 attempts; last: attempt 5: … (primed=Some(0.1140873) a=Some(0.037559524) b=Some(0.03327381), elapsed 376.375µs)`.

- **Known gaps, stated plainly:** the residual failure probability is five consecutive premise-blown 200ms windows on one runner — negligible but not zero by construction; a persistent-pathological runner fails loudly rather than skipping.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

- Low risk (test-only). Revert the single commit.
