### PR TITLE
fix(runtime): suppress final reply duplicated by a same-turn send_via delivery

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6212,7 +6212,9 @@ async fn process_channel_message_body(
         msg
     };
 
-    let target_channel = find_channel_for_message(&ctx.channels_by_name, &msg).cloned();
+    let target_entry = find_channel_entry_for_message(&ctx.channels_by_name, &msg);
+    let originating_channel_key = target_entry.as_ref().map(|(key, _)| key.clone());
+    let target_channel = target_entry.map(|(_, ch)| ch);
 
     if let Some(channel) = target_channel.as_ref() {
         if channel.drop_self_messages(&msg) {
@@ -7088,7 +7090,7 @@ async fn process_channel_message_body(
     // the tool-call loop below. Allocating per turn (rather than clearing a shared
     // handle) keeps concurrent same-agent turns from reading each other's routes.
     let turn_routing: tools::TurnRoutingHandle =
-        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        std::sync::Arc::new(std::sync::Mutex::new(tools::TurnRouting::default()));
 
     let tool_receipts_collector: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
         std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -7646,11 +7648,10 @@ async fn process_channel_message_body(
 
             // Read the last routing instruction set by `send_via` this turn from
             // the per-turn handle scoped into TURN_ROUTING around the loop above.
-            let turn_route = turn_routing
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .last()
-                .cloned();
+            let (turn_route, immediate_sends) = {
+                let turn = turn_routing.lock().unwrap_or_else(|e| e.into_inner());
+                (turn.routes.last().cloned(), turn.immediate_sends.clone())
+            };
 
             // Resolve the delivery channel and modality from the routing entry.
             // `None` entry → default delivery (originating channel, no modality override).
@@ -7692,9 +7693,40 @@ async fn process_channel_message_body(
                     .as_ref()
                     .and_then(|r| r.channel.as_deref())
                     .is_some();
+                let delivery_channel_key = turn_route
+                    .as_ref()
+                    .and_then(|r| r.channel.clone())
+                    .filter(|k| !k.is_empty())
+                    .or_else(|| originating_channel_key.clone());
+                // Same-turn duplicate guard: models sometimes place identical
+                // text in both the assistant `content` and an immediate
+                // `send_via` `body`. When that immediate send already delivered
+                // exactly this content to exactly this destination, delivering
+                // the ordinary reply again would double the message. Different
+                // content, or the same content to a different destination, is
+                // intentional fanout and delivers normally.
+                let duplicate_of_immediate_send = immediate_sends.iter().any(|s| {
+                    Some(s.channel_key.as_str()) == delivery_channel_key.as_deref()
+                        && s.recipient == delivery_recipient
+                        && s.body == delivered_response.trim()
+                });
                 // Whether the agent's reply reached a channel — gates the
                 // `fire_message_sent` observer hook below.
-                let reply_delivered = if is_redirect {
+                let reply_delivered = if duplicate_of_immediate_send {
+                    if let Some(ref draft_id) = draft_message_id {
+                        let _ = channel.cancel_draft(&delivery_recipient, draft_id).await;
+                    }
+                    ::zeroclaw_log::record!(
+                        INFO,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                            .with_attrs(::serde_json::json!({
+                                "channel": delivery_channel_key,
+                                "recipient": delivery_recipient,
+                            })),
+                        "suppressing final reply: an immediate send_via delivery already sent identical content to this destination this turn"
+                    );
+                    true
+                } else if is_redirect {
                     // Routing redirects to a different channel: cancel any in-progress
                     // draft on the originating channel before delivering elsewhere.
                     if let (Some(orig_ch), Some(draft_id)) =
@@ -10024,6 +10056,29 @@ fn find_channel_for_message<'a>(
     msg.channel
         .split_once(':')
         .and_then(|(base, _)| channels.get(base))
+}
+
+/// Like [`find_channel_for_message`], but also returns the registry key the
+/// channel resolved under, so delivery accounting can compare destinations
+/// in the same key namespace `send_via` records them in.
+fn find_channel_entry_for_message(
+    channels: &HashMap<String, Arc<dyn Channel>>,
+    msg: &zeroclaw_api::channel::ChannelMessage,
+) -> Option<(String, Arc<dyn Channel>)> {
+    if let Some(alias) = msg.channel_alias.as_deref().filter(|s| !s.is_empty()) {
+        let composite = format!("{}.{alias}", msg.channel);
+        if let Some(ch) = channels.get(&composite) {
+            return Some((composite, Arc::clone(ch)));
+        }
+    }
+    if let Some(ch) = channels.get(&msg.channel) {
+        return Some((msg.channel.clone(), Arc::clone(ch)));
+    }
+    msg.channel.split_once(':').and_then(|(base, _)| {
+        channels
+            .get(base)
+            .map(|ch| (base.to_string(), Arc::clone(ch)))
+    })
 }
 
 fn send_message_to_peer_tool_available(
@@ -18482,6 +18537,181 @@ api_key = "anthropic-key"
                 "chat-42".to_string(),
                 "ok".to_string()
             )]
+        );
+    }
+
+    /// Provider that first calls `send_via` with a `body` targeting the test
+    /// channel, then answers the tool-result round with `final_text` as the
+    /// turn's assistant content.
+    struct SendViaBodyModelProvider {
+        body: &'static str,
+        final_text: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl ModelProvider for SendViaBodyModelProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok(format!(
+                "<tool_call>\n{{\"name\":\"send_via\",\"arguments\":{{\"target\":\"test-channel\",\"body\":\"{}\"}}}}\n</tool_call>",
+                self.body
+            ))
+        }
+
+        async fn chat_with_history(
+            &self,
+            messages: &[ChatMessage],
+            model: &str,
+            temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            let has_tool_results = messages
+                .iter()
+                .any(|msg| msg.role == "user" && msg.content.contains("[Tool results]"));
+            if has_tool_results {
+                Ok(self.final_text.to_string())
+            } else {
+                self.chat_with_system(None, "", model, temperature).await
+            }
+        }
+    }
+    impl ::zeroclaw_api::attribution::Attributable for SendViaBodyModelProvider {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+        fn alias(&self) -> &str {
+            "SendViaBodyModelProvider"
+        }
+    }
+
+    /// Real `SendViaTool` wired to the given channel under the same
+    /// `"test-channel"` key the orchestrator's registry uses, in a peer group
+    /// whose external peer matches the test message's reply target.
+    fn send_via_tool_for(channel: Arc<dyn Channel>) -> Box<dyn Tool> {
+        let map: tools::PerToolChannelHandle = Arc::new(parking_lot::RwLock::new(HashMap::new()));
+        map.write().insert("test-channel".to_string(), channel);
+        let mut groups = HashMap::new();
+        groups.insert(
+            "test-group".to_string(),
+            zeroclaw_config::multi_agent::PeerGroupConfig {
+                channel: "test-channel".into(),
+                external_peers: vec![zeroclaw_config::multi_agent::PeerUsername::new("chat-42")],
+                ..zeroclaw_config::multi_agent::PeerGroupConfig::default()
+            },
+        );
+        Box::new(tools::SendViaTool::new(
+            Arc::new(zeroclaw_config::policy::SecurityPolicy::default()),
+            map,
+            Arc::new(move || groups.clone()),
+        ))
+    }
+
+    /// Regression for the same-turn duplicate-delivery guard: a model that
+    /// places identical text in an immediate `send_via` `body` and in the
+    /// turn's assistant content must produce exactly one delivered message.
+    #[tokio::test]
+    async fn duplicate_send_via_body_suppresses_final_reply() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let runtime_ctx = test_runtime_ctx_with_observer_and_tools(
+            Arc::clone(&channel),
+            Arc::new(SendViaBodyModelProvider {
+                body: "Hello there!",
+                final_text: "Hello there!",
+            }),
+            zeroclaw_config::schema::Config::default(),
+            zeroclaw_config::schema::AliasedAgentConfig::default(),
+            "test-provider",
+            None,
+            Arc::new(NoopObserver),
+            vec![send_via_tool_for(Arc::clone(&channel))],
+        );
+
+        process_channel_message(
+            runtime_ctx,
+            message_sent_hook_test_message(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        // The test ctx enables show_tool_calls, so the channel also receives a
+        // "🔧 `send_via`: ..." tool-call notification; that surface is
+        // unrelated to delivery accounting and is filtered out here.
+        let sent: Vec<String> = channel_impl
+            .sent_messages
+            .lock()
+            .await
+            .iter()
+            .filter(|entry| !entry.contains("🔧"))
+            .cloned()
+            .collect();
+        assert_eq!(
+            sent.as_slice(),
+            ["chat-42:Hello there!"],
+            "identical content must reach the destination exactly once"
+        );
+        assert_eq!(
+            channel_impl.final_send_calls.load(Ordering::SeqCst),
+            0,
+            "the ordinary reply must be suppressed as a duplicate of the immediate send_via delivery"
+        );
+    }
+
+    /// Distinct content is intentional fanout: both the immediate `send_via`
+    /// message and the turn's ordinary reply must be delivered.
+    #[tokio::test]
+    async fn distinct_send_via_body_and_reply_both_deliver() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let runtime_ctx = test_runtime_ctx_with_observer_and_tools(
+            Arc::clone(&channel),
+            Arc::new(SendViaBodyModelProvider {
+                body: "Heads-up: report archived.",
+                final_text: "Done, and I sent the heads-up.",
+            }),
+            zeroclaw_config::schema::Config::default(),
+            zeroclaw_config::schema::AliasedAgentConfig::default(),
+            "test-provider",
+            None,
+            Arc::new(NoopObserver),
+            vec![send_via_tool_for(Arc::clone(&channel))],
+        );
+
+        process_channel_message(
+            runtime_ctx,
+            message_sent_hook_test_message(),
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent: Vec<String> = channel_impl
+            .sent_messages
+            .lock()
+            .await
+            .iter()
+            .filter(|entry| !entry.contains("🔧"))
+            .cloned()
+            .collect();
+        assert_eq!(
+            sent.as_slice(),
+            [
+                "chat-42:Heads-up: report archived.",
+                "chat-42:Done, and I sent the heads-up."
+            ],
+            "distinct content is intentional fanout and both messages must deliver"
+        );
+        assert_eq!(
+            channel_impl.final_send_calls.load(Ordering::SeqCst),
+            1,
+            "the ordinary reply still uses the final-response send path"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -106,7 +106,8 @@ pub use zeroclaw_tools::reaction::ReactionTool;
 pub use zeroclaw_tools::report_template_tool::ReportTemplateTool;
 pub use zeroclaw_tools::screenshot::ScreenshotTool;
 pub use zeroclaw_tools::send_via::{
-    AgentPeerGroupResolver, SendViaTool, TURN_ROUTING, TurnRoutingHandle,
+    AgentPeerGroupResolver, ImmediateSendRecord, SendViaTool, TURN_ROUTING, TurnRouting,
+    TurnRoutingHandle,
 };
 pub use zeroclaw_tools::sessions::{
     SessionDeleteTool, SessionResetTool, SessionsCurrentTool, SessionsHistoryTool,

--- a/crates/zeroclaw-tools/src/send_via.rs
+++ b/crates/zeroclaw-tools/src/send_via.rs
@@ -38,10 +38,35 @@ pub struct TurnRoutingEntry {
     pub recipient: Option<String>,
 }
 
+/// One successful immediate (`body`) delivery performed by `send_via` this
+/// turn. The orchestrator's duplicate-delivery guard reads these after the
+/// tool loop: when the turn's ordinary reply targets the same channel and
+/// recipient with identical content, delivering it again would duplicate the
+/// message, so the ordinary reply is suppressed.
+#[derive(Debug, Clone)]
+pub struct ImmediateSendRecord {
+    /// Resolved channel key the message was sent through (e.g. `"telegram.default"`).
+    pub channel_key: String,
+    /// Concrete recipient the message was addressed to.
+    pub recipient: String,
+    /// Message content exactly as sent.
+    pub body: String,
+}
+
+/// One turn's routing state: routing instructions written in no-body mode and
+/// the immediate deliveries performed in body mode.
+#[derive(Debug, Default)]
+pub struct TurnRouting {
+    /// Routing instructions for the turn's main reply; the last entry wins.
+    pub routes: Vec<TurnRoutingEntry>,
+    /// Immediate (`body`) sends that were actually delivered this turn.
+    pub immediate_sends: Vec<ImmediateSendRecord>,
+}
+
 /// Handle to one turn's routing state. The orchestrator creates a fresh handle
 /// before each `run_tool_call_loop` call, scopes it into [`TURN_ROUTING`] for the
 /// duration of the loop, and reads it back after the loop completes.
-pub type TurnRoutingHandle = Arc<Mutex<Vec<TurnRoutingEntry>>>;
+pub type TurnRoutingHandle = Arc<Mutex<TurnRouting>>;
 
 /// Static routing/modality wording that suggests a `send_via` call. Each entry
 /// is a multiword phrase that, taken whole, requests a destination or delivery
@@ -384,16 +409,34 @@ impl Tool for SendViaTool {
             };
 
             return match channel.send(&message).await {
-                Ok(()) => Ok(ToolResult {
-                    success: true,
-                    output: ToolOutput::json(json!({
-                        "target": channel_key,
-                        "mode": "immediate",
-                        "resolved_modality": modality_str(modality),
-                        "status": "ok"
-                    })),
-                    error: None,
-                }),
+                Ok(()) => {
+                    // Record the delivery for the orchestrator's same-turn
+                    // duplicate guard. Outside a scoped turn there is no
+                    // reader, so the record is intentionally dropped.
+                    let _ = TURN_ROUTING.try_with(|handle| {
+                        if let Some(handle) = handle {
+                            handle
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .immediate_sends
+                                .push(ImmediateSendRecord {
+                                    channel_key: channel_key.clone(),
+                                    recipient: recipient.clone(),
+                                    body: body.clone(),
+                                });
+                        }
+                    });
+                    Ok(ToolResult {
+                        success: true,
+                        output: ToolOutput::json(json!({
+                            "target": channel_key,
+                            "mode": "immediate",
+                            "resolved_modality": modality_str(modality),
+                            "status": "ok"
+                        })),
+                        error: None,
+                    })
+                }
                 Err(e) => Ok(ToolResult {
                     success: false,
                     output: ToolOutput::json(json!({
@@ -485,7 +528,11 @@ impl Tool for SendViaTool {
         let queued = TURN_ROUTING
             .try_with(|handle| {
                 if let Some(handle) = handle {
-                    handle.lock().unwrap_or_else(|e| e.into_inner()).push(entry);
+                    handle
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .routes
+                        .push(entry);
                     true
                 } else {
                     false
@@ -597,7 +644,7 @@ mod tests {
         for (name, ch) in channels {
             map.write().insert(name.to_string(), ch);
         }
-        let routing: TurnRoutingHandle = Arc::new(Mutex::new(Vec::new()));
+        let routing: TurnRoutingHandle = Arc::new(Mutex::new(TurnRouting::default()));
         let groups = Arc::new(peer_groups);
         let inner = SendViaTool::new(
             Arc::new(SecurityPolicy::default()),
@@ -789,7 +836,8 @@ mod tests {
         assert_eq!(out["mode"], "routing");
         assert_eq!(out["resolved_modality"], "text");
 
-        let entries = routing.lock().unwrap();
+        let state = routing.lock().unwrap();
+        let entries = &state.routes;
         assert_eq!(entries.len(), 1);
         assert!(entries[0].channel.is_none());
         assert!(matches!(entries[0].modality, OutputModality::Text));
@@ -804,7 +852,8 @@ mod tests {
         let result = tool.execute(json!({ "modality": "voice" })).await.unwrap();
 
         assert!(result.success);
-        let entries = routing.lock().unwrap();
+        let state = routing.lock().unwrap();
+        let entries = &state.routes;
         assert_eq!(entries.len(), 1);
         assert!(matches!(entries[0].modality, OutputModality::Voice));
     }
@@ -828,7 +877,8 @@ mod tests {
         assert!(result.success);
         let out: serde_json::Value = serde_json::from_str(&result.output).unwrap();
         assert_eq!(out["mode"], "routing");
-        let entries = routing.lock().unwrap();
+        let state = routing.lock().unwrap();
+        let entries = &state.routes;
         assert_eq!(entries[0].channel.as_deref(), Some("telegram.default"));
         assert!(matches!(entries[0].modality, OutputModality::Voice));
         assert_eq!(
@@ -860,7 +910,7 @@ mod tests {
                 .unwrap()
                 .contains("no external_peers")
         );
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
     }
 
     #[tokio::test]
@@ -872,7 +922,7 @@ mod tests {
         assert!(!result.success);
         let out: serde_json::Value = serde_json::from_str(&result.output).unwrap();
         assert_eq!(out["status"], "rejected");
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
     }
 
     // ── Immediate send mode ───────────────────────────────────────────────────
@@ -908,7 +958,14 @@ mod tests {
             "immediate send must deliver to the resolved external_peers recipient"
         );
         // routing state untouched
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
+
+        // delivery recorded for the orchestrator's same-turn duplicate guard
+        let state = routing.lock().unwrap();
+        assert_eq!(state.immediate_sends.len(), 1);
+        assert_eq!(state.immediate_sends[0].channel_key, "telegram.default");
+        assert_eq!(state.immediate_sends[0].recipient, "@amaury");
+        assert_eq!(state.immediate_sends[0].body, "extra message");
     }
 
     #[tokio::test]
@@ -920,7 +977,7 @@ mod tests {
         assert!(!result.success);
         let out: serde_json::Value = serde_json::from_str(&result.output).unwrap();
         assert_eq!(out["status"], "rejected");
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
     }
 
     #[tokio::test]
@@ -945,7 +1002,7 @@ mod tests {
                 .unwrap()
                 .contains("no external_peers")
         );
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
     }
 
     #[tokio::test]
@@ -1078,7 +1135,7 @@ mod tests {
         );
         // nothing was sent and no routing entry leaked
         assert!(sent.read().is_empty());
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
 
         // A peer-group name still resolves unambiguously.
         let result = tool
@@ -1157,7 +1214,7 @@ mod tests {
                 .contains("no matching channel is registered")
         );
         assert!(main_sent.read().is_empty());
-        assert!(routing.lock().unwrap().is_empty());
+        assert!(routing.lock().unwrap().routes.is_empty());
     }
 
     // ── Concurrency isolation ─────────────────────────────────────────────────
@@ -1192,7 +1249,7 @@ mod tests {
         // Each turn: scope a fresh handle, queue a route, hold the scope across an
         // await so the two turns genuinely overlap, then read back only our handle.
         async fn run_turn(tool: Arc<SendViaTool>, target: &str) -> Vec<TurnRoutingEntry> {
-            let handle: TurnRoutingHandle = Arc::new(Mutex::new(Vec::new()));
+            let handle: TurnRoutingHandle = Arc::new(Mutex::new(TurnRouting::default()));
             let target = target.to_string();
             TURN_ROUTING
                 .scope(Some(Arc::clone(&handle)), async move {
@@ -1201,7 +1258,7 @@ mod tests {
                     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 })
                 .await;
-            handle.lock().unwrap().clone()
+            handle.lock().unwrap().routes.clone()
         }
 
         let (tg, mail) = tokio::join!(
@@ -1247,7 +1304,7 @@ mod tests {
         let tool = SendViaTool::new(Arc::new(SecurityPolicy::default()), map, resolver);
 
         async fn route(tool: &SendViaTool, target: &str) -> TurnRoutingEntry {
-            let handle: TurnRoutingHandle = Arc::new(Mutex::new(Vec::new()));
+            let handle: TurnRoutingHandle = Arc::new(Mutex::new(TurnRouting::default()));
             let result = TURN_ROUTING
                 .scope(
                     Some(Arc::clone(&handle)),
@@ -1256,7 +1313,7 @@ mod tests {
                 .await
                 .unwrap();
             assert!(result.success, "{:?}", result.error);
-            handle.lock().unwrap()[0].clone()
+            handle.lock().unwrap().routes[0].clone()
         }
 
         let before = route(&tool, "g1").await;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - When a model places identical text in both its assistant `content` and an immediate `send_via` `body` targeting the originating destination, ZeroClaw delivered both copies — the reporter saw every Telegram exchange doubled. This implements the narrow same-turn guard from the issue's triage: suppress the ordinary reply **only** when an immediate `send_via` delivery this turn matches it exactly (same resolved channel key, same recipient, identical content).
  - `send_via` now records each successful immediate (`body`) delivery in the per-turn routing state: `TurnRoutingHandle` becomes `Arc<Mutex<TurnRouting>>` holding the existing routing instructions (`routes`) plus the new `immediate_sends` records. Recording happens only on a successful `channel.send`.
  - After the tool loop, the orchestrator resolves the ordinary reply's destination key (redirect target, or the originating channel's registry key via a new `find_channel_entry_for_message` that returns the key alongside the channel) and skips final delivery on an exact match, cancelling any draft placeholder and logging the suppression. `reply_delivered` stays true — the content did reach the destination — so the `message_sent` observer hook still fires.
  - Different content, or the same content to a different destination, is intentional fanout per the accepted `send_via` contract (#6969/#7361) and still delivers. Suppressing all narration alongside tool calls would be too broad — this guard fires only on the exact-duplicate case.
  - The guard lives in shared delivery accounting, not Telegram-specific code, so the same model response cannot duplicate on any channel — as the triage requested.
- **Scope boundary:** No change to `send_via`'s routing-instruction mode, its authority/recipient resolution, the tool's schema or description, or any channel implementation. No config surface added.
- **Blast radius:** Final-reply delivery for turns that used an immediate `send_via`. Turns without `send_via` take the `immediate_sends.is_empty()` fast path and are unaffected.
- **Linked issue(s):** Fixes #9718. Related #6969, #7361 (send_via contract), #6093, #8951 (other narration-duplication fixes).
- **Labels:** `bug`, `channel`, `channel:core`, `distinguished contributor`, `risk:high`, `runtime`, `size:M`, `tool`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the reporter's setup reproduces the delta directly.
- **Interface(s) exercised:** `channel` (reported on `channel:telegram`; the guard is channel-agnostic).
- **Setup / preconditions:** the issue's configuration — a Telegram channel with a single agent and an OpenAI-compatible provider whose model emits both `content` and a `send_via` `tool_call` with the same text (reported with google/gemma-4-12b and granite-4.1-8b via LM Studio).
- **Steps to run:** send any message to the bot.
- **Expected on this branch (after):** one reply arrives; the daemon log records `suppressing final reply: an immediate send_via delivery already sent identical content to this destination this turn`.
- **Prior behavior on `master` (before):** the same reply arrives twice.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI — all three touched crates are default-features and fully exercised by lib tests.
- **Known CI coverage gap, if any:** none for this surface.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-tools -p zeroclaw-runtime -p zeroclaw-channels --all-targets -- -D warnings` — no warnings.
  - `cargo test -p zeroclaw-tools --lib` —
    ```
    test result: ok. 1637 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.53s
    ```
  - `cargo test -p zeroclaw-channels --lib` —
    ```
    test result: ok. 1455 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 14.10s
    ```
    (One unrelated test flaked once while two workspaces compiled concurrently on this machine; it passes deterministically on a normal run, as above.)
- **Beyond CI, what did you manually verify?** New turn-level regressions drive a **real** `SendViaTool` through `process_channel_message`'s tool-call loop with a provider stub that emits the `send_via` tool call and then the assistant content, exactly modeling the issue: identical content → delivered exactly once, final-send path not used (`final_send_calls == 0`); distinct content → both messages delivered and the ordinary reply still uses `send_final`. A `send_via` unit test asserts the immediate delivery is recorded with the resolved channel key, recipient, and body. These tests encode the exact double-delivery the issue reports, and the suppression path they assert does not exist on `master` (the pre-fix code has no delivery accounting), so they fail there by construction. Not verified: a live Telegram round-trip with an LM Studio model (no such endpoint here); the turn-level tests exercise the same orchestrator path a live channel takes.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No` — the guard compares already-delivered content; nothing model-visible changes.

## Compatibility (required)

- Backward compatible? `Yes` — only exact-duplicate final replies (same destination, same content as an immediate send this turn) stop delivering; that delivery was the reported defect.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` of this PR's squash commit restores unconditional final delivery.
- **Feature flags or config toggles:** none — the guard is exact-match-only by design.
- **Observable failure symptoms:** if the guard ever over-fires, the INFO log `suppressing final reply: an immediate send_via delivery already sent identical content to this destination this turn` appears on turns whose reply then never arrives; grep for that line.