### PR TITLE
fix(providers): scope reasoning-tools fallback classifier to one error clause

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -931,13 +931,41 @@ fn mentions_tools_token(message: &str) -> bool {
     false
 }
 
+/// Split a provider error message into independent clauses at `;`, newlines,
+/// and sentence-ending periods (a `.` followed by whitespace or end of
+/// input, so identifiers like `gpt-4.1` stay intact).
+///
+/// Compound provider errors can chain unrelated failures in one message;
+/// capability predicates must be evaluated within a single clause so that
+/// independent clauses cannot collectively satisfy them.
+fn error_message_clauses(message: &str) -> Vec<&str> {
+    let bytes = message.as_bytes();
+    let mut clauses = Vec::new();
+    let mut start = 0usize;
+    for (i, c) in message.char_indices() {
+        let is_boundary = match c {
+            ';' | '\n' => true,
+            '.' => bytes.get(i + 1).is_none_or(u8::is_ascii_whitespace),
+            _ => false,
+        };
+        if is_boundary {
+            clauses.push(&message[start..i]);
+            start = i + c.len_utf8();
+        }
+    }
+    clauses.push(&message[start..]);
+    clauses
+}
+
 /// Whether an endpoint explicitly rejected combining function tools with
 /// `reasoning_effort`.
 ///
 /// This predicate is intentionally narrow: callers may retry once with
 /// `reasoning_effort: "none"` only when the endpoint itself reports this exact
 /// capability mismatch. Other reasoning or tool errors must propagate
-/// unchanged.
+/// unchanged. A single clause of the message must report the relationship —
+/// unrelated clauses of a compound error (e.g. `reasoning_effort value is
+/// unsupported; tools must be an array`) do not collectively qualify.
 pub(crate) fn rejects_tools_with_reasoning_effort(status: reqwest::StatusCode, body: &str) -> bool {
     if !matches!(
         status,
@@ -965,22 +993,24 @@ pub(crate) fn rejects_tools_with_reasoning_effort(status: reqwest::StatusCode, b
         }
         Err(_) => (body.to_ascii_lowercase(), String::new()),
     };
-    let mentions_reasoning_effort = parameter == "reasoning_effort"
-        || message.contains("reasoning_effort")
-        || message.contains("reasoning effort");
-    let mentions_tools = mentions_tools_token(&message);
-    let reports_incompatibility = [
-        "not supported",
-        "unsupported",
-        "cannot be used",
-        "can't be used",
-        "incompatible",
-        "not allowed",
-    ]
-    .iter()
-    .any(|hint| message.contains(hint));
+    error_message_clauses(&message).into_iter().any(|clause| {
+        let mentions_reasoning_effort = parameter == "reasoning_effort"
+            || clause.contains("reasoning_effort")
+            || clause.contains("reasoning effort");
+        let mentions_tools = mentions_tools_token(clause);
+        let reports_incompatibility = [
+            "not supported",
+            "unsupported",
+            "cannot be used",
+            "can't be used",
+            "incompatible",
+            "not allowed",
+        ]
+        .iter()
+        .any(|hint| clause.contains(hint));
 
-    mentions_reasoning_effort && mentions_tools && reports_incompatibility
+        mentions_reasoning_effort && mentions_tools && reports_incompatibility
+    })
 }
 
 /// Format an error including its full source chain and sanitize the result.
@@ -3698,6 +3728,44 @@ mod tests {
         assert!(rejects_tools_with_reasoning_effort(
             reqwest::StatusCode::BAD_REQUEST,
             r#"{"error":{"message":"reasoning_effort cannot be used with \"tools\".","param":"reasoning_effort"}}"#
+        ));
+    }
+
+    #[test]
+    fn tool_reasoning_rejection_requires_conflict_within_one_clause() {
+        // Independent clauses of a compound error must not collectively
+        // satisfy the predicate: neither clause below reports a relationship
+        // between tools and reasoning effort, so retrying with
+        // reasoning_effort "none" would silently downgrade the operator's
+        // configured effort before the unrelated tools error propagates.
+        assert!(!rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"reasoning_effort value is unsupported; tools must be an array"}}"#
+        ));
+        assert!(!rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+            "reasoning_effort value is unsupported; tools must be an array"
+        ));
+        assert!(!rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"reasoning_effort value is invalid. Tools are not allowed for this endpoint."}}"#
+        ));
+        assert!(!rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            "reasoning_effort is unsupported\ntools are not allowed"
+        ));
+
+        // A genuine relationship stated in one clause still matches, even
+        // when other clauses surround it.
+        assert!(rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"The request was rejected. reasoning_effort cannot be used with tools. Remove one and retry."}}"#
+        ));
+        // A sentence-internal period (e.g. a version number) is not a clause
+        // boundary.
+        assert!(rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"reasoning_effort is not supported with tools for model gpt-4.1"}}"#
         ));
     }
 

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -993,10 +993,16 @@ pub(crate) fn rejects_tools_with_reasoning_effort(status: reqwest::StatusCode, b
         }
         Err(_) => (body.to_ascii_lowercase(), String::new()),
     };
