### PR TITLE
fix(log): bridge log-facade records into the tracing pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10819,6 +10819,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -10836,6 +10848,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -11316,6 +11329,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -13895,6 +13914,7 @@ version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
+ "log",
  "parking_lot",
  "serde",
  "serde_json",
@@ -13904,6 +13924,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "uuid",
  "zeroclaw-api",

--- a/crates/zeroclaw-log/Cargo.toml
+++ b/crates/zeroclaw-log/Cargo.toml
@@ -18,10 +18,12 @@ strum = "0.28"
 strum_macros = "0.28"
 tokio = { version = "1.50", default-features = false, features = ["sync"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std", "fmt", "ansi", "env-filter"] }
+tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std", "fmt", "ansi", "env-filter", "tracing-log"] }
 uuid = { version = "1.18", default-features = false, features = ["v4", "std"] }
 
 [dev-dependencies]
+log = "0.4"
 tempfile = "3.26"
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "time"] }
 

--- a/crates/zeroclaw-log/Cargo.toml
+++ b/crates/zeroclaw-log/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 zeroclaw-api.workspace = true
 anyhow = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
+log = "0.4"
 parking_lot = "0.12"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
@@ -18,12 +19,11 @@ strum = "0.28"
 strum_macros = "0.28"
 tokio = { version = "1.50", default-features = false, features = ["sync"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracing-log = { version = "0.2", default-features = false, features = ["log-tracer", "std"] }
+tracing-log = { version = "0.2", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std", "fmt", "ansi", "env-filter", "tracing-log"] }
 uuid = { version = "1.18", default-features = false, features = ["v4", "std"] }
 
 [dev-dependencies]
-log = "0.4"
 tempfile = "3.26"
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "time"] }
 

--- a/crates/zeroclaw-log/src/lib.rs
+++ b/crates/zeroclaw-log/src/lib.rs
@@ -5,6 +5,7 @@ pub mod chain;
 pub mod config;
 pub mod event;
 pub mod layer;
+mod log_bridge;
 pub mod migrate;
 pub mod observer_bridge;
 pub mod reader;

--- a/crates/zeroclaw-log/src/log_bridge.rs
+++ b/crates/zeroclaw-log/src/log_bridge.rs
@@ -9,43 +9,75 @@
 //! verbosity.
 //!
 //! Filling that slot with a bare [`tracing_log::LogTracer`] would recover the
-//! diagnostics *and* hand every third-party message string to
-//! [`crate::layer::LogCaptureLayer`], which materializes it as ordinary event
-//! text and persists it to `runtime-trace.jsonl` (rolling persistence is on by
-//! default, at an `INFO` floor). Third-party `INFO`/`WARN` sites are not ours
-//! to review: at the locked `whatsapp-rust` revision, `src/pair_code.rs` logs
-//! the configured phone number and the generated pair code at `INFO`, and
-//! other sites log JIDs. Those strings would bypass the deliberate
-//! `LoginEvent::PairCode` → `ephemeral_attrs` boundary and
+//! diagnostics *and* hand every third-party string on the record to
+//! [`crate::layer::LogCaptureLayer`], which materializes them as event text
+//! and attributes and persists them to `runtime-trace.jsonl` (rolling
+//! persistence is on by default, at an `INFO` floor). Third-party call sites
+//! are not ours to review: at the locked `whatsapp-rust` revision,
+//! `src/pair_code.rs` logs the configured phone number and the generated pair
+//! code at `INFO`, and other sites log JIDs. Those strings would bypass the
+//! deliberate `LoginEvent::PairCode` → `ephemeral_attrs` boundary and
 //! [`crate::writer::record_event`]'s guarantee that pairing credentials never
 //! reach disk.
 //!
-//! So the bridge forwards a record's *metadata* and drops its *text*. The
-//! message body is the one free-text channel a `log` record carries, it is
-//! written by code this workspace does not review, and nothing here can tell
-//! a harmless sentence from a name, a brand, an identifier or a credential.
-//! So none of it crosses: every bridged record carries the fixed
-//! [`REDACTED_MESSAGE`] marker in place of whatever the dependency formatted.
-//! There is no heuristic and no allowlist, so there is no rule to get wrong
-//! and nothing an unusual message shape can talk its way past.
+//! # What crosses the boundary
 //!
-//! What does cross is structured metadata: severity, the dependency's own
-//! target, its module path and its source `file:line`. Those are fixed at
-//! each call site in the dependency's own source rather than formatted from
-//! runtime values, so they carry no payload. They are also enough to keep the
-//! diagnostics actionable — the severity says how bad it was, and the target
-//! plus `file:line` name the exact line that fired, so the wording can be
-//! read from the dependency's source instead of from our trace — and enough
-//! for `RUST_LOG` directives to keep addressing a dependency by its own
-//! target.
+//! A `log::Record` carries four string-shaped channels — `args`, `target`,
+//! `module_path`, `file` — plus a numeric `line`. None of the four is a
+//! static-only channel: [`log::RecordBuilder`] takes a borrowed `&str` for
+//! each of them, and the `log!` macros take a `target:` *expression*, not a
+//! literal. So none of them may be forwarded on the assumption that the
+//! dependency put a constant there.
+//!
+//! - **`args` (the message body) is dropped.** It is the record's free-text
+//!   channel, written by code this workspace does not review, and nothing
+//!   here can tell a harmless sentence from a name, a brand, an identifier or
+//!   a credential. Every bridged record carries the fixed
+//!   [`REDACTED_MESSAGE`] marker instead. There is no heuristic and no
+//!   allowlist, so there is no rule to get wrong.
+//! - **`module_path` and `file` are dropped.** They are unbounded strings and
+//!   they are redundant: for a record logged without an explicit `target:`,
+//!   `log` uses the module path *as* the target, so the target below already
+//!   carries the same provenance in a bounded form.
+//! - **`line` is forwarded.** It is a `u32`; it has no text channel to carry.
+//! - **`target` is reduced to the safe representation below.** It is the one
+//!   field the filters read, so dropping it would take `RUST_LOG` target
+//!   selection — `RUST_LOG=whatsapp_rust=debug` — with it.
+//!
+//! # The safe target representation
+//!
+//! A target crosses **verbatim** only if it is non-empty, at most
+//! [`MAX_TARGET_LEN`] bytes, and made entirely of ASCII alphanumerics, `_`,
+//! `:` and `/`. Anything else is replaced *whole* by the constant
+//! [`REDACTED_TARGET`] — never truncated and never rewritten character by
+//! character, because a partial target leaks the fragments it kept.
+//!
+//! That charset is the union of the two target shapes this workspace's
+//! dependency tree actually produces: Rust module paths (`whatsapp_rust`,
+//! `whatsapp_rust::socket`), which are the default target of every `log!`
+//! call without a `target:` argument, and the slash-separated component
+//! targets the pinned `whatsapp-rust` revision writes by hand
+//! (`Client/PairCode`, `Client/UnifiedSession` — 21 bytes at its longest).
+//!
+//! State the limit of this plainly: the charset bounds the target's *shape*,
+//! not its meaning. An identifier-shaped word is an identifier-shaped word,
+//! so a dependency that put `Alice` in a runtime target would still see
+//! `Alice` cross. What the rule guarantees is that the surviving field is a
+//! short, bounded, identifier-shaped token rather than an arbitrary string:
+//! no whitespace, no punctuation, no `@`, no non-ASCII, nothing over
+//! [`MAX_TARGET_LEN`] bytes, and so no room for a formatted sentence, a
+//! phone number, a JID, a path or a credential. The three genuinely unbounded
+//! channels are gone entirely; this one is kept, bounded, because the
+//! filtering contract needs it.
 //!
 //! Note the deliberate contrast with [`zeroclaw_memory::redact`], which is
 //! allow-by-default: it rewrites *recognized* patterns in user content the
 //! operator opted into storing. Here the input is unreviewed third-party text
-//! entering a credential-adjacent sink, so none of it is passed.
+//! entering a credential-adjacent sink, so the text channels are not passed.
 //!
 //! [`zeroclaw_memory::redact`]: https://docs.rs/zeroclaw-memory
 
+use tracing::level_filters::LevelFilter;
 use tracing_log::AsTrace;
 
 /// Fixed text substituted for every third-party `log` message body.
@@ -56,45 +88,117 @@ use tracing_log::AsTrace;
 /// withheld by design rather than lost.
 pub(crate) const REDACTED_MESSAGE: &str = "[third-party message redacted]";
 
+/// Fixed text substituted for a `log` target that is not in the safe
+/// representation documented at the module level.
+///
+/// Whole-target replacement, for the same reason the message body is replaced
+/// whole: a truncated or character-scrubbed target would still carry the
+/// fragments it kept. Its own shape is deliberately outside the safe charset,
+/// so it cannot be mistaken for a target a dependency chose and so
+/// [`safe_target`] is idempotent over it.
+pub(crate) const REDACTED_TARGET: &str = "[third-party target redacted]";
+
+/// Byte ceiling for a target that crosses verbatim. Generous next to the
+/// real ones — the longest target in the pinned `whatsapp-rust` revision is
+/// 21 bytes — and small enough that nothing sentence-shaped fits.
+pub(crate) const MAX_TARGET_LEN: usize = 128;
+
+/// True for the bytes a verbatim target may contain: ASCII alphanumerics,
+/// `_` and `:` for Rust module paths, `/` for the pinned dependency's
+/// hand-written component targets.
+fn is_safe_target_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b':' | b'/')
+}
+
+/// The target as it is allowed to cross: the dependency's own value when it
+/// is in the safe representation, [`REDACTED_TARGET`] otherwise.
+///
+/// Borrowing rather than allocating keeps this on the hot path of every
+/// dependency record, including the ones the filters are about to discard.
+fn safe_target(target: &str) -> &str {
+    let bytes = target.as_bytes();
+    if !bytes.is_empty()
+        && bytes.len() <= MAX_TARGET_LEN
+        && bytes.iter().all(|byte| is_safe_target_byte(*byte))
+    {
+        target
+    } else {
+        REDACTED_TARGET
+    }
+}
+
 /// The `log` logger installed in the process-global slot. Forwards each
 /// record into `tracing` through [`tracing_log::format_trace`], which is the
 /// same dispatch [`tracing_log::LogTracer`] performs — identical callsite,
