### PR TITLE
fix(runtime): prevent node request replay

### DIFF
--- a/crates/zeroclaw-runtime/src/nodes/transport.rs
+++ b/crates/zeroclaw-runtime/src/nodes/transport.rs
@@ -1,20 +1,46 @@
 //! Corporate-friendly secure node transport using standard HTTPS + HMAC-SHA256 authentication.
 
+use std::collections::HashMap;
+
 use anyhow::{Result, bail};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
+use parking_lot::Mutex;
 use sha2::Sha256;
+use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
 
+const DEFAULT_REPLAY_CACHE_CAPACITY: usize = 16_384;
+
 /// Signs a request payload with HMAC-SHA256.
-/// Uses `timestamp` + `nonce` alongside the payload to prevent replay attacks.
+/// Authenticates a timestamp and canonical nonce alongside the payload.
 pub fn sign_request(
     shared_secret: &str,
     payload: &[u8],
     timestamp: i64,
     nonce: &str,
 ) -> Result<String> {
+    parse_canonical_nonce(nonce)?;
+    compute_signature(shared_secret, payload, timestamp, nonce)
+}
+
+fn compute_signature(
+    shared_secret: &str,
+    payload: &[u8],
+    timestamp: i64,
+    nonce: &str,
+) -> Result<String> {
+    let mac = request_mac(shared_secret, payload, timestamp, nonce)?;
+    Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
+fn request_mac(
+    shared_secret: &str,
+    payload: &[u8],
+    timestamp: i64,
+    nonce: &str,
+) -> Result<HmacSha256> {
     let mut mac = HmacSha256::new_from_slice(shared_secret.as_bytes()).map_err(|e| {
         ::zeroclaw_log::record!(
             ERROR,
@@ -28,10 +54,37 @@ pub fn sign_request(
     mac.update(&timestamp.to_le_bytes());
     mac.update(nonce.as_bytes());
     mac.update(payload);
-    Ok(hex::encode(mac.finalize().into_bytes()))
+    Ok(mac)
 }
 
-/// Verify a signed request, rejecting stale timestamps for replay protection.
+fn verify_signature(
+    shared_secret: &str,
+    payload: &[u8],
+    timestamp: i64,
+    nonce: &str,
+    signature: &str,
+) -> Result<bool> {
+    if signature.len() != 64
+        || !signature
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Ok(false);
+    }
+
+    let mut provided = [0_u8; 32];
+    if hex::decode_to_slice(signature, &mut provided).is_err() {
+        return Ok(false);
+    }
+
+    let mac = request_mac(shared_secret, payload, timestamp, nonce)?;
+    Ok(mac.verify_slice(&provided).is_ok())
+}
+
+/// Verify a signed request's timestamp, canonical nonce, and HMAC.
+///
+/// This helper is stateless. Use [`NodeTransport::verify_incoming`] when replay
+/// rejection is required.
 pub fn verify_request(
     shared_secret: &str,
     payload: &[u8],
@@ -40,43 +93,138 @@ pub fn verify_request(
     signature: &str,
     max_age_secs: i64,
 ) -> Result<bool> {
-    let now = Utc::now().timestamp();
-    if (now - timestamp).abs() > max_age_secs {
+    verify_request_at(
+        shared_secret,
+        payload,
+        timestamp,
+        nonce,
+        signature,
+        max_age_secs,
+        Utc::now().timestamp(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_request_at(
+    shared_secret: &str,
+    payload: &[u8],
+    timestamp: i64,
+    nonce: &str,
+    signature: &str,
+    max_age_secs: i64,
+    now: i64,
+) -> Result<bool> {
+    parse_canonical_nonce(nonce)?;
+    verify_canonical_request_at(
+        shared_secret,
+        payload,
+        timestamp,
+        nonce,
+        signature,
+        max_age_secs,
+        now,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_canonical_request_at(
+    shared_secret: &str,
+    payload: &[u8],
+    timestamp: i64,
+    nonce: &str,
+    signature: &str,
+    max_age_secs: i64,
+    now: i64,
+) -> Result<bool> {
+    let max_age_secs = u64::try_from(max_age_secs)
+        .map_err(|_| anyhow::anyhow!("Maximum request age must be non-negative"))?;
+    if now.abs_diff(timestamp) > max_age_secs {
         bail!("Request timestamp too old or too far in future");
     }
 
-    let expected = sign_request(shared_secret, payload, timestamp, nonce)?;
-    Ok(constant_time_eq(expected.as_bytes(), signature.as_bytes()))
+    verify_signature(shared_secret, payload, timestamp, nonce, signature)
 }
 
-/// Constant-time comparison to prevent timing attacks.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
+fn parse_canonical_nonce(nonce: &str) -> Result<Uuid> {
+    let parsed = Uuid::parse_str(nonce)
+        .map_err(|_| anyhow::anyhow!("Invalid nonce: expected a canonical UUID"))?;
+    if parsed.hyphenated().to_string() != nonce {
+        bail!("Invalid nonce: expected a lowercase hyphenated UUID");
     }
-    a.iter()
-        .zip(b.iter())
-        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
-        == 0
+    Ok(parsed)
 }
 
 // ── Node transport client ───────────────────────────────────────
+
+struct ReplayCache {
+    live_nonces: HashMap<Uuid, i64>,
+    capacity: usize,
+    earliest_expiry: Option<i64>,
+}
+
+impl ReplayCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            live_nonces: HashMap::new(),
+            capacity,
+            earliest_expiry: None,
+        }
+    }
+
+    fn accept(&mut self, nonce: Uuid, expires_at: i64, now: i64) -> Result<()> {
+        if self.earliest_expiry.is_some_and(|expiry| expiry < now) {
+            let mut next_expiry: Option<i64> = None;
+            self.live_nonces.retain(|_, expiry| {
+                if *expiry < now {
+                    return false;
+                }
+                next_expiry = Some(next_expiry.map_or(*expiry, |next| next.min(*expiry)));
+                true
+            });
+            self.earliest_expiry = next_expiry;
+        }
+
+        if self.live_nonces.contains_key(&nonce) {
+            bail!("Request nonce has already been used");
+        }
+        if self.live_nonces.len() >= self.capacity {
+            bail!("Node replay cache is at capacity");
+        }
+
+        self.live_nonces.insert(nonce, expires_at);
+        self.earliest_expiry = Some(
+            self.earliest_expiry
+                .map_or(expires_at, |earliest| earliest.min(expires_at)),
+        );
+        Ok(())
+    }
+}
 
 pub struct NodeTransport {
     http: reqwest::Client,
     shared_secret: String,
     max_request_age_secs: i64,
+    replay_cache: Mutex<ReplayCache>,
 }
 
 impl NodeTransport {
     pub fn new(shared_secret: String) -> Self {
+        Self::with_limits(shared_secret, 300, DEFAULT_REPLAY_CACHE_CAPACITY)
+    }
+
+    fn with_limits(
+        shared_secret: String,
+        max_request_age_secs: i64,
+        replay_cache_capacity: usize,
+    ) -> Self {
         Self {
             http: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
                 .expect("HTTP client build"),
             shared_secret,
-            max_request_age_secs: 300, // 5 min replay window
+            max_request_age_secs,
+            replay_cache: Mutex::new(ReplayCache::new(replay_cache_capacity)),
         }
     }
 
@@ -115,13 +263,30 @@ impl NodeTransport {
         Ok(resp.json().await?)
     }
 
-    /// Verify an incoming request from a peer node.
+    /// Verify an incoming request and reject a reused nonce.
     pub fn verify_incoming(
         &self,
         payload: &[u8],
         timestamp_header: &str,
         nonce_header: &str,
         signature_header: &str,
+    ) -> Result<bool> {
+        self.verify_incoming_at(
+            payload,
+            timestamp_header,
+            nonce_header,
+            signature_header,
+            Utc::now().timestamp(),
+        )
+    }
+
+    fn verify_incoming_at(
+        &self,
+        payload: &[u8],
+        timestamp_header: &str,
+        nonce_header: &str,
+        signature_header: &str,
+        now: i64,
     ) -> Result<bool> {
         let timestamp: i64 = timestamp_header.parse().map_err(|_| {
             ::zeroclaw_log::record!(
@@ -133,14 +298,23 @@ impl NodeTransport {
             );
             anyhow::Error::msg("Invalid timestamp header")
         })?;
-        verify_request(
+        let nonce = parse_canonical_nonce(nonce_header)?;
+        let authenticated = verify_canonical_request_at(
             &self.shared_secret,
             payload,
             timestamp,
             nonce_header,
             signature_header,
             self.max_request_age_secs,
-        )
+            now,
+        )?;
+        if !authenticated {
+            return Ok(false);
+        }
+
+        let expires_at = timestamp.saturating_add(self.max_request_age_secs);
+        self.replay_cache.lock().accept(nonce, expires_at, now)?;
+        Ok(true)
     }
 }
 
@@ -149,53 +323,51 @@ mod tests {
     use super::*;
 
     const TEST_SECRET: &str = "test-shared-secret-key";
+    const NONCE_A: &str = "00000000-0000-4000-8000-000000000001";
+    const NONCE_B: &str = "00000000-0000-4000-8000-000000000002";
+    const NONCE_C: &str = "00000000-0000-4000-8000-000000000003";
 
     #[test]
     fn sign_request_deterministic() {
-        let sig1 = sign_request(TEST_SECRET, b"hello", 1_700_000_000, "nonce-1").unwrap();
-        let sig2 = sign_request(TEST_SECRET, b"hello", 1_700_000_000, "nonce-1").unwrap();
+        let sig1 = sign_request(TEST_SECRET, b"hello", 1_700_000_000, NONCE_A).unwrap();
+        let sig2 = sign_request(TEST_SECRET, b"hello", 1_700_000_000, NONCE_A).unwrap();
         assert_eq!(sig1, sig2, "Same inputs must produce the same signature");
+        assert_eq!(
+            sig1, "38aa64525ffcc81a26ac62add71310d01a1a420b2aed800efcdd6321415c0322",
+            "Canonical sender framing must remain wire-compatible"
+        );
     }
 
     #[test]
     fn verify_request_accepts_valid_signature() {
         let now = Utc::now().timestamp();
-        let sig = sign_request(TEST_SECRET, b"payload", now, "nonce-a").unwrap();
-        let ok = verify_request(TEST_SECRET, b"payload", now, "nonce-a", &sig, 300).unwrap();
+        let sig = sign_request(TEST_SECRET, b"payload", now, NONCE_A).unwrap();
+        let ok = verify_request(TEST_SECRET, b"payload", now, NONCE_A, &sig, 300).unwrap();
         assert!(ok, "Valid signature must pass verification");
     }
 
     #[test]
     fn verify_request_rejects_tampered_payload() {
         let now = Utc::now().timestamp();
-        let sig = sign_request(TEST_SECRET, b"original", now, "nonce-b").unwrap();
-        let ok = verify_request(TEST_SECRET, b"tampered", now, "nonce-b", &sig, 300).unwrap();
+        let sig = sign_request(TEST_SECRET, b"original", now, NONCE_B).unwrap();
+        let ok = verify_request(TEST_SECRET, b"tampered", now, NONCE_B, &sig, 300).unwrap();
         assert!(!ok, "Tampered payload must fail verification");
     }
 
     #[test]
     fn verify_request_rejects_expired_timestamp() {
         let old = Utc::now().timestamp() - 600;
-        let sig = sign_request(TEST_SECRET, b"data", old, "nonce-c").unwrap();
-        let result = verify_request(TEST_SECRET, b"data", old, "nonce-c", &sig, 300);
+        let sig = sign_request(TEST_SECRET, b"data", old, NONCE_C).unwrap();
+        let result = verify_request(TEST_SECRET, b"data", old, NONCE_C, &sig, 300);
         assert!(result.is_err(), "Expired timestamp must be rejected");
     }
 
     #[test]
     fn verify_request_rejects_wrong_secret() {
         let now = Utc::now().timestamp();
-        let sig = sign_request(TEST_SECRET, b"data", now, "nonce-d").unwrap();
-        let ok = verify_request("wrong-secret", b"data", now, "nonce-d", &sig, 300).unwrap();
+        let sig = sign_request(TEST_SECRET, b"data", now, NONCE_A).unwrap();
+        let ok = verify_request("wrong-secret", b"data", now, NONCE_A, &sig, 300).unwrap();
         assert!(!ok, "Wrong secret must fail verification");
-    }
-
-    #[test]
-    fn constant_time_eq_correctness() {
-        assert!(constant_time_eq(b"abc", b"abc"));
-        assert!(!constant_time_eq(b"abc", b"abd"));
-        assert!(!constant_time_eq(b"abc", b"ab"));
-        assert!(!constant_time_eq(b"", b"a"));
-        assert!(constant_time_eq(b"", b""));
     }
 
     #[test]
@@ -209,7 +381,7 @@ mod tests {
         let transport = NodeTransport::new(TEST_SECRET.into());
         let now = Utc::now().timestamp();
         let payload = b"test-body";
-        let nonce = "incoming-nonce";
+        let nonce = NONCE_A;
         let sig = sign_request(TEST_SECRET, payload, now, nonce).unwrap();
 
         let ok = transport
@@ -227,11 +399,267 @@ mod tests {
 
     #[test]
     fn sign_request_different_nonce_different_signature() {
-        let sig1 = sign_request(TEST_SECRET, b"data", 1_700_000_000, "nonce-1").unwrap();
-        let sig2 = sign_request(TEST_SECRET, b"data", 1_700_000_000, "nonce-2").unwrap();
+        let sig1 = sign_request(TEST_SECRET, b"data", 1_700_000_000, NONCE_A).unwrap();
+        let sig2 = sign_request(TEST_SECRET, b"data", 1_700_000_000, NONCE_B).unwrap();
         assert_ne!(
             sig1, sig2,
             "Different nonces must produce different signatures"
+        );
+    }
+
+    #[test]
+    fn node_transport_rejects_replayed_request() {
+        let transport = NodeTransport::new(TEST_SECRET.into());
+        let now = 1_700_000_000;
+        let signature = sign_request(TEST_SECRET, b"payload", now, NONCE_A).unwrap();
+
+        assert!(
+            transport
+                .verify_incoming_at(b"payload", &now.to_string(), NONCE_A, &signature, now)
+                .unwrap()
+        );
+        let replay = transport
+            .verify_incoming_at(b"payload", &now.to_string(), NONCE_A, &signature, now)
+            .unwrap_err();
+        assert!(replay.to_string().contains("already been used"));
+    }
+
+    #[test]
+    fn node_transport_accepts_exactly_one_concurrent_request() {
+        let transport = NodeTransport::new(TEST_SECRET.into());
+        let now = 1_700_000_000;
+        let timestamp = now.to_string();
+        let signature = sign_request(TEST_SECRET, b"payload", now, NONCE_A).unwrap();
+        let barrier = std::sync::Barrier::new(8);
+
+        let outcomes = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        transport
+                            .verify_incoming_at(b"payload", &timestamp, NONCE_A, &signature, now)
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, Ok(true)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes.iter().filter(|outcome| outcome.is_err()).count(),
+            7
+        );
+    }
+
+    #[test]
+    fn invalid_signature_does_not_reserve_nonce() {
+        let transport = NodeTransport::new(TEST_SECRET.into());
+        let now = 1_700_000_000;
+        let signature = sign_request(TEST_SECRET, b"payload", now, NONCE_A).unwrap();
+        let uppercase_signature = signature.to_uppercase();
+        let non_hex_signature = "g".repeat(64);
+
+        assert!(
+            !transport
+                .verify_incoming_at(b"payload", &now.to_string(), NONCE_A, "bad", now)
+                .unwrap()
+        );
+        assert!(
+            !transport
+                .verify_incoming_at(
+                    b"payload",
+                    &now.to_string(),
+                    NONCE_A,
+                    &uppercase_signature,
+                    now,
+                )
+                .unwrap()
+        );
+        assert!(
+            !transport
+                .verify_incoming_at(
+                    b"payload",
+                    &now.to_string(),
+                    NONCE_A,
+                    &non_hex_signature,
+                    now,
+                )
+                .unwrap()
+        );
+        assert!(
+            transport
+                .verify_incoming_at(b"payload", &now.to_string(), NONCE_A, &signature, now)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn expired_cache_entry_is_pruned() {
+        let transport = NodeTransport::with_limits(TEST_SECRET.into(), 300, 1);
+        let first_timestamp = 100;
+        let first_signature =
+            sign_request(TEST_SECRET, b"first", first_timestamp, NONCE_A).unwrap();
+        assert!(
+            transport
+                .verify_incoming_at(
+                    b"first",
+                    &first_timestamp.to_string(),
+                    NONCE_A,
+                    &first_signature,
+                    first_timestamp,
+                )
+                .unwrap()
+        );
+
+        let exact_expiry = first_timestamp + 300;
+        let replay = transport
+            .verify_incoming_at(
+                b"first",
+                &first_timestamp.to_string(),
+                NONCE_A,
+                &first_signature,
+                exact_expiry,
+            )
+            .unwrap_err();
+        assert!(replay.to_string().contains("already been used"));
+
+        let second_timestamp = 401;
+        let second_signature =
+            sign_request(TEST_SECRET, b"second", second_timestamp, NONCE_B).unwrap();
+        assert!(
+            transport
+                .verify_incoming_at(
+                    b"second",
+                    &second_timestamp.to_string(),
+                    NONCE_B,
+                    &second_signature,
+                    second_timestamp,
+                )
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn full_live_cache_fails_closed_without_eviction() {
+        let transport = NodeTransport::with_limits(TEST_SECRET.into(), 300, 1);
+        let now = 1_700_000_000;
+        let first_signature = sign_request(TEST_SECRET, b"first", now, NONCE_A).unwrap();
+        let second_signature = sign_request(TEST_SECRET, b"second", now, NONCE_B).unwrap();
+
+        assert!(
+            transport
+                .verify_incoming_at(b"first", &now.to_string(), NONCE_A, &first_signature, now)
+                .unwrap()
+        );
+        let full = transport
+            .verify_incoming_at(b"second", &now.to_string(), NONCE_B, &second_signature, now)
+            .unwrap_err();
+        assert!(full.to_string().contains("at capacity"));
+
+        let replay = transport
+            .verify_incoming_at(b"first", &now.to_string(), NONCE_A, &first_signature, now)
+            .unwrap_err();
+        assert!(replay.to_string().contains("already been used"));
+    }
+
+    #[test]
+    fn verify_request_rejects_noncanonical_nonce_forms() {
+        let now = 1_700_000_000;
+        let invalid_nonces = [
+            "00000000000040008000000000000001",
+            "00000000-0000-4000-8000-00000000000A",
+            "{00000000-0000-4000-8000-000000000001}",
+            "not-a-uuid",
+        ];
+
+        for nonce in invalid_nonces {
+            let signature = compute_signature(TEST_SECRET, b"payload", now, nonce).unwrap();
+            let result =
+                verify_request_at(TEST_SECRET, b"payload", now, nonce, &signature, 300, now);
+            assert!(result.is_err(), "nonce should be rejected: {nonce}");
+        }
+    }
+
+    #[test]
+    fn invalid_headers_do_not_reserve_nonce() {
+        let transport = NodeTransport::with_limits(TEST_SECRET.into(), 300, 1);
+        let now = 1_700_000_000;
+        let compact_nonce = "00000000000040008000000000000001";
+        let compact_signature =
+            compute_signature(TEST_SECRET, b"payload", now, compact_nonce).unwrap();
+
+        assert!(
+            transport
+                .verify_incoming_at(b"payload", "not-a-number", NONCE_A, "bad", now)
+                .is_err()
+        );
+        assert!(
+            transport
+                .verify_incoming_at(
+                    b"payload",
+                    &now.to_string(),
+                    compact_nonce,
+                    &compact_signature,
+                    now,
+                )
+                .is_err()
+        );
+
+        let canonical_signature = sign_request(TEST_SECRET, b"payload", now, NONCE_A).unwrap();
+        assert!(
+            transport
+                .verify_incoming_at(
+                    b"payload",
+                    &now.to_string(),
+                    NONCE_A,
+                    &canonical_signature,
+                    now,
+                )
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn verify_request_preserves_timestamp_boundaries() {
+        let now = 1_700_000_000;
+        let boundary = now - 300;
+        let signature = sign_request(TEST_SECRET, b"payload", boundary, NONCE_A).unwrap();
+        assert!(
+            verify_request_at(
+                TEST_SECRET,
+                b"payload",
+                boundary,
+                NONCE_A,
+                &signature,
+                300,
+                now,
+            )
+            .unwrap()
+        );
+
+        let stale = now - 301;
+        let signature = sign_request(TEST_SECRET, b"payload", stale, NONCE_B).unwrap();
+        assert!(
+            verify_request_at(
+                TEST_SECRET,
+                b"payload",
+                stale,
+                NONCE_B,
+                &signature,
+                300,
+                now,
+            )
+            .is_err()
         );
     }
 }

--- a/crates/zeroclaw-runtime/src/nodes/transport.rs
+++ b/crates/zeroclaw-runtime/src/nodes/transport.rs
@@ -137,7 +137,7 @@ fn verify_canonical_request_at(
     now: i64,
 ) -> Result<bool> {
     let max_age_secs = u64::try_from(max_age_secs)
-        .map_err(|_| anyhow::anyhow!("Maximum request age must be non-negative"))?;
+        .map_err(|_| anyhow::Error::msg("Maximum request age must be non-negative"))?;
     if now.abs_diff(timestamp) > max_age_secs {
         bail!("Request timestamp too old or too far in future");
     }
@@ -147,7 +147,7 @@ fn verify_canonical_request_at(
 
 fn parse_canonical_nonce(nonce: &str) -> Result<Uuid> {
     let parsed = Uuid::parse_str(nonce)
-        .map_err(|_| anyhow::anyhow!("Invalid nonce: expected a canonical UUID"))?;
+        .map_err(|_| anyhow::Error::msg("Invalid nonce: expected a canonical UUID"))?;
     if parsed.hyphenated().to_string() != nonce {
         bail!("Invalid nonce: expected a lowercase hyphenated UUID");
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Require lowercase hyphenated UUID nonces for node request signing and verification so the HMAC input has an unambiguous nonce boundary.
  - Add bounded, atomic replay admission to `NodeTransport`, rejecting duplicate nonces while their signed request remains valid and failing closed when the live cache is full.
  - Add deterministic coverage for replay, concurrent admission, malformed input, signature compatibility, expiry, and capacity behavior.
- **Scope boundary:** This PR does not wire a receiving endpoint, persist nonce history across restarts, share replay state across transport instances or processes, change node configuration, or introduce a protocol version.
- **Blast radius:** The exported runtime node-transport signing and verification contract. The built-in sender remains wire-compatible because it already emits canonical UUID v4 nonces. There is currently no in-repository receiving caller; external callers using arbitrary nonce strings must switch to canonical UUID strings.
- **Linked issue(s):** None.
- **Labels:** `bug`, `risk:high`, `size:L`, `runtime`, `domain:security`

### What this does, simply

ZeroClaw has code for signing messages sent between nodes so a receiver can tell they are genuine. That receiver is not wired into ZeroClaw yet. Before this change, a valid message could be copied and sent again for up to five minutes, and a future or external receiver could accept every copy.

Now the receiver remembers each accepted message for five minutes and rejects repeats. It checks the message first, so bad messages do not fill its memory. If that memory is full, it rejects new messages instead of forgetting old ones too soon.

This memory is not saved to disk or shared between running copies of ZeroClaw. It resets when ZeroClaw restarts, and a receiver must keep using the same checker for this protection to work.

### Scope and maintenance tradeoff

The existing node-transport module already owns signing and incoming verification, so the smallest coherent repair keeps replay admission there. Moving the latent transport to a new crate, wiring configuration, or adding a receiver would introduce separate ownership and protocol decisions that are not required to close this security gap.

The runtime crate's checked-in `AGENTS.md` describes it as a transitional holding area and says not to add new functionality. My reading is that making this existing module's replay-protection claim true is maintenance rather than a new runtime capability; maintainers should confirm that placement before merge.

The diff is test-heavy: 254 of the 428 net new lines are deterministic in-module regressions. Production code adds canonical nonce parsing, standard constant-time HMAC verification, and a bounded cache.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. No receiving endpoint currently calls this module; the focused unit suite directly exercises the changed boundary.

### How I tested

- **CI checks relied on and why they cover this change:** Required exact-head CI is green, including lint, tests, security checks, supported build targets, MSRV, and the required gate.
- **Known CI coverage gap, if any:** There is no end-to-end receiver test because no receiving endpoint currently calls this module.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
[exit 0]

$ cargo test -p zeroclaw-runtime nodes::transport::tests -- --nocapture
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 3789 filtered out
```

- **Beyond CI, what did you manually verify?** The deterministic suite covers byte-stable canonical signatures, payload and secret tampering, stale and exact-boundary timestamps, malformed nonce and signature forms, first acceptance followed by replay rejection, exactly one successful concurrent admission, invalid requests not reserving capacity, expiry pruning, and fail-closed capacity without live-entry eviction. I did not run an end-to-end receiver smoke because this module has no receiving caller.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** No broad local workspace build was run; the focused runtime suite exercises the changed module, while required CI will provide workspace integration evidence on the published head. The macOS linker emitted a non-fatal `__eh_frame section too large` warning while linking the test binary; linking completed and the test command exited successfully.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.** Shared-secret storage and access are unchanged; request authentication and nonce admission are tightened.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **No.** The built-in sender remains wire-compatible, but callers that pass arbitrary nonce strings to the exported signing or verification helpers must migrate to lowercase hyphenated UUID strings.
- Config / env / CLI surface changed? **No.**
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is `No` or either surface/floor question is `Yes`: Existing callers should generate a UUID nonce and pass its lowercase hyphenated representation. No configuration or stored-data migration is required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merged commit for this PR, or before squash merge run `git revert 5bf27b2599a9c1aa34621cce4f95fbbb826fcc1f 8b06d7c810b29c169acc53119dd9e2492f0d5e8c` on the contribution branch.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A future receiving caller would observe errors for noncanonical nonces, reused nonces, stale timestamps, or replay-cache capacity exhaustion. Reverting restores the prior stateless verification behavior and its replay exposure.