-    error_message_clauses(&message).into_iter().any(|clause| {
-        let mentions_reasoning_effort = parameter == "reasoning_effort"
-            || clause.contains("reasoning_effort")
-            || clause.contains("reasoning effort");
+    let clauses = error_message_clauses(&message);
+    // The structured `param` field is message-global; letting it satisfy an
+    // arbitrary clause would recreate the cross-clause false positive, so it
+    // counts as the reasoning signal only when the message has a single
+    // substantive clause for it to describe.
+    let single_clause = clauses.iter().filter(|c| !c.trim().is_empty()).count() <= 1;
+    clauses.into_iter().any(|clause| {
+        let mentions_reasoning_effort = clause.contains("reasoning_effort")
+            || clause.contains("reasoning effort")
+            || (single_clause && parameter == "reasoning_effort");
         let mentions_tools = mentions_tools_token(clause);
         let reports_incompatibility = [
             "not supported",
@@ -3753,6 +3759,25 @@ mod tests {
         assert!(!rejects_tools_with_reasoning_effort(
             reqwest::StatusCode::BAD_REQUEST,
             "reasoning_effort is unsupported\ntools are not allowed"
+        ));
+
+        // The structured `param` field must not bridge clauses either: it is
+        // message-global, so in a compound error it cannot supply the
+        // reasoning signal for an unrelated tools clause — in either order.
+        assert!(!rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"tools are unsupported; reasoning_effort value is invalid","param":"reasoning_effort"}}"#
+        ));
+        assert!(!rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"reasoning_effort value is invalid; tools are unsupported","param":"reasoning_effort"}}"#
+        ));
+
+        // A single-clause structured error may rely on `param` alone for the
+        // reasoning signal.
+        assert!(rejects_tools_with_reasoning_effort(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"tools are not supported at the requested effort","param":"reasoning_effort"}}"#
         ));
 
         // A genuine relationship stated in one clause still matches, even


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `rejects_tools_with_reasoning_effort` classifier (introduced by #9304) evaluated its reasoning, tools, and incompatibility predicates across the entire selected provider-error message, so unrelated clauses of a compound error could collectively satisfy it. The issue's example — `reasoning_effort value is unsupported; tools must be an array` — was classified as a tools-plus-reasoning capability conflict, causing one extra authenticated request with `reasoning_effort: "none"` and a silent downgrade of the operator-selected effort before the unrelated tools error propagated.
  - The message is now split into clauses at semicolons, newlines, and sentence-ending periods (a `.` followed by whitespace or end of input, so identifiers like `gpt-4.1` stay intact), and a **single clause** must satisfy all three predicates. Genuine single-clause conflicts keep matching, including when surrounded by other sentences.
  - The `param == "reasoning_effort"` structured-field path now supplies the reasoning signal only when the selected message has a single substantive clause. In compound messages, the reasoning, tools, and incompatibility signals must co-occur within one clause.
- **Scope boundary:** Only the classifier and its helper in `crates/zeroclaw-providers/src/lib.rs`. The three call sites in `compatible.rs` (and the Azure path through them) are untouched; no change to when the fallback retries once it does fire.
- **Blast radius:** OpenAI-compatible and Azure Chat Completions error handling on HTTP 400/422 tool turns. Strictly narrows when the one-shot `reasoning_effort: "none"` retry fires.
- **Linked issue(s):** Fixes #10190. Related #9304.
- **Labels:** `bug`, `distinguished contributor`, `provider`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — pure classifier predicate change with deterministic unit coverage; the A/B is visible by running the new test against `master` (below), and there is no provider that emits the compound error on demand.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI; the changed code is in the default-feature build of `zeroclaw-providers` and fully exercised by lib tests.
- **Known CI coverage gap, if any:** none for this surface.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-providers --lib --tests -- -D warnings` — finished with no warnings.
  - `cargo test -p zeroclaw-providers --lib tool_reasoning_rejection` —
    ```
    test tests::tool_reasoning_rejection_detection_is_narrow ... ok
    test tests::tool_reasoning_rejection_ignores_tool_substrings_in_identifiers ... ok
    test tests::tool_reasoning_rejection_requires_conflict_within_one_clause ... ok
    test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1403 filtered out
    ```
  - `cargo test -p zeroclaw-providers --lib` —
    ```
    test result: ok. 1402 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 11.57s
    ```
  - New regression grafted onto `master` (45e5ce137) to prove it distinguishes the fix:
    ```
    test tests::tool_reasoning_rejection_requires_conflict_within_one_clause ... FAILED
    assertion failed: !rejects_tools_with_reasoning_effort(reqwest::StatusCode::BAD_REQUEST,
    ```
    (fails on `master` on the issue's exact compound example; passes on this branch).
- **Beyond CI, what did you manually verify?** All pre-existing positive fixtures in the two existing classifier tests still match under clause scoping (they each state the conflict within one clause). Negative coverage now includes the issue's example in JSON and plain-body form, a two-sentence compound, and a newline-separated compound. Not verified: live provider traffic (no endpoint reproducibly emits the compound error).
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — the change strictly removes a class of extra authenticated retry requests.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No` — the classifier consumes provider error text as data; matching is narrowed, never widened.

## Compatibility (required)

- Backward compatible? `Yes` — only compound-clause false positives stop retrying; single-clause conflicts behave identically.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge-sha>` restores the prior whole-message classifier.
- **Feature flags or config toggles:** `None`.
- **Observable failure symptoms:** An unrelated compound provider error again produces a second authenticated POST with `reasoning_effort: "none"` and a retry log carrying `reasoning_effort_override_reason = "endpoint_rejected_tools_with_reasoning"`; or a genuine single-clause tools/reasoning incompatibility stops producing that bounded retry and propagates the original HTTP 400/422 response.
