### PR TITLE
ci(codeql): consolidate rust and js analysis into codeql.yml

### DIFF
--- a/.github/workflows/ci-code-analysis.yml
+++ b/.github/workflows/ci-code-analysis.yml
@@ -1,4 +1,4 @@
-# Static analysis — fast pattern checks on every PR, deep taint on master+schedule.
+# Static analysis — fast Semgrep pattern checks on every PR and master push.
 #
 # Semgrep: fast pattern scan (injection / path-traversal / unsafe patterns, plus
 #   config-layer surfaces CodeQL does not cover — GitHub Actions YAML, Dockerfiles,
@@ -7,12 +7,11 @@
 #   as SARIF to the GitHub Security tab. Report-only (no --error) — surfaced, never
 #   gating. .semgrepignore suppresses known false-positive surfaces (tests, examples,
 #   docs theme).
-# CodeQL (master push + daily): 10-30 min, inter-procedural taint tracking,
-#   SARIF results published to GitHub Security tab.
 #
-# We deliberately do NOT gate every PR on CodeQL. A 20-minute analysis that
-# sometimes times out on Rust is a productivity tax, not a security guarantee.
-# Semgrep covers the fast path; CodeQL catches what Semgrep misses.
+# Deep CodeQL taint analysis (Rust and JS/TS) lives in the sibling codeql.yml
+# (master push + daily schedule + manual dispatch). It is deliberately not
+# PR-triggered — see the rationale there — which also keeps it from rendering
+# as a permanently skipped check on every PR.
 
 name: Code Analysis
 
@@ -21,8 +20,6 @@ on:
     branches: [master]
   push:
     branches: [master]
-  schedule:
-    - cron: '37 5 * * *'   # daily at 05:37 UTC — random offset to spread load
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,7 +39,6 @@ jobs:
     permissions:
       contents: read
       security-events: write   # upload SARIF to the Security tab
-    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -71,39 +67,7 @@ jobs:
         if: always()
         # Fork PRs may have read-only tokens; trusted-event upload failures stay visible.
         continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
-        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           sarif_file: semgrep.sarif
           category: semgrep
-
-  # ── Deep taint analysis (master push + daily, ~15 min) ────────────────
-
-  codeql:
-    name: CodeQL
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      security-events: write
-    if: |
-      github.repository == 'zeroclaw-labs/zeroclaw' &&
-      github.ref == 'refs/heads/master' &&
-      (github.event_name == 'push' || github.event_name == 'schedule')
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: 1.96.1
-      - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y libudev-dev
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
-        with:
-          languages: rust
-          config-file: .github/codeql/codeql-config.yml
-      - name: Build
-        run: cargo build --locked --workspace --exclude zeroclaw-desktop --features ci-all
-        env:
-          CARGO_TERM_COLOR: always
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,21 +1,29 @@
 name: CodeQL
 
-# Static analysis for JavaScript/TypeScript source under web/.
-# Uses the existing .github/codeql/codeql-config.yml (paths-ignore tests/).
-# Rust CodeQL lives in the sibling ci-code-analysis.yml workflow (master push
-# + daily, alongside Semgrep); language coverage is split across the two.
+# Deep static analysis for both CodeQL-covered languages:
+#   javascript-typescript — web/ dashboard source (autobuild extraction)
+#   rust                  — workspace crates (manual cargo build)
+# Uses the shared .github/codeql/codeql-config.yml (paths-ignore tests/).
+# Semgrep's fast per-PR pattern scan lives in the sibling ci-code-analysis.yml.
+#
+# We deliberately do NOT trigger CodeQL on PRs. A 10-30 minute analysis that
+# sometimes times out on Rust is a productivity tax, not a security guarantee.
+# Semgrep covers the fast path on every PR; CodeQL catches what Semgrep
+# misses, after merge. Keeping this job out of PR-triggered workflows also
+# keeps it from rendering as a permanently skipped check on every PR.
 #
 # Triggers:
 #   push to master     — immediate feedback on merged code
-#   schedule           — weekly catch for new queries (query packs update
+#   schedule           — daily catch for new queries (query packs update
 #                        independently of the codebase)
-#   workflow_dispatch  — manual re-run after a config change
+#   workflow_dispatch  — manual re-run after a config change, or an
+#                        on-demand scan of a branch before merge
 
 on:
   push:
     branches: [master]
   schedule:
-    - cron: '34 10 * * 2'   # Tuesdays at 10:34 UTC
+    - cron: '37 5 * * *'   # daily at 05:37 UTC — random offset to spread load
   workflow_dispatch:
 
 concurrency:
@@ -29,15 +37,27 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # Results upload to this repo's Security tab; skip on forks.
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript-typescript]
+        language: [javascript-typescript, rust]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+
+      - name: Install system dependencies
+        if: matrix.language == 'rust'
+        run: sudo apt-get update -qq && sudo apt-get install -y libudev-dev
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
@@ -46,7 +66,14 @@ jobs:
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
+        if: matrix.language == 'javascript-typescript'
         uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+
+      - name: Build
+        if: matrix.language == 'rust'
+        run: cargo build --locked --workspace --exclude zeroclaw-desktop --features ci-all
+        env:
+          CARGO_TERM_COLOR: always
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,8 @@
 name: CodeQL
 
 # Deep static analysis for both CodeQL-covered languages:
-#   javascript-typescript — web/ dashboard source (autobuild extraction)
+#   javascript-typescript — web/ dashboard source (no build step needed;
+#                           CodeQL extracts interpreted languages directly)
 #   rust                  — workspace crates (manual cargo build)
 # Uses the shared .github/codeql/codeql-config.yml (paths-ignore tests/).
 # Semgrep's fast per-PR pattern scan lives in the sibling ci-code-analysis.yml.
@@ -26,9 +27,12 @@ on:
     - cron: '37 5 * * *'   # daily at 05:37 UTC — random offset to spread load
   workflow_dispatch:
 
+# A scan of a superseded commit has no value: a newer push cancels any
+# in-flight run so the latest master analysis is never queued behind a
+# stale or scheduled one (same policy the Rust job had in its old home).
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -64,10 +68,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
-
-      - name: Autobuild
-        if: matrix.language == 'javascript-typescript'
-        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
 
       - name: Build
         if: matrix.language == 'rust'

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -297,9 +297,10 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `sigstore/cosign-installer` (`v3.8.1`) | `release-stable-manual.yml`, `docker-publish.yml` | Install cosign for keyless GHCR container-image signing |
 | `anchore/sbom-action` (`v0.24.0`) | `release-stable-manual.yml` | Generate SPDX + CycloneDX SBOMs for each release |
 | `aquasecurity/trivy-action` (`v0.36.0`) | `docker-image-pr.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | Report-only container vulnerability scanning |
-| `github/codeql-action/upload-sarif` (`v3.36.2`) | `docker-publish.yml`, `trivy-scheduled.yml` | Upload Trivy SARIF reports to the Security tab |
-| `github/codeql-action/init` (`v3`) | `ci-code-analysis.yml` | Initialize CodeQL Rust analysis |
-| `github/codeql-action/analyze` (`v3`) | `ci-code-analysis.yml` | Upload CodeQL SARIF to the Security tab |
+| `github/codeql-action/upload-sarif` (`v3.36.2`) | `docker-publish.yml`, `trivy-scheduled.yml`, `ci-code-analysis.yml` | Upload Trivy and Semgrep SARIF reports to the Security tab |
+| `github/codeql-action/init` (`v3.36.2`) | `codeql.yml` | Initialize CodeQL analysis (Rust and JS/TS) |
+| `github/codeql-action/autobuild` (`v3.36.2`) | `codeql.yml` | JS/TS source extraction |
+| `github/codeql-action/analyze` (`v3.36.2`) | `codeql.yml` | Upload CodeQL SARIF to the Security tab |
 
 The GitHub Release itself is created with `gh release create` inside the `publish` job, not a release action.
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -288,7 +288,7 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `actions/download-artifact` (`v8.0.1`) | `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `docker-publish.yml` | Download build artifacts and Trivy SARIF handoff artifacts |
 | `actions/attest` (`v4.2.2`) | `release-stable-manual.yml` | Generate GitHub-hosted Build Level 2 provenance for release assets |
 | `actions/labeler` (`v6.1.0`) | `pr-path-labeler.yml` | Apply path/scope labels from `.github/labeler.yml` |
-| `dtolnay/rust-toolchain` (`stable`, `v1`) | `ci.yml`, `platform-tests.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml` | Install Rust toolchain |
+| `dtolnay/rust-toolchain` (`stable`, `v1`) | `ci.yml`, `platform-tests.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `daily-audit.yml`, `docs-deploy.yml`, `codeql.yml` | Install Rust toolchain |
 | `Swatinem/rust-cache` (`v2.9.2`) | `ci.yml` (GitHub-hosted path of `./.github/actions/rust-cache`), `platform-tests.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`, `cross-platform-clippy.yml`, `docs-deploy.yml` | Cargo build/dependency caching on GitHub-hosted runners |
 | `useblacksmith/rust-cache` (`v3.0.1`) | `ci.yml` (Blacksmith path of `./.github/actions/rust-cache`) | Cargo build/dependency caching on Blacksmith sticky disk; selected only when `CI_USE_BLACKSMITH=true` |
 | `docker/setup-buildx-action` (`v3.11.1`, `v4.0.0`) | `release-stable-manual.yml`, `docker-publish.yml` | Docker Buildx setup |
@@ -299,7 +299,6 @@ All third-party refs are pinned to a full commit SHA with a trailing version com
 | `aquasecurity/trivy-action` (`v0.36.0`) | `docker-image-pr.yml`, `docker-publish.yml`, `trivy-scheduled.yml` | Report-only container vulnerability scanning |
 | `github/codeql-action/upload-sarif` (`v3.36.2`) | `docker-publish.yml`, `trivy-scheduled.yml`, `ci-code-analysis.yml` | Upload Trivy and Semgrep SARIF reports to the Security tab |
 | `github/codeql-action/init` (`v3.36.2`) | `codeql.yml` | Initialize CodeQL analysis (Rust and JS/TS) |
-| `github/codeql-action/autobuild` (`v3.36.2`) | `codeql.yml` | JS/TS source extraction |
 | `github/codeql-action/analyze` (`v3.36.2`) | `codeql.yml` | Upload CodeQL SARIF to the Security tab |
 
 The GitHub Release itself is created with `gh release create` inside the `publish` job, not a release action.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Move the Rust CodeQL job out of the `pull_request`-triggered `Code Analysis` workflow into `codeql.yml`'s language matrix, next to JavaScript/TypeScript. The scan itself does not move, speed up, or slow down — it runs on the same events as before. What changes is **which file declares the job**, and that matters because a workflow file's triggers apply to the whole file, not to individual jobs: `ci-code-analysis.yml` must fire on every PR for Semgrep, there is no way to say "on PRs, only open the Semgrep half," and GitHub displays a gated-off job as **"skipped"** — it does not distinguish "skipped because something went wrong" from "skipped because it was never meant to run here." So every PR carried a misleading "CodeQL — skipped" badge for a job that could never run on a PR by design, which reads like a broken or bypassed security gate. In `codeql.yml`, which has no `pull_request` trigger, the file is never opened on PRs, so the row is simply absent — which is the truth.
  - The job steps are carried over verbatim (toolchain `1.96.1`, `libudev-dev`, `cargo build --locked --workspace --exclude zeroclaw-desktop --features ci-all`).
  - `ci-code-analysis.yml` is now Semgrep-only: the daily `schedule` trigger and Semgrep's `if: github.event_name != 'schedule'` guard are removed together (leaving them would have made *Semgrep* the new permanently-skipped stub on scheduled runs).
  - Cadence: Rust is unchanged (master push + daily 05:37 UTC cron, now in `codeql.yml`). JS/TS moves from weekly (Tue 10:34) to the same daily cron. JS/TS already runs on every master push and completes in about two minutes, so the schedule change adds roughly six short runs, or about 11 runner-minutes per week. Both languages gain `workflow_dispatch` — Rust previously had no manual re-run path. Manual pre-merge dispatch can target upstream branches; fork refs cannot be selected by the upstream workflow, and the repository guard excludes a fork-local run.
  - All `github/codeql-action/*` refs now pin the same `dd903d2e` commit SHA (`v3.36.2`); the previous `b0c4fd77` ref is an annotated-tag object that the commits API cannot resolve, which defeats SHA-pin auditing. The maintainer actions table in `ci-and-actions.md` is synced to match (it previously listed neither `codeql.yml` nor the autobuild/Semgrep-upload usages).
  - Allowlist impact: none. `github/codeql-action/*` is covered by `github_owned_allowed: true` and `dtolnay/rust-toolchain@*` is already in `patterns_allowed`; no new action sources are introduced.
  - Review follow-up (51193b0cc, from the Codex review pass): the merged workflow now uses `cancel-in-progress: true` — restoring the Rust job's old latest-wins policy (a scan of a superseded commit has no value; new behavior only for JS/TS) — and the JS/TS Autobuild step is removed outright, since CodeQL extracts interpreted languages without a build and the step was a documented no-op.
- **Scope boundary:** No change to what runs on PRs (Semgrep, diff-aware, report-only — exactly as before). No change to CodeQL queries, `codeql-config.yml`, Semgrep config, or any required check. No behavior change to `docker-publish.yml` / `trivy-scheduled.yml` SARIF uploads.
- **Blast radius:** GitHub Actions only. One-time Security-tab effect: the Rust analysis moves from `.github/workflows/ci-code-analysis.yml:codeql` to `.github/workflows/codeql.yml:analyze` with category `/language:rust`. The six currently open CodeQL alerts are JavaScript findings under the unchanged `/language:javascript-typescript` analysis and are not expected to re-key. The 27 dismissed Rust test-fixture alerts may appear under the new analysis key and require re-triage after the first master run. This remains report-only; nothing gates on it. Rust job timeout grows 45→60 min (shared matrix timeout — extra headroom for the analysis that motivated the "sometimes times out" note).
- **Linked issue(s):** Related #9161, Related #8057
- **Labels:** `ci`, `docs`, `distinguished contributor`, `domain:security`, `risk:high`, `size:S`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — CI-wiring change with no runtime surface. This PR's own checks list is the before/after evidence: `Code Analysis / Semgrep` runs and there is no skipped `CodeQL` entry (compare any open PR against `master`, which shows the permanent "CodeQL — skipped" stub).

### How I tested

- **CI checks relied on and why they cover this change:** This PR's own `Code Analysis` run executes the modified `ci-code-analysis.yml` (PR runs use the head's workflow definitions), which validates the Semgrep-only shape end-to-end. Automatic PR CI does not execute the merged `codeql.yml` matrix. An exact-head manual run is unavailable because this PR's head is a fork ref: upstream dispatch cannot select it, and the workflow's repository guard excludes a fork-local run. The maintainer accepted this narrow validation exception; see the gap below.
- **Known CI coverage gap, if any:** The consolidated `codeql.yml` matrix has not executed on this head. The Rust leg first runs automatically on the post-merge master push, and `workflow_dispatch` allows an immediate manual rerun on an upstream ref if anything looks off. Risk is bounded: its steps are verbatim from the job that passed on the latest master push (`Code Analysis` run 32456927655, `CodeQL` job: success), and the JS/TS leg matches the workflow that passed on the same push (`CodeQL` run 32456927610). Both jobs are report-only and the rollback path below restores the prior workflow split.
- **Commands run and tail output:**

  ```text
  $ actionlint .github/workflows/codeql.yml .github/workflows/ci-code-analysis.yml
  actionlint: clean

  $ ./scripts/ci/docs_quality_gate.sh
  Linting: 15 file(s)
  Summary: 0 error(s)
  ```

- **Beyond CI, what did you manually verify?** CodeQL is not a required status check (branch protection requires only `CI Required Gate`, so no protection settings reference the moved job); no workflow, script, or doc references the removed `codeql` job name programmatically; effective Actions policy confirms `github_owned_allowed: true` covers the remaining CodeQL actions and `dtolnay/rust-toolchain@*` is allowlisted. Not verified: an actual execution of the merged Rust matrix leg (covered by the gap note above).
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** `docs_links_gate.sh` not run — no links added or changed in the docs diff (existing table rows edited in place). An exact-head CodeQL dispatch was not run because the head is a fork ref that the guarded upstream workflow cannot execute; the maintainer accepted the report-only validation gap described above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — both workflows keep `contents: read` + `security-events: write`, unchanged.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No` — the CodeQL build keeps the pinned `1.96.1` toolchain.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the landed squash commit with `git revert <landed-squash-commit>` to restore the split CodeQL jobs and prior schedules.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Missing or repeatedly cancelled CodeQL runs, an unexpected skipped CodeQL row on pull requests, failed SARIF uploads, or previously dismissed Rust findings reappearing after the analysis-key change.
