### PR TITLE
fix(memory): run pgvector setup inside the postgres-memory-init thread

### DIFF
--- a/crates/zeroclaw-memory/src/postgres.rs
+++ b/crates/zeroclaw-memory/src/postgres.rs
@@ -77,44 +77,35 @@ impl PostgresMemory {
         let qualified_table = format!("{schema_ident}.{table_ident}");
         let qualified_agents = format!("{schema_ident}.agents");
 
-        let client = Self::initialize_client(
+        let pgvector = if pgvector_enabled.unwrap_or(false) {
+            Some(pgvector_dimensions.unwrap_or(1536))
+        } else {
+            None
+        };
+
+        let (client, pgvector_ok) = Self::initialize_client(
             db_url.to_string(),
             connect_timeout_secs,
             schema_ident.clone(),
             qualified_table.clone(),
+            pgvector,
         )?;
 
-        let pgvector_enabled = pgvector_enabled.unwrap_or(false);
-        let pgvector_dimensions = pgvector_dimensions.unwrap_or(1536);
-
-        if pgvector_enabled {
-            let client_ref = Arc::new(Mutex::new(client));
-            let ext_ok = {
-                let mut c = client_ref.lock();
-                Self::try_enable_pgvector(&mut c, &qualified_table, pgvector_dimensions).is_ok()
-            };
-            if !ext_ok {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
-                    "pgvector extension not available; falling back to keyword-only recall"
-                );
-            }
-            Ok(Self {
-                alias: alias.to_string(),
-                client: DropOnThread::new(client_ref),
-                qualified_table,
-                qualified_agents,
-            })
-        } else {
-            Ok(Self {
-                alias: alias.to_string(),
-                client: DropOnThread::new(Arc::new(Mutex::new(client))),
-                qualified_table,
-                qualified_agents,
-            })
+        if !pgvector_ok {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown),
+                "pgvector extension not available; falling back to keyword-only recall"
+            );
         }