-/// identical `log.target` / `log.module_path` / `log.file` / `log.line`
-/// normalization — except that the message it carries is always
-/// [`REDACTED_MESSAGE`] instead of the dependency's own text.
+/// identical `log.target` / `log.line` normalization — except that the
+/// message it carries is always [`REDACTED_MESSAGE`], its target is the safe
+/// representation, and `module_path` / `file` are not forwarded at all.
 struct RedactingLogBridge;
 
 static BRIDGE: RedactingLogBridge = RedactingLogBridge;
 
 impl log::Log for RedactingLogBridge {
-    /// Always true: `log`-side filtering would silently pre-empt the
-    /// `RUST_LOG` directives, so the tracing filters stay the single place
-    /// that decides what is recorded.
-    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
-        true
+    /// The same contract [`tracing_log::LogTracer`] implements: the global
+    /// max level, then the active dispatcher. Without it `log_enabled!`
+    /// answers `true` for every level and target — the bridge sets `log`'s
+    /// own max level to `Trace` — and a dependency guarding an expensive
+    /// diagnostic behind `log_enabled!` builds it even when the `EnvFilter`
+    /// is `off`.
+    ///
+    /// The dispatcher is asked about the *safe* target, because that is the
+    /// target the record will actually be dispatched under; asking about the
+    /// raw one would let `log_enabled!` disagree with what gets recorded.
+    ///
+    /// How far that agreement reaches is bounded by `tracing-subscriber`, not
+    /// by this bridge. `log` can only ask `Subscriber::enabled`, and a
+    /// *per-layer* filter — what [`install_global_subscriber`] uses, since
+    /// stderr and the recorded trace filter differently — deliberately does
+    /// not answer through it: `Filtered::enabled` returns `true` so the other
+    /// layers still get their say, and drops the event later in `on_event`.
+    /// So under per-layer filters this answers from the process-wide max
+    /// level, which still turns away the common case of a dependency's chatty
+    /// `DEBUG`/`TRACE` tiers while the floor is `INFO`, but not a
+    /// target-specific exclusion. A globally filtered subscriber is answered
+    /// exactly.
+    ///
+    /// [`install_global_subscriber`]: crate::install_global_subscriber
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        if metadata.level().as_trace() > LevelFilter::current() {
+            return false;
+        }
+        let metadata = log::Metadata::builder()
+            .level(metadata.level())
+            .target(safe_target(metadata.target()))
+            .build();
+        tracing::dispatcher::get_default(|dispatch| dispatch.enabled(&metadata.as_trace()))
     }
 
     fn log(&self, record: &log::Record<'_>) {
+        let target = safe_target(record.target());
         // Ask the subscriber first so a record no layer wants costs nothing
         // to dispatch. `format_trace` repeats this check; doing it here keeps
         // a dependency's chatty `DEBUG`/`TRACE` tiers off the callsite
         // machinery when the filter floor is `INFO`.
-        if !tracing::dispatcher::get_default(|dispatch| dispatch.enabled(&record.as_trace())) {
+        if !self.enabled(
+            &log::Metadata::builder()
+                .level(record.level())
+                .target(target)
+                .build(),
+        ) {
             return;
         }
         // Rebuilt field by field rather than copied from the incoming record:
         // this list is the whole of what may cross the boundary, so a future
         // `log` release that grows another payload channel (structured
-        // key-values, say) cannot ride along unreviewed. `args` is the free
-        // text channel and it is overwritten rather than forwarded — the
-        // dependency's own message is never read.
+        // key-values, say) cannot ride along unreviewed. `args` is overwritten
+        // rather than forwarded, `target` is the safe representation, and
+        // `module_path` / `file` are left unset — the builder defaults them to
+        // `None` and `tracing_log` then omits the fields entirely.
         let _ = tracing_log::format_trace(
             &log::Record::builder()
                 .args(format_args!("{REDACTED_MESSAGE}"))
                 .level(record.level())
-                .target(record.target())
-                .module_path(record.module_path())
-                .file(record.file())
+                .target(target)
                 .line(record.line())
                 .build(),
         );
@@ -141,4 +245,63 @@ pub(crate) fn install_or_panic() {
 /// [`install_or_panic`].
 pub(crate) fn install_best_effort_for_tests() {
     let _ = install();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shapes the pinned dependency tree actually emits must cross
+    /// untouched, or the bridge stops being addressable by `RUST_LOG` and
+    /// stops naming which dependency spoke.
+    #[test]
+    fn real_dependency_targets_cross_verbatim() {
+        for target in [
+            "whatsapp_rust",
+            "whatsapp_rust::socket",
+            "Client/PairCode",
+            "Client/UnifiedSession",
+            "usync",
+            "h2",
+        ] {
+            assert_eq!(
+                safe_target(target),
+                target,
+                "a target the dependency tree really uses must cross verbatim"
+            );
+        }
+    }
+
+    /// Everything outside the documented representation is replaced whole:
+    /// no truncation, no character scrubbing, so no fragment survives.
+    #[test]
+    fn targets_outside_the_safe_representation_are_replaced_whole() {
+        let over_long = "a".repeat(MAX_TARGET_LEN + 1);
+        for target in [
+            "",
+            "has space",
+            "972501234567@s.whatsapp.net",
+            "/etc/passwd\n",
+            "Zoë Müller",
+            "target=Alice",
+            "quoted\"target",
+            over_long.as_str(),
+        ] {
+            assert_eq!(
+                safe_target(target),
+                REDACTED_TARGET,
+                "a target outside the safe representation must be replaced whole: {target:?}"
+            );
+        }
+        // The boundary itself, so the cap is a cap and not an off-by-one.
+        let at_limit = "a".repeat(MAX_TARGET_LEN);
+        assert_eq!(safe_target(&at_limit), at_limit);
+    }
+
+    /// The replacement is itself outside the representation, so re-running
+    /// the rule over an already-replaced target cannot resurrect anything.
+    #[test]
+    fn the_target_replacement_is_idempotent() {
+        assert_eq!(safe_target(REDACTED_TARGET), REDACTED_TARGET);
+    }
 }

--- a/crates/zeroclaw-log/src/log_bridge.rs
+++ b/crates/zeroclaw-log/src/log_bridge.rs
@@ -20,121 +20,53 @@
 //! [`crate::writer::record_event`]'s guarantee that pairing credentials never
 //! reach disk.
 //!
-//! So the bridge is a scrubbing adapter, not a pass-through. A target
-//! allowlist alone cannot draw the line — in `whatsapp-rust` the useful
-//! failure diagnostics and the identifier-bearing lines share a target — so
-//! the boundary sits on the message text and is **deny by default**: a token
-//! is forwarded verbatim only when it cannot express an identifier or a
-//! credential, and anything else becomes [`REDACTED`]. Severity, target,
-//! module path and source location are structured metadata, never free text,
-//! and are forwarded untouched so `RUST_LOG` directives and the failure's
-//! provenance still work.
+//! So the bridge forwards a record's *metadata* and drops its *text*. The
+//! message body is the one free-text channel a `log` record carries, it is
+//! written by code this workspace does not review, and nothing here can tell
+//! a harmless sentence from a name, a brand, an identifier or a credential.
+//! So none of it crosses: every bridged record carries the fixed
+//! [`REDACTED_MESSAGE`] marker in place of whatever the dependency formatted.
+//! There is no heuristic and no allowlist, so there is no rule to get wrong
+//! and nothing an unusual message shape can talk its way past.
+//!
+//! What does cross is structured metadata: severity, the dependency's own
+//! target, its module path and its source `file:line`. Those are fixed at
+//! each call site in the dependency's own source rather than formatted from
+//! runtime values, so they carry no payload. They are also enough to keep the
+//! diagnostics actionable — the severity says how bad it was, and the target
+//! plus `file:line` name the exact line that fired, so the wording can be
+//! read from the dependency's source instead of from our trace — and enough
+//! for `RUST_LOG` directives to keep addressing a dependency by its own
+//! target.
 //!
 //! Note the deliberate contrast with [`zeroclaw_memory::redact`], which is
 //! allow-by-default: it rewrites *recognized* patterns in user content the
 //! operator opted into storing. Here the input is unreviewed third-party text
-//! entering a credential-adjacent sink, so an unclassifiable token must be
-//! dropped rather than passed.
+//! entering a credential-adjacent sink, so none of it is passed.
 //!
 //! [`zeroclaw_memory::redact`]: https://docs.rs/zeroclaw-memory
 
 use tracing_log::AsTrace;
 
-/// Placeholder substituted for any token the scrubber cannot vouch for.
-pub(crate) const REDACTED: &str = "[redacted]";
-
-/// Longest bare-decimal token forwarded verbatim. Sized below every
-/// identifier shape this boundary defends against: an E.164 phone number
-/// carries at least 7 digits and a `whatsapp-rust` pair code is 8 Crockford
-/// Base32 characters, so four digits cannot spell either. Keeps close codes
-/// (`1006`), HTTP statuses and small counts readable in a failure line.
-const MAX_BARE_DIGITS: usize = 4;
-
-/// Shortest all-uppercase-letter run treated as a possible pair code. The
-/// generator emits 8 Crockford Base32 characters, and roughly one code in
-/// twenty comes out with no digit at all, so an all-caps run cannot be waved
-/// through on "it has no digits". Mixed-case words (`WebSocket`) and short
-/// all-caps words (`WARN`, `HTTP`, `TLS`, `IQ`) stay readable.
-const MIN_UPPERCASE_RUN: usize = 6;
-
-/// Scrub a third-party log message, deny by default.
+/// Fixed text substituted for every third-party `log` message body.
 ///
-/// Whitespace and token order are preserved so the line still reads; each
-/// whitespace-delimited token is either forwarded verbatim or replaced whole
-/// by [`REDACTED`], with any surrounding ASCII punctuation kept so the
-/// sentence does not lose its shape.
-///
-/// A token survives only when, ignoring leading/trailing ASCII punctuation,
-/// it satisfies all of:
-///
-/// * it contains no `@` — that is a JID or an email address;
-/// * it contains no numeric character, *unless* it is at most
-///   [`MAX_BARE_DIGITS`] ASCII digits and nothing else;
-/// * it is not a run of [`MIN_UPPERCASE_RUN`] or more ASCII uppercase
-///   letters.
-///
-/// Everything else — phone numbers, pair codes, JIDs, LIDs, session and
-/// message ids, keys, hex and Base64 blobs — falls to the default and is
-/// redacted, because the boundary cannot tell them apart from the identifiers
-/// it exists to withhold.
-pub(crate) fn scrub(message: &str) -> String {
-    let mut out = String::with_capacity(message.len());
-    let mut rest = message;
-    while !rest.is_empty() {
-        let token_start = rest
-            .find(|c: char| !c.is_whitespace())
-            .unwrap_or(rest.len());
-        out.push_str(&rest[..token_start]);
-        rest = &rest[token_start..];
-        if rest.is_empty() {
-            break;
-        }
-        let token_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
-        push_scrubbed_token(&mut out, &rest[..token_end]);
-        rest = &rest[token_end..];
-    }
-    out
-}
-
-fn push_scrubbed_token(out: &mut String, token: &str) {
-    let core = token.trim_matches(|c: char| c.is_ascii_punctuation());
-    if core.is_empty() || core_is_safe(core) {
-        out.push_str(token);
-        return;
-    }
-    // Keep the punctuation that framed the token (`(`, `,`, `:`, `.`) so the
-    // surrounding sentence still parses; only the payload is replaced.
-    let lead = token.len()
-        - token
-            .trim_start_matches(|c: char| c.is_ascii_punctuation())
-            .len();
-    let trail = token.len() - core.len() - lead;
-    out.push_str(&token[..lead]);
-    out.push_str(REDACTED);
-    out.push_str(&token[token.len() - trail..]);
-}
-
-fn core_is_safe(core: &str) -> bool {
-    if core.contains('@') {
-        return false;
-    }
-    if core.chars().any(char::is_numeric) {
-        return core.len() <= MAX_BARE_DIGITS && core.bytes().all(|b| b.is_ascii_digit());
-    }
-    !(core.len() >= MIN_UPPERCASE_RUN && core.chars().all(|c| c.is_ascii_uppercase()))
-}
+/// Not a per-token placeholder: the message is never inspected, so this
+/// replaces the whole of it every time. Its presence in a record is the
+/// signal that a dependency logged at that call site and that the wording was
+/// withheld by design rather than lost.
+pub(crate) const REDACTED_MESSAGE: &str = "[third-party message redacted]";
 
 /// The `log` logger installed in the process-global slot. Forwards each
 /// record into `tracing` through [`tracing_log::format_trace`], which is the
 /// same dispatch [`tracing_log::LogTracer`] performs — identical callsite,
 /// identical `log.target` / `log.module_path` / `log.file` / `log.line`
-/// normalization — except that the message it carries has been through
-/// [`scrub`].
-struct ScrubbingLogBridge;
+/// normalization — except that the message it carries is always
+/// [`REDACTED_MESSAGE`] instead of the dependency's own text.
+struct RedactingLogBridge;
 
-static BRIDGE: ScrubbingLogBridge = ScrubbingLogBridge;
+static BRIDGE: RedactingLogBridge = RedactingLogBridge;
 
-impl log::Log for ScrubbingLogBridge {
+impl log::Log for RedactingLogBridge {
     /// Always true: `log`-side filtering would silently pre-empt the
     /// `RUST_LOG` directives, so the tracing filters stay the single place
     /// that decides what is recorded.
@@ -143,21 +75,22 @@ impl log::Log for ScrubbingLogBridge {
     }
 
     fn log(&self, record: &log::Record<'_>) {
-        // Ask the subscriber first so a record no layer wants costs no
-        // rendering or scrubbing. `format_trace` repeats this check; doing it
-        // here keeps the chatty `DEBUG`/`TRACE` tiers of a dependency off the
-        // allocator when the filter floor is `INFO`.
+        // Ask the subscriber first so a record no layer wants costs nothing
+        // to dispatch. `format_trace` repeats this check; doing it here keeps
+        // a dependency's chatty `DEBUG`/`TRACE` tiers off the callsite
+        // machinery when the filter floor is `INFO`.
         if !tracing::dispatcher::get_default(|dispatch| dispatch.enabled(&record.as_trace())) {
             return;
         }
-        let scrubbed = scrub(&record.args().to_string());
         // Rebuilt field by field rather than copied from the incoming record:
-        // this is the whole list of things allowed across the boundary, so a
-        // future `log` release that grows another payload channel (structured
-        // key-values, say) cannot ride along unreviewed.
+        // this list is the whole of what may cross the boundary, so a future
+        // `log` release that grows another payload channel (structured
+        // key-values, say) cannot ride along unreviewed. `args` is the free
+        // text channel and it is overwritten rather than forwarded — the
+        // dependency's own message is never read.
         let _ = tracing_log::format_trace(
             &log::Record::builder()
-                .args(format_args!("{scrubbed}"))
+                .args(format_args!("{REDACTED_MESSAGE}"))
                 .level(record.level())
                 .target(record.target())
                 .module_path(record.module_path())
@@ -170,7 +103,7 @@ impl log::Log for ScrubbingLogBridge {
     fn flush(&self) {}
 }
 
-/// Install the scrubbing bridge into the process-global `log` slot.
+/// Install the redacting bridge into the process-global `log` slot.
 ///
 /// Fails when another logger already owns that slot; `log` permits exactly
 /// one per process.
@@ -208,90 +141,4 @@ pub(crate) fn install_or_panic() {
 /// [`install_or_panic`].
 pub(crate) fn install_best_effort_for_tests() {
     let _ = install();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn scrub_redacts_pairing_credentials_and_identifiers() {
-        // Message shapes from whatsapp-rust `src/pair_code.rs` at the locked
-        // revision, plus a JID-bearing line from `src/message.rs`.
-        assert_eq!(
-            scrub("Starting pair code authentication for phone: 972501234567"),
-            format!("Starting pair code authentication for phone: {REDACTED}")
-        );
-        assert_eq!(
-            scrub("Stage 1 complete, waiting for phone confirmation. Code: 3K7XW2QZ"),
-            format!("Stage 1 complete, waiting for phone confirmation. Code: {REDACTED}")
-        );
-        // A pair code that happens to draw no digits from the Crockford
-        // alphabet must not slip through the digit rule.
-        assert_eq!(scrub("Code: ZXKWQTRV"), format!("Code: {REDACTED}"));
-        assert_eq!(
-            scrub("Failed to decrypt from 972501234567@s.whatsapp.net"),
-            format!("Failed to decrypt from {REDACTED}")
-        );
-        assert_eq!(
-            scrub("group 120363012345678901@g.us went silent"),
-            format!("group {REDACTED} went silent")
-        );
-        assert_eq!(
-            scrub("phone: +972-50-123-4567"),
-            format!("phone: +{REDACTED}")
-        );
-    }
-
-    #[test]
-    fn scrub_keeps_dependency_failure_diagnostics_readable() {
-        for line in [
-            "websocket read failed: connection reset by peer",
-            "Failed to send companion_finish: broken pipe",
-            "Missing or invalid primary identity pub in notification",
-        ] {
-            assert_eq!(scrub(line), line, "failure diagnostic must survive intact");
-        }
-        // Short bare numbers stay: close codes, statuses, counts.
-        assert_eq!(
-            scrub("socket closed with code 1006 after 3 retries"),
-            "socket closed with code 1006 after 3 retries"
-        );
-        // Mixed case and short all-caps words are prose, not codes.
-        assert_eq!(
-            scrub("WebSocket handshake failed over TLS"),
-            "WebSocket handshake failed over TLS"
-        );
-    }
-
-    #[test]
-    fn scrub_is_deny_by_default_for_unclassifiable_tokens() {
-        // Neither a phone nor a JID nor a pair code, but equally
-        // unvouchable: ids, keys, blobs, and long digit runs.
-        for token in [
-            "3EB0C767D26A1D8B1F49",
-            "session-9f2c41ab",
-            "1234567",
-            "sk_live_abc123def456",
-            "١٢٣٤٥٦٧٨",
-        ] {
-            let out = scrub(&format!("saw {token} here"));
-            assert_eq!(
-                out,
-                format!("saw {REDACTED} here"),
-                "unclassifiable token must fail closed: {token}"
-            );
-        }
-    }
-
-    #[test]
-    fn scrub_preserves_whitespace_and_framing_punctuation() {
-        assert_eq!(
-            scrub("info (from=972501234567@s.whatsapp.net):\n\tdecrypt failed"),
-            format!("info ({REDACTED}):\n\tdecrypt failed")
-        );
-        assert_eq!(scrub(""), "");
-        assert_eq!(scrub("   "), "   ");
-        assert_eq!(scrub("-->"), "-->");
-    }
 }

--- a/crates/zeroclaw-log/src/log_bridge.rs
+++ b/crates/zeroclaw-log/src/log_bridge.rs
@@ -1,0 +1,272 @@
+//! Fail-closed bridge from the `log` facade into `tracing`.
+//!
+//! Dependencies log through `log`, not `tracing` — `whatsapp-rust` and
+//! friends. Installing a `tracing` subscriber does nothing for them: `log`
+//! keeps its own global logger slot, and while that slot is empty every
+//! `log::warn!` in the dependency tree is discarded at the macro's own
+//! max-level check. Those records reach neither stderr nor the JSONL trace,
+//! so a transport failure inside a dependency leaves no evidence at any
+//! verbosity.
+//!
+//! Filling that slot with a bare [`tracing_log::LogTracer`] would recover the
+//! diagnostics *and* hand every third-party message string to
+//! [`crate::layer::LogCaptureLayer`], which materializes it as ordinary event
+//! text and persists it to `runtime-trace.jsonl` (rolling persistence is on by
+//! default, at an `INFO` floor). Third-party `INFO`/`WARN` sites are not ours
+//! to review: at the locked `whatsapp-rust` revision, `src/pair_code.rs` logs
+//! the configured phone number and the generated pair code at `INFO`, and
+//! other sites log JIDs. Those strings would bypass the deliberate
+//! `LoginEvent::PairCode` → `ephemeral_attrs` boundary and
+//! [`crate::writer::record_event`]'s guarantee that pairing credentials never
+//! reach disk.
+//!
+//! So the bridge is a scrubbing adapter, not a pass-through. A target
+//! allowlist alone cannot draw the line — in `whatsapp-rust` the useful
+//! failure diagnostics and the identifier-bearing lines share a target — so
+//! the boundary sits on the message text and is **deny by default**: a token
+//! is forwarded verbatim only when it cannot express an identifier or a
+//! credential, and anything else becomes [`REDACTED`]. Severity, target,
+//! module path and source location are structured metadata, never free text,
+//! and are forwarded untouched so `RUST_LOG` directives and the failure's
+//! provenance still work.
+//!
+//! Note the deliberate contrast with [`zeroclaw_memory::redact`], which is
+//! allow-by-default: it rewrites *recognized* patterns in user content the
+//! operator opted into storing. Here the input is unreviewed third-party text
+//! entering a credential-adjacent sink, so an unclassifiable token must be
+//! dropped rather than passed.
+//!
+//! [`zeroclaw_memory::redact`]: https://docs.rs/zeroclaw-memory
+
+use tracing_log::AsTrace;
+
+/// Placeholder substituted for any token the scrubber cannot vouch for.
+pub(crate) const REDACTED: &str = "[redacted]";
+
+/// Longest bare-decimal token forwarded verbatim. Sized below every
+/// identifier shape this boundary defends against: an E.164 phone number
+/// carries at least 7 digits and a `whatsapp-rust` pair code is 8 Crockford
+/// Base32 characters, so four digits cannot spell either. Keeps close codes
+/// (`1006`), HTTP statuses and small counts readable in a failure line.
+const MAX_BARE_DIGITS: usize = 4;
+
+/// Shortest all-uppercase-letter run treated as a possible pair code. The
+/// generator emits 8 Crockford Base32 characters, and roughly one code in
+/// twenty comes out with no digit at all, so an all-caps run cannot be waved
+/// through on "it has no digits". Mixed-case words (`WebSocket`) and short
+/// all-caps words (`WARN`, `HTTP`, `TLS`, `IQ`) stay readable.
+const MIN_UPPERCASE_RUN: usize = 6;
+
+/// Scrub a third-party log message, deny by default.
+///
+/// Whitespace and token order are preserved so the line still reads; each
+/// whitespace-delimited token is either forwarded verbatim or replaced whole
+/// by [`REDACTED`], with any surrounding ASCII punctuation kept so the
+/// sentence does not lose its shape.
+///
+/// A token survives only when, ignoring leading/trailing ASCII punctuation,
+/// it satisfies all of:
+///
+/// * it contains no `@` — that is a JID or an email address;
+/// * it contains no numeric character, *unless* it is at most
+///   [`MAX_BARE_DIGITS`] ASCII digits and nothing else;
+/// * it is not a run of [`MIN_UPPERCASE_RUN`] or more ASCII uppercase
+///   letters.
+///
+/// Everything else — phone numbers, pair codes, JIDs, LIDs, session and
+/// message ids, keys, hex and Base64 blobs — falls to the default and is
+/// redacted, because the boundary cannot tell them apart from the identifiers
+/// it exists to withhold.
+pub(crate) fn scrub(message: &str) -> String {
+    let mut out = String::with_capacity(message.len());
+    let mut rest = message;
+    while !rest.is_empty() {
+        let token_start = rest
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(rest.len());
+        out.push_str(&rest[..token_start]);
+        rest = &rest[token_start..];
+        if rest.is_empty() {
+            break;
+        }
+        let token_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        push_scrubbed_token(&mut out, &rest[..token_end]);
+        rest = &rest[token_end..];
+    }
+    out
+}
+
+fn push_scrubbed_token(out: &mut String, token: &str) {
+    let core = token.trim_matches(|c: char| c.is_ascii_punctuation());
+    if core.is_empty() || core_is_safe(core) {
+        out.push_str(token);
+        return;
+    }
+    // Keep the punctuation that framed the token (`(`, `,`, `:`, `.`) so the
+    // surrounding sentence still parses; only the payload is replaced.
+    let lead = token.len()
+        - token
+            .trim_start_matches(|c: char| c.is_ascii_punctuation())
+            .len();
+    let trail = token.len() - core.len() - lead;
+    out.push_str(&token[..lead]);
+    out.push_str(REDACTED);
+    out.push_str(&token[token.len() - trail..]);
+}
+
+fn core_is_safe(core: &str) -> bool {
+    if core.contains('@') {
+        return false;
+    }
+    if core.chars().any(char::is_numeric) {
+        return core.len() <= MAX_BARE_DIGITS && core.bytes().all(|b| b.is_ascii_digit());
+    }
+    !(core.len() >= MIN_UPPERCASE_RUN && core.chars().all(|c| c.is_ascii_uppercase()))
+}
+
+/// The `log` logger installed in the process-global slot. Forwards each
+/// record into `tracing` through [`tracing_log::format_trace`], which is the
+/// same dispatch [`tracing_log::LogTracer`] performs — identical callsite,
+/// identical `log.target` / `log.module_path` / `log.file` / `log.line`
+/// normalization — except that the message it carries has been through
+/// [`scrub`].
+struct ScrubbingLogBridge;
+
+static BRIDGE: ScrubbingLogBridge = ScrubbingLogBridge;
+
+impl log::Log for ScrubbingLogBridge {
+    /// Always true: `log`-side filtering would silently pre-empt the
+    /// `RUST_LOG` directives, so the tracing filters stay the single place
+    /// that decides what is recorded.
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        // Ask the subscriber first so a record no layer wants costs no
+        // rendering or scrubbing. `format_trace` repeats this check; doing it
+        // here keeps the chatty `DEBUG`/`TRACE` tiers of a dependency off the
+        // allocator when the filter floor is `INFO`.
+        if !tracing::dispatcher::get_default(|dispatch| dispatch.enabled(&record.as_trace())) {
+            return;
+        }
+        let scrubbed = scrub(&record.args().to_string());
+        // Rebuilt field by field rather than copied from the incoming record:
+        // this is the whole list of things allowed across the boundary, so a
+        // future `log` release that grows another payload channel (structured
+        // key-values, say) cannot ride along unreviewed.
+        let _ = tracing_log::format_trace(
+            &log::Record::builder()
+                .args(format_args!("{scrubbed}"))
+                .level(record.level())
+                .target(record.target())
+                .module_path(record.module_path())
+                .file(record.file())
+                .line(record.line())
+                .build(),
+        );
+    }
+
+    fn flush(&self) {}
+}
+
+/// Install the scrubbing bridge into the process-global `log` slot.
+///
+/// `log` permits exactly one global logger per process, so a second call —
+/// a re-entrant setup, or the next test in a shared test binary — returns
+/// `Err` and is deliberately discarded, mirroring how
+/// [`crate::try_install_capture_subscriber`] treats a repeated
+/// `set_global_default`.
+pub(crate) fn install() {
+    if log::set_logger(&BRIDGE).is_ok() {
+        // The bridge decides nothing about verbosity, so let every record
+        // reach it and let the tracing filters do the filtering.
+        log::set_max_level(log::LevelFilter::Trace);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_redacts_pairing_credentials_and_identifiers() {
+        // Message shapes from whatsapp-rust `src/pair_code.rs` at the locked
+        // revision, plus a JID-bearing line from `src/message.rs`.
+        assert_eq!(
+            scrub("Starting pair code authentication for phone: 972501234567"),
+            format!("Starting pair code authentication for phone: {REDACTED}")
+        );
+        assert_eq!(
+            scrub("Stage 1 complete, waiting for phone confirmation. Code: 3K7XW2QZ"),
+            format!("Stage 1 complete, waiting for phone confirmation. Code: {REDACTED}")
+        );
+        // A pair code that happens to draw no digits from the Crockford
+        // alphabet must not slip through the digit rule.
+        assert_eq!(scrub("Code: ZXKWQTRV"), format!("Code: {REDACTED}"));
+        assert_eq!(
+            scrub("Failed to decrypt from 972501234567@s.whatsapp.net"),
+            format!("Failed to decrypt from {REDACTED}")
+        );
+        assert_eq!(
+            scrub("group 120363012345678901@g.us went silent"),
+            format!("group {REDACTED} went silent")
+        );
+        assert_eq!(
+            scrub("phone: +972-50-123-4567"),
+            format!("phone: +{REDACTED}")
+        );
+    }
+
+    #[test]
+    fn scrub_keeps_dependency_failure_diagnostics_readable() {
+        for line in [
+            "websocket read failed: connection reset by peer",
+            "Failed to send companion_finish: broken pipe",
+            "Missing or invalid primary identity pub in notification",
+        ] {
+            assert_eq!(scrub(line), line, "failure diagnostic must survive intact");
+        }
+        // Short bare numbers stay: close codes, statuses, counts.
+        assert_eq!(
+            scrub("socket closed with code 1006 after 3 retries"),
+            "socket closed with code 1006 after 3 retries"
+        );
+        // Mixed case and short all-caps words are prose, not codes.
+        assert_eq!(
+            scrub("WebSocket handshake failed over TLS"),
+            "WebSocket handshake failed over TLS"
+        );
+    }
+
+    #[test]
+    fn scrub_is_deny_by_default_for_unclassifiable_tokens() {
+        // Neither a phone nor a JID nor a pair code, but equally
+        // unvouchable: ids, keys, blobs, and long digit runs.
+        for token in [
+            "3EB0C767D26A1D8B1F49",
+            "session-9f2c41ab",
+            "1234567",
+            "sk_live_abc123def456",
+            "١٢٣٤٥٦٧٨",
+        ] {
+            let out = scrub(&format!("saw {token} here"));
+            assert_eq!(
+                out,
+                format!("saw {REDACTED} here"),
+                "unclassifiable token must fail closed: {token}"
+            );
+        }
+    }
+
+    #[test]
+    fn scrub_preserves_whitespace_and_framing_punctuation() {
+        assert_eq!(
+            scrub("info (from=972501234567@s.whatsapp.net):\n\tdecrypt failed"),
+            format!("info ({REDACTED}):\n\tdecrypt failed")
+        );
+        assert_eq!(scrub(""), "");
+        assert_eq!(scrub("   "), "   ");
+        assert_eq!(scrub("-->"), "-->");
+    }
+}

--- a/crates/zeroclaw-log/src/log_bridge.rs
+++ b/crates/zeroclaw-log/src/log_bridge.rs
@@ -172,17 +172,42 @@ impl log::Log for ScrubbingLogBridge {
 
 /// Install the scrubbing bridge into the process-global `log` slot.
 ///
-/// `log` permits exactly one global logger per process, so a second call —
-/// a re-entrant setup, or the next test in a shared test binary — returns
-/// `Err` and is deliberately discarded, mirroring how
-/// [`crate::try_install_capture_subscriber`] treats a repeated
-/// `set_global_default`.
-pub(crate) fn install() {
-    if log::set_logger(&BRIDGE).is_ok() {
-        // The bridge decides nothing about verbosity, so let every record
-        // reach it and let the tracing filters do the filtering.
-        log::set_max_level(log::LevelFilter::Trace);
+/// Fails when another logger already owns that slot; `log` permits exactly
+/// one per process.
+fn install() -> Result<(), log::SetLoggerError> {
+    log::set_logger(&BRIDGE)?;
+    // The bridge decides nothing about verbosity, so let every record reach
+    // it and let the tracing filters do the filtering.
+    log::set_max_level(log::LevelFilter::Trace);
+    Ok(())
+}
+
+/// Production install: panics when the bridge cannot take the `log` slot.
+///
+/// A silent failure here is worse than a crash. The tracing subscriber is
+/// installed by the time this runs, so discarding the error would leave the
+/// daemon looking healthy while the dependency records this bridge exists to
+/// recover stay missing — the exact invisible-failure mode the bridge was
+/// added to end.
+pub(crate) fn install_or_panic() {
+    if let Err(err) = install() {
+        panic!(
+            "installing the `log` -> tracing bridge failed ({err}): another logger already \
+             owns the process-global `log` slot, so dependency diagnostics would be lost \
+             silently. Remove the competing `log::set_logger` call."
+        );
     }
+}
+
+/// Test-only install: tolerates the slot already being taken.
+///
+/// Test binaries call [`crate::try_install_capture_subscriber`] once per test,
+/// and `log` allows a single logger per process, so every call after the first
+/// necessarily fails. The already-installed logger is this same bridge, so
+/// ignoring the error is correct *here and only here*. Production goes through
+/// [`install_or_panic`].
+pub(crate) fn install_best_effort_for_tests() {
+    let _ = install();
 }
 
 #[cfg(test)]

--- a/crates/zeroclaw-log/src/log_bridge.rs
+++ b/crates/zeroclaw-log/src/log_bridge.rs
@@ -46,29 +46,32 @@
 //!
 //! # The safe target representation
 //!
-//! A target crosses **verbatim** only if it is non-empty, at most
-//! [`MAX_TARGET_LEN`] bytes, and made entirely of ASCII alphanumerics, `_`,
-//! `:` and `/`. Anything else is replaced *whole* by the constant
-//! [`REDACTED_TARGET`] — never truncated and never rewritten character by
-//! character, because a partial target leaks the fragments it kept.
+//! The target that crosses is drawn from a reviewed, finite vocabulary —
+//! never from the record. Two constant tables, both read off the locked
+//! dependency sources, are that whole vocabulary:
 //!
-//! That charset is the union of the two target shapes this workspace's
-//! dependency tree actually produces: Rust module paths (`whatsapp_rust`,
-//! `whatsapp_rust::socket`), which are the default target of every `log!`
-//! call without a `target:` argument, and the slash-separated component
-//! targets the pinned `whatsapp-rust` revision writes by hand
-//! (`Client/PairCode`, `Client/UnifiedSession` — 21 bytes at its longest).
+//! - [`TARGET_LITERALS`]: the hand-written `target: "..."` literals in the
+//!   pinned `whatsapp-rust` revision (38 at `cbcdd2a6`, `AppState` through
+//!   `usync`; the pin contains no computed target expression). An incoming
+//!   target crosses only on an exact match, and what crosses is the table's
+//!   own constant.
+//! - [`TARGET_CRATES`]: the crates in the pinned tree that log through the
+//!   facade *without* an explicit `target:`, so their records arrive with
+//!   the module path as the target. Only the crate's reviewed name crosses:
+//!   everything after `::` in a module path is still a runtime string that a
+//!   hand-built record can abuse (`whatsapp_rust::<jid>` is charset-clean),
+//!   so `whatsapp_rust::socket` is reduced to `whatsapp_rust`.
 //!
-//! State the limit of this plainly: the charset bounds the target's *shape*,
-//! not its meaning. An identifier-shaped word is an identifier-shaped word,
-//! so a dependency that put `Alice` in a runtime target would still see
-//! `Alice` cross. What the rule guarantees is that the surviving field is a
-//! short, bounded, identifier-shaped token rather than an arbitrary string:
-//! no whitespace, no punctuation, no `@`, no non-ASCII, nothing over
-//! [`MAX_TARGET_LEN`] bytes, and so no room for a formatted sentence, a
-//! phone number, a JID, a path or a credential. The three genuinely unbounded
-//! channels are gone entirely; this one is kept, bounded, because the
-//! filtering contract needs it.
+//! Anything else is replaced *whole* by [`REDACTED_TARGET`] — never
+//! truncated and never rewritten character by character, because a partial
+//! target leaks the fragments it kept. Fitness is provenance against the
+//! tables, not shape: a phone-shaped, secret-shaped or name-shaped runtime
+//! value cannot cross no matter which characters it is made of, because the
+//! emitted target is by construction one of this file's constants. The
+//! price is granularity, not filterability: `RUST_LOG=whatsapp_rust=debug`
+//! still addresses every record of the crate, while a per-module directive
+//! (`whatsapp_rust::socket=debug`) no longer matches anything, since the
+//! reduction happens before the filters look.
 //!
 //! Note the deliberate contrast with [`zeroclaw_memory::redact`], which is
 //! allow-by-default: it rewrites *recognized* patterns in user content the
@@ -93,38 +96,76 @@ pub(crate) const REDACTED_MESSAGE: &str = "[third-party message redacted]";
 ///
 /// Whole-target replacement, for the same reason the message body is replaced
 /// whole: a truncated or character-scrubbed target would still carry the
-/// fragments it kept. Its own shape is deliberately outside the safe charset,
-/// so it cannot be mistaken for a target a dependency chose and so
-/// [`safe_target`] is idempotent over it.
+/// fragments it kept. It appears in neither reviewed table, so it cannot be
+/// mistaken for a target a dependency chose and [`safe_target`] is idempotent
+/// over it.
 pub(crate) const REDACTED_TARGET: &str = "[third-party target redacted]";
 
-/// Byte ceiling for a target that crosses verbatim. Generous next to the
-/// real ones — the longest target in the pinned `whatsapp-rust` revision is
-/// 21 bytes — and small enough that nothing sentence-shaped fits.
-pub(crate) const MAX_TARGET_LEN: usize = 128;
+/// The hand-written `target: "..."` literals in the pinned `whatsapp-rust`
+/// revision (`cbcdd2a6`), read off its sources whole — the pin has no
+/// computed target expression. Byte-sorted for the binary search; a test
+/// pins the ordering. An entry here is a claim that this exact string was
+/// seen in the reviewed dependency source, so the table only grows by
+/// re-reading a pin.
+pub(crate) const TARGET_LITERALS: &[&str] = &[
+    "AppState",
+    "Blocking",
+    "Bot/PairCode",
+    "Chatstate",
+    "ChatstateHandler",
+    "Client/AccountSync",
+    "Client/Ack",
+    "Client/AppState",
+    "Client/Business",
+    "Client/Contacts",
+    "Client/CsToken",
+    "Client/DeviceProps",
+    "Client/DeviceRegistry",
+    "Client/Foo",
+    "Client/Group",
+    "Client/Groups",
+    "Client/IQ",
+    "Client/Keepalive",
+    "Client/Mex",
+    "Client/OfflineResume",
+    "Client/OfflineSync",
+    "Client/PDO",
+    "Client/PairCode",
+    "Client/PairTest",
+    "Client/Picture",
+    "Client/Receipt",
+    "Client/Recv",
+    "Client/Send",
+    "Client/Status",
+    "Client/TcToken",
+    "Client/UnifiedSession",
+    "MessageQueue",
+    "Mex",
+    "PresenceHandler",
+    "TcToken",
+    "UnifiedSession",
+    "blocklist",
+    "usync",
+];
 
-/// True for the bytes a verbatim target may contain: ASCII alphanumerics,
-/// `_` and `:` for Rust module paths, `/` for the pinned dependency's
-/// hand-written component targets.
-fn is_safe_target_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b':' | b'/')
-}
+/// The crates in the pinned tree that log through the facade without an
+/// explicit `target:`, so their records carry the module path as the
+/// target. A module-path target is reduced to its crate's reviewed name;
+/// the segments after `::` are runtime strings and never cross.
+pub(crate) const TARGET_CRATES: &[&str] = &["wacore", "whatsapp_rust"];
 
-/// The target as it is allowed to cross: the dependency's own value when it
-/// is in the safe representation, [`REDACTED_TARGET`] otherwise.
-///
-/// Borrowing rather than allocating keeps this on the hot path of every
-/// dependency record, including the ones the filters are about to discard.
-fn safe_target(target: &str) -> &str {
-    let bytes = target.as_bytes();
-    if !bytes.is_empty()
-        && bytes.len() <= MAX_TARGET_LEN
-        && bytes.iter().all(|byte| is_safe_target_byte(*byte))
-    {
-        target
-    } else {
-        REDACTED_TARGET
+/// The target as it is allowed to cross: a constant from the reviewed
+/// tables, or [`REDACTED_TARGET`]. Never a borrow of the record's own
+/// value, so the emitted vocabulary is closed by construction.
+fn safe_target(target: &str) -> &'static str {
+    if let Ok(found) = TARGET_LITERALS.binary_search(&target) {
+        return TARGET_LITERALS[found];
     }
+    let root = target.split("::").next().unwrap_or(target);
+    if let Ok(found) = TARGET_CRATES.binary_search(&root) {
+        return TARGET_CRATES[found];
+    }
+    REDACTED_TARGET
 }
 
 /// The `log` logger installed in the process-global slot. Forwards each
@@ -251,51 +292,71 @@ pub(crate) fn install_best_effort_for_tests() {
 mod tests {
     use super::*;
 
-    /// The shapes the pinned dependency tree actually emits must cross
-    /// untouched, or the bridge stops being addressable by `RUST_LOG` and
-    /// stops naming which dependency spoke.
+    /// Both tables must be byte-sorted or the binary searches silently miss
+    /// entries — a miss here fails closed (redaction), but it would still be
+    /// a reviewed name going dark.
     #[test]
-    fn real_dependency_targets_cross_verbatim() {
-        for target in [
-            "whatsapp_rust",
-            "whatsapp_rust::socket",
-            "Client/PairCode",
-            "Client/UnifiedSession",
-            "usync",
-            "h2",
-        ] {
-            assert_eq!(
-                safe_target(target),
-                target,
-                "a target the dependency tree really uses must cross verbatim"
+    fn the_reviewed_tables_are_sorted_for_the_binary_search() {
+        for table in [TARGET_LITERALS, TARGET_CRATES] {
+            assert!(
+                table.windows(2).all(|pair| pair[0] < pair[1]),
+                "a reviewed table must be strictly byte-sorted: {table:?}"
             );
         }
     }
 
-    /// Everything outside the documented representation is replaced whole:
-    /// no truncation, no character scrubbing, so no fragment survives.
+    /// The targets the pinned dependency actually emits must cross as their
+    /// reviewed constants, or the bridge stops being addressable by
+    /// `RUST_LOG` and stops naming which dependency spoke.
     #[test]
-    fn targets_outside_the_safe_representation_are_replaced_whole() {
-        let over_long = "a".repeat(MAX_TARGET_LEN + 1);
+    fn reviewed_dependency_targets_cross_as_their_constants() {
+        for target in [
+            "AppState",
+            "Client/PairCode",
+            "Client/UnifiedSession",
+            "usync",
+        ] {
+            assert_eq!(
+                safe_target(target),
+                target,
+                "a hand-written literal from the pinned source must cross"
+            );
+        }
+        // Module-path targets reduce to the crate's reviewed name: the crate
+        // is provable, the path after `::` is a runtime string.
+        assert_eq!(safe_target("whatsapp_rust"), "whatsapp_rust");
+        assert_eq!(safe_target("whatsapp_rust::socket"), "whatsapp_rust");
+        assert_eq!(safe_target("wacore::send"), "wacore");
+        // Which is also what defuses a payload smuggled behind a real crate
+        // name — charset-clean, and it still cannot cross.
+        assert_eq!(safe_target("whatsapp_rust::9725012345678"), "whatsapp_rust");
+    }
+
+    /// Everything outside the reviewed tables is replaced whole — no
+    /// truncation, no character scrubbing — and shape does not help:
+    /// every value here fits the old charset rule and each one is exactly
+    /// the kind of runtime payload the tables exist to stop.
+    #[test]
+    fn payload_shaped_targets_are_replaced_whole_whatever_their_shape() {
+        let over_long = "a".repeat(4096);
         for target in [
             "",
+            "9725012345678",              // bare numeric, phone-shaped
+            "sk_live_4eC39HqLyjWDarjtT1", // underscore-separated, secret-shaped
+            "Alice",                      // identifier-shaped name
+            "Client/Foo2",                // near-miss of a reviewed literal
             "has space",
             "972501234567@s.whatsapp.net",
             "/etc/passwd\n",
             "Zoë Müller",
-            "target=Alice",
-            "quoted\"target",
             over_long.as_str(),
         ] {
             assert_eq!(
                 safe_target(target),
                 REDACTED_TARGET,
-                "a target outside the safe representation must be replaced whole: {target:?}"
+                "a target outside the reviewed tables must be replaced whole: {target:?}"
             );
         }
-        // The boundary itself, so the cap is a cap and not an off-by-one.
-        let at_limit = "a".repeat(MAX_TARGET_LEN);
-        assert_eq!(safe_target(&at_limit), at_limit);
     }
 
     /// The replacement is itself outside the representation, so re-running

--- a/crates/zeroclaw-log/src/log_bridge.rs
+++ b/crates/zeroclaw-log/src/log_bridge.rs
@@ -55,12 +55,14 @@
 //!   `usync`; the pin contains no computed target expression). An incoming
 //!   target crosses only on an exact match, and what crosses is the table's
 //!   own constant.
-//! - [`TARGET_CRATES`]: the crates in the pinned tree that log through the
-//!   facade *without* an explicit `target:`, so their records arrive with
-//!   the module path as the target. Only the crate's reviewed name crosses:
-//!   everything after `::` in a module path is still a runtime string that a
-//!   hand-built record can abuse (`whatsapp_rust::<jid>` is charset-clean),
-//!   so `whatsapp_rust::socket` is reduced to `whatsapp_rust`.
+//! - [`TARGET_CRATES`]: the crates the `whatsapp-web` feature activates that
+//!   log through the facade *without* an explicit `target:`, so their records
+//!   arrive with the module path as the target. Only the crate's reviewed
+//!   name crosses: everything after `::` in a module path is still a runtime
+//!   string that a hand-built record can abuse (`whatsapp_rust::<jid>` is
+//!   charset-clean), so `whatsapp_rust::socket` is reduced to
+//!   `whatsapp_rust`. The table's own doc comment carries the per-crate
+//!   decision for the whole activated graph.
 //!
 //! Anything else is replaced *whole* by [`REDACTED_TARGET`] — never
 //! truncated and never rewritten character by character, because a partial
@@ -101,12 +103,13 @@ pub(crate) const REDACTED_MESSAGE: &str = "[third-party message redacted]";
 /// over it.
 pub(crate) const REDACTED_TARGET: &str = "[third-party target redacted]";
 
-/// The hand-written `target: "..."` literals in the pinned `whatsapp-rust`
-/// revision (`cbcdd2a6`), read off its sources whole — the pin has no
-/// computed target expression. Byte-sorted for the binary search; a test
-/// pins the ordering. An entry here is a claim that this exact string was
-/// seen in the reviewed dependency source, so the table only grows by
-/// re-reading a pin.
+/// The hand-written `target: "..."` literals across the whole activated
+/// `whatsapp-web` graph at pin `cbcdd2a6`, read off its sources whole — the
+/// pin has no computed target expression (`src/handlers/macros.rs` takes
+/// `target: $target:literal`, so its expansions are literals too).
+/// Byte-sorted for the binary search; a test pins the ordering. An entry here
+/// is a claim that this exact string was seen in the reviewed dependency
+/// source, so the table only grows by re-reading a pin.
 pub(crate) const TARGET_LITERALS: &[&str] = &[
     "AppState",
     "Blocking",
@@ -148,11 +151,46 @@ pub(crate) const TARGET_LITERALS: &[&str] = &[
     "usync",
 ];
 
-/// The crates in the pinned tree that log through the facade without an
-/// explicit `target:`, so their records carry the module path as the
-/// target. A module-path target is reduced to its crate's reviewed name;
-/// the segments after `::` are runtime strings and never cross.
-pub(crate) const TARGET_CRATES: &[&str] = &["wacore", "whatsapp_rust"];
+/// The crates the `whatsapp-web` feature activates that log through the
+/// facade without an explicit `target:`, so their records carry the module
+/// path as the target. A module-path target is reduced to its crate's
+/// reviewed name; the segments after `::` are runtime strings and never
+/// cross.
+///
+/// Every package in the locked `whatsapp-web` graph at pin `cbcdd2a6`, and
+/// the decision made for it. "Default-target calls" counts `log` macro calls
+/// with no `target:`; their target is the module path, whose root is the
+/// crate's lib name.
+///
+/// | activated package | default-target calls | decision |
+/// |---|---:|---|
+/// | `whatsapp-rust` | 540 | **preserve** as `whatsapp_rust` — client, message and socket diagnostics; the crate this bridge exists to recover |
+/// | `wacore` | 38 | **preserve** as `wacore` — send path, prekey fetch, device persistence |
+/// | `wacore-libsignal` | 35 | **preserve** as `wacore_libsignal` — session and MAC failures; the ones worth reading when decryption breaks |
+/// | `whatsapp-rust-tokio-transport` | 8 | **preserve** as `whatsapp_rust_tokio_transport` — websocket dial and read failures |
+/// | `wacore-noise` | 2 | **preserve** as `wacore_noise` — frame decode; two `trace!`s, but the same rule as its siblings costs nothing |
+/// | `wacore-appstate` | 0 | nothing to decide — all 8 of its calls pass `target: "AppState"`, already in [`TARGET_LITERALS`] |
+/// | `wacore-binary`, `waproto`, `whatsapp-rust-ureq-http-client`, `wacore-derive` | 0 | nothing to decide — none depends on `log` |
+///
+/// Preserving each root rather than folding them into one family keeps the
+/// answer to "which component spoke" in the only field that survives the
+/// boundary, since `module_path` and `file` are dropped. `EnvFilter` matches
+/// a directive's target as a prefix, so `RUST_LOG=whatsapp_rust=debug` picks
+/// up `whatsapp_rust_tokio_transport` too and `wacore=debug` picks up
+/// `wacore_libsignal` and `wacore_noise`; a directive naming the crate
+/// exactly selects just that crate. A test pins both.
+///
+/// A crate outside this table crosses as [`REDACTED_TARGET`] with its
+/// severity and line intact — still more than `master` gives, which is
+/// nothing — and widening the table is a one-line change reviewed against a
+/// named pin.
+pub(crate) const TARGET_CRATES: &[&str] = &[
+    "wacore",
+    "wacore_libsignal",
+    "wacore_noise",
+    "whatsapp_rust",
+    "whatsapp_rust_tokio_transport",
+];
 
 /// The target as it is allowed to cross: a constant from the reviewed
 /// tables, or [`REDACTED_TARGET`]. Never a borrow of the record's own
@@ -330,6 +368,81 @@ mod tests {
         // Which is also what defuses a payload smuggled behind a real crate
         // name — charset-clean, and it still cannot cross.
         assert_eq!(safe_target("whatsapp_rust::9725012345678"), "whatsapp_rust");
+    }
+
+    /// The activated `whatsapp-web` graph at pin `cbcdd2a6` has exactly five
+    /// crates that log without an explicit `target:`, and each one is a
+    /// deliberate `preserve` in the table above. Pinned as a set so a crate
+    /// cannot be dropped from the vocabulary — which fails closed, but
+    /// closed means a reviewed component goes anonymous — and so a root
+    /// cannot be added without re-reading a pin.
+    #[test]
+    fn every_activated_default_target_crate_crosses_as_its_own_root() {
+        assert_eq!(
+            TARGET_CRATES,
+            [
+                "wacore",
+                "wacore_libsignal",
+                "wacore_noise",
+                "whatsapp_rust",
+                "whatsapp_rust_tokio_transport",
+            ],
+            "the reviewed vocabulary must be the activated graph's \
+             default-target crates, no more and no less"
+        );
+        // A bare root, and the module path a default-target call actually
+        // produces at each of the sites read off the pin.
+        for (emitted, module_path) in [
+            ("whatsapp_rust", "whatsapp_rust::message"),
+            ("wacore", "wacore::send"),
+            ("wacore_libsignal", "wacore_libsignal::protocol::session"),
+            ("wacore_noise", "wacore_noise::framing"),
+            (
+                "whatsapp_rust_tokio_transport",
+                "whatsapp_rust_tokio_transport::lib",
+            ),
+        ] {
+            assert_eq!(
+                safe_target(emitted),
+                emitted,
+                "an activated crate's own root must cross"
+            );
+            assert_eq!(
+                safe_target(module_path),
+                emitted,
+                "a module path must reduce to its crate's reviewed name"
+            );
+            // And the same reduction defuses a payload smuggled behind that
+            // crate's name, for every root in the table rather than one.
+            assert_eq!(
+                safe_target(&format!("{emitted}::972501234567")),
+                emitted,
+                "a runtime segment behind a reviewed root must not cross"
+            );
+        }
+        // The rest of the activated graph emits nothing on the default
+        // target, so its roots are absent by decision, not by oversight:
+        // `wacore_appstate` logs only through `target: "AppState"`, and the
+        // other four do not depend on `log` at all.
+        for absent in [
+            "wacore_appstate",
+            "wacore_binary",
+            "wacore_derive",
+            "waproto",
+            "whatsapp_rust_ureq_http_client",
+        ] {
+            assert_eq!(
+                safe_target(absent),
+                REDACTED_TARGET,
+                "a package with no default-target call must not be in the \
+                 vocabulary: {absent}"
+            );
+        }
+        assert_eq!(
+            safe_target("AppState"),
+            "AppState",
+            "`wacore-appstate`'s records cross by their literal instead"
+        );
     }
 
     /// Everything outside the reviewed tables is replaced whole — no

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -52,15 +52,26 @@ pub fn install_global_subscriber(
         .with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-    crate::log_bridge::install();
+    // Fail loudly: the subscriber above is already installed, so a discarded
+    // error here would leave the daemon looking healthy while every
+    // dependency record stays missing.
+    crate::log_bridge::install_or_panic();
 }
 
+/// Test-only subscriber install. Best-effort by design: a test binary calls
+/// this once per test, and both the `tracing` global default and the `log`
+/// logger slot accept exactly one installation per process, so every call
+/// after the first necessarily fails and is deliberately ignored. Production
+/// daemons go through [`install_global_subscriber`], which panics instead.
+///
+/// Not part of the public API despite the `pub`: it is reachable only so
+/// other workspace crates' `#[cfg(test)]` modules can install the pipeline.
 #[doc(hidden)]
 pub fn try_install_capture_subscriber() {
     use tracing_subscriber::Registry;
     let subscriber = Registry::default().with(LogCaptureLayer);
     let _ = tracing::subscriber::set_global_default(subscriber);
-    crate::log_bridge::install();
+    crate::log_bridge::install_best_effort_for_tests();
 }
 
 /// Test support: install a process-global subscriber that hands every
@@ -622,6 +633,34 @@ mod tests {
             persisted.contains(crate::log_bridge::REDACTED),
             "the scrubbed payload must be marked, not silently elided: {persisted}"
         );
+    }
+
+    /// Blocker-2 contract: the production install path is loud when the
+    /// process-global `log` slot is already owned, because a discarded error
+    /// there leaves the tracing subscriber installed and the dependency
+    /// records permanently missing. The test-only path stays tolerant so a
+    /// shared test binary can call it once per test.
+    #[test]
+    fn log_bridge_install_is_loud_in_production_and_tolerant_in_tests() {
+        // Guarantee the slot is occupied regardless of test ordering: either
+        // this call wins it, or an earlier test already did.
+        crate::log_bridge::install_best_effort_for_tests();
+
+        let panicked = std::panic::catch_unwind(crate::log_bridge::install_or_panic);
+        let payload = panicked.expect_err(
+            "the production install path must not silently accept a conflicting logger",
+        );
+        let message = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .unwrap_or_default();
+        assert!(
+            message.contains("another logger already owns the process-global `log` slot"),
+            "the panic must name the conflict so an operator can act on it: {message:?}"
+        );
+
+        // The test-only path swallows the same failure by design.
+        crate::log_bridge::install_best_effort_for_tests();
     }
 
     /// Regression for dependency logs vanishing without a trace: transports

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -902,6 +902,190 @@ mod tests {
         );
     }
 
+    /// One default-target call site per activated crate, spelled as the
+    /// module path `log` derives from `module_path!()` when the call passes
+    /// no `target:`. Each is a real site at pin `cbcdd2a`; the expected root
+    /// is what `TARGET_CRATES` must reduce it to.
+    const ACTIVATED_CRATE_SITES: &[(&str, &str)] = &[
+        ("whatsapp_rust::message", "whatsapp_rust"),
+        ("wacore::send", "wacore"),
+        (
+            "wacore_libsignal::protocol::session_cipher",
+            "wacore_libsignal",
+        ),
+        ("wacore_noise::framing", "wacore_noise"),
+        (
+            "whatsapp_rust_tokio_transport",
+            "whatsapp_rust_tokio_transport",
+        ),
+    ];
+
+    /// Whether the fmt layer rendered a record under exactly this target.
+    /// `tracing_log` puts the bridged target back on the normalized metadata,
+    /// so the fmt line reads `DEBUG <target>: <message>`. Matched as a whole
+    /// token because a `contains` would let the `wacore` directive look
+    /// satisfied by a `wacore_libsignal` record, which is the distinction
+    /// these tests exist to make.
+    fn renders_target(out: &str, target: &str) -> bool {
+        let rendered = format!("{target}:");
+        out.split_whitespace().any(|token| token == rendered)
+    }
+
+    /// Every crate the `whatsapp-web` feature activates that logs without an
+    /// explicit `target:` must arrive at the real sinks under its own
+    /// reviewed root, not under the shared redaction marker.
+    ///
+    /// `module_path` and `file` are dropped at the boundary, so the target is
+    /// the only field left that says which component spoke. A crate missing
+    /// from `TARGET_CRATES` still fails closed — its record crosses as
+    /// `[third-party target redacted]` — but that makes an activated part of
+    /// the WhatsApp protocol stack indistinguishable from an unreviewed
+    /// transitive dependency, which is the opposite of what this bridge is
+    /// for. So the coverage is pinned against the locked graph rather than
+    /// left to the two crates that happened to be read first.
+    #[test]
+    fn every_activated_crate_reaches_the_sinks_under_its_own_root() {
+        let _writer_guard = crate::writer::WRITER_TEST_LOCK.lock();
+        let _hook_guard = crate::broadcast::HOOK_TEST_LOCK.lock();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = crate::config::LogConfig {
+            log_persistence: "rolling".into(),
+            log_persistence_max_entries: 1000,
+            ..crate::config::LogConfig::default()
+        };
+        crate::writer::init_from_config(&cfg, tmp.path());
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel(256);
+        crate::broadcast::set_broadcast_hook(tx);
+
+        crate::try_install_capture_subscriber();
+
+        let subscriber = tracing_subscriber::registry().with(LogCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            for (site, _) in ACTIVATED_CRATE_SITES {
+                log::warn!(target: *site, "{TRANSPORT_FAILURE}");
+            }
+        });
+
+        let mut broadcast = Vec::new();
+        while let Ok(value) = rx.try_recv() {
+            broadcast.push(value.to_string());
+        }
+        crate::broadcast::clear_broadcast_hook();
+
+        crate::writer::flush_for_test().unwrap();
+        let persisted =
+            std::fs::read_to_string(crate::writer::runtime_trace_path().unwrap()).unwrap();
+
+        let bridged: Vec<serde_json::Value> = persisted
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|value| value["attributes"]["log.target"].is_string())
+            .collect();
+        assert_eq!(
+            bridged.len(),
+            ACTIVATED_CRATE_SITES.len(),
+            "every activated crate's record must be persisted: {persisted}"
+        );
+        assert_eq!(
+            broadcast.len(),
+            ACTIVATED_CRATE_SITES.len(),
+            "every activated crate's record must also be broadcast: {broadcast:?}"
+        );
+
+        for ((site, root), record) in ACTIVATED_CRATE_SITES.iter().zip(&bridged) {
+            assert_eq!(
+                record["attributes"]["log.target"], *root,
+                "`{site}` must arrive under its crate's reviewed root, not the \
+                 redaction marker: {record}"
+            );
+            assert_eq!(
+                record["message"],
+                crate::log_bridge::REDACTED_MESSAGE,
+                "the message body is still withheld for every crate: {record}"
+            );
+            assert!(
+                record["attributes"]["log.module_path"].is_null()
+                    && record["attributes"]["log.file"].is_null(),
+                "the dropped channels stay dropped for every crate: {record}"
+            );
+            assert_eq!(
+                record["severity_text"], "WARN",
+                "severity survives for every crate: {record}"
+            );
+        }
+
+        // The other half of the decision: the packages in the same activated
+        // graph that emit nothing on the default target are absent from the
+        // vocabulary, so a record claiming their root is redacted like any
+        // other unreviewed one.
+        assert_eq!(
+            crate::log_bridge::TARGET_CRATES.len(),
+            ACTIVATED_CRATE_SITES.len(),
+            "the vocabulary and the reviewed call-site list must describe the \
+             same set of crates"
+        );
+    }
+
+    /// The filter contract per crate: a directive naming a crate selects that
+    /// crate's bridged records, and `EnvFilter` matches a directive target as
+    /// a prefix, so the family directives documented on `TARGET_CRATES`
+    /// (`wacore=debug`, `whatsapp_rust=debug`) reach the sibling crates whose
+    /// roots extend them. Pinned per directive rather than described, because
+    /// the reduction happens before the filters look and a missing root would
+    /// silently stop being addressable.
+    #[test]
+    fn each_activated_crate_is_selectable_by_its_own_directive() {
+        crate::try_install_capture_subscriber();
+
+        for (directive, expected) in [
+            (
+                "wacore",
+                &["wacore", "wacore_libsignal", "wacore_noise"][..],
+            ),
+            ("wacore_libsignal", &["wacore_libsignal"][..]),
+            ("wacore_noise", &["wacore_noise"][..]),
+            (
+                "whatsapp_rust",
+                &["whatsapp_rust", "whatsapp_rust_tokio_transport"][..],
+            ),
+            (
+                "whatsapp_rust_tokio_transport",
+                &["whatsapp_rust_tokio_transport"][..],
+            ),
+        ] {
+            let buf = BufMakeWriter::default();
+            let fmt_layer = fmt::layer()
+                .fmt_fields(RedactEphemeralFields)
+                .with_writer(buf.clone())
+                .with_ansi(false)
+                .event_format(AgentAliasFormatter::new())
+                .with_filter(EnvFilter::new(format!("{directive}=debug")));
+            let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+            tracing::subscriber::with_default(subscriber, || {
+                for (site, _) in ACTIVATED_CRATE_SITES {
+                    log::debug!(target: *site, "{TRANSPORT_FAILURE}");
+                }
+            });
+
+            let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+            for (_, root) in ACTIVATED_CRATE_SITES {
+                assert_eq!(
+                    renders_target(&out, root),
+                    expected.contains(root),
+                    "`RUST_LOG={directive}=debug` must {} `{root}`: {out:?}",
+                    if expected.contains(root) {
+                        "select"
+                    } else {
+                        "not select"
+                    }
+                );
+            }
+        }
+    }
+
     /// `log_enabled!` must answer with the active tracing filter, the way
     /// `tracing_log::LogTracer` does. The bridge sets `log`'s own max level to
     /// `Trace`, so an unconditional `enabled` makes every guarded diagnostic

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -664,27 +664,27 @@ mod tests {
         );
 
         // What the bridge is still worth: severity and provenance. The
-        // transport failure is now findable only by its target, which is the
-        // point — for a record logged without an explicit `target:` the
-        // target *is* the module path, so target plus line names the
-        // dependency call site precisely enough to read the wording from its
-        // own source.
+        // transport failure is findable by its crate's reviewed name — a
+        // module-path target reduces to the crate, since everything after
+        // `::` is a runtime string — plus its severity and line. The
+        // hand-written literals (`Client/PairCode` above) keep their full
+        // reviewed spelling.
         let failure = bridged
             .iter()
-            .find(|record| record["attributes"]["log.target"] == "whatsapp_rust::socket")
+            .find(|record| {
+                record["attributes"]["log.target"] == "whatsapp_rust"
+                    && record["severity_text"] == "WARN"
+                    && record["attributes"]["log.line"].as_u64().is_some()
+            })
             .unwrap_or_else(|| {
                 panic!(
                     "the dependency's transport failure must still be persisted, \
-                     addressable by its target: {persisted}"
+                     addressable by its crate name: {persisted}"
                 )
             });
         assert_eq!(
-            failure["severity_text"], "WARN",
-            "the failure must keep its severity: {failure}"
-        );
-        assert_eq!(
-            failure["attributes"]["log.target"], "whatsapp_rust::socket",
-            "the failure must keep the dependency's own target so RUST_LOG \
+            failure["attributes"]["log.target"], "whatsapp_rust",
+            "the failure must carry the crate's reviewed name so RUST_LOG \
              directives still address it: {failure}"
         );
         assert!(
@@ -716,12 +716,17 @@ mod tests {
     /// Markers a dependency could put in a record's metadata at runtime.
     /// Deliberately identifier-shaped for the two dropped channels: if
     /// `module_path` and `file` were sanitized rather than dropped, these
-    /// would sail through any charset rule. The target marker is wrapped in
-    /// characters outside the safe representation, which is what makes the
-    /// whole target collapse to the constant.
+    /// would sail through any charset rule.
     const DYNAMIC_TARGET_PAYLOAD: &str = "zeroclaw_dynamic_target_marker";
     const DYNAMIC_MODULE_PAYLOAD: &str = "zeroclaw_dynamic_module_marker";
     const DYNAMIC_FILE_PAYLOAD: &str = "zeroclaw_dynamic_file_marker";
+    /// Runtime targets that FIT the retired charset rule — bare numeric,
+    /// underscore-separated secret-shaped, identifier-shaped — and must be
+    /// stopped anyway: fitness is provenance against the reviewed tables,
+    /// not shape.
+    const NUMERIC_TARGET_PAYLOAD: &str = "31337000073313370001";
+    const SECRET_TARGET_PAYLOAD: &str = "sk_live_zeroclaw_marker_token";
+    const NAME_TARGET_PAYLOAD: &str = "ZeroclawDynamicNameMarker";
 
     /// The metadata half of the credential boundary, through the same real
     /// sinks: the global `LogCaptureLayer`, the rolling JSONL writer and the
@@ -765,11 +770,15 @@ mod tests {
         // `Location::caller()`. This is the shape a dependency reaches for
         // when it builds a record itself — which the `log` API permits.
         let dynamic_target = format!("dependency for {DYNAMIC_TARGET_PAYLOAD}!");
-        let over_long_target = "b".repeat(crate::log_bridge::MAX_TARGET_LEN + 1);
 
         let subscriber = tracing_subscriber::registry().with(LogCaptureLayer);
         tracing::subscriber::with_default(subscriber, || {
-            for target in [dynamic_target.as_str(), over_long_target.as_str()] {
+            for target in [
+                dynamic_target.as_str(),
+                NUMERIC_TARGET_PAYLOAD,
+                SECRET_TARGET_PAYLOAD,
+                NAME_TARGET_PAYLOAD,
+            ] {
                 log::logger().log(
                     &log::Record::builder()
                         .args(format_args!("third-party wording"))
@@ -801,7 +810,9 @@ mod tests {
                 ("target", DYNAMIC_TARGET_PAYLOAD),
                 ("module path", DYNAMIC_MODULE_PAYLOAD),
                 ("source file", DYNAMIC_FILE_PAYLOAD),
-                ("over-long target", over_long_target.as_str()),
+                ("phone-shaped numeric target", NUMERIC_TARGET_PAYLOAD),
+                ("secret-shaped target", SECRET_TARGET_PAYLOAD),
+                ("name-shaped target", NAME_TARGET_PAYLOAD),
                 ("message body", "third-party wording"),
             ] {
                 assert!(
@@ -820,7 +831,7 @@ mod tests {
             .collect();
         assert_eq!(
             bridged.len(),
-            2,
+            4,
             "a record with unsafe metadata must still be recorded, sanitized \
              rather than suppressed: {persisted}"
         );
@@ -848,8 +859,9 @@ mod tests {
 
         // That the sanitizer is not simply eating every target is pinned by
         // `dependency_records_reach_the_sinks_without_their_message_text`,
-        // which sees `Client/PairCode` and `whatsapp_rust::socket` reach both
-        // sinks verbatim through this same wiring.
+        // which sees `Client/PairCode` cross verbatim and
+        // `whatsapp_rust::socket` cross as its crate's reviewed name through
+        // this same wiring.
     }
 
     /// The other half of keeping `RUST_LOG` working: a bridged record must be
@@ -875,9 +887,14 @@ mod tests {
 
         let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
         assert!(
-            out.contains("whatsapp_rust::socket"),
+            out.contains("whatsapp_rust"),
             "`RUST_LOG=whatsapp_rust=debug` must still select the dependency's \
-             records by its own target: {out:?}"
+             records by its crate name: {out:?}"
+        );
+        assert!(
+            !out.contains("whatsapp_rust::socket"),
+            "the module path after `::` is a runtime string and must not \
+             survive into the emitted target: {out:?}"
         );
         assert!(
             !out.contains("some_other_dependency"),
@@ -923,6 +940,54 @@ mod tests {
                 "`log_enabled!` must be false for a target the filter excludes"
             );
         });
+    }
+
+    /// The production wiring is different, and the difference is intentional:
+    /// `install_global_subscriber` attaches its `EnvFilter`s *per layer*, and
+    /// a per-layer filter deliberately answers `Subscriber::enabled` with
+    /// `true`, deferring the real decision to `on_event` so the other layers
+    /// get their say. So under the production shape, `log_enabled!` is gated
+    /// by the process-wide max level but NOT by target-specific directives —
+    /// a dependency's guarded diagnostic may be built and then dropped at the
+    /// layer. Documented on `RedactingLogBridge::enabled`; this pins the
+    /// behavior with the production filter shape so the limitation stays a
+    /// described one rather than a silent one.
+    #[test]
+    fn log_enabled_under_per_layer_filters_is_level_gated_only() {
+        crate::try_install_capture_subscriber();
+
+        let buf = BufMakeWriter::default();
+        let fmt_layer = fmt::layer()
+            .fmt_fields(RedactEphemeralFields)
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .event_format(AgentAliasFormatter::new())
+            .with_filter(EnvFilter::new("whatsapp_rust=debug"));
+        let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Only the target half is pinnable here: the other gate,
+            // `LevelFilter::current()`, is a process-global hint this scoped
+            // subscriber cannot isolate from the test binary's global one.
+            // The target half answers `true` by design: `Filtered::enabled`
+            // defers, and the layer drops the event later.
+            assert!(
+                log::log_enabled!(target: "unmatched_dependency_target", log::Level::Debug),
+                "a per-layer filter cannot make `log_enabled!` target-aware; \
+                 if this starts failing, the limitation documented on \
+                 `RedactingLogBridge::enabled` has changed"
+            );
+            // And the drop happens where it belongs — the record built after
+            // that `true` still never reaches the layer's output.
+            log::debug!(target: "unmatched_dependency_target", "guarded diagnostic");
+        });
+
+        let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            out.is_empty(),
+            "the unmatched record must be dropped by the per-layer filter \
+             even though `log_enabled!` said yes: {out:?}"
+        );
     }
 
     /// Blocker-2 contract: the production install path is loud when the
@@ -980,7 +1045,7 @@ mod tests {
 
         tracing::subscriber::with_default(subscriber, || {
             log::warn!(
-                target: "zeroclaw_log_bridge_probe",
+                target: "whatsapp_rust::bridge_probe",
                 "dependency log facade marker"
             );
         });
@@ -1008,9 +1073,14 @@ mod tests {
             "bridged record must keep its severity: {line:?}"
         );
         assert!(
-            line.contains("zeroclaw_log_bridge_probe"),
-            "bridged record must keep the dependency's own target so RUST_LOG \
+            line.contains("whatsapp_rust"),
+            "bridged record must carry the crate's reviewed name so RUST_LOG \
              directives still address it: {line:?}"
+        );
+        assert!(
+            !line.contains("bridge_probe"),
+            "the module path after `::` is a runtime string and must not \
+             survive into the emitted target: {line:?}"
         );
         assert!(
             !line.contains("log.target"),

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -499,15 +499,28 @@ mod tests {
     /// Message shapes lifted from `whatsapp-rust` at the revision this
     /// workspace pins (`cbcdd2a`): `src/pair_code.rs` logs the configured
     /// phone number and the generated pair code at `INFO`, `src/message.rs`
-    /// logs JIDs, and the transport logs a genuinely useful failure with no
-    /// identifier in it at all.
+    /// logs JIDs, and the transport logs a failure with no identifier in it
+    /// at all.
     const PAIR_PHONE: &str = "972501234567";
     const PAIR_CODE: &str = "3K7XW2QZ";
     /// A pair code that drew no digits out of the Crockford alphabet — about
-    /// one code in twenty. A digits-only rule would leak it.
+    /// one code in twenty, and the shape a digits-only rule would leak.
     const PAIR_CODE_ALL_LETTERS: &str = "ZXKWQTRV";
     const PEER_JID: &str = "972501234567@s.whatsapp.net";
     const TRANSPORT_FAILURE: &str = "websocket read failed: connection reset by peer";
+
+    /// Free-text shapes that no message heuristic can classify: an ordinary
+    /// given name, a mixed-case brand, a non-ASCII name, and a secret with no
+    /// digit and no `@` in it. Each is indistinguishable from prose by
+    /// inspection, which is why the boundary does not inspect.
+    const PERSON_NAME: &str = "Alice";
+    const BRAND_NAME: &str = "Acme";
+    const UNICODE_NAME: &str = "Zoë Müller";
+    const NONNUMERIC_SECRET: &str = "sk_live_zzyxwvutsrq";
+
+    /// Every third-party `log` record emitted by the body below. Pins that
+    /// the bridge forwards each one as a record rather than dropping it.
+    const BRIDGED_RECORD_COUNT: usize = 8;
 
     /// The credential boundary, exercised through the real sinks rather than
     /// the fmt probe: the global `LogCaptureLayer`, `writer::record_event`'s
@@ -519,11 +532,18 @@ mod tests {
     /// phone-number lines would land in `runtime-trace.jsonl` and on the live
     /// stream — bypassing the `LoginEvent::PairCode` -> `ephemeral_attrs`
     /// boundary and `record_event`'s guarantee that pairing credentials are
-    /// never persisted. The scrubbing bridge must keep those markers out of
-    /// both sinks while the useful transport failure still arrives with its
-    /// severity and its originating target intact.
+    /// never persisted.
+    ///
+    /// The bridge instead drops the message body of every third-party record
+    /// and forwards only its metadata, so this asserts both halves of that
+    /// bargain: no fragment of any dependency message text reaches either
+    /// sink — not the credentials, not the names and secrets a heuristic
+    /// would have waved through, not even the prose around them — while the
+    /// severity, the dependency's own target, its module path and its source
+    /// `file:line` all arrive intact, which is what makes the surviving
+    /// record worth persisting.
     #[test]
-    fn dependency_records_reach_the_sinks_without_pairing_credentials() {
+    fn dependency_records_reach_the_sinks_without_their_message_text() {
         let _writer_guard = crate::writer::WRITER_TEST_LOCK.lock();
         let _hook_guard = crate::broadcast::HOOK_TEST_LOCK.lock();
 
@@ -559,6 +579,18 @@ mod tests {
                 target: "whatsapp_rust::message",
                 "Failed to parse message info (from={PEER_JID}): bad MAC"
             );
+            log::info!(
+                target: "whatsapp_rust::message",
+                "delivering receipt to contact {PERSON_NAME} of {BRAND_NAME}"
+            );
+            log::info!(
+                target: "whatsapp_rust::message",
+                "push name updated to {UNICODE_NAME}"
+            );
+            log::warn!(
+                target: "whatsapp_rust::handshake",
+                "rejected credential {NONNUMERIC_SECRET}"
+            );
             log::warn!(
                 target: "whatsapp_rust::socket",
                 "{TRANSPORT_FAILURE}"
@@ -584,6 +616,18 @@ mod tests {
                 ("pair code", PAIR_CODE),
                 ("all-letter pair code", PAIR_CODE_ALL_LETTERS),
                 ("peer JID", PEER_JID),
+                // The four shapes a message heuristic cannot rule on. Each
+                // one is plain prose to any classifier, and each one used to
+                // cross verbatim.
+                ("person name", PERSON_NAME),
+                ("brand name", BRAND_NAME),
+                ("non-ASCII name", UNICODE_NAME),
+                ("nonnumeric secret", NONNUMERIC_SECRET),
+                // Not just the payloads: no third-party message text at all,
+                // including the prose that framed them and a failure line
+                // with no identifier in it.
+                ("message prose", "Starting pair code authentication"),
+                ("identifier-free failure text", TRANSPORT_FAILURE),
             ] {
                 assert!(
                     !body.contains(marker),
@@ -592,19 +636,43 @@ mod tests {
             }
         }
 
-        // The useful failure survives, with severity and provenance.
-        let failure = persisted
+        // Every emission still arrives as a record: the text is withheld, the
+        // event is not suppressed.
+        let bridged: Vec<serde_json::Value> = persisted
             .lines()
             .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-            .find(|value| {
-                value["message"]
-                    .as_str()
-                    .is_some_and(|m| m.contains(TRANSPORT_FAILURE))
-            })
+            .filter(|value| value["attributes"]["log.target"].is_string())
+            .collect();
+        assert_eq!(
+            bridged.len(),
+            BRIDGED_RECORD_COUNT,
+            "every third-party record must still be persisted, message withheld \
+             rather than event dropped: {persisted}"
+        );
+        for record in &bridged {
+            assert_eq!(
+                record["message"],
+                crate::log_bridge::REDACTED_MESSAGE,
+                "every bridged message body must be the fixed marker: {record}"
+            );
+        }
+        assert_eq!(
+            broadcast.len(),
+            BRIDGED_RECORD_COUNT,
+            "every third-party record must also reach the live broadcast: {broadcast:?}"
+        );
+
+        // What the bridge is still worth: severity and provenance. The
+        // transport failure is now findable only by its target, which is the
+        // point — target plus `file:line` names the dependency call site
+        // precisely enough to read the wording from its own source.
+        let failure = bridged
+            .iter()
+            .find(|record| record["attributes"]["log.target"] == "whatsapp_rust::socket")
             .unwrap_or_else(|| {
                 panic!(
-                    "the dependency's transport failure must still be persisted \
-                     verbatim: {persisted}"
+                    "the dependency's transport failure must still be persisted, \
+                     addressable by its target: {persisted}"
                 )
             });
         assert_eq!(
@@ -617,21 +685,30 @@ mod tests {
              directives still address it: {failure}"
         );
         assert!(
-            broadcast
-                .iter()
-                .any(|frame| frame.contains(TRANSPORT_FAILURE)),
-            "the failure must also reach the live broadcast: {broadcast:?}"
+            failure["attributes"]["log.module_path"]
+                .as_str()
+                .is_some_and(|path| path.starts_with("zeroclaw_log")),
+            "the failure must keep its module path: {failure}"
+        );
+        assert!(
+            failure["attributes"]["log.file"]
+                .as_str()
+                .is_some_and(|file| file.ends_with("subscriber.rs")),
+            "the failure must keep its source file: {failure}"
+        );
+        assert!(
+            failure["attributes"]["log.line"].as_u64().is_some(),
+            "the failure must keep its source line: {failure}"
         );
 
-        // The redacted lines are still visible as records — the operator sees
-        // that pairing happened, just not the credential.
-        assert!(
-            persisted.contains("Starting pair code authentication for phone:"),
-            "a scrubbed record must stay visible, not be dropped: {persisted}"
-        );
-        assert!(
-            persisted.contains(crate::log_bridge::REDACTED),
-            "the scrubbed payload must be marked, not silently elided: {persisted}"
+        // Severities are per-record, not flattened onto the marker.
+        assert_eq!(
+            bridged
+                .iter()
+                .filter(|record| record["severity_text"] == "INFO")
+                .count(),
+            5,
+            "each record must keep its own severity: {persisted}"
         );
     }
 
@@ -671,6 +748,10 @@ mod tests {
     /// verbosity. Installing this crate's subscriber machinery must be
     /// enough on its own for a bare `log::warn!` to arrive as a tracing
     /// event; removing the bridge install makes this test go silent.
+    ///
+    /// It arrives with its text withheld: stderr is a sink like any other, so
+    /// the bridged line shows the redaction marker under the dependency's own
+    /// target and severity, never the dependency's wording.
     #[test]
     fn log_facade_records_reach_the_subscriber() {
         // Real entry point: installs the capture layer *and* the bridge.
@@ -692,9 +773,13 @@ mod tests {
         });
 
         let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            !out.contains("dependency log facade marker"),
+            "the dependency's own message text must not reach stderr either: {out:?}"
+        );
         let line = out
             .lines()
-            .find(|line| line.contains("dependency log facade marker"))
+            .find(|line| line.contains(crate::log_bridge::REDACTED_MESSAGE))
             .unwrap_or_else(|| {
                 panic!(
                     "a `log` record must reach the tracing subscriber; without the \

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -52,6 +52,7 @@ pub fn install_global_subscriber(
         .with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    install_log_bridge();
 }
 
 #[doc(hidden)]
@@ -59,6 +60,33 @@ pub fn try_install_capture_subscriber() {
     use tracing_subscriber::Registry;
     let subscriber = Registry::default().with(LogCaptureLayer);
     let _ = tracing::subscriber::set_global_default(subscriber);
+    install_log_bridge();
+}
+
+/// Route records emitted through the `log` facade into `tracing`.
+///
+/// Dependencies log through `log`, not `tracing` — `whatsapp-rust` and
+/// friends. Installing a `tracing` subscriber does nothing for them: `log`
+/// keeps its own global logger slot, and while that slot is empty every
+/// `log::warn!` in the dependency tree is discarded at the macro's own
+/// max-level check. Those records reached neither stderr nor the JSONL
+/// trace, so a transport failure inside a dependency left no evidence at
+/// any verbosity.
+///
+/// `LogTracer` fills that slot and re-dispatches each record as a `tracing`
+/// event against the current subscriber, so bridged records go through the
+/// same `EnvFilter` directives, the same `LogCaptureLayer` persistence and
+/// the same alias-prefixed stderr formatting as native `record!` emissions.
+/// It sets the `log` max level to `Trace` on purpose: `log`-side filtering
+/// would silently pre-empt the `RUST_LOG` directives, so the tracing filters
+/// stay the single place that decides.
+///
+/// Idempotent. `log` permits exactly one global logger per process, so a
+/// second call — a re-entrant setup, or the next test in a shared test
+/// binary — returns `Err` and is deliberately discarded, mirroring how
+/// `try_install_capture_subscriber` treats a repeated `set_global_default`.
+fn install_log_bridge() {
+    let _ = tracing_log::LogTracer::init();
 }
 
 /// Test support: install a process-global subscriber that hands every
@@ -480,6 +508,64 @@ mod tests {
         assert!(
             !out.contains(F_EPHEMERAL_ATTRS),
             "bool-recorded ephemeral field leaked: {out:?}"
+        );
+    }
+
+    /// Regression for dependency logs vanishing without a trace: transports
+    /// like `whatsapp-rust` emit through the `log` facade, not `tracing`.
+    /// Installing a `tracing` subscriber leaves `log`'s own global logger
+    /// slot empty, and every such record used to be discarded at the macro's
+    /// max-level check — reaching neither stderr nor the JSONL trace at any
+    /// verbosity. Installing this crate's subscriber machinery must be
+    /// enough on its own for a bare `log::warn!` to arrive as a tracing
+    /// event; removing the `LogTracer` init makes this test go silent.
+    #[test]
+    fn log_facade_records_reach_the_subscriber() {
+        // Real entry point: installs the capture layer *and* the bridge.
+        crate::try_install_capture_subscriber();
+
+        let buf = BufMakeWriter::default();
+        let fmt_layer = fmt::layer()
+            .fmt_fields(RedactEphemeralFields)
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .event_format(AgentAliasFormatter::new());
+        let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            log::warn!(
+                target: "zeroclaw_log_bridge_probe",
+                "dependency log facade marker"
+            );
+        });
+
+        let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        let line = out
+            .lines()
+            .find(|line| line.contains("dependency log facade marker"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "a `log` record must reach the tracing subscriber; without the \
+                     LogTracer bridge it is dropped at the log facade: {out:?}"
+                )
+            });
+        assert!(
+            line.starts_with("[system] "),
+            "bridged record must go through the alias-prefixing formatter: {line:?}"
+        );
+        assert!(
+            line.contains("WARN"),
+            "bridged record must keep its severity: {line:?}"
+        );
+        assert!(
+            line.contains("zeroclaw_log_bridge_probe"),
+            "bridged record must keep the dependency's own target so RUST_LOG \
+             directives still address it: {line:?}"
+        );
+        assert!(
+            !line.contains("log.target"),
+            "normalized metadata must replace the raw `log.*` transport fields \
+             rather than printing them alongside: {line:?}"
         );
     }
 }

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -535,13 +535,14 @@ mod tests {
     /// never persisted.
     ///
     /// The bridge instead drops the message body of every third-party record
-    /// and forwards only its metadata, so this asserts both halves of that
-    /// bargain: no fragment of any dependency message text reaches either
-    /// sink — not the credentials, not the names and secrets a heuristic
-    /// would have waved through, not even the prose around them — while the
-    /// severity, the dependency's own target, its module path and its source
-    /// `file:line` all arrive intact, which is what makes the surviving
-    /// record worth persisting.
+    /// and forwards only bounded metadata, so this asserts both halves of
+    /// that bargain: no fragment of any dependency message text reaches
+    /// either sink — not the credentials, not the names and secrets a
+    /// heuristic would have waved through, not even the prose around them —
+    /// while the severity, the dependency's own target and its source line
+    /// all arrive intact, which is what makes the surviving record worth
+    /// persisting. The unbounded `module_path` and `file` channels are gone;
+    /// the `log_bridge` module docs give the reasoning.
     #[test]
     fn dependency_records_reach_the_sinks_without_their_message_text() {
         let _writer_guard = crate::writer::WRITER_TEST_LOCK.lock();
@@ -664,8 +665,10 @@ mod tests {
 
         // What the bridge is still worth: severity and provenance. The
         // transport failure is now findable only by its target, which is the
-        // point — target plus `file:line` names the dependency call site
-        // precisely enough to read the wording from its own source.
+        // point — for a record logged without an explicit `target:` the
+        // target *is* the module path, so target plus line names the
+        // dependency call site precisely enough to read the wording from its
+        // own source.
         let failure = bridged
             .iter()
             .find(|record| record["attributes"]["log.target"] == "whatsapp_rust::socket")
@@ -685,16 +688,14 @@ mod tests {
              directives still address it: {failure}"
         );
         assert!(
-            failure["attributes"]["log.module_path"]
-                .as_str()
-                .is_some_and(|path| path.starts_with("zeroclaw_log")),
-            "the failure must keep its module path: {failure}"
+            failure["attributes"]["log.module_path"].is_null(),
+            "the module path is an unbounded string channel and must not be \
+             forwarded at all: {failure}"
         );
         assert!(
-            failure["attributes"]["log.file"]
-                .as_str()
-                .is_some_and(|file| file.ends_with("subscriber.rs")),
-            "the failure must keep its source file: {failure}"
+            failure["attributes"]["log.file"].is_null(),
+            "the source file is an unbounded string channel and must not be \
+             forwarded at all: {failure}"
         );
         assert!(
             failure["attributes"]["log.line"].as_u64().is_some(),
@@ -710,6 +711,218 @@ mod tests {
             5,
             "each record must keep its own severity: {persisted}"
         );
+    }
+
+    /// Markers a dependency could put in a record's metadata at runtime.
+    /// Deliberately identifier-shaped for the two dropped channels: if
+    /// `module_path` and `file` were sanitized rather than dropped, these
+    /// would sail through any charset rule. The target marker is wrapped in
+    /// characters outside the safe representation, which is what makes the
+    /// whole target collapse to the constant.
+    const DYNAMIC_TARGET_PAYLOAD: &str = "zeroclaw_dynamic_target_marker";
+    const DYNAMIC_MODULE_PAYLOAD: &str = "zeroclaw_dynamic_module_marker";
+    const DYNAMIC_FILE_PAYLOAD: &str = "zeroclaw_dynamic_file_marker";
+
+    /// The metadata half of the credential boundary, through the same real
+    /// sinks: the global `LogCaptureLayer`, the rolling JSONL writer and the
+    /// broadcast hook.
+    ///
+    /// `log::RecordBuilder` takes a borrowed `&str` for `target`,
+    /// `module_path` and `file`, and the `log!` macros take a `target:`
+    /// expression rather than a literal, so a dependency can put a runtime
+    /// value in any of the three. Forwarding them as trusted provenance
+    /// therefore reopens the same persistence path the message-body
+    /// redaction closes: `tracing_log` normalizes them into `log.target` /
+    /// `log.module_path` / `log.file`, `LogCaptureLayer` puts unrecognized
+    /// fields into the attributes map, and `writer::record_event` sends that
+    /// map to both broadcast and disk.
+    ///
+    /// So: `module_path` and `file` are dropped outright and must not appear
+    /// even when their content is a plain identifier, and a target outside
+    /// the documented safe representation is replaced whole rather than
+    /// trimmed to its acceptable characters.
+    #[test]
+    fn dynamic_record_metadata_never_reaches_the_sinks() {
+        let _writer_guard = crate::writer::WRITER_TEST_LOCK.lock();
+        let _hook_guard = crate::broadcast::HOOK_TEST_LOCK.lock();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = crate::config::LogConfig {
+            log_persistence: "rolling".into(),
+            log_persistence_max_entries: 1000,
+            ..crate::config::LogConfig::default()
+        };
+        crate::writer::init_from_config(&cfg, tmp.path());
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel(256);
+        crate::broadcast::set_broadcast_hook(tx);
+
+        // Real entry point: installs the capture layer *and* the bridge.
+        crate::try_install_capture_subscriber();
+
+        // Built by hand rather than through `log::warn!`, because the macro
+        // fills `module_path` and `file` from `module_path!()` and
+        // `Location::caller()`. This is the shape a dependency reaches for
+        // when it builds a record itself — which the `log` API permits.
+        let dynamic_target = format!("dependency for {DYNAMIC_TARGET_PAYLOAD}!");
+        let over_long_target = "b".repeat(crate::log_bridge::MAX_TARGET_LEN + 1);
+
+        let subscriber = tracing_subscriber::registry().with(LogCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            for target in [dynamic_target.as_str(), over_long_target.as_str()] {
+                log::logger().log(
+                    &log::Record::builder()
+                        .args(format_args!("third-party wording"))
+                        .level(log::Level::Warn)
+                        .target(target)
+                        .module_path(Some(DYNAMIC_MODULE_PAYLOAD))
+                        .file(Some(DYNAMIC_FILE_PAYLOAD))
+                        .line(Some(4242))
+                        .build(),
+                );
+            }
+        });
+
+        let mut broadcast = Vec::new();
+        while let Ok(value) = rx.try_recv() {
+            broadcast.push(value.to_string());
+        }
+        crate::broadcast::clear_broadcast_hook();
+
+        crate::writer::flush_for_test().unwrap();
+        let persisted =
+            std::fs::read_to_string(crate::writer::runtime_trace_path().unwrap()).unwrap();
+
+        for (sink, body) in [
+            ("persisted runtime-trace.jsonl", persisted.as_str()),
+            ("live broadcast", broadcast.concat().as_str()),
+        ] {
+            for (what, marker) in [
+                ("target", DYNAMIC_TARGET_PAYLOAD),
+                ("module path", DYNAMIC_MODULE_PAYLOAD),
+                ("source file", DYNAMIC_FILE_PAYLOAD),
+                ("over-long target", over_long_target.as_str()),
+                ("message body", "third-party wording"),
+            ] {
+                assert!(
+                    !body.contains(marker),
+                    "a runtime value in a record's {what} must not reach the {sink}: {body}"
+                );
+            }
+        }
+
+        // Not silently dropped: the records still arrive, carrying the two
+        // constants and nothing the caller chose but the severity and line.
+        let bridged: Vec<serde_json::Value> = persisted
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|value| value["attributes"]["log.target"].is_string())
+            .collect();
+        assert_eq!(
+            bridged.len(),
+            2,
+            "a record with unsafe metadata must still be recorded, sanitized \
+             rather than suppressed: {persisted}"
+        );
+        for record in &bridged {
+            assert_eq!(
+                record["attributes"]["log.target"],
+                crate::log_bridge::REDACTED_TARGET,
+                "an unsafe target must be replaced whole, not trimmed: {record}"
+            );
+            assert_eq!(
+                record["message"],
+                crate::log_bridge::REDACTED_MESSAGE,
+                "the message body must still be the fixed marker: {record}"
+            );
+            assert!(
+                record["attributes"]["log.module_path"].is_null()
+                    && record["attributes"]["log.file"].is_null(),
+                "the dropped channels must be absent, not sanitized: {record}"
+            );
+            assert_eq!(
+                record["attributes"]["log.line"], 4242,
+                "the numeric line still crosses: {record}"
+            );
+        }
+
+        // That the sanitizer is not simply eating every target is pinned by
+        // `dependency_records_reach_the_sinks_without_their_message_text`,
+        // which sees `Client/PairCode` and `whatsapp_rust::socket` reach both
+        // sinks verbatim through this same wiring.
+    }
+
+    /// The other half of keeping `RUST_LOG` working: a bridged record must be
+    /// selected by an `EnvFilter` directive naming the dependency's own
+    /// target, and a record from another target must not be.
+    #[test]
+    fn env_filter_directives_still_select_bridged_records_by_target() {
+        crate::try_install_capture_subscriber();
+
+        let buf = BufMakeWriter::default();
+        let fmt_layer = fmt::layer()
+            .fmt_fields(RedactEphemeralFields)
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .event_format(AgentAliasFormatter::new())
+            .with_filter(EnvFilter::new("whatsapp_rust=debug"));
+        let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            log::debug!(target: "whatsapp_rust::socket", "selected");
+            log::debug!(target: "some_other_dependency", "not selected");
+        });
+
+        let out = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            out.contains("whatsapp_rust::socket"),
+            "`RUST_LOG=whatsapp_rust=debug` must still select the dependency's \
+             records by its own target: {out:?}"
+        );
+        assert!(
+            !out.contains("some_other_dependency"),
+            "a target the directive does not name must stay filtered out: {out:?}"
+        );
+    }
+
+    /// `log_enabled!` must answer with the active tracing filter, the way
+    /// `tracing_log::LogTracer` does. The bridge sets `log`'s own max level to
+    /// `Trace`, so an unconditional `enabled` makes every guarded diagnostic
+    /// in the dependency tree look wanted: the caller builds the record and
+    /// evaluates its formatting arguments, and only then does the dispatcher
+    /// throw it away.
+    ///
+    /// The subscriber here filters globally rather than per layer, because
+    /// `Subscriber::enabled` is the only thing `log` can ask and per-layer
+    /// filters deliberately do not answer through it — see the note on
+    /// `RedactingLogBridge::enabled`.
+    #[test]
+    fn log_enabled_agrees_with_the_active_tracing_filter() {
+        crate::try_install_capture_subscriber();
+
+        let off = tracing_subscriber::registry()
+            .with(LogCaptureLayer)
+            .with(EnvFilter::new("off"));
+        tracing::subscriber::with_default(off, || {
+            assert!(
+                !log::log_enabled!(target: "unmatched_dependency_target", log::Level::Info),
+                "`log_enabled!` must be false under an `off` filter"
+            );
+        });
+
+        let selective = tracing_subscriber::registry()
+            .with(LogCaptureLayer)
+            .with(EnvFilter::new("whatsapp_rust=debug"));
+        tracing::subscriber::with_default(selective, || {
+            assert!(
+                log::log_enabled!(target: "whatsapp_rust", log::Level::Debug),
+                "`log_enabled!` must be true for a target the filter selects"
+            );
+            assert!(
+                !log::log_enabled!(target: "unmatched_dependency_target", log::Level::Debug),
+                "`log_enabled!` must be false for a target the filter excludes"
+            );
+        });
     }
 
     /// Blocker-2 contract: the production install path is loud when the

--- a/crates/zeroclaw-log/src/subscriber.rs
+++ b/crates/zeroclaw-log/src/subscriber.rs
@@ -52,7 +52,7 @@ pub fn install_global_subscriber(
         .with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-    install_log_bridge();
+    crate::log_bridge::install();
 }
 
 #[doc(hidden)]
@@ -60,33 +60,7 @@ pub fn try_install_capture_subscriber() {
     use tracing_subscriber::Registry;
     let subscriber = Registry::default().with(LogCaptureLayer);
     let _ = tracing::subscriber::set_global_default(subscriber);
-    install_log_bridge();
-}
-
-/// Route records emitted through the `log` facade into `tracing`.
-///
-/// Dependencies log through `log`, not `tracing` — `whatsapp-rust` and
-/// friends. Installing a `tracing` subscriber does nothing for them: `log`
-/// keeps its own global logger slot, and while that slot is empty every
-/// `log::warn!` in the dependency tree is discarded at the macro's own
-/// max-level check. Those records reached neither stderr nor the JSONL
-/// trace, so a transport failure inside a dependency left no evidence at
-/// any verbosity.
-///
-/// `LogTracer` fills that slot and re-dispatches each record as a `tracing`
-/// event against the current subscriber, so bridged records go through the
-/// same `EnvFilter` directives, the same `LogCaptureLayer` persistence and
-/// the same alias-prefixed stderr formatting as native `record!` emissions.
-/// It sets the `log` max level to `Trace` on purpose: `log`-side filtering
-/// would silently pre-empt the `RUST_LOG` directives, so the tracing filters
-/// stay the single place that decides.
-///
-/// Idempotent. `log` permits exactly one global logger per process, so a
-/// second call — a re-entrant setup, or the next test in a shared test
-/// binary — returns `Err` and is deliberately discarded, mirroring how
-/// `try_install_capture_subscriber` treats a repeated `set_global_default`.
-fn install_log_bridge() {
-    let _ = tracing_log::LogTracer::init();
+    crate::log_bridge::install();
 }
 
 /// Test support: install a process-global subscriber that hands every
@@ -511,6 +485,145 @@ mod tests {
         );
     }
 
+    /// Message shapes lifted from `whatsapp-rust` at the revision this
+    /// workspace pins (`cbcdd2a`): `src/pair_code.rs` logs the configured
+    /// phone number and the generated pair code at `INFO`, `src/message.rs`
+    /// logs JIDs, and the transport logs a genuinely useful failure with no
+    /// identifier in it at all.
+    const PAIR_PHONE: &str = "972501234567";
+    const PAIR_CODE: &str = "3K7XW2QZ";
+    /// A pair code that drew no digits out of the Crockford alphabet — about
+    /// one code in twenty. A digits-only rule would leak it.
+    const PAIR_CODE_ALL_LETTERS: &str = "ZXKWQTRV";
+    const PEER_JID: &str = "972501234567@s.whatsapp.net";
+    const TRANSPORT_FAILURE: &str = "websocket read failed: connection reset by peer";
+
+    /// The credential boundary, exercised through the real sinks rather than
+    /// the fmt probe: the global `LogCaptureLayer`, `writer::record_event`'s
+    /// rolling JSONL persistence, and the broadcast hook, wired exactly as
+    /// the daemon wires them.
+    ///
+    /// A bare `LogTracer` would hand every third-party `log` message to those
+    /// sinks as ordinary event text, so `whatsapp-rust`'s `INFO` pair-code and
+    /// phone-number lines would land in `runtime-trace.jsonl` and on the live
+    /// stream — bypassing the `LoginEvent::PairCode` -> `ephemeral_attrs`
+    /// boundary and `record_event`'s guarantee that pairing credentials are
+    /// never persisted. The scrubbing bridge must keep those markers out of
+    /// both sinks while the useful transport failure still arrives with its
+    /// severity and its originating target intact.
+    #[test]
+    fn dependency_records_reach_the_sinks_without_pairing_credentials() {
+        let _writer_guard = crate::writer::WRITER_TEST_LOCK.lock();
+        let _hook_guard = crate::broadcast::HOOK_TEST_LOCK.lock();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = crate::config::LogConfig {
+            log_persistence: "rolling".into(),
+            log_persistence_max_entries: 1000,
+            ..crate::config::LogConfig::default()
+        };
+        crate::writer::init_from_config(&cfg, tmp.path());
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel(256);
+        crate::broadcast::set_broadcast_hook(tx);
+
+        // Real entry point: installs the capture layer *and* the bridge.
+        crate::try_install_capture_subscriber();
+
+        let subscriber = tracing_subscriber::registry().with(LogCaptureLayer);
+        tracing::subscriber::with_default(subscriber, || {
+            log::info!(
+                target: "Client/PairCode",
+                "Starting pair code authentication for phone: {PAIR_PHONE}"
+            );
+            log::info!(
+                target: "Client/PairCode",
+                "Stage 1 complete, waiting for phone confirmation. Code: {PAIR_CODE}"
+            );
+            log::info!(
+                target: "Client/PairCode",
+                "Stage 1 complete, waiting for phone confirmation. Code: {PAIR_CODE_ALL_LETTERS}"
+            );
+            log::warn!(
+                target: "whatsapp_rust::message",
+                "Failed to parse message info (from={PEER_JID}): bad MAC"
+            );
+            log::warn!(
+                target: "whatsapp_rust::socket",
+                "{TRANSPORT_FAILURE}"
+            );
+        });
+
+        let mut broadcast = Vec::new();
+        while let Ok(value) = rx.try_recv() {
+            broadcast.push(value.to_string());
+        }
+        crate::broadcast::clear_broadcast_hook();
+
+        crate::writer::flush_for_test().unwrap();
+        let persisted =
+            std::fs::read_to_string(crate::writer::runtime_trace_path().unwrap()).unwrap();
+
+        for (sink, body) in [
+            ("persisted runtime-trace.jsonl", persisted.as_str()),
+            ("live broadcast", broadcast.concat().as_str()),
+        ] {
+            for (what, marker) in [
+                ("phone number", PAIR_PHONE),
+                ("pair code", PAIR_CODE),
+                ("all-letter pair code", PAIR_CODE_ALL_LETTERS),
+                ("peer JID", PEER_JID),
+            ] {
+                assert!(
+                    !body.contains(marker),
+                    "third-party {what} must not reach the {sink}: {body}"
+                );
+            }
+        }
+
+        // The useful failure survives, with severity and provenance.
+        let failure = persisted
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .find(|value| {
+                value["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains(TRANSPORT_FAILURE))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "the dependency's transport failure must still be persisted \
+                     verbatim: {persisted}"
+                )
+            });
+        assert_eq!(
+            failure["severity_text"], "WARN",
+            "the failure must keep its severity: {failure}"
+        );
+        assert_eq!(
+            failure["attributes"]["log.target"], "whatsapp_rust::socket",
+            "the failure must keep the dependency's own target so RUST_LOG \
+             directives still address it: {failure}"
+        );
+        assert!(
+            broadcast
+                .iter()
+                .any(|frame| frame.contains(TRANSPORT_FAILURE)),
+            "the failure must also reach the live broadcast: {broadcast:?}"
+        );
+
+        // The redacted lines are still visible as records — the operator sees
+        // that pairing happened, just not the credential.
+        assert!(
+            persisted.contains("Starting pair code authentication for phone:"),
+            "a scrubbed record must stay visible, not be dropped: {persisted}"
+        );
+        assert!(
+            persisted.contains(crate::log_bridge::REDACTED),
+            "the scrubbed payload must be marked, not silently elided: {persisted}"
+        );
+    }
+
     /// Regression for dependency logs vanishing without a trace: transports
     /// like `whatsapp-rust` emit through the `log` facade, not `tracing`.
     /// Installing a `tracing` subscriber leaves `log`'s own global logger
@@ -518,7 +631,7 @@ mod tests {
     /// max-level check — reaching neither stderr nor the JSONL trace at any
     /// verbosity. Installing this crate's subscriber machinery must be
     /// enough on its own for a bare `log::warn!` to arrive as a tracing
-    /// event; removing the `LogTracer` init makes this test go silent.
+    /// event; removing the bridge install makes this test go silent.
     #[test]
     fn log_facade_records_reach_the_subscriber() {
         // Real entry point: installs the capture layer *and* the bridge.
@@ -546,7 +659,7 @@ mod tests {
             .unwrap_or_else(|| {
                 panic!(
                     "a `log` record must reach the tracing subscriber; without the \
-                     LogTracer bridge it is dropped at the log facade: {out:?}"
+                     bridge it is dropped at the log facade: {out:?}"
                 )
             });
         assert!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `install_global_subscriber` set a tracing subscriber but left `log`'s global logger slot empty, so records from `log`-facade dependencies (whatsapp-rust among them) were discarded at the `log` macro's max-level check, reaching neither stderr nor the persisted trace at any verbosity. A transport failure inside a dependency left no evidence anywhere.
  - Fills that slot with `log_bridge::RedactingLogBridge`, a `log::Log` implementation that re-dispatches each record through `tracing_log::format_trace` — the same callsite and the same `log.target` / `log.line` normalization a bare `LogTracer` performs. Bridged records then flow through the same `EnvFilter` directives, the same `LogCaptureLayer` persistence and the same alias-prefixed stderr formatting as native `record!` emissions, and `RUST_LOG=whatsapp_rust=debug` addresses the dependency by its own target.
  - **No unbounded third-party string crosses.** A `log::Record` has four string-shaped channels — `args`, `target`, `module_path`, `file` — and none of them is static-only: `RecordBuilder` takes a borrowed `&str` for each, and the `log!` macros take a `target:` expression rather than a literal. So the forwarded record is rebuilt field by field and each channel is decided explicitly:
    - `args` (the message body) is always the fixed marker `[third-party message redacted]`; the dependency's own text is never read.
    - `module_path` and `file` are dropped outright. Both are unbounded, and both are redundant: a record logged without an explicit `target:` already carries its module path *as* the target.
    - `line` is forwarded — it is a `u32` and has no text channel.
    - `target` is forwarded only in an explicit safe representation, because it is the field the filters read and `RUST_LOG` target selection dies without it.
  - **The safe target representation** (`crates/zeroclaw-log/src/log_bridge.rs`): the emitted target is drawn from a reviewed, finite vocabulary — never from the record. `TARGET_LITERALS` holds the 38 hand-written `target: "..."` literals read off the pinned `whatsapp-rust` revision (`cbcdd2a` contains no computed target expression); an incoming target crosses only on an exact match, and what crosses is the table's own constant. `TARGET_CRATES` holds the five activated crates in that pinned tree that log through the facade without an explicit `target:` (`wacore`, `wacore_libsignal`, `wacore_noise`, `whatsapp_rust`, `whatsapp_rust_tokio_transport`); their module-path targets are reduced to the crate's reviewed name, because everything after `::` is still a runtime string a hand-built record can abuse (`whatsapp_rust::<jid>` is charset-clean, and collapses to `whatsapp_rust`). Anything else is replaced **whole** by `[third-party target redacted]`, never truncated and never scrubbed character by character. Fitness is provenance against the tables, not shape.
  - `enabled` performs the checks `tracing_log::LogTracer` performs — the process-wide max level, then the active dispatcher, asked about the sanitized target — instead of returning `true` unconditionally. Global filters can reject a target during `log_enabled!`; with production's per-layer filters, the check is level-gated only and can return true before a layer drops the event.
  - Production install is loud: `install_or_panic` panics naming the conflict if another logger already owns the process-global `log` slot, because the tracing subscriber is installed by that point and a discarded error would leave the daemon looking healthy with every dependency record missing. Repeated-call tolerance is isolated in `install_best_effort_for_tests`, called only from the doc-hidden `try_install_capture_subscriber` so shared test binaries still work.
  - Also enables tracing-subscriber's `tracing-log` feature so the formatter normalizes bridged metadata; without it every bridged record prints under the literal target `log` with raw `log.*` fields dangling alongside.
- **Scope boundary:** `zeroclaw-log` only; no call sites change; first-party code keeps using `record!`/tracing directly (the workspace lint banning first-party `log` macros is untouched, and there are zero first-party `log::` macro uses).
- **Blast radius:** dependencies' `log` records across the whole process become visible where they were previously dropped, so record volume can rise under permissive `RUST_LOG`; which records pass stays decided by the existing tracing filters. What each record *says* no longer varies: every third-party body is the same marker, and every surviving field is either a constant, a bounded token or a number.
- **Known cost, stated plainly:** this trades message text and precise source location for provenance. A dependency's failure wording is no longer in our trace at all — the identifier-free `websocket read failed: connection reset by peer` line is redacted along with everything else — and the `file`/`module_path` fields that used to pin the exact source file are gone. What survives is severity + a bounded target + `line`. Default module-path targets collapse to a crate root, so target + line does not uniquely identify a source file. A hand-written target like `Client/PairCode` names the component and the line but not the file. That is strictly more than `master` gives (nothing), and it is the only boundary that is fail-closed without a reviewer standing behind each dependency's format strings *and* each dependency's metadata arguments.
- **Linked issue(s):** Closes #10202
- **Labels:** `bug`, `dependencies`, `observability:log`, `domain:security`, `needs-maintainer-review`, `risk:high`, `size:XL`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** surface `cli` (daemon stderr, the persisted JSONL trace, and the live broadcast stream)
- **Setup / preconditions:** any config with a whatsapp-web channel (whatsapp-rust emits via the `log` facade)
- **Steps to run:** start `RUST_LOG=whatsapp_rust=debug zeroclaw --verbose daemon` and trigger channel activity (link or reconnect). This selects normalized `whatsapp_rust` targets; explicit literal targets need their own directives, such as `Client/PairCode=debug`. A configured recording-level override takes precedence over `RUST_LOG`.
- **Expected on this branch (after):** `whatsapp_rust` records appear on stderr and in the persisted trace under their reviewed target (hand-written literals verbatim, module-path records as their crate's name), with their severity and their source line, and with `[third-party message redacted]` as the message. No `log.module_path` or `log.file` attribute is present at all. No phone number, pair code, JID, push name or business name appears in stderr, `runtime-trace.jsonl` or the live stream.
- **Prior behavior on `master` (before):** the same run shows none of those records at any verbosity.

### How I tested

- **CI checks relied on and why they cover this change:** the current-head Quality Gate on `98f0956048dbfc0e4fe19875887471bfdeefdf5e` passed, including the workspace test job, lint and MSRV checks. The [test job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33311233607/job/99256591558) ran the new five-root vocabulary, real JSONL/broadcast and per-crate filter regressions. The local commands below are historical evidence from `d9349891837d75273420733718eea8af26a43b4a`, not claims of local execution on the current head.
- **Known CI coverage gap, if any:** no live daemon run against a real WhatsApp session — see the environment limitation below.
- **Commands run and tail output** (all on `d9349891837d75273420733718eea8af26a43b4a`):

  `cargo fmt --all -- --check` — exit 0, no output.

  `cargo clippy --locked --offline -p zeroclaw-log --all-targets -- -D warnings` — exit 0, no warnings.

  `cargo test -p zeroclaw-log --locked --offline` — exit 0
  ```
  test result: ok. 118 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  ```
  (110 → 118: four unit tests pinning the target representation and four sink/filter regressions, listed below.)

  `cargo build --locked --offline --no-default-features --features whatsapp-web --bin zeroclaw` — exit 0; compiled the feature-gated channel and the pinned `whatsapp-rust` dependency path.

  `git diff --check` — exit 0.
- **Current-head additions:** `every_activated_default_target_crate_crosses_as_its_own_root`, `every_activated_crate_reaches_the_sinks_under_its_own_root` and `each_activated_crate_is_selectable_by_its_own_directive` cover the repaired five-root inventory and passed in current-head CI.
- **Earlier privacy/filter regressions retained on this head:**
  - `subscriber::tests::dynamic_record_metadata_never_reaches_the_sinks` (`crates/zeroclaw-log/src/subscriber.rs:688`) — the metadata regression the review asked for, through the real sinks (`LogCaptureLayer` + rolling JSONL writer + broadcast hook, wired as the daemon wires them). It builds `log::Record`s by hand with runtime marker strings in `target`, `module_path` and `file` — the targets now include the three shapes review named, bare numeric, underscore-separated secret-shaped and identifier-shaped, each of which fit the retired charset rule — and asserts none reaches persistence or broadcast, while the records themselves still arrive carrying the two constants and their line. The markers for the two dropped fields are deliberately plain identifiers — a charset rule would have waved them through, so this asserts they are *dropped*, not sanitized.
  - `subscriber::tests::env_filter_directives_still_select_bridged_records_by_target` (`crates/zeroclaw-log/src/subscriber.rs:802`) — the other half: `EnvFilter::new("whatsapp_rust=debug")` still selects a bridged `whatsapp_rust::socket` record — emitted as its crate's reviewed name, `whatsapp_rust`; the module path after `::` is a runtime string and is asserted not to survive — and still excludes another target.
  - `subscriber::tests::log_enabled_agrees_with_the_active_tracing_filter` (`crates/zeroclaw-log/src/subscriber.rs:843`) — `log_enabled!` is false under `EnvFilter::new("off")`, true for a target the filter selects, false for one it excludes.
  - `subscriber::tests::log_enabled_under_per_layer_filters_is_level_gated_only` — the production filter shape (per-layer `EnvFilter`s, as `install_global_subscriber` wires them): `log_enabled!` is deliberately not target-aware there, because `Filtered::enabled` defers and the layer drops in `on_event` — documented on `RedactingLogBridge::enabled` as intentional, and pinned with the record built after that `true` shown never reaching the layer's output.
  - `log_bridge::tests::the_reviewed_tables_are_sorted_for_the_binary_search`, `::reviewed_dependency_targets_cross_as_their_constants` (literals verbatim, module paths collapsed to the crate, a payload smuggled behind a real crate name defused), `::payload_shaped_targets_are_replaced_whole_whatever_their_shape`, `::the_target_replacement_is_idempotent` — the representation itself.
- **Beyond CI, what did you manually verify?** Mutations against the new regressions, both restored afterward and all green:

  Forward `record.target()` / `record.module_path()` / `record.file()` as before this revision: `dynamic_record_metadata_never_reaches_the_sinks` fails with the leak verbatim in the persisted JSONL, which is the reported failure mode —
  ```
  a runtime value in a record's target must not reach the persisted runtime-trace.jsonl:
  {..., "attributes":{"log.file":"zeroclaw_dynamic_file_marker","log.line":4242,
   "log.module_path":"zeroclaw_dynamic_module_marker",
   "log.target":"dependency for zeroclaw_dynamic_target_marker!"},
   "message":"[third-party message redacted]","severity_text":"WARN", ...}
  ```
  Restore `enabled` to an unconditional `true`: `log_enabled_agrees_with_the_active_tracing_filter` fails on `` `log_enabled!` must be false under an `off` filter ``.

  The earlier revision's mutations still hold: forwarding `record.args()` unchanged (a bare `LogTracer`) fails `dependency_records_reach_the_sinks_without_their_message_text` on the phone number, and restoring the deleted token scrubber fails it on the person name.
- **Environment limitation for the live WhatsApp smoke — not run, and not claimed:** the requested A/B across a real session's stderr, `runtime-trace.jsonl` and live stream needs a WhatsApp account that can be linked, paired and torn down while a debug daemon holds the session. The accounts reachable from this environment are production numbers carrying real conversations, and the boundary under test is exactly the pairing/profile data those numbers would put through the sinks, so running it there would create the leak the change exists to prevent. Every account the author operates belongs to a client, so the review-response comment proposes the project acquire a dedicated SIM-backed smoke account and offers to build the recurring harness around it — pair once, keep the session on disk, scripted A/B thereafter. Until that account exists and its result is posted, the daemon startup path, the real dependency call sites, the `RUST_LOG=whatsapp_rust=debug` selection and the vendor session lifecycle are covered by the in-process sink regressions and the feature-gated build only.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No (fixtures use synthetic phone numbers, codes, JIDs, names and secrets)
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation:

This PR opens a path for third-party `log` records to reach `LogCaptureLayer`, `runtime-trace.jsonl` and the live broadcast. Every channel on the record is decided explicitly rather than forwarded on trust, because `log::RecordBuilder` accepts a borrowed runtime `&str` for `target`, `module_path` and `file` just as `args` accepts runtime formatting.

**Message text.** No third-party message body travels that path. The rule is one sentence with no exceptions: the body of every bridged record is replaced by the constant `[third-party message redacted]`, and the dependency's own text is never read. There is no token classifier, no length threshold, no character rule and no target allowlist, so no message shape — a name, a brand, a Unicode display name, a digitless secret, a Base64 blob, a phone number, a pair code, a JID — can be classified as safe by mistake. A previous revision of this PR did try to classify tokens; review correctly established that any such predicate admits ordinary-looking user data, and it is gone.

**Metadata.** `module_path` and `file` are unbounded strings with no bounded representation worth defining, so they are not forwarded at all — the field is absent from the event, not sanitized within it. `line` is a `u32`. The target is the one field kept, because `RUST_LOG` addressing depends on it, and it is kept under the reviewed vocabulary described above: the pin's hand-written literals on exact match, the crate name alone for the pin's facade-logging crates, or else replaced whole by a constant.

**What that does and does not guarantee.** The emitted target is, by construction, one of the constants in `log_bridge.rs`: no runtime value crosses in that field at all, so phone-shaped, secret-shaped and name-shaped targets redact regardless of their characters — the residual the previous revision documented (`Alice` crossing as a conforming identifier) is closed. The price is granularity, not filterability: `RUST_LOG=whatsapp_rust=debug` addresses normalized module-path targets with that prefix, but not explicit literals such as `Client/PairCode`, which need a matching directive, a per-module directive (`whatsapp_rust::socket=debug`) no longer matches anything, and transitive crates outside the tables (`h2` and friends) cross as the marker with severity and line intact. Widening the vocabulary is a one-line reviewed change against a named pin. All four string channels are now closed.

No existing credential path changes: `LoginEvent::PairCode` → `ephemeral_attrs` → `record_event`'s persistence exclusion and the ephemeral broadcast marker are untouched.

Regression coverage runs through the real sinks (capture layer + rolling JSONL writer + broadcast hook, wired as the daemon wires them). The message-body regression emits whatsapp-rust's line shapes at the pinned revision `cbcdd2a` — pair code, all-letter pair code, phone number, JID — plus the four shapes the earlier review named: an alphabetic given name (`Alice`), a mixed-case brand (`Acme`), a non-ASCII name (`Zoë Müller`) and a nonnumeric secret-like payload (`sk_live_zzyxwvutsrq`). It asserts none of those, and no message prose at all, reaches either sink. The metadata regression asserts the same for runtime values placed in `target`, `module_path` and `file`. The positive halves assert that every emission still arrives as a record in both sinks with its own severity, the dependency's target and its source line, so the bridge's remaining value is pinned rather than assumed.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

**Risk.** Two residual risks. First, the diagnostic cost: a dependency's wording never appears in our logs and its source file no longer does either, so an operator debugging a dependency maps target + line back to its source. That is deliberate and is the only version of this boundary that is fail-closed. Second, `install_global_subscriber` panics if another logger owns the process-global `log` slot. Nothing in the workspace calls `log::set_logger` (zero hits outside this module) and the panic names the conflicting call, so the failure is a startup crash with a clear cause rather than a silent loss of dependency diagnostics.

- **Fast rollback command/path:** after a squash merge, `git revert <squash-commit-sha>` removes the complete bridge and restores the behavior where dependency records are dropped at the facade. If landed with a merge commit, use `git revert -m 1 <merge-sha>` instead. Do not revert only an intermediate privacy repair: that can restore unsafe forwarding. No config, schema, on-disk format or public API changes are required for rollback.
- **Feature flags or config toggles:** `None`. `RUST_LOG` / the recording filter decide *which* records are kept, never *what* they contain, so there is no runtime switch that can re-enable third-party message text or unsanitized metadata — that is the point.
- **Observable failure symptoms:**
  - *Redaction regressed (privacy):* a bridged record's message must be exactly `[third-party message redacted]`; `log.module_path` and `log.file` must be absent; and `log.target` must equal one of the reviewed `TARGET_LITERALS` / `TARGET_CRATES` constants or `[third-party target redacted]`. Check persisted JSONL and live-stream records against that finite vocabulary. A charset-only check is insufficient: an alphabetic name or secret outside the tables is still a leak.
  - *Bridge missing (the bug this PR fixes, returning):* with a whatsapp-web channel active, `grep -c 'log.target' runtime-trace.jsonl` stays `0`, and `RUST_LOG=whatsapp_rust=debug` produces no `whatsapp_rust` lines on stderr.
  - *Targets over-sanitized:* every persisted `log.target` reads `[third-party target redacted]`, so `RUST_LOG` directives no longer address a dependency. That would mean a facade-logging crate is missing from the tables; add its crate name to `TARGET_CRATES` (or its literal to `TARGET_LITERALS`) with the same evidence-first reasoning against a named pin, do not disable the rule.
  - *Install conflict:* daemon exits at startup with `installing the log -> tracing bridge failed (...): another logger already owns the process-global log slot`. Grep the startup log for `owns the process-global`.
  - *Volume:* dependency records at the `INFO` floor now persist where they previously vanished, so `runtime-trace.jsonl` reaches its rotation trigger sooner. Watch the archive count under the trace directory; lower `log_persistence_max_entries` or raise the recording floor if it moves materially.
