### PR TITLE
fix(channels): make WeCom health checks side-effect free and errcode-aware

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -12115,6 +12115,12 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
         println!("  ℹ️  Webhook   check via `zeroclaw gateway` then GET /health");
     }
 
+    if !config_arc.read().channels.wecom.is_empty() {
+        println!(
+            "  ℹ️  WeCom     healthy = configuration check only (the webhook API has no message-free probe); delivery is validated on real sends"
+        );
+    }
+
     println!();
     println!("Summary: {healthy} healthy, {unhealthy} unhealthy, {timeout} timed out");
     Ok(())

--- a/crates/zeroclaw-channels/src/wecom.rs
+++ b/crates/zeroclaw-channels/src/wecom.rs
@@ -13,6 +13,8 @@ pub struct WeComChannel {
     /// Resolves inbound external peers from canonical state at message-time.
     /// No cache (see AGENTS.md "ABSOLUTE RULE — SINGLE SOURCE OF TRUTH").
     peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    /// API host, overridable for tests (mirrors `LineChannel`).
+    api_base_url: String,
 }
 
 impl WeComChannel {
@@ -25,7 +27,14 @@ impl WeComChannel {
             webhook_key,
             alias: alias.into(),
             peer_resolver,
+            api_base_url: "https://qyapi.weixin.qq.com".into(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_api_base_url(mut self, url: &str) -> Self {
+        self.api_base_url = url.trim_end_matches('/').to_string();
+        self
     }
 
     fn http_client(&self) -> reqwest::Client {
@@ -34,8 +43,8 @@ impl WeComChannel {
 
     fn webhook_url(&self) -> String {
         format!(
-            "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={}",
-            self.webhook_key
+            "{}/cgi-bin/webhook/send?key={}",
+            self.api_base_url, self.webhook_key
         )
     }
 
@@ -119,23 +128,19 @@ impl Channel for WeComChannel {
     }
 
     async fn health_check(&self) -> bool {
-        // Verify we can reach the WeCom API endpoint.
-        let resp = self
-            .http_client()
-            .post(self.webhook_url())
-            .json(&serde_json::json!({
-                "msgtype": "text",
-                "text": {
-                    "content": "health_check"
-                }
-            }))
-            .send()
-            .await;
-
-        match resp {
-            Ok(r) => r.status().is_success(),
-            Err(_) => false,
-        }
+        // WeCom's Bot Webhook API has no side-effect-free validation surface:
+        // every documented webhook operation posts a visible message to the
+        // group. Routine health and doctor checks must not create user-visible
+        // traffic, so this validates configuration only. Delivery — including
+        // WeCom's application-level `errcode` — is validated on real sends.
+        let configured = !self.webhook_key.trim().is_empty();
+        ::zeroclaw_log::record!(
+            DEBUG,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_attrs(::serde_json::json!({"alias": self.alias, "configured": configured})),
+            "wecom health: configuration-only validation (the webhook API has no message-free probe)"
+        );
+        configured
     }
 }
 
@@ -183,6 +188,82 @@ mod tests {
     fn test_user_denied_empty() {
         let ch = WeComChannel::new("key".into(), "wecom_test_alias", Arc::new(Vec::new));
         assert!(!ch.is_user_allowed("anyone"));
+    }
+
+    #[tokio::test]
+    async fn health_check_is_side_effect_free_and_reflects_configuration() {
+        use wiremock::MockServer;
+
+        // No mock is mounted: any request would fail the test via the
+        // received-requests assertion below.
+        let server = MockServer::start().await;
+
+        let ch = WeComChannel::new("key-abc".into(), "wecom_test_alias", Arc::new(Vec::new))
+            .with_api_base_url(&server.uri());
+        assert!(ch.health_check().await, "configured key reads healthy");
+
+        let empty = WeComChannel::new(String::new(), "wecom_test_alias", Arc::new(Vec::new))
+            .with_api_base_url(&server.uri());
+        assert!(!empty.health_check().await, "missing key reads unhealthy");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert!(
+            received.is_empty(),
+            "health_check must not call the WeCom API (would post a visible message); saw {} request(s)",
+            received.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn send_reports_api_level_failure_despite_http_success() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cgi-bin/webhook/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errcode": 93000,
+                "errmsg": "invalid webhook url"
+            })))
+            .mount(&server)
+            .await;
+
+        let ch = WeComChannel::new("bad-key".into(), "wecom_test_alias", Arc::new(Vec::new))
+            .with_api_base_url(&server.uri());
+
+        let error = ch
+            .send(&SendMessage::new("hello", "group"))
+            .await
+            .expect_err("HTTP 200 with nonzero errcode must not read as delivered");
+        let message = error.to_string();
+        assert!(
+            message.contains("errcode=93000"),
+            "error should surface the WeCom errcode: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_succeeds_on_errcode_zero() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cgi-bin/webhook/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errcode": 0,
+                "errmsg": "ok"
+            })))
+            .mount(&server)
+            .await;
+
+        let ch = WeComChannel::new("good-key".into(), "wecom_test_alias", Arc::new(Vec::new))
+            .with_api_base_url(&server.uri());
+
+        ch.send(&SendMessage::new("hello", "group"))
+            .await
+            .expect("errcode 0 delivers");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `WeComChannel::health_check()` posted the literal message `health_check` to the configured webhook and treated any HTTP-success status as healthy. Channel Doctor therefore created user-visible WeCom group traffic on every run, and an application-level failure (WeCom returns HTTP 200 with a nonzero JSON `errcode`) could still read as healthy.
  - WeCom's Bot Webhook API exposes no side-effect-free validation surface — every documented webhook operation posts a visible message — so per the issue's proposed direction, `health_check` now validates configuration only (webhook key present) without any network call, and logs the distinction (`configuration-only validation`).
  - `channel doctor` prints the same caveat for configured WeCom aliases (mirroring the existing informational Webhook line), so diagnostics distinguish configuration validation from live delivery validation.
  - Delivery correctness — including the nonzero-`errcode` rejection — lives on the send path (already implemented on `master`) and now has wiremock regression coverage for the HTTP-200-plus-API-failure case, enabled by a test-only injectable API base URL mirroring `LineChannel::with_api_base_url`.
