### PR TITLE
fix(channels): mark Google TTS API key header sensitive

### DIFF
--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
+use reqwest::header::HeaderValue;
 
 use zeroclaw_config::schema::{Config, TtsProviderConfig};
 
@@ -12,6 +13,9 @@ const DEFAULT_MAX_TEXT_LENGTH: usize = 4096;
 
 /// Default HTTP request timeout for TTS API calls.
 const TTS_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+const GOOGLE_TTS_ENDPOINT: &str = "https://texttospeech.googleapis.com/v1/text:synthesize";
+const GOOGLE_TTS_API_KEY_HEADER: &str = "x-goog-api-key";
 
 /// Maximum time allowed for a local ffmpeg transcode.
 const FFMPEG_TRANSCODE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
@@ -320,6 +324,34 @@ impl GoogleTtsProvider {
                 .context("Failed to build HTTP client for Google TTS")?,
         })
     }
+
+    fn sensitive_api_key_header(&self) -> Result<HeaderValue> {
+        let mut value = HeaderValue::from_str(&self.api_key).map_err(|_| {
+            anyhow::Error::msg("Google TTS API key contains invalid header characters")
+        })?;
+        value.set_sensitive(true);
+        Ok(value)
+    }
+
+    fn build_synthesize_request(&self, text: &str, voice: &str) -> Result<reqwest::RequestBuilder> {
+        let body = serde_json::json!({
+            "input": { "text": text },
+            "voice": {
+                "languageCode": self.language_code,
+                "name": voice,
+            },
+            "audioConfig": {
+                "audioEncoding": "MP3",
+            },
+        });
+        let api_key = self.sensitive_api_key_header()?;
+
+        Ok(self
+            .client
+            .post(GOOGLE_TTS_ENDPOINT)
+            .header(GOOGLE_TTS_API_KEY_HEADER, api_key)
+            .json(&body))
+    }
 }
 
 #[async_trait::async_trait]
@@ -334,23 +366,8 @@ impl TtsProvider for GoogleTtsProvider {
     }
 
     async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>> {
-        let url = "https://texttospeech.googleapis.com/v1/text:synthesize";
-        let body = serde_json::json!({
-            "input": { "text": text },
-            "voice": {
-                "languageCode": self.language_code,
-                "name": voice,
-            },
-            "audioConfig": {
-                "audioEncoding": "MP3",
-            },
-        });
-
         let resp = self
-            .client
-            .post(url)
-            .header("x-goog-api-key", &self.api_key)
-            .json(&body)
+            .build_synthesize_request(text, voice)?
             .send()
             .await
             .context("Failed to send Google TTS request")?;
@@ -1329,6 +1346,74 @@ mod tests {
             },
         );
         cfg
