### PR TITLE
fix(tests): make shell dialect assertion platform-aware

### DIFF
--- a/crates/zeroclaw-api/src/runtime_traits.rs
+++ b/crates/zeroclaw-api/src/runtime_traits.rs
@@ -382,11 +382,11 @@ mod tests {
     }
 
     #[test]
-    fn default_shell_dialect_is_posix() {
-        // Any adapter that does not override `shell_dialect` uses the
-        // conservative POSIX default. Concrete adapters report their actual
-        // execution sink, including the configured native shell dialect.
+    fn dummy_runtime_shell_dialect_matches_compilation_platform() {
         let runtime = DummyRuntime;
+        #[cfg(windows)]
+        assert_eq!(runtime.shell_dialect(), ShellDialect::WindowsCmd);
+        #[cfg(not(windows))]
         assert_eq!(runtime.shell_dialect(), ShellDialect::Posix);
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Renamed the `DummyRuntime` shell-dialect regression and made its expected value follow the compilation platform. The fixture already reports `WindowsCmd` on Windows and `Posix` elsewhere, but the test still asserted `Posix` unconditionally.
- **Scope boundary:** This changes one test only. It does not change `RuntimeAdapter`, `DummyRuntime`, shell selection, command construction, or production behavior.
- **Blast radius:** Limited to the `zeroclaw-api` unit-test suite and the Windows portability inventory.
- **Linked issue(s):** Related #7462
- **Labels:** `tests`, `type:test`, `risk:low`, `risk:manual`, `size:XS`

### What this does, simply

ZeroClaw's dummy runtime follows the host platform when it reports which shell language it uses. The test expected the Unix answer even on Windows, so a correct Windows result failed the suite. This PR makes the test check the answer that the fixture is already designed to return on each platform; runtime behavior does not change.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a test-only correction with no user-visible behavior, and the exact-head hosted Windows test already passed.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed on `039b513ccf`, covering formatting, lint, Linux workspace tests, and Windows compilation. [Scheduled Platform Tests run 32430311832](https://github.com/Audacity88/zeroclaw/actions/runs/32430311832) executed the repaired test on Windows and passed it.
- **Known CI coverage gap, if any:** None for the changed assertion. The advisory Windows workspace job remained red because 19 tests outside this PR's one-file scope failed; it ran 13,696 tests, with 13,677 passed, 19 failed, and 17 skipped. The macOS platform job passed.
- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-api runtime_traits::tests::dummy_runtime_shell_dialect_matches_compilation_platform -- --exact
running 1 test
test runtime_traits::tests::dummy_runtime_shell_dialect_matches_compilation_platform ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 178 filtered out

$ cargo fmt --all -- --check
# passed

$ scripts/ci/comment_hygiene_gate.sh crates/zeroclaw-api/src/runtime_traits.rs
Comment hygiene gate passed.

$ git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Confirmed the test expectation matches both existing `DummyRuntime::shell_dialect` cfg branches and that the surviving diff changes no production code. The exact-head Windows run recorded `runtime_traits::tests::dummy_runtime_shell_dialect_matches_compilation_platform` as passed.
- **Visual interface changed?** N/A; no visual interface changed.
- **If any command was intentionally skipped, why:** Broad local workspace Cargo and the broad pre-push hook were skipped because the change is isolated to one unit-test assertion; focused validation passed and fresh required CI will cover the wider repository gates.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low risk. Revert commit `039b513ccf`.