- **Scope boundary:** No change to `send()` behavior, the channel's registration, config surface, or any other channel's health semantics. No new "delivery probe" was added — the issue asks that any such probe be explicit and separately named; none exists today.
- **Blast radius:** WeCom health reporting in `channel doctor` (and anything else calling `Channel::health_check` — the doctor is the only consumer). Operators no longer see stray `health_check` messages in WeCom groups; a well-formed-but-revoked key now reads healthy at config level rather than sending a probe message, with the caveat line explaining exactly that.
- **Linked issue(s):** Fixes #9665.
- **Labels:** `bug`, `channel`, `channel:core`, `channel:wecom`, `distinguished contributor`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — visible-traffic delta needs a real WeCom webhook to observe.
- **Interface(s) exercised:** `cli` (`zeroclaw channel doctor`).
- **Setup / preconditions:** a configured `[channels.wecom.<alias>]` with a valid webhook key.
- **Steps to run:** `zeroclaw channel doctor`.
- **Expected on this branch (after):** the WeCom group receives **no** message; doctor reports the alias healthy plus an ℹ️ line saying WeCom health is a configuration check only.
- **Prior behavior on `master` (before):** every doctor run posts a literal `health_check` message into the WeCom group.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI for the default feature set (covers the `channel doctor` line via `zeroclaw-channels` default build). `channel-wecom` is not in default features, so the feature-enabled runs below are the primary evidence for the channel itself.
- **Known CI coverage gap, if any:** CI jobs that do not enable `channel-wecom` never compile `wecom.rs`; covered locally with the feature enabled.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-channels --all-targets -- -D warnings` — no warnings (default features).
  - `cargo clippy -p zeroclaw-channels --all-targets --features channel-wecom -- -D warnings` — no warnings.
  - `cargo test -p zeroclaw-channels --lib --features channel-wecom wecom::` —
    ```
    test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 1454 filtered out; finished in 0.28s
    ```
  - `cargo test -p zeroclaw-channels --lib` (default features) —
    ```
    test result: ok. 1453 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 15.11s
    ```
- **Beyond CI, what did you manually verify?** New tests assert: `health_check` performs **zero** HTTP requests (wiremock records no received requests) while reflecting key presence; `send()` with HTTP 200 + `errcode: 93000` returns an error naming the errcode; `send()` with `errcode: 0` succeeds. Not verified: a live WeCom webhook (no WeCom tenant available); the send path itself is unchanged.
- **Visual interface changed?** `N/A` (one new informational doctor line, exercised by inspection; no layout/rendering logic involved)
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — the change strictly removes a network call (and its message side effect).
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — health semantics change from "endpoint reachable + HTTP success" to "configured"; the doctor caveat line documents this in the same output.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk single-commit change: `git revert <sha>` restores the previous probe behavior.