### PR TITLE
perf(ci): consolidate Blacksmith Rust caches by family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -258,6 +259,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH == 'true' && matrix.target == 'x86_64-unknown-linux-gnu' }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && matrix.target == 'x86_64-unknown-linux-gnu' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install Linux system dependencies
@@ -352,6 +354,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -402,6 +405,7 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check
@@ -441,6 +445,7 @@ jobs:
       - uses: ./.github/actions/rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-msrv-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install system dependencies
@@ -471,6 +476,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-i686-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install 32-bit system libraries
@@ -494,6 +500,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Ensure web/dist placeholder exists
@@ -550,6 +557,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check firmware protocol crate
@@ -633,7 +641,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
-          shared-key: test
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || 'test' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Ensure web/dist placeholder exists
@@ -908,6 +916,7 @@ jobs:
         id: rust-cache
         with:
           use-blacksmith: ${{ vars.CI_USE_BLACKSMITH }}
+          shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Check generated install surfaces are in sync with the spec

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -256,7 +256,15 @@ Most Rust-heavy jobs in `ci.yml` cache through the local `./.github/actions/rust
   runs use `SCCACHE_GHA_RW_MODE=READ_ONLY`; they can consume master-seeded
   entries but cannot populate or evict the shared compiler cache. Changing
   `SCCACHE_GHA_VERSION` in the composite intentionally invalidates the cache.
-
+- **Blacksmith target caches use three bounded families.** Stable native Linux
+  jobs (`lint`, Linux `build`, `check`, plugin backends, `bench`, `test`,
+  `parallel-runtime-test`, and `installer-drift`) share
+  `blacksmith-linux-stable-v1`. The i686 and MSRV jobs use separate families so
+  target/toolchain artifacts do not inflate the native cache. The cache action
+  still appends OS/architecture plus rustc, compiler-environment, manifest, and
+  lockfile hashes; `shared-key` removes only job-ID fragmentation. When
+  Blacksmith is off, keys remain job-specific (including Parallel Runtime
+  Test's established `test` fallback key).
 - **Cache writes are master-only.** `save-if` is conditioned on `github.ref == 'refs/heads/master'`, so PR runs read the master-seeded cache but never update it. PR branches can't pollute the shared cache with branch-specific artifacts. The `push` trigger on `master` is what gives the workflow a trusted cache-writing run after merges.
 - **Cache saves on failure.** `cache-on-failure: true` is set on every job, so a partial run still seeds the next attempt warm.
 - **Windows build cache is enabled.** The Windows build leg runs the same pinned Rust cache action as Linux and macOS. If Windows cache behavior flakes or regresses, revert the workflow change and document the failing restore/save evidence in the cache issue.

--- a/tests/architecture/ci_cache_groups.rs
+++ b/tests/architecture/ci_cache_groups.rs
@@ -1,0 +1,73 @@
+//! Architecture invariants for the Blacksmith Rust cache families.
+
+use std::{fs, path::Path};
+
+fn quality_gate() -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(root.join(".github/workflows/ci.yml"))
+        .expect("Quality Gate workflow should be readable")
+}
+
+fn top_level_job<'a>(workflow: &'a str, name: &str) -> &'a str {
+    let marker = format!("\n  {name}:\n");
+    let (_, rest) = workflow
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("workflow must contain the {name} job"));
+    let end = rest
+        .match_indices("\n  ")
+        .find_map(|(offset, _)| {
+            let line = rest[offset + 1..].lines().next()?;
+            (line.starts_with("  ")
+                && !line.starts_with("    ")
+                && !line.trim_start().starts_with('#')
+                && line.trim_end().ends_with(':'))
+            .then_some(offset)
+        })
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+#[test]
+fn blacksmith_cache_families_are_shared_without_cross_target_pollution() {
+    let workflow = quality_gate();
+    let stable_key =
+        "shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || '' }}";
+
+    for job in [
+        "lint",
+        "check",
+        "check-plugin-backends",
+        "bench",
+        "test",
+        "installer-drift",
+    ] {
+        assert!(
+            top_level_job(&workflow, job).contains(stable_key),
+            "{job} must use the shared stable-native Blacksmith cache"
+        );
+    }
+
+    let build = top_level_job(&workflow, "build");
+    assert!(build.contains(
+        "shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && matrix.target == 'x86_64-unknown-linux-gnu' && 'blacksmith-linux-stable-v1' || '' }}"
+    ));
+
+    let parallel = top_level_job(&workflow, "parallel-runtime-test");
+    assert!(parallel.contains(
+        "shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-stable-v1' || 'test' }}"
+    ));
+
+    assert!(top_level_job(&workflow, "check-32bit").contains(
+        "shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-i686-v1' || '' }}"
+    ));
+    assert!(top_level_job(&workflow, "msrv").contains(
+        "shared-key: ${{ vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-linux-msrv-v1' || '' }}"
+    ));
+
+    for job in ["windows-clippy-tools", "test-landlock", "security"] {
+        assert!(
+            !top_level_job(&workflow, job).contains("blacksmith-linux-"),
+            "{job} must keep its existing non-Blacksmith cache isolation"
+        );
+    }
+}

--- a/tests/test_architecture.rs
+++ b/tests/test_architecture.rs
@@ -20,3 +20,6 @@ mod desktop_release;
 
 #[path = "architecture/container_release.rs"]
 mod container_release;
+
+#[path = "architecture/ci_cache_groups.rs"]
+mod ci_cache_groups;


### PR DESCRIPTION
## Summary

- **Base branch:** `ci/blacksmith-shared-sccache`. **Depends on #10154**; retarget to `master` after the parent merges.
- **What changed and why:**
  - Replace Blacksmith's automatic job-ID cache fragmentation with three bounded `shared-key` families. Eight stable native Linux job definitions share `blacksmith-linux-stable-v1`; i686 and MSRV remain isolated in their own families.
  - Apply shared keys only when `CI_USE_BLACKSMITH=true`. GitHub-hosted/fork fallback runs keep automatic per-job keys, including Parallel Runtime Test's existing `test` key.
  - Add an architecture invariant that pins every intended family and rejects accidental Blacksmith grouping on Windows Clippy, Landlock, or Security.
- **Scope boundary:** Does not change the sccache setup in #10154, cache provider/action, job graph, commands, runners, apt/system dependencies, timeouts, or master-only save policy. It deliberately avoids the separate CI flakiness work.
- **Blast radius:** Blacksmith target/dependency cache restore/save keys for the Quality Gate. The cache action still appends OS/architecture, rustc version, compiler environment, manifests, and lockfiles, so `shared-key` removes only job-ID fragmentation rather than mixing incompatible compiler inputs.
- **Linked issue(s):** Depends on #10154. Related #7108.
- **Labels:** `ci`, `docs`, `risk:high`, `size:S`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the exact workflow-key contract is covered by the focused architecture test. Live cache restoration requires #10154 to merge, this PR to retarget to master, and a trusted master seed run.

### How I tested

```sh
$ ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml")'
YAML OK

$ actionlint .github/workflows/ci.yml
# exit 0

$ cargo test --locked --test architecture \
    ci_cache_groups::blacksmith_cache_families_are_shared_without_cross_target_pollution \
    -- --exact
running 1 test
test ci_cache_groups::blacksmith_cache_families_are_shared_without_cross_target_pollution ... ok
test result: ok. 1 passed; 0 failed

$ DOCS_FILES=docs/book/src/maintainers/ci-and-actions.md \
    BASE_SHA=$(git rev-parse upstream/ci/blacksmith-shared-sccache) \
    bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
Summary: 0 error(s)
```

- **CI checks relied on and why they cover this change:** The parent #10154 proves the provider-aware Blacksmith cache path and required Rust jobs. After #10154 merges and this PR retargets to master, a fresh `CI Required Gate` will validate all new shared-key expressions in the real workflow.
- **Known CI coverage gap, if any:** Stacked PRs targeting a feature branch do not receive the master-targeted Quality Gate. No shared family exists on master yet, so warm restoration and cache-size reduction cannot be measured until a trusted master run seeds the three new families and a later PR reads them.
- **Commands run and tail output:** See above.
- **Beyond CI, what did you manually verify?** Read the pinned rust-cache key implementation: `shared-key` replaces only the GitHub job ID; OS/architecture, rustc/toolchain, `RUST*`/compiler environment, manifests, and lockfiles remain in the key. Counted exactly eight stable-family definitions, one i686 family, and one MSRV family. Confirmed fallback expressions resolve to empty/job-specific keys except Parallel Runtime Test's preserved `test` key.
- **Visual interface changed?** `N/A` — CI cache-key policy only.
- **If any command was intentionally skipped, why:** Full workspace Cargo checks duplicate the parent Quality Gate and do not test cache-key policy. Live cache timing is deferred until the parent and this stack land, because PRs remain restore-only and cannot seed new families.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — the existing cache provider/backend is unchanged.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` product/operator surface; only reviewed CI cache keys change when the existing Blacksmith toggle is true.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this commit to restore automatic per-job cache keys. Setting `CI_USE_BLACKSMITH=false` immediately bypasses every new family while a revert is prepared.
- **Feature flags or config toggles:** Existing repository variable `CI_USE_BLACKSMITH`; no new toggle.
- **Observable failure symptoms:** Blacksmith cache restore/save errors, unexpectedly large cache archives, lower hit rates, or slower compile jobs after the new families are seeded. Compare cache configuration logs and job timings; i686/MSRV must continue showing their dedicated keys.