+
+        Ok(Self {
+            alias: alias.to_string(),
+            client: DropOnThread::new(Arc::new(Mutex::new(client))),
+            qualified_table,
+            qualified_agents,
+        })
     }
 
     fn initialize_client(
@@ -122,10 +113,11 @@ impl PostgresMemory {
         connect_timeout_secs: Option<u64>,
         schema_ident: String,
         qualified_table: String,
-    ) -> Result<Client> {
+        pgvector: Option<usize>,
+    ) -> Result<(Client, bool)> {
         let init_handle = std::thread::Builder::new()
             .name("postgres-memory-init".to_string())
-            .spawn(move || -> Result<Client> {
+            .spawn(move || -> Result<(Client, bool)> {
                 let mut config: postgres::Config = db_url
                     .parse()
                     .context("invalid PostgreSQL connection URL")?;
@@ -145,7 +137,16 @@ impl PostgresMemory {
                     &schema_ident,
                     &qualified_table,
                 )?;
-                Ok(client)
+                // The synchronous postgres client uses block_on internally,
+                // so pgvector setup must also stay on this plain OS thread —
+                // calling it from a Tokio runtime thread panics.
+                let pgvector_ok = match pgvector {
+                    Some(dimensions) => {
+                        Self::try_enable_pgvector(&mut client, &qualified_table, dimensions).is_ok()
+                    }
+                    None => true,
+                };
+                Ok((client, pgvector_ok))
             })
             .context("failed to spawn PostgreSQL initializer thread")?;
 
@@ -959,6 +960,96 @@ mod tests {
             outcome.unwrap().is_err(),
             "PostgresMemory::new should return a connect error for an unreachable endpoint"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn new_with_pgvector_enabled_does_not_panic_inside_tokio_runtime() {
+        let outcome = std::panic::catch_unwind(|| {
+            PostgresMemory::new(
+                "test",
+                "postgres://zeroclaw:password@127.0.0.1:1/zeroclaw",
+                "public",
+                "memories",
+                Some(1),
+                Some(true),
+                Some(4),
+            )
+        });
+
+        assert!(
+            outcome.is_ok(),
+            "PostgresMemory::new should not panic with pgvector enabled"
+        );
+        assert!(
+            outcome.unwrap().is_err(),
+            "PostgresMemory::new should return a connect error for an unreachable endpoint"
+        );
+    }
+
+    struct TestSchema {
+        admin: Client,
+        name: String,
+    }
+
+    impl TestSchema {
+        fn create(database_url: &str, purpose: &str) -> Self {
+            let name = format!("zc_mem_{purpose}_{}", std::process::id());
+            let mut admin = Client::connect(database_url, NoTls).unwrap();
+            admin
+                .batch_execute(&format!(
+                    "DROP SCHEMA IF EXISTS {0} CASCADE; CREATE SCHEMA {0}",
+                    quote_identifier(&name)
+                ))
+                .unwrap();
+            Self { admin, name }
+        }
+    }
+
+    impl Drop for TestSchema {
+        fn drop(&mut self) {
+            let _ = self.admin.batch_execute(&format!(
+                "DROP SCHEMA IF EXISTS {} CASCADE",
+                quote_identifier(&self.name)
+            ));
+        }
+    }
+
+    /// Live regression for the nested-runtime panic in the pgvector-enabled
+    /// construction path: `try_enable_pgvector` must run inside the
+    /// `postgres-memory-init` OS thread, because the synchronous postgres
+    /// client calls `block_on` internally and panics on a Tokio runtime
+    /// thread. The pgvector extension does not need to be installed in the
+    /// target database — an unavailable extension takes the graceful
+    /// keyword-only fallback, while the pre-fix code panics before that
+    /// fallback is reached.
+    #[test]
+    #[ignore = "requires ZEROCLAW_TEST_POSTGRES_URL"]
+    fn postgres_new_with_pgvector_enabled_from_tokio_runtime_does_not_panic() {
+        let database_url = std::env::var("ZEROCLAW_TEST_POSTGRES_URL")
+            .expect("set ZEROCLAW_TEST_POSTGRES_URL to run ignored PostgreSQL tests");
+        let schema = TestSchema::create(&database_url, "vec");
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let memory = runtime.block_on(async {
+            PostgresMemory::new(
+                "test",
+                &database_url,
+                &schema.name,
+                "memories",
+                Some(5),
+                Some(true),
+                Some(4),
+            )
+        });
+
+        let memory =
+            memory.expect("pgvector-enabled construction from a Tokio runtime should succeed");
+        drop(memory);
+        drop(runtime);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `try_enable_pgvector` ran on the caller thread after `initialize_client` returned. The synchronous `postgres` client calls `block_on` internally, so constructing `PostgresMemory` with `pgvector_enabled = true` from a Tokio runtime panicked (`Cannot start a runtime from within a runtime`), and the unwinding `Client` drop could raise a second panic that aborts gateway/agent startup.
  - The pgvector setup now runs inside the existing `postgres-memory-init` OS-thread closure, after schema init and the V3 migration. The thread returns `(Client, bool)`; the caller emits the existing keyword-only fallback warning when extension setup fails, so graceful degradation is unchanged.
  - This follows the direction confirmed by the maintainer on the issue and the approach of #7668 (which fixed the same class of panic on the `Client` drop path); it replaces the closed, unmerged #9100 with the regression coverage that review asked for.
  - New coverage: a guard test that pgvector-enabled construction against an unreachable endpoint returns `Err` without panicking, and an ignored live regression (`ZEROCLAW_TEST_POSTGRES_URL`, same convention as the `knowledge_graph_pg` live tests) that constructs `PostgresMemory` with pgvector enabled from a multi-thread Tokio runtime — it reaches the moved setup, panics on `master`, and passes on this branch. The pgvector extension does not need to be installed for the test to distinguish the fix.
- **Scope boundary:** Only the construction path in `crates/zeroclaw-memory/src/postgres.rs`. No changes to `store`/`recall`, async methods, the database schema, the config surface, or any caller (`PostgresMemory::new` keeps its signature).
- **Blast radius:** PostgreSQL memory-backend construction only (`memory-postgres` feature). Affects gateway/agent startup for deployments with the postgres backend and pgvector enabled.
- **Linked issue(s):** Fixes #9085. Related #7668, #9100.
- **Labels:** `bug`, `distinguished contributor`, `memory`, `memory:backend`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — needs any reachable PostgreSQL (the pgvector extension is *not* required).
- **Interface(s) exercised:** none (backend construction path; no user-visible surface change).
- **Setup / preconditions:** a PostgreSQL you can point `ZEROCLAW_TEST_POSTGRES_URL` at; or a ZeroClaw config using the postgres memory backend with `pgvector_enabled = true`.
- **Steps to run:**
  ```sh
  ZEROCLAW_TEST_POSTGRES_URL="postgres://<user>@<host>:<port>/<db>" \
    cargo test -p zeroclaw-memory --features memory-postgres --lib \
    postgres_new_with_pgvector -- --ignored
  ```
- **Expected on this branch (after):** the test passes (construction succeeds; with the extension absent it logs the keyword-only fallback warning).
- **Prior behavior on `master` (before):** the production panic reproduces with the same test grafted onto `master` (or by starting a gateway configured with pgvector enabled): `thread panicked at postgres-0.19.13/src/connection.rs:66: Cannot start a runtime from within a runtime`.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head GitHub `Format`, `Lint`, `Test`, `Check (all features)`, and `CI Required Gate` checks passed. The changed code is behind the `memory-postgres` feature, so the feature-enabled local runs below remain the primary evidence.
- **Known CI coverage gap, if any:** CI jobs that do not enable `memory-postgres` never compile this path; covered locally with the feature on.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-memory --all-targets -- -D warnings` and `cargo clippy -p zeroclaw-memory --features memory-postgres --all-targets -- -D warnings` — both finished with no warnings.
  - `cargo test -p zeroclaw-memory --features memory-postgres` —
    ```
    test result: ok. 523 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 3.38s
    test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
    ```
  - Live regression on this branch against PostgreSQL 16.10 (Homebrew), extension absent:
    ```
    running 1 test
    test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 525 filtered out; finished in 0.07s
    ```
  - Same test grafted onto `master` (45e5ce137), same database:
    ```
    thread 'postgres::tests::postgres_new_with_pgvector_enabled_from_tokio_runtime_does_not_panic' panicked at
    postgres-0.19.13/src/connection.rs:66:22:
    Cannot start a runtime from within a runtime.
    ```
- **Beyond CI, what did you manually verify?** The extension-missing fallback still constructs successfully and logs the existing warning (my test database has no pgvector extension, so the live test exercises exactly that path). Not verified: a database where `CREATE EXTENSION vector` succeeds (no pgvector build on this machine); that path runs the same statements as before, only on a different thread.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (`ZEROCLAW_TEST_POSTGRES_URL` is a pre-existing test-only variable)
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Single-commit change: `git revert <sha>` restores the previous construction path.
