### PR TITLE
docs(maintainers): calibrate risk review policy

### DIFF
--- a/docs/book/src/contributing/agent-guidelines.md
+++ b/docs/book/src/contributing/agent-guidelines.md
@@ -76,13 +76,9 @@ The stability-tier definitions and versioning policy live in [FND-001](../founda
 
 Stable components follow the breaking-change policy. Beta components may make breaking changes in a MINOR release with changelog notes. Experimental components carry no stability guarantee. Tiers are promoted, never demoted, through deliberate team decision.
 
-Change-risk routing is:
+Change-risk routing is consequence-based, not path-based. Use the [maintainer label guide](../maintainers/labels.md#risk-labels) for the canonical definitions: `risk:low` covers documentation, fixtures, and mechanical metadata with no production, compatibility, build, release, or governance effect; `risk:medium` covers ordinary behavioral work; and `risk:high` covers concrete trust, credential, compatibility, governance, or release-authority boundaries. `domain:security` is independent from `risk:*` and identifies an effective security boundary.
 
-- **Low:** docs, chores, and tests without behavior changes.
-- **Medium:** most implementation changes without boundary or security impact.
-- **High:** `crates/zeroclaw-runtime/src/`, especially `src/security/`; `crates/zeroclaw-gateway/src/`; `crates/zeroclaw-tools/src/`; `.github/workflows/`; access control; and other trust-boundary changes.
-
-Classify uncertainty upward. Validation and rollback evidence should match the actual blast radius, not only the number of changed lines. Use [How to contribute](./how-to.md) for PR mechanics and [Testing](./testing.md) for the validation taxonomy.
+A PR carrying either `risk:high` or `domain:security` needs deep review and two independent Core Team approvals before merge. Classify uncertainty upward. Validation and rollback evidence should match the actual blast radius, not only the number of changed lines. Use [How to contribute](./how-to.md) for PR mechanics and [Testing](./testing.md) for the validation taxonomy.
 
 ## Skill Discovery
 

--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -113,11 +113,9 @@ feat(scope): short description
 
 Body uses the PR template. **The testing section is required**: explain how the change was checked, and paste the checks that match the change. The reviewer-run A/B recipe under `How you can test` is only needed when manual verification adds useful signal; mark it `N/A` for docs-only, pure-refactor, or trivial changes without a meaningful reviewer test path. For docs-only PRs, use `scripts/ci/docs_quality_gate.sh` and `scripts/ci/docs_links_gate.sh` or explain why link checking had no added links to inspect. For Rust/code PRs, use the evidence that matches the changed surface: required CI checks, focused crate or regression tests, manual smoke, or full workspace checks when broad coverage proves something narrower evidence would miss. Fresh required CI is enough when it covers the changed surface; extra local Cargo is not required just to duplicate the same head, target, and feature set. Add more evidence when the PR depends on a known CI coverage gap: platform-specific tests, cross-platform lint, desktop app coverage, release target builds, stale CI, or unavailable CI. "It works on my machine" is not evidence.
 
-Risk labels:
+Risk labels describe the actual change and consequence, not its broad path. Follow the [maintainer label guide](../maintainers/labels.md#risk-labels): `risk:low` is documentation, fixtures, or mechanical metadata with no production, compatibility, build, release, or governance effect; `risk:medium` is ordinary behavioral work; and `risk:high` is a concrete trust, credential, compatibility, governance, or release-authority boundary. `domain:security` is independent from `risk:*` and identifies an effective security boundary.
 
-- `risk:low`: rollback is a revert; no user action needed
-- `risk:medium`: users may need to update config / env / CLI usage; rollback plan required
-- `risk:high`: security-critical, schema changes, breaking behaviour. Rollback plan, feature flag, and observable failure symptoms required
+A PR carrying either `risk:high` or `domain:security` needs deep review, a rollback plan matched to the change, and two independent Core Team approvals before merge. Use `risk:manual` when a maintainer needs to freeze future automatic risk replacement; it cannot lower the review requirement.
 
 ## After the PR
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -400,14 +400,14 @@ Tier 2 has no durable membership record at present. Establishing one, or retirin
 
 The `CODEOWNERS` file makes governance automatic. It defines which paths require review from which team before a PR can merge. GitHub enforces this as a required review: the PR cannot be merged until the requirement is satisfied.
 
-The block below is the original illustrative proposal, kept for the reasoning it shows about routing by risk tier. It is not the current file and should not be copied. `.github/CODEOWNERS` already exists and is actively maintained; it routes to individual handles rather than team handles, and its paths follow the post-microkernel crate layout established in #6537. The `@zeroclaw-labs/zeroclaw-core` and `@zeroclaw-labs/zeroclaw-contributors` handles used here were never created; see §5.3. Read the live file for current routing.
+The block below is the original illustrative proposal, kept for the reasoning it shows about protected review routing. It is not the current file and should not be copied. `.github/CODEOWNERS` already exists and is actively maintained; it routes to individual handles rather than team handles, and its paths follow the post-microkernel crate layout established in #6537. The `@zeroclaw-labs/zeroclaw-core` and `@zeroclaw-labs/zeroclaw-contributors` handles used here were never created; see §5.3. Its broad routing paths are not the current `risk:high` classifier; read the live file and the [maintainer label guide](../maintainers/labels.md#risk-labels) for current routing and risk semantics.
 
 ```
-# CODEOWNERS — Automatic review routing by risk tier
-# See AGENTS.md for risk tier definitions.
+# CODEOWNERS — Automatic review routing by protected surface
+# See the maintainer label guide for risk definitions.
 # See the governance foundation doc and RFC issue template for team tier definitions.
 
-# ── High Risk: requires Core Team approval ──────────────────────────────────
+# ── Protected review routing: Core Team review ──────────────────────────────
 
 src/security/**                 @zeroclaw-labs/zeroclaw-core
 src/gateway/**                  @zeroclaw-labs/zeroclaw-core
@@ -443,7 +443,7 @@ Configure the following branch protection rules for `master`:
 | Rule | Setting | Reason |
 |---|---|---|
 | Require a pull request before merging | Enabled | No direct pushes to master, ever |
-| Require approvals | 1 for Low/Medium risk; 2 for High risk | CODEOWNERS enforcement handles the "who" |
+| Require approvals | At least 1 native approval; `risk:high` or `domain:security` requires 2 independent Core Team approvals before merge | CODEOWNERS routes review; the conditional two-approval rule is an explicit merge requirement |
 | Require status checks to pass | `cargo fmt`, `cargo clippy`, `cargo test` | CI must be green before merge |
 | Require branches to be up to date | Enabled | Prevents merging stale code |
 | Require conversation resolution | Enabled | All review comments must be resolved |
@@ -452,6 +452,8 @@ Configure the following branch protection rules for `master`:
 | Allow deletions | Disabled | Protect the branch |
 
 **Why admins cannot bypass:** One of the most common mistakes in small team projects is treating branch protection as "for other people." When an admin can bypass, they will, under time pressure, in an emergency, "just this once." Then it becomes the norm. The rule must apply to everyone for it to mean anything. If there is a genuine emergency, the right response is to follow the process faster, not to skip it.
+
+GitHub's native approval count is configured per protected branch or ruleset target, not conditionally by PR label. Until a separately approved technical enforcement design has a machine-readable authority for Core Team approval, maintainers must apply the `risk:high OR domain:security` requirement through the documented merge checklist and retain an auditable review record. `risk:manual` freezes future automatic risk replacement only; it cannot lower this requirement.
 
 ### 6.3 Required Status Checks
 
@@ -490,7 +492,7 @@ A gate that flags valid architectural decisions because the tool misread the con
 
 **CODEOWNERS is the architectural compliance gate. The reviewer is the tool.**
 
-The `CODEOWNERS` configuration in §6.1 already enforces that PRs touching high-risk paths, crate boundaries, trait definitions, the dependency graph, `src/security/`, `.github/`, require review from a Core Team member. That Core Team member, equipped with the RFCs as their reference framework, is the architectural compliance check. They bring the contextual judgment that no automation can replicate.
+The `CODEOWNERS` configuration in §6.1 already routes protected review surfaces such as crate boundaries, trait definitions, the dependency graph, `src/security/`, and `.github/` to a Core Team reviewer. That routing is distinct from `risk:*` classification. The Core Team reviewer, equipped with the RFCs as their reference framework, is the architectural compliance check. They bring the contextual judgment that no automation can replicate.
 
 This is why the RFCs, the AGENTS.md files, and the documentation standards exist: not so a machine can parse them and produce a score, but so a human reviewer has a consistent, documented framework to apply. The RFC answers "why does this architecture exist." The reviewer answers "does this PR serve or undermine that why."
 
@@ -700,9 +702,9 @@ Use `#f1f5f9` (light gray) for all component labels to distinguish them visually
 
 | Label | Color | Use |
 |---|---|---|
-| `risk:low` | `#dcfce7` | Docs, tests, minor changes |
-| `risk:medium` | `#fef9c3` | Most `src/**` changes |
-| `risk:high` | `#fee2e2` | Security, gateway, runtime, CI |
+| `risk:low` | `#dcfce7` | Documentation, fixtures, generated references, and mechanical metadata with no production, compatibility, build, release, or governance effect |
+| `risk:medium` | `#fef9c3` | Ordinary behavioral production work, including most runtime, gateway, provider, channel, tool, config, application, and CI changes |
+| `risk:high` | `#fee2e2` | Concrete trust, credential, compatibility, governance, or release-authority boundary requiring deep review and two independent Core Team approvals |
 
 ### `status:` Where is this in the process?
 

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -1,8 +1,8 @@
 # FND-003: Team Organization, Project Governance, and Contribution Pipeline
 
-> Starting v0.7.0 · Type: Governance · Rev. 15
+> Starting v0.7.0 · Type: Governance · Rev. 16
 >
-> **Canonical reference** · Ratified by the team · Rev. 15
+> **Canonical reference** · Ratified by the team · Rev. 16
 > Original governance discussion: [#5577](https://github.com/zeroclaw-labs/zeroclaw/issues/5577)
 > Follow-up work-lane and label-governance policy: [#6808](https://github.com/zeroclaw-labs/zeroclaw/issues/6808)
 
@@ -33,6 +33,7 @@
 | 13 | 2026-07-18 | Replaced the universal ADR requirement with an explicit durable-disposition rule for accepted RFCs; reserved ADRs for significant architecture decisions ([#9136](https://github.com/zeroclaw-labs/zeroclaw/pull/9136)) |
 | 14 | 2026-07-25 | Retired the `CONTRIBUTORS.md` membership record and the `zeroclaw-core`/`zeroclaw-contributors` team names, none of which were ever created; §5.3 now names the `core-contributors` GitHub team, CODEOWNERS, and the Communication maintainer table as the real records ([#9388](https://github.com/zeroclaw-labs/zeroclaw/pull/9388)) |
 | 15 | 2026-08-10 | Narrowed the RFC trigger to four project-level categories and named the ordinary work that does not require an RFC; replaced the seven-day discussion period with 48h ordinary / 72h exceptional; defined the 72-hour vote against an immutable snapshot, the 30-day active electorate, two-ballot quorum, silence-as-approval after quorum, non-vetoing `REVISE`, and outcome precedence; made two-thirds the default threshold and reserved unanimity for expensive or irreversible decisions; retired the nonexistent parallel `rfc:*` label family; added the GitHub bridge record for Core meeting decisions ([#9499](https://github.com/zeroclaw-labs/zeroclaw/pull/9499)) |
+| 16 | 2026-08-22 | Calibrated consequence-based PR risk routing, retained `risk:manual` as an automation freeze, and required two independent Core Team approvals for `risk:high` or `domain:security` PRs ([#10192](https://github.com/zeroclaw-labs/zeroclaw/pull/10192)) |
 
 ---
 
@@ -443,7 +444,7 @@ Configure the following branch protection rules for `master`:
 | Rule | Setting | Reason |
 |---|---|---|
 | Require a pull request before merging | Enabled | No direct pushes to master, ever |
-| Require approvals | At least 1 native approval; `risk:high` or `domain:security` requires 2 independent Core Team approvals before merge | CODEOWNERS routes review; the conditional two-approval rule is an explicit merge requirement |
+| Require approvals | At least 1 GitHub approval; `risk:high` or `domain:security` requires 2 independent Core Team approvals before merge | CODEOWNERS routes review; the conditional two-approval rule is an explicit merge requirement |
 | Require status checks to pass | `cargo fmt`, `cargo clippy`, `cargo test` | CI must be green before merge |
 | Require branches to be up to date | Enabled | Prevents merging stale code |
 | Require conversation resolution | Enabled | All review comments must be resolved |

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -47,7 +47,7 @@ Dependabot also seeds configured labels on its own PRs from `.github/dependabot.
 
 Today `.github/labeler.yml` owns only path and scope labels such as `docs`, `ci`, `channel`, `provider:openai`, and `tool:file`. It does not own `risk:*`, `size:*`, `type:*`, contributor-tier, status, resolution, stale, or pickup labels.
 
-If risk or size automation is added later, it should recalculate on every pushed PR update so the labels continue to describe the actual diff under review. Risk automation must honor `risk:manual` as an override that prevents future automated risk replacement for that PR until a maintainer removes the override.
+Size automation may recalculate on every pushed PR update so labels continue to describe the actual diff under review. #9345 owns the separate risk-classifier rollout. Its risk phase remains report-only until maintainers review the evidence and separately enable mutation. Report-only output must record the proposed risk, matching rule evidence, current risk, `risk:manual` state, and `domain:security` state so maintainers can audit mismatches and security-shaped work that escaped both triggers. Any future risk automation must honor `risk:manual` as a hard freeze: it cannot add, remove, or replace a PR's `risk:*` label until a maintainer removes the override.
 
 ## Cleanup protocol
 
@@ -164,7 +164,9 @@ Some scoped component labels are manual routing labels rather than synchronized 
 
 `domain:architecture` identifies cross-component ownership, source-of-truth, dependency-direction, interface/contract, and architecture-decision work. Do not apply it merely because an issue is an RFC.
 
-`domain:security` identifies cross-cutting trust-boundary or security-impact work, including work outside the base `security` source paths. These domain labels remain manual because path matching cannot infer architectural or security impact reliably.
+`domain:security` identifies an effective authentication, authorization, credential, secret-handling, confinement, tool-permission, security-policy, cryptographic-identity, or untrusted-input boundary. Apply it when the changed behavior crosses that boundary, including outside canonical security paths. Do not apply it only because a PR discusses security, changes security documentation or tests, updates an advisory dependency, or performs generic hardening without changing a trust boundary. The label remains manual because path matching cannot reliably infer this consequence.
+
+`domain:security` is independent from `risk:*`. A PR carrying either `risk:high` or `domain:security` requires deep review and two independent Core Team approvals before merge. Automated review does not count as a Core Team approval.
 
 The following duplicate domain and product-surface labels are pending retirement. Do not apply them to new work. They remain live only until a separate exact operation packet migrates any remaining open references and deletes the definitions.
 
@@ -303,16 +305,16 @@ New or manual applications should use the canonical no-space labels below. Exist
 
 | Label | Meaning |
 |---|---|
-| `risk:low` | No high-risk paths touched, small change |
-| `risk:medium` | Behavioral `crates/*/src/**` changes without boundary or security impact |
-| `risk:high` | Touches a high-risk path, or large security-adjacent change |
-| `risk:manual` | Maintainer override that freezes automated risk recalculation |
+| `risk:low` | Documentation, localization, fixtures, generated references, or mechanical metadata with no production, compatibility, build, release, or governance effect |
+| `risk:medium` | Ordinary behavioral production change, including most runtime, gateway, provider, channel, tool, config, application, and CI work |
+| `risk:high` | A concrete trust, credential, compatibility, governance, or release-authority boundary that needs deep review and two independent Core Team approvals |
+| `risk:manual` | Maintainer override that freezes future automated risk replacement; it does not lower review or approval requirements |
 
-High-risk paths (canonical set; other maintainer pages reference this list): `crates/zeroclaw-runtime/src/**`, `crates/zeroclaw-gateway/src/**`, `crates/zeroclaw-tools/src/**`, `crates/zeroclaw-runtime/src/security/**`, `.github/workflows/**`.
+`risk:*` describes the actual diff and its consequence, not broad component location. A production-inert test-only change inside a high-risk boundary may be `risk:medium` when the complete test-only boundary is demonstrable; #9530 is authoritative for that exception.
 
-Apply `risk:high` to any PR that raises the workspace MSRV, pinned Rust toolchain, generated installer/Docker toolchain baseline, or release workflow toolchain floor. Do not downgrade the risk just because the diff looks like CI, dependency, or docs housekeeping: a higher required Rust version affects downstream source builds, distro packages, container builds, and users pinned to older toolchains.
+Use `risk:manual` whenever a maintainer's intended risk differs from a future automatic result, including #9530's demonstrable production-inert test-only downgrade. Apply `risk:high` with `risk:manual` when a non-security change has a destructive, data-loss, breaking-default, governance, release-security, or another concrete high-risk consequence outside the stable automatic rules. This preserves the accepted manual escalation path rather than creating another label family. Record the rationale in the review or PR record.
 
-When uncertain, treat as higher risk.
+When uncertain, classify upward and ask a maintainer to resolve the boundary. Do not widen automatic path rules merely to avoid a review decision.
 
 ## Contributor tier labels
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -35,7 +35,7 @@ Do not mirror native PR review state into manual board lanes. GitHub PR state ow
 
 This keeps the board useful without asking maintainers to update it after every push, review, or CI run.
 
-Risk and size auto-labeling is a separate workflow question. #9345 may recalculate labels on PR updates only after its risk classifier has completed report-only review and maintainers separately enable mutation. Risk automation must honor `risk:manual` until a maintainer removes that override. The issue-dashboard planner does not apply or recalculate PR risk, size, or type labels.
+Size and risk auto-labeling are separate workflow questions. #9345 may recalculate deterministic size labels on PR updates. Its risk classifier remains report-only until maintainers review the evidence and separately enable risk-label mutation. Risk automation must honor `risk:manual` until a maintainer removes that override. The issue-dashboard planner does not apply or recalculate PR risk, size, or type labels.
 
 ### Issue routing evidence
 

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -16,10 +16,10 @@ The control loop that delivers this is layered on purpose:
 
 - **Intake classification**: path/size/risk labels route the PR to the right depth.
 - **Deterministic validation**: the merge gate depends on reproducible checks, not subjective comments.
-- **Risk-based review depth**: high-risk paths get deep review, low-risk paths stay fast.
+- **Risk-based review depth**: high-risk consequences and security boundaries get deep review, while low-risk work stays fast.
 - **Rollback-first merge contract**: every merge path includes a concrete recovery story.
 
-Automation handles path/scope labels, manual issue-dashboard planning reports, and CI gating. Risk, size, type, and contributor-tier labels are maintainer intake decisions unless a maintained workflow explicitly owns them. Final merge accountability stays with human maintainers and PR authors.
+Automation handles path/scope labels, manual issue-dashboard planning reports, and CI gating. Risk, size, type, and contributor-tier labels are maintainer intake decisions unless a maintained workflow explicitly owns them. Final merge accountability stays with human maintainers and PR authors. A PR carrying either `risk:high` or `domain:security` requires deep review and two independent Core Team approvals; automated review does not count as a Core Team approval.
 
 ## Project board contract
 
@@ -35,7 +35,7 @@ Do not mirror native PR review state into manual board lanes. GitHub PR state ow
 
 This keeps the board useful without asking maintainers to update it after every push, review, or CI run.
 
-Risk and size auto-labeling is a separate workflow question. If it is added later, it should recalculate on PR updates so labels describe the current diff, and risk automation must honor `risk:manual` until a maintainer removes that override. The issue-dashboard planner does not apply or recalculate PR risk, size, or type labels.
+Risk and size auto-labeling is a separate workflow question. #9345 may recalculate labels on PR updates only after its risk classifier has completed report-only review and maintainers separately enable mutation. Risk automation must honor `risk:manual` until a maintainer removes that override. The issue-dashboard planner does not apply or recalculate PR risk, size, or type labels.
 
 ### Issue routing evidence
 
@@ -103,7 +103,7 @@ PR lanes are routing expectations, not another required label family. Use them t
 | A: maintenance fast lane | Docs-only corrections, small tests that leave behavior unchanged, metadata/template fixes, narrow examples, CI/tooling fixes that preserve permissions and release behavior | Lightest review; fast merge once CI, template, labels, and privacy checks are clean. Usually `risk:low` and `size:XS` or `size:S`. |
 | B: narrow bug/fix lane | Small bug fixes with clear failing behavior, targeted provider/channel/tool fixes with focused validation, compatibility fixes that preserve behavior outside the reported path | Normal review by one subsystem-aware reviewer unless risk or ownership says otherwise. Merge when the linked issue is actually satisfied, validation is credible, and CI is green. |
 | C: feature slice lane | Additive feature work, new provider/channel/tool support, new config surface, scoped user-visible behavior changes | Normal review plus boundary-specific validation. Milestone fit matters, and the PR should say whether it implements, depends on, or is related to a tracker. |
-| D: architecture, migration, and high-risk lane | Runtime, gateway, security, tool-execution, workflow, broad crate migration, lifecycle, persistence, provider payload, channel behavior, permission, MSRV/toolchain floor, or release-infrastructure changes | Deep review, evidence matched to the changed risk, rollback and compatibility analysis, and possible milestone sequencing or second-maintainer review. |
+| D: architecture, migration, and elevated-review lane | Concrete trust, credential, compatibility, governance, release-authority, migration, lifecycle, persistence, permission, or toolchain-floor boundary; any PR carrying `risk:high` or `domain:security` | Deep review, evidence matched to the changed risk, and rollback and compatibility analysis. A PR carrying `risk:high` or `domain:security` also requires two independent Core Team approvals. |
 | E: supersede, replacement, and overlap lane | Multiple PRs solving the same issue, newer PRs replacing older ones, contributor work carried forward from another PR, old PR made obsolete by current `master` | Coordinate before deep review. Choose one canonical path when possible, use `Supersedes #N` only when accurate, and preserve attribution when work is materially carried forward. |
 
 Do not build a separate manual PR board for these lanes unless native GitHub state and CODEOWNERS stop answering the routing question. Check native GitHub merge state before normal lane review: `DIRTY` means resolve conflicts first; `BEHIND` alone is mergeability housekeeping, not an author-facing blocker.
@@ -137,8 +137,8 @@ Before requesting review, the PR has all of these:
 Before merge:
 
 - `CI Required Gate` is green.
-- Required reviewers approved (including any CODEOWNERS paths).
-- Risk labels match touched paths. See [Labels](./labels.md).
+- Required reviewers approved (including any CODEOWNERS paths); a PR carrying `risk:high` or `domain:security` has two independent Core Team approvals.
+- Risk labels match the actual diff and consequence rather than broad component location. See [Labels](./labels.md).
 - Migration / compatibility impact is documented.
 - Rollback path is concrete and fast.
 
@@ -150,6 +150,7 @@ Every merge:
 - CI gate is green.
 - Docs-quality checks are green when docs changed.
 - Security and privacy fields are complete; evidence is redacted / anonymized.
+- A PR carrying `risk:high` or `domain:security` has two independent Core Team approvals; automated review does not count.
 - Agent-workflow notes are sufficient for reproducibility (if AI-assisted).
 - Rollback plan is explicit.
 - Commit title follows Conventional Commits.
@@ -195,23 +196,22 @@ The reviewer-side queue management, backlog pruning order, stale handling, label
 
 ## Security and stability rules
 
-These paths require stricter review and stronger test evidence. The canonical
-high-risk path set is defined in [Labels → Risk labels](./labels.md#risk-labels).
-In review terms that set covers:
+Review these paths attentively because they often contain boundary-relevant behavior:
 
 - `crates/zeroclaw-runtime/` (including `src/security/`)
 - `crates/zeroclaw-gateway/` (ingress, authentication, pairing)
 - `crates/zeroclaw-tools/` (anything with execution capability)
 - `.github/workflows/` and the release pipeline
 
-Filesystem access boundaries and network/authentication behavior inside those
-crates carry the same scrutiny even when the diff looks small.
+Path location alone does not select `risk:high`. Classify the actual diff and consequence under [Labels → Risk labels](./labels.md#risk-labels). A trust, credential, compatibility, governance, release-authority, or cross-cutting security boundary receives deep review when the PR carries `risk:high` or `domain:security`.
 
-**Minimum for risky PRs:** threat / risk statement, mitigation notes, rollback steps.
+Filesystem access boundaries and network or authentication behavior inside these crates deserve particular attention even when the diff is small.
 
-**Recommended for high-risk PRs:** a focused test proving boundary behavior, plus one explicit failure-mode scenario with expected degradation.
+**Minimum for `risk:high` or `domain:security` PRs:** threat or risk statement, mitigation notes, rollback steps, and two independent Core Team approvals.
 
-For agent-assisted contributions on these paths, reviewers also verify the author can talk through runtime behavior and blast radius, not just paste validation output.
+**Recommended for `risk:high` or `domain:security` PRs:** a focused test proving boundary behavior, plus one explicit failure-mode scenario with expected degradation.
+
+For agent-assisted contributions that cross these boundaries, reviewers also verify the author can talk through runtime behavior and blast radius, not just paste validation output.
 
 ## Failure recovery
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -124,7 +124,7 @@ If the PR also changes `[workspace.package] rust-version` or pinned Rust toolcha
 
 Open a PR. Label it `type:ci`, `size:XS`, and any path labels the PR labeler
 adds. If the PR raises a toolchain floor, also apply `risk:high` and route it
-through lane D. Get one maintainer review. Merge when CI is green. The **Installer Drift**
+through lane D. Get two independent Core Team approvals. Merge only when CI is green. The **Installer Drift**
 gate in CI fails the PR if a generated surface is out of sync with the spec, so
 a missed regeneration cannot land. The
 **Validate Translations Pin** gate resolves the submodule at the pinned commit

--- a/docs/book/src/maintainers/reviewer-playbook.md
+++ b/docs/book/src/maintainers/reviewer-playbook.md
@@ -13,22 +13,24 @@ Use [PR lanes](./pr-workflow.md#pr-lanes) for routing expectations; use this pla
 | Situation | Action | Section |
 |---|---|---|
 | Intake fails in the first 5 minutes | Leave one actionable checklist comment, stop deep review | [Five-minute intake](#five-minute-intake) |
-| Risk is high or unclear | Treat as `risk:high` until proven otherwise | [Review depth matrix](#review-depth-matrix) |
+| Risk or security-boundary classification is unclear | Classify upward and resolve it with a maintainer before merge | [Review depth matrix](#review-depth-matrix) |
 | Diff adds a parallel interpretive surface | Verify it is derived from, or explicitly points to, the canonical source | [Drift-surface review](#drift-surface-review) |
 | Automation output is wrong or noisy | Apply the override protocol | [Automation override](#automation-override) |
 | Need to hand off to another maintainer | Use the handoff template | [Handoff](#handoff) |
 
 ## Review depth matrix
 
-| Risk label | Typical paths | Minimum depth | Required evidence |
+| Trigger | Typical work | Minimum depth | Required evidence |
 |---|---|---|---|
-| `risk:low` | Docs, tests, chore, isolated non-runtime | 1 reviewer + CI gate | Coherent validation evidence, no behavior ambiguity |
-| `risk:medium` | `crates/zeroclaw-providers/`, `crates/zeroclaw-channels/`, `crates/zeroclaw-memory/`, `crates/zeroclaw-config/` | 1 subsystem-aware reviewer + behavior verification | Focused scenario proof, explicit side effects |
-| `risk:high` | The [canonical high-risk path set](./labels.md#risk-labels) (runtime, gateway, tools, security, `.github/workflows/`) | Fast triage + deep review + rollback readiness | Security and failure-mode checks, rollback clarity |
+| `risk:low` | Documentation, localization, fixtures, generated references, or mechanical metadata with no production, compatibility, build, release, or governance effect | 1 reviewer + CI gate | Coherent validation evidence, no behavior ambiguity |
+| `risk:medium` | Ordinary behavioral runtime, gateway, provider, channel, tool, config, application, and CI work | 1 subsystem-aware reviewer + behavior verification | Focused scenario proof, explicit side effects |
+| `risk:high` or `domain:security` | A concrete trust, credential, compatibility, governance, release-authority, or cross-cutting security boundary | Fast triage + deep review + rollback readiness + two independent Core Team approvals | Security and failure-mode checks, rollback clarity |
 
-When uncertain, treat as higher risk.
+`domain:security` remains independent from `risk:*`: use it for an effective security or trust boundary, not simply because the changed component is security-shaped. Either label triggers the same deep-review and two-independent-Core-approval path. Automated review does not count as a Core Team approval.
 
-Risk labels are currently manual. If future risk automation is restored, follow the [labels automation contract](./labels.md#automation-contract): apply `risk:manual` when a maintainer correction should not be overwritten on the next pushed update.
+When uncertain, classify upward and ask a maintainer to resolve the boundary before merge.
+
+Risk labels are currently manual. #9345 keeps any future risk classifier report-only until maintainers separately enable mutation. Follow the [labels automation contract](./labels.md#automation-contract): `risk:manual` freezes automated risk replacement when a maintainer correction should persist, but it never lowers the review or approval requirement.
 
 Labels are maintainer metadata. If the correct label is obvious and you have permission, fix it yourself before finalizing the review. Ask the author only when the right label choice is ambiguous or nobody with label permissions is available.
 
@@ -108,7 +110,7 @@ drives downstream coverage.
 
 ### Deep-review checklist (high-risk only)
 
-For `risk:high` PRs, verify a concrete example in each category. One concrete instance beats five generic claims.
+For PRs carrying `risk:high` or `domain:security`, verify a concrete example in each category. One concrete instance beats five generic claims.
 
 - **Security boundaries**: deny-by-default behavior preserved, no accidental scope broadening.
 - **Failure modes**: error handling explicit, degrades safely.
@@ -196,7 +198,7 @@ If the underlying bug or feature is still valid, preserve it in an issue, tracke
 
 Use this when automation output creates review side effects:
 
-1. **Incorrect risk label**: set the intended `risk:*` label. If future risk automation is active, also follow the [labels automation contract](./labels.md#automation-contract) for `risk:manual`.
+1. **Incorrect risk label**: set the intended `risk:*` label. If future risk automation is active, also follow the [labels automation contract](./labels.md#automation-contract) for `risk:manual`; the override does not bypass the `risk:high OR domain:security` approval rule.
 2. **Incorrect auto-close on issue triage**: reopen, remove the route label, leave one clarifying comment.
 3. **Label spam or noise**: keep one canonical maintainer comment, remove redundant route labels.
 4. **Ambiguous PR scope**: request a split before deep review; don't try to review across two concerns at once.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Aligns the standing maintainer label guide, reviewer playbook, PR workflow, and FND-003 around accepted RFC #9990. Risk now describes the actual consequence of a change rather than a broad path; either `risk:high` or `domain:security` requires deep review and two independent Core Team approvals; #9530's production-inert test-only exception, `risk:manual`, and #9345's report-only classifier phase have one consistent contract.
- **Scope boundary:** Does not change live GitHub workflows or branch-protection settings, relabel existing PRs, or change runtime behavior. It documents the human merge-checklist rule that applies prospectively after this bootstrap policy PR lands: a PR carrying `risk:high` or `domain:security` needs two independent Core Team approvals. #9345 remains report-only, and #10185 stays open until the audit and enforcement surfaces are complete before any automatic risk-label mutation.
- **Blast radius:** Maintainer intake, review, and merge-checklist guidance for PRs whose actual consequence crosses a trust, credential, compatibility, governance, release-authority, or effective security boundary.
- **Linked issue(s):** Related #10185, #9990, #9530, and #9345. This PR does not close the tracker.
- **Labels:** `docs`, `distinguished contributor`, `domain:architecture`, `risk:high`, `size:XS`, `type:docs`

### What this does, simply

ZeroClaw's review labels tell maintainers how carefully to examine a pull request. The old guidance mostly chose the label from the folder a change touched. That made a test-only change under a runtime or workflow folder look high risk even though it could not affect the shipped program, while a change with real security impact elsewhere could look routine.

This PR changes the question maintainers ask: what could this change actually affect? A change involving permissions, credentials, compatibility, governance, or who is allowed to release gets a deep review and two approvals from different Core Team members. A change that crosses a real security boundary gets the same treatment no matter which folder it lives in. Automated feedback never counts as one of those approvals.

This is written guidance and the human merge checklist. It does not relabel existing pull requests, alter GitHub's current branch-protection settings, or turn on automatic enforcement.

### Why it matters

Maintainers need policy that is both strict at real boundaries and understandable for ordinary work. The updated documentation gives reviewers one rule to apply across intake, review, and merge, while keeping automation report-only until its evidence has been reviewed.

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A. This is a documentation-only policy change with no runtime or visual interface.

### How I tested

- **CI checks relied on and why they cover this change:** The required `CI Required Gate` passed on exact head `2607863c7ee96c6edad361f74b5df58f1e475a01`. The `Docs Style` job also passed and runs both documentation quality and added-link validation across all seven changed Markdown files. `Lint`, `Test`, and `Repository Structure` passed on the same head.
- **Known CI coverage gap, if any:** None for the changed surface. There is no runtime, configuration, or external-interface behavior to cover because this PR changes none.
- **Commands run and tail output:** The following focused commands were run on the initial four-file documentation commit; current-head hosted `Docs Style` covers the final seven-file diff.

```bash
BASE_SHA='' DOCS_FILES=$'docs/book/src/foundations/fnd-003-governance.md\ndocs/book/src/maintainers/labels.md\ndocs/book/src/maintainers/pr-workflow.md\ndocs/book/src/maintainers/reviewer-playbook.md' bash scripts/ci/docs_quality_gate.sh
BASE_SHA='' DOCS_FILES=$'docs/book/src/foundations/fnd-003-governance.md\ndocs/book/src/maintainers/labels.md\ndocs/book/src/maintainers/pr-workflow.md\ndocs/book/src/maintainers/reviewer-playbook.md' bash scripts/ci/docs_links_gate.sh
git diff --check origin/master..HEAD
```

The focused quality gate reported no prose em dashes and `markdownlint-cli2` reported `0 error(s)`. The focused link gate ran 6 tests successfully and checked the one added local documentation link target. The diff check passed.
- **Beyond CI, what did you manually verify?** Compared the seven documents against #9990's accepted policy, #9530's demonstrable production-inert test-only exception, and #9345's report-only boundary. Verified that the documentation distinguishes the human merge-checklist rule from future technical enforcement and does not imply that CODEOWNERS routing classifies risk.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Cargo was skipped because no Rust or runtime behavior changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any Yes, describe the risk and mitigation: N/A.
- **Security behavior:** No runtime or automatic enforcement changes. The documentation requires deeper human review and two independent Core Team approvals for future PRs carrying `risk:high` or `domain:security`; the report-only audit and any later technical enforcement remain tracked separately.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is No or either surface/floor question is Yes: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Before merge, revert both branch commits in reverse order with `git revert 2607863c7ee96c6edad361f74b5df58f1e475a01 4035d8271d4bf9507c140856319a467792a0106c`. After merge, read the landed squash SHA from GitHub and run `git revert <post-merge-squash-sha>`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Conflicting maintainer guidance could lead to an incorrect risk label, inconsistent approval expectations, or incorrect treatment of `risk:manual` during future automation work.
