### PR TITLE
fix(tools): bound agent-browser subprocess waits with a deadline and kill_on_drop

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -7878,6 +7878,11 @@ pub struct BrowserConfig {
     /// Browser automation backend: "agent_browser" | "rust_native" | "computer_use" | "auto"
     #[serde(default = "default_browser_backend")]
     pub backend: String,
+    /// Timeout in seconds for agent-browser CLI commands (default: 60).
+    /// Bounds every `browser` tool action on the `agent_browser` backend so a
+    /// wedged CLI cannot hang an agent turn indefinitely.
+    #[serde(default = "default_browser_timeout_secs")]
+    pub timeout_secs: u64,
     /// Show browser window for agent_browser backend. When unset, inherits AGENT_BROWSER_HEADED.
     #[serde(default)]
     pub headed: Option<bool>,
@@ -7914,6 +7919,10 @@ fn default_browser_backend() -> String {
     "agent_browser".into()
 }
 
+fn default_browser_timeout_secs() -> u64 {
+    60
+}
+
 fn default_browser_webdriver_url() -> String {
     "http://127.0.0.1:9515".into()
 }
@@ -7925,6 +7934,7 @@ impl Default for BrowserConfig {
             allowed_domains: vec!["*".into()],
             session_name: None,
             backend: default_browser_backend(),
+            timeout_secs: default_browser_timeout_secs(),
             headed: None,
             native_headless: default_true(),
             native_webdriver_url: default_browser_webdriver_url(),
@@ -31120,6 +31130,7 @@ default_temperature = 0.7
         assert!(b.enabled);
         assert_eq!(b.allowed_domains, vec!["*".to_string()]);
         assert_eq!(b.backend, "agent_browser");
+        assert_eq!(b.timeout_secs, 60);
         assert_eq!(b.headed, None);
         assert!(b.native_headless);
         assert_eq!(b.native_webdriver_url, "http://127.0.0.1:9515");
@@ -31139,6 +31150,7 @@ default_temperature = 0.7
             allowed_domains: vec!["example.com".into(), "docs.example.com".into()],
             session_name: None,
             backend: "auto".into(),
+            timeout_secs: 45,
             headed: Some(true),
             native_headless: false,
             native_webdriver_url: "http://localhost:4444".into(),
@@ -31160,6 +31172,7 @@ default_temperature = 0.7
         assert_eq!(parsed.allowed_domains.len(), 2);
         assert_eq!(parsed.allowed_domains[0], "example.com");
         assert_eq!(parsed.backend, "auto");
+        assert_eq!(parsed.timeout_secs, 45);
         assert_eq!(parsed.headed, Some(true));
         assert!(!parsed.native_headless);
         assert_eq!(parsed.native_webdriver_url, "http://localhost:4444");

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1094,6 +1094,7 @@ pub fn all_tools_with_runtime(
                 max_coordinate_x: browser_config.computer_use.max_coordinate_x,
                 max_coordinate_y: browser_config.computer_use.max_coordinate_y,
             },
+            browser_config.timeout_secs,
             browser_config.allowed_private_hosts.clone(),
         ) {
             Ok(tool) => {

--- a/crates/zeroclaw-tools/src/browser.rs
+++ b/crates/zeroclaw-tools/src/browser.rs
@@ -581,6 +581,12 @@ impl BrowserTool {
     /// the child when the deadline passes or the awaiting future is dropped.
     /// The error names the action so a hung command is distinguishable from a
     /// hung availability probe.
+    ///
+    /// Containment is scoped to the direct child: `kill_on_drop` does not
+    /// walk the process tree, so descendants the CLI spawned (e.g. a
+    /// browser) are left to the CLI's own lifecycle handling. Bounding the
+    /// agent turn is this seam's contract; tree-wide reaping would need the
+    /// process-group/Job-Object approach used by the coding-CLI runners.
     async fn run_bounded_command(
         mut cmd: Command,
         action: &str,
@@ -3184,7 +3190,7 @@ mod tests {
         // `sh -c 'sleep 60'` ignores the appended `--version` argument, so
         // this models a CLI that accepts the probe but never returns.
         let mut command = Command::new("sh");
-        command.arg("-c").arg("sleep 60");
+        command.arg("-c").arg("exec sleep 60");
 
         let started = std::time::Instant::now();
         let available = BrowserTool::probe_agent_browser(command, Duration::from_millis(20)).await;
@@ -3215,7 +3221,7 @@ mod tests {
     #[tokio::test]
     async fn run_bounded_command_times_out_and_names_action() {
         let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg("sleep 60");
+        cmd.arg("-c").arg("exec sleep 60");
 
         let started = std::time::Instant::now();
         let error = BrowserTool::run_bounded_command(cmd, "open", Duration::from_millis(20))

--- a/crates/zeroclaw-tools/src/browser.rs
+++ b/crates/zeroclaw-tools/src/browser.rs
@@ -14,6 +14,14 @@ use tokio::process::Command;
 use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult};
 use zeroclaw_config::policy::SecurityPolicy;
 
+/// Deadline for the `agent-browser --version` availability probe. It is a
+/// liveness check, not user work, so it is deliberately short and not
+/// configurable.
+const AGENT_BROWSER_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Fallback for `browser.timeout_secs` used by the legacy `new()` constructor.
+const AGENT_BROWSER_DEFAULT_TIMEOUT_SECS: u64 = 60;
+
 /// Computer-use sidecar settings.
 #[derive(Clone)]
 pub struct ComputerUseConfig {
@@ -68,6 +76,7 @@ pub struct BrowserTool {
     #[allow(dead_code)]
     native_chrome_path: Option<String>,
     computer_use: ComputerUseConfig,
+    timeout_secs: u64,
     #[cfg(feature = "browser-native")]
     native_state: tokio::sync::Mutex<native_backend::NativeBrowserState>,
 }
@@ -213,6 +222,7 @@ impl BrowserTool {
             "http://127.0.0.1:9515".into(),
             None,
             ComputerUseConfig::default(),
+            AGENT_BROWSER_DEFAULT_TIMEOUT_SECS,
             Vec::new(),
         )
     }
@@ -228,6 +238,7 @@ impl BrowserTool {
         native_webdriver_url: String,
         native_chrome_path: Option<String>,
         computer_use: ComputerUseConfig,
+        timeout_secs: u64,
         allowed_private_hosts: Vec<String>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -247,6 +258,7 @@ impl BrowserTool {
             native_webdriver_url,
             native_chrome_path,
             computer_use,
+            timeout_secs,
             #[cfg(feature = "browser-native")]
             native_state: tokio::sync::Mutex::new(native_backend::NativeBrowserState::default()),
         })
@@ -259,14 +271,30 @@ impl BrowserTool {
         } else {
             "agent-browser"
         };
-        Command::new(cmd)
+        Self::probe_agent_browser(Command::new(cmd), AGENT_BROWSER_PROBE_TIMEOUT).await
+    }
+
+    /// Bounded `--version` probe: a wedged CLI must make the backend read as
+    /// unavailable instead of hanging the agent turn indefinitely.
+    async fn probe_agent_browser(mut command: Command, deadline: Duration) -> bool {
+        command
             .arg("--version")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false)
+            .kill_on_drop(true);
+        match tokio::time::timeout(deadline, command.status()).await {
+            Ok(Ok(status)) => status.success(),
+            Ok(Err(_)) => false,
+            Err(_) => {
+                ::zeroclaw_log::record!(
+                    DEBUG,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                    "agent-browser availability probe timed out; treating backend as unavailable"
+                );
+                false
+            }
+        }
     }
 
     /// Backward-compatible alias.
@@ -498,6 +526,10 @@ impl BrowserTool {
 
     /// Execute an agent-browser command
     async fn run_command(&self, args: &[&str]) -> anyhow::Result<AgentBrowserResponse> {
+        if self.timeout_secs == 0 {
+            anyhow::bail!("browser.timeout_secs must be > 0");
+        }
+
         let mut cmd = self.agent_browser_command();
 
         // Add --json for machine-readable output
@@ -509,11 +541,9 @@ impl BrowserTool {
             &format!("Running: agent-browser {} --json", args.join(" "))
         );
 
-        let output = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await?;
+        let action = args.first().copied().unwrap_or("<none>");
+        let output =
+            Self::run_bounded_command(cmd, action, Duration::from_secs(self.timeout_secs)).await?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -544,6 +574,27 @@ impl BrowserTool {
                 data: None,
                 error: Some(stderr.trim().to_string()),
             })
+        }
+    }
+
+    /// Await an agent-browser subprocess with a wall-clock deadline, killing
+    /// the child when the deadline passes or the awaiting future is dropped.
+    /// The error names the action so a hung command is distinguishable from a
+    /// hung availability probe.
+    async fn run_bounded_command(
+        mut cmd: Command,
+        action: &str,
+        deadline: Duration,
+    ) -> anyhow::Result<std::process::Output> {
+        cmd.stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        match tokio::time::timeout(deadline, cmd.output()).await {
+            Ok(output) => Ok(output?),
+            Err(_) => anyhow::bail!(
+                "agent-browser '{action}' timed out after {}s (browser.timeout_secs); the subprocess was killed",
+                deadline.as_secs()
+            ),
         }
     }
 
@@ -2759,6 +2810,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             ComputerUseConfig::default(),
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -2787,6 +2839,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             ComputerUseConfig::default(),
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -2815,6 +2868,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             ComputerUseConfig::default(),
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -2834,6 +2888,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             ComputerUseConfig::default(),
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -2859,6 +2914,7 @@ mod tests {
                 endpoint: "http://computer-use.example.com/v1/actions".into(),
                 ..ComputerUseConfig::default()
             },
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -2883,6 +2939,7 @@ mod tests {
                 allow_remote_endpoint: true,
                 ..ComputerUseConfig::default()
             },
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -2907,6 +2964,7 @@ mod tests {
                 max_coordinate_y: Some(100),
                 ..ComputerUseConfig::default()
             },
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -3118,6 +3176,108 @@ mod tests {
         }
     }
 
+    // ── bounded subprocess wait tests ───────────────────────────
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_times_out_stalled_cli_and_reports_unavailable() {
+        // `sh -c 'sleep 60'` ignores the appended `--version` argument, so
+        // this models a CLI that accepts the probe but never returns.
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("sleep 60");
+
+        let started = std::time::Instant::now();
+        let available = BrowserTool::probe_agent_browser(command, Duration::from_millis(20)).await;
+
+        assert!(!available, "a stalled probe must read as unavailable");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "probe waited too long: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_reports_available_for_successful_process() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("exit 0");
+        assert!(BrowserTool::probe_agent_browser(command, Duration::from_secs(5)).await);
+    }
+
+    #[tokio::test]
+    async fn probe_reports_unavailable_for_missing_binary() {
+        let command = Command::new("zeroclaw-test-missing-agent-browser");
+        assert!(!BrowserTool::probe_agent_browser(command, Duration::from_secs(5)).await);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_bounded_command_times_out_and_names_action() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("sleep 60");
+
+        let started = std::time::Instant::now();
+        let error = BrowserTool::run_bounded_command(cmd, "open", Duration::from_millis(20))
+            .await
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("'open' timed out"),
+            "timeout error must name the action: {message}"
+        );
+        assert!(
+            message.contains("browser.timeout_secs"),
+            "timeout error must name the config key: {message}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "bounded command waited too long: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_bounded_command_passes_through_completed_process() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("printf ok");
+
+        let output = BrowserTool::run_bounded_command(cmd, "open", Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "ok");
+    }
+
+    #[tokio::test]
+    async fn run_command_rejects_zero_timeout() {
+        let security = Arc::new(SecurityPolicy::default());
+        let tool = BrowserTool::new_with_backend(
+            security,
+            vec!["*".into()],
+            None,
+            "agent_browser".into(),
+            None,
+            true,
+            "http://127.0.0.1:9515".into(),
+            None,
+            ComputerUseConfig::default(),
+            0,
+            Vec::new(),
+        )
+        .unwrap();
+
+        let error = tool.run_command(&["open"]).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("browser.timeout_secs must be > 0")
+        );
+    }
+
     // ── allowed_private_hosts opt-in tests ──────────────────────
 
     fn private_host_tool(
@@ -3135,6 +3295,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             ComputerUseConfig::default(),
+            60,
             allowed_private_hosts
                 .into_iter()
                 .map(String::from)
@@ -3597,6 +3758,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             test_computer_use_config(),
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -3769,6 +3931,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             config,
+            60,
             Vec::new(),
         )
         .unwrap()
@@ -3860,6 +4023,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             config,
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -3928,6 +4092,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             config,
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -4000,6 +4165,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             config,
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -4092,6 +4258,7 @@ mod tests {
             "http://127.0.0.1:9515".into(),
             None,
             config,
+            60,
             Vec::new(),
         )
         .unwrap();
@@ -4214,6 +4381,7 @@ mod tests {
                 "http://127.0.0.1:9515".into(),
                 None,
                 config,
+                60,
                 Vec::new(),
             )
             .unwrap();


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Both `agent-browser` subprocess waits in `crates/zeroclaw-tools/src/browser.rs` were unbounded — the `--version` availability probe and the `run_command` executor awaited the CLI with no wall-clock deadline and no `kill_on_drop`. A wedged CLI (e.g. a page paused on a JavaScript `confirm`, see #9945) hung the agent turn indefinitely. Same defect class as #8560, whose fix covered only `browser_open`.
  - The availability probe now runs under a short fixed 5s deadline (it is a liveness check, deliberately not configurable) and reads as unavailable on timeout.
  - `run_command` is bounded by a new `browser.timeout_secs` config key (default 60), following the `timeout_secs` naming already used by `text_browser`, `http_request`, and `web_fetch`. The timeout error names the action and the config key, so a hung action is distinguishable from a hung probe. Both children are killed when the deadline passes or the awaiting future is dropped, mirroring the `browser_delegate` pattern the issue cites.
  - A zero value is rejected at use with the same style of error as the existing `browser.computer_use.timeout_ms` validation.
- **Scope boundary:** No change to the computer_use, rust_native, or browser_open paths; no change to which actions exist (the missing `dialog` action stays tracked in #9945); the CLI's own `--idle-timeout` flag (mentioned as a consideration in the issue) is not passed — that belongs with #9945's dialog work if wanted.
- **Blast radius:** `browser` tool on the `agent_browser` and `auto` backends; every action now has a 60s default ceiling where it previously could wait forever. Operators with legitimately slower actions can raise `browser.timeout_secs`.
- **Linked issue(s):** Fixes #9946. Related #8560, #9945.
- **Labels:** `bug`, `config`, `distinguished contributor`, `risk:high`, `runtime`, `size:M`, `tool`, `tool:browser`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the issue's stub reproduction shows the delta directly.
- **Interface(s) exercised:** `cli` (agent turn using the `browser` tool).
- **Setup / preconditions:** shadow the CLI with a stub that never returns:
  ```sh
  mkdir -p /tmp/ab-stub
  printf '#!/bin/sh\nsleep infinity\n' > /tmp/ab-stub/agent-browser
  chmod +x /tmp/ab-stub/agent-browser
  ```
  and configure `browser.backend = "agent_browser"`.
- **Steps to run:** with `PATH=/tmp/ab-stub:$PATH`, drive any agent turn that invokes the `browser` tool (e.g. an `open` action).
- **Expected on this branch (after):** the availability probe gives up after ~5s (backend reads unavailable / falls through per `auto` resolution); if the probe is satisfied and an action runs, it fails within `browser.timeout_secs` with `agent-browser 'open' timed out after 60s (browser.timeout_secs); the subprocess was killed`, and the stub process is gone afterwards.
- **Prior behavior on `master` (before):** the turn hangs indefinitely with the stub process still running.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI covers all three touched crates on the default feature set (none of the changed code is feature-gated).
- **Known CI coverage gap, if any:** the new subprocess tests are `#[cfg(unix)]` (mirroring the existing `browser_open` timeout tests); Windows only compiles them out. The Windows code path differs only in the binary name.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-tools -p zeroclaw-config -p zeroclaw-runtime --all-targets -- -D warnings` — finished with no warnings.
  - `cargo test -p zeroclaw-tools --lib browser` —
    ```
    test result: ok. 161 passed; 0 failed; 0 ignored; 0 measured; 1482 filtered out; finished in 0.74s
    ```
  - `cargo test -p zeroclaw-config --lib` —
    ```
    test result: ok. 1383 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.94s
    ```
- **Beyond CI, what did you manually verify?** New unit tests cover: stalled probe times out (<2s wall clock) and reads unavailable; successful probe still reads available; missing binary reads unavailable; a stalled command errors naming both the action and `browser.timeout_secs` while killing the child; a completing command passes its output through; `timeout_secs = 0` is rejected. Config tests assert the serde default (60) and a round-trip of an explicit value. Not verified: a live `agent-browser` install (not present on this machine); the bounded wrapper is exercised by the tests above and the wrapped call sites are unchanged otherwise.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — with one behavioral bound: actions that previously ran longer than 60s (while the wait was unbounded) now need `browser.timeout_secs` raised.
- Config / env / CLI surface changed? `Yes` — new optional `browser.timeout_secs` key, default 60; existing configs need no action.
- Rust/MSRV/toolchain floor changed? `No`
- Upgrade steps: none required; raise `browser.timeout_secs` only if agent-browser actions legitimately exceed 60s.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` of this PR's squash commit restores the unbounded waits.
- **Feature flags or config toggles:** `browser.timeout_secs` can be raised to effectively restore long waits without a revert.
- **Observable failure symptoms:** tool results containing `timed out after Ns (browser.timeout_secs); the subprocess was killed`, or the availability-probe debug log `agent-browser availability probe timed out`.