### PR TITLE
fix(i18n): localize terminal approval prompts

### DIFF
--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -1122,6 +1122,11 @@ tool-runtime-command-build-failed = Failed to build runtime command: {$error}
 tool-runtime-command-docker-workspace-path = Failed to build runtime command: Failed to canonicalize Docker workspace path {$path}: {$cause}
 tool-runtime-command-docker-allowed-root = Failed to build runtime command: Failed to canonicalize Docker workspace root {$path}: {$cause}
 
+# ── Terminal tool approval ──
+# The ASCII shortcut tokens stay aligned with the Rust-owned response parser.
+cli-approval-request = 🔧 Agent wants to execute: {$tool}
+cli-approval-prompt = { "   " }[Y]es / [N]o / [A]lways for {$tool}:{ " " }
+
 # ── Tool approval (channels, #9409) ──
 # Human-visible copy for the operator-facing tool-approval prompt, shared
 # across the button adapters (Telegram, Discord, Slack) and the text-reply

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -966,6 +966,11 @@ sop-rpc-decision-unauthorized = La identidad RPC no está autorizada para resolv
 sop-rpc-policy-missing = La política de aprobación de SOP '{$name}' no está configurada.
 sop-rpc-policy-unavailable = La política del SOP en espera no está disponible: {$reason}.
 
+# ── Aprobación de herramientas en la terminal ──
+# Los atajos ASCII se mantienen alineados con el analizador de respuestas de Rust.
+cli-approval-request = 🔧 El agente quiere ejecutar: {$tool}
+cli-approval-prompt = { "   " }[Y] Sí / [N] No / [A] Siempre para {$tool}:{ " " }
+
 # ── Tool approval (channels, #9409) ──
 # Human-visible copy for the operator-facing tool-approval prompt, shared
 # across the button adapters (Telegram, Discord, Slack) and the text-reply

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -969,6 +969,11 @@ sop-rpc-decision-unauthorized = L’identité RPC n’est pas autorisée à rés
 sop-rpc-policy-missing = La politique d’approbation SOP « {$name} » n’est pas configurée.
 sop-rpc-policy-unavailable = La politique du SOP en attente est indisponible : {$reason}.
 
+# ── Approbation des outils dans le terminal ──
+# Les raccourcis ASCII restent alignés sur l'analyseur de réponses Rust.
+cli-approval-request = 🔧 L'agent veut exécuter : {$tool}
+cli-approval-prompt = { "   " }[Y] Oui / [N] Non / [A] Toujours pour {$tool} :{ " " }
+
 # ── Tool approval (channels, #9409) ──
 # Human-visible copy for the operator-facing tool-approval prompt, shared
 # across the button adapters (Telegram, Discord, Slack) and the text-reply

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -966,6 +966,11 @@ sop-rpc-decision-unauthorized = RPC プリンシパルには、この SOP ステ
 sop-rpc-policy-missing = SOP 承認ポリシー '{$name}' が構成されていません。
 sop-rpc-policy-unavailable = 待機中の SOP ポリシーを利用できません: {$reason}。
 
+# ── ターミナルでのツール承認 ──
+# ASCII ショートカットは Rust 側の応答パーサーと一致させます。
+cli-approval-request = 🔧 エージェントが実行しようとしています: {$tool}
+cli-approval-prompt = { "   " }[Y] はい / [N] いいえ / [A] 常に許可（{$tool}）:{ " " }
+
 # ── Tool approval (channels, #9409) ──
 # Human-visible copy for the operator-facing tool-approval prompt, shared
 # across the button adapters (Telegram, Discord, Slack) and the text-reply

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -965,6 +965,11 @@ sop-rpc-decision-unauthorized = RPC 主体无权对该 SOP 步骤作出决策。
 sop-rpc-policy-missing = 未配置 SOP 审批策略“{$name}”。
 sop-rpc-policy-unavailable = 暂停的 SOP 策略不可用：{$reason}。
 
+# ── 终端工具审批 ──
+# ASCII 快捷键与 Rust 响应解析器保持一致。
+cli-approval-request = 🔧 代理想要执行：{$tool}
+cli-approval-prompt = { "   " }[Y] 是 / [N] 否 / [A] 始终允许 {$tool}：{ " " }
+
 # ── Tool approval (channels, #9409) ──
 # Human-visible copy for the operator-facing tool-approval prompt, shared
 # across the button adapters (Telegram, Discord, Slack) and the text-reply

--- a/crates/zeroclaw-runtime/src/approval/mod.rs
+++ b/crates/zeroclaw-runtime/src/approval/mod.rs
@@ -261,10 +261,17 @@ impl ApprovalManager {
 /// terminal when available, falling back to stdin otherwise.
 fn prompt_cli_interactive(request: &ApprovalRequest) -> ApprovalResponse {
     let summary = summarize_args(&request.arguments);
+    let tool_args = [("tool", request.tool_name.as_str())];
     eprintln!();
-    eprintln!("🔧 Agent wants to execute: {}", request.tool_name);
+    eprintln!(
+        "{}",
+        crate::i18n::get_required_cli_string_with_args("cli-approval-request", &tool_args)
+    );
     eprintln!("   {summary}");
-    eprint!("   [Y]es / [N]o / [A]lways for {}: ", request.tool_name);
+    eprint!(
+        "{}",
+        crate::i18n::get_required_cli_string_with_args("cli-approval-prompt", &tool_args)
+    );
     let _ = io::stderr().flush();
 
     let Ok(line) = read_cli_approval_line() else {

--- a/crates/zeroclaw-runtime/src/i18n.rs
+++ b/crates/zeroclaw-runtime/src/i18n.rs
@@ -685,6 +685,50 @@ mod tests {
     }
 
     #[test]
+    fn cli_approval_prompt_strings_format_in_all_locales() {
+        let tool = "shell";
+        let cases = [
+            ("cli-approval-request", &["shell"][..]),
+            ("cli-approval-prompt", &["shell", "[Y]", "[N]", "[A]"][..]),
+        ];
+
+        for (source, locale) in [
+            (include_str!("../locales/en/cli.ftl"), "en"),
+            (include_str!("../locales/es/cli.ftl"), "es"),
+            (include_str!("../locales/fr/cli.ftl"), "fr"),
+            (include_str!("../locales/ja/cli.ftl"), "ja"),
+            (include_str!("../locales/zh-CN/cli.ftl"), "zh-CN"),
+        ] {
+            for (key, expected_parts) in cases {
+                let value = format_ftl_message(source, locale, key, &[("tool", tool)])
+                    .unwrap_or_else(|| panic!("{key} should format in {locale}"));
+                for expected in expected_parts {
+                    assert!(
+                        value.contains(expected),
+                        "{key} in {locale} should preserve {expected:?}; got: {value:?}"
+                    );
+                }
+                if key == "cli-approval-prompt" {
+                    assert!(
+                        value.ends_with(' ') && !value.ends_with("  "),
+                        "{key} in {locale} should end with exactly one space; got: {value:?}"
+                    );
+                }
+            }
+        }
+
+        let english = include_str!("../locales/en/cli.ftl");
+        assert_eq!(
+            format_ftl_message(english, "en", "cli-approval-request", &[("tool", tool)]).as_deref(),
+            Some("🔧 Agent wants to execute: shell")
+        );
+        assert_eq!(
+            format_ftl_message(english, "en", "cli-approval-prompt", &[("tool", tool)]).as_deref(),
+            Some("   [Y]es / [N]o / [A]lways for shell: ")
+        );
+    }
+
+    #[test]
     fn channel_compile_guidance_cli_strings_format_from_fluent() {
         let cases = [
             (

--- a/tests/architecture/cli_fluent_coverage.rs
+++ b/tests/architecture/cli_fluent_coverage.rs
@@ -17,6 +17,7 @@ const SCAN_ROOTS: &[&str] = &[
     "src",
     "crates/zeroclaw-gateway/src",
     "crates/zeroclaw-providers/src/auth",
+    "crates/zeroclaw-runtime/src/approval",
 ];
 const LEGACY_ALLOWLIST: &str = include_str!("cli_fluent_legacy_allowlist.tsv");
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Localizes the interactive terminal tool-approval request and decision prompt through the runtime Fluent catalogs; preserves tool names, redacted argument summaries, accepted response tokens, and approval semantics; extends the structural localization guard to the runtime approval module; and tests all five built-in locales, including exact trailing prompt spacing.
- **Scope boundary:** This PR covers only terminal approval presentation. It does not change channel approval adapters, policy decisions, response parsing, logs, panic text, protocol values, or other runtime localization pockets.
- **Blast radius:** Interactive CLI approval text in English, Spanish, French, Japanese, and Simplified Chinese, plus architecture enforcement for new direct print literals under the approval module.
- **Linked issue(s):** Related #9972
- **Labels:** `enhancement`, `runtime`, `tests`, `distinguished contributor`, `risk:medium`, `size:XS`

### What this does, simply

When an agent asks to run a tool in an interactive terminal, ZeroClaw shows the request and the available yes, no, and always choices. That text was printed directly in English even when the runtime locale selected another language. This PR moves the presentation text into the existing runtime translation catalogs while keeping tool names and the accepted keyboard responses unchanged.

A repository check now also watches the approval code, so new operator-facing text there has to go through the translation files instead of being printed in English again. The check leaves debug output and machine-readable values alone.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli`
- **Setup / preconditions:** Configure a non-English runtime locale and an interactive supervised agent whose shell tool requires approval. A local model provider is sufficient.
- **Steps to run:** Ask the agent to invoke a harmless shell command, inspect the approval request, then enter `n`.
- **Expected on this branch (after):** The request and choices use the configured locale, the tool name remains exact, and `n` denies the command.
- **Prior behavior on `master` (before):** The same approval request and choices are printed in English regardless of the configured locale.

### How I tested

- **CI checks relied on and why they cover this change:** Required current-head CI passed, including formatting, lint, tests, cross-target compilation, and repository integration.
- **Known CI coverage gap, if any:** None. Focused local tests and a production CLI smoke cover the changed behavior directly, and required CI passed at this head.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

cargo test --test architecture cli_fluent_coverage -- --nocapture
# test result: ok. 9 passed; 0 failed; 17 filtered out

cargo test -p zeroclaw-runtime cli_approval_prompt_strings_format_in_all_locales -- --nocapture
# test result: ok. 1 passed; 0 failed; 3800 filtered out
```

- **Beyond CI, what did you manually verify?** Using a secret-free Simplified Chinese configuration and a local Ollama model, the production CLI displayed the localized approval request and choices. Entering `n` denied a harmless `printf` request, and the command did not run. I did not exercise channel-owned approval adapters because they are outside this PR.
- **Visual interface changed?** Yes
- **Tested revision, interface, and terminal or viewport dimensions:** `17e852b88ebec3e976ce6d1cbd8afbcecbc2724e`; `cli`; privacy-safe evidence capture at 673 x 439 pixels.
- **Screenshot evidence:**
<img width="676" height="438" alt="image" src="https://github.com/user-attachments/assets/e4a9c45b-697f-46fd-a225-f3a1c9a51e95" />

- **Action or changed state and observed result:** The agent requested the shell tool, the CLI displayed localized approval choices, and entering `n` denied execution.
- **If any command was intentionally skipped, why:** No broad local workspace suite was run because focused architecture, catalog-formatting, and production-interface checks directly cover this narrow slice; required CI remains the integration backstop.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes - terminal approval presentation now follows the configured locale; accepted input tokens and approval behavior are unchanged.
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: No upgrade is required. Existing configurations and response tokens continue to work.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert commit `17e852b88ebec3e976ce6d1cbd8afbcecbc2724e`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Missing Fluent-message warnings, malformed or untranslated terminal approval text, or approval prompts that no longer accept the existing `y`/`yes`, `a`/`always`, and denial responses.