+    }
+
+    fn google_tts_provider(api_key: &str) -> GoogleTtsProvider {
+        GoogleTtsProvider::new(
+            "test",
+            &TtsProviderConfig {
+                api_key: Some(api_key.to_string()),
+                ..TtsProviderConfig::default()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn google_synthesize_request_preserves_endpoint_body_and_sensitive_header() {
+        let credential = "synthetic-google-tts-key";
+        let provider = google_tts_provider(credential);
+        let request = provider
+            .build_synthesize_request("hello world", "en-US-Standard-A")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(request.url().as_str(), GOOGLE_TTS_ENDPOINT);
+        assert!(!request.url().as_str().contains(credential));
+        assert!(!request.url().query_pairs().any(|(name, _)| name == "key"));
+
+        let header = request
+            .headers()
+            .get(GOOGLE_TTS_API_KEY_HEADER)
+            .expect("Google TTS API key header");
+        assert_eq!(header.to_str().unwrap(), credential);
+        assert!(header.is_sensitive());
+
+        let payload = request
+            .body()
+            .and_then(|body| body.as_bytes())
+            .expect("Google TTS request body should be bytes");
+        let body: serde_json::Value = serde_json::from_slice(payload).unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "input": { "text": "hello world" },
+                "voice": {
+                    "languageCode": "en-US",
+                    "name": "en-US-Standard-A",
+                },
+                "audioConfig": {
+                    "audioEncoding": "MP3",
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn google_tts_rejects_control_characters_without_echoing_credential() {
+        let credential = "synthetic-google-tts-key\r\ninjected: value";
+        let provider = google_tts_provider(credential);
+        let error = match provider.build_synthesize_request("hello", "en-US-Standard-A") {
+            Ok(_) => panic!("control characters must be rejected before dispatch"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Google TTS API key contains invalid header characters"
+        );
+        assert!(!error.to_string().contains(credential));
     }
 
     fn config_with_piper_alias() -> Config {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Builds the Google TTS `x-goog-api-key` header as a fallible `HeaderValue` and marks it sensitive so request-header diagnostics redact the credential.
  - Rejects malformed header values before dispatch with fixed error text that does not repeat the key.
  - Adds request-level regressions that preserve the endpoint, JSON body, header value, and sensitive flag.
- **Scope boundary:** This PR does not change credential storage, Google TTS configuration, endpoint selection, request or response semantics, shared cross-crate constants, WeCom, or other providers.
- **Blast radius:** Google Text-to-Speech synthesis requests authenticated with an API key. Other TTS providers and non-TTS channel behavior are unchanged.
- **Linked issue(s):** Closes #10175. Related #10107.
- **Labels:** `bug`, `channel`, `distinguished contributor`, `domain:security`, `follow-up`, `risk:high`, `size:S`

### What this does, simply

Google TTS converts agent replies into speech by sending text and an API key to Google's service. ZeroClaw already put the key in Google's authentication header, but the header was not marked sensitive, so a diagnostic that printed request headers could print the key too.

This PR marks that header sensitive and rejects a malformed key before any request is sent, using an error message that never repeats the key. It does not move the key, alter stored configuration, or change the text, voice, audio format, or response handling.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. A live vendor check requires a real Google project credential; request-level regressions prove the changed credential properties without sending or exposing one.

### How I tested

- **CI checks relied on and why they cover this change:** All visible required GitHub CI checks pass on head `a22a9252ce`, including Test, Lint, all feature combinations, Linux, macOS, Windows, MSRV, Security, Semgrep, and the final required gate.
- **Known CI coverage gap, if any:** No live Google TTS request verifies vendor acceptance with a real project credential. The endpoint and required header name are unchanged, and the focused tests inspect the production request builder directly.
- **Commands run and tail output:**

  ```text
  cargo fmt --all -- --check
  # no output; exit 0

  cargo test -p zeroclaw-channels --lib tts::tests::google_synthesize_request_preserves_endpoint_body_and_sensitive_header -- --exact
  test result: ok. 1 passed; 0 failed; 0 ignored; 1425 filtered out

  cargo test -p zeroclaw-channels --lib tts::tests::google_tts_rejects_control_characters_without_echoing_credential -- --exact
  test result: ok. 1 passed; 0 failed; 0 ignored; 1425 filtered out

  git diff --check origin/master...HEAD
  # no output; exit 0

  bash scripts/ci/comment_hygiene_gate.sh
  Comment hygiene gate passed.
  ```

- **Beyond CI, what did you manually verify?** Inspected the built request to confirm the credential is absent from the URL, present only in the required sensitive header, and absent from malformed-header errors. I also verified that the endpoint, JSON body, voice, and MP3 encoding remain unchanged. No live Google request was made.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** A live Google TTS call was skipped to avoid requiring or exposing a real credential. Broad local workspace validation was not selected because the focused request tests and required hosted CI cover this one-file provider change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any **Yes**, describe the risk and mitigation: The Google TTS API key remains in provider memory and the existing authentication header; it is now marked sensitive before attachment. Malformed values fail before dispatch with credential-free error text, and no new persistence or logging path is introduced.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: Not applicable.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged commit>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Google TTS synthesis fails before dispatch for a malformed configured key, or Google returns authentication failures such as HTTP 401/403 for synthesis requests. Other TTS providers continue to operate.
