### PR TITLE
fix(daemon): make the socket-ownership conflict error actionable

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/local.rs
+++ b/crates/zeroclaw-runtime/src/rpc/local.rs
@@ -408,16 +408,39 @@ mod platform {
                             lock_path.display()
                         );
                     }
+                    // Best-effort: record this owner's pid so a conflicting
+                    // startup can name the live owner in its error. Ownership
+                    // itself is the flock — a failed write only degrades the
+                    // conflict diagnostic, never correctness.
+                    {
+                        use std::io::Write;
+                        let _ = file.set_len(0);
+                        let _ = (&file).write_all(std::process::id().to_string().as_bytes());
+                    }
                     Ok(Self { _file: file })
                 }
-                Err(TryLockError::WouldBlock) => Err(std::io::Error::new(
-                    ErrorKind::AddrInUse,
-                    format!(
-                        "local IPC endpoint lifecycle is already owned at {}",
-                        path.display()
-                    ),
-                )
-                .into()),
+                Err(TryLockError::WouldBlock) => {
+                    // The flock is released automatically when the owning
+                    // process exits, so a held lock proves the owner is
+                    // alive right now — this branch is never a stale socket.
+                    let owner = read_owner_pid(&file)
+                        .map(|pid| format!(" (pid {pid})"))
+                        .unwrap_or_default();
+                    Err(std::io::Error::new(
+                        ErrorKind::AddrInUse,
+                        format!(
+                            "another ZeroClaw daemon{owner} is already running and owns the \
+                             local IPC endpoint at {}. The owner is alive — this is not a \
+                             stale socket, so do not delete it. If ZeroCode is running, it \
+                             supervises its daemon and restarts it when killed; quit ZeroCode \
+                             to stop that daemon. Stop a standalone daemon with SIGTERM \
+                             (`kill <pid>`), or `zeroclaw service stop` if it runs as a \
+                             managed service.",
+                            path.display()
+                        ),
+                    )
+                    .into())
+                }
                 Err(TryLockError::Error(error)) => Err(error).with_context(|| {
                     format!(
                         "locking local IPC endpoint lifecycle at {}",
@@ -426,6 +449,19 @@ mod platform {
                 }),
             }
         }
+    }
+
+    /// Owner pid recorded in the lifecycle lock file by [`EndpointLock::acquire`].
+    /// Absent or unparsable content (e.g. a lock held by an older daemon that
+    /// did not record its pid) degrades to `None` and the conflict error omits
+    /// the pid clause.
+    fn read_owner_pid(file: &std::fs::File) -> Option<u32> {
+        use std::io::{Read, Seek, SeekFrom};
+        let mut handle = file;
+        handle.seek(SeekFrom::Start(0)).ok()?;
+        let mut contents = String::new();
+        handle.take(32).read_to_string(&mut contents).ok()?;
+        contents.trim().parse().ok()
     }
 
     /// Removes the bound socket only while the path still names this listener.
@@ -1060,6 +1096,48 @@ mod tests {
         );
         let _next_owner = platform::EndpointLock::acquire(&sock_path).unwrap();
         drop(replacement);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn endpoint_lock_conflict_names_live_owner_and_recovery_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_path = tmp.path().join("daemon.sock");
+
+        let _owner = platform::EndpointLock::acquire(&sock_path).unwrap();
+        let error = platform::EndpointLock::acquire(&sock_path)
+            .expect_err("a held lifecycle lock must reject a second acquire");
+
+        let io = error
+            .downcast_ref::<std::io::Error>()
+            .expect("ownership conflict stays an io::Error");
+        assert_eq!(io.kind(), ErrorKind::AddrInUse);
+
+        let message = io.to_string();
+        assert!(
+            message.contains(&format!("(pid {})", std::process::id())),
+            "conflict error must name the recorded owner pid: {message}"
+        );
+        assert!(
+            message.contains("another ZeroClaw daemon"),
+            "conflict error must say a daemon is already running: {message}"
+        );
+        assert!(
+            message.contains("not a stale socket"),
+            "conflict error must distinguish a live owner from a stale socket: {message}"
+        );
+        assert!(
+            message.contains("ZeroCode"),
+            "conflict error must explain ZeroCode supervision: {message}"
+        );
+        assert!(
+            message.contains("zeroclaw service stop"),
+            "conflict error must give a safe recovery path: {message}"
+        );
+        assert!(
+            !message.contains("lifecycle lock"),
+            "conflict error should describe the situation, not the lock mechanism: {message}"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - A second daemon hitting a live-owned local IPC socket failed with `local IPC endpoint lifecycle is already owned at <path>` — a message about the internal lock mechanism, not the situation. It did not say another daemon is running, identify the owner, warn that ZeroCode supervises and restarts its managed daemon, or say whether the socket is stale, steering users toward killing the wrong process or deleting a socket with a live owner (the confusion documented in the issue).
  - The lifecycle-lock owner now records its pid in the lock file after acquiring (best-effort: ownership stays the flock itself; a failed write only degrades the diagnostic). The lock file previously carried no content, so this is backward compatible; a lock held by an older daemon simply yields the message without the pid clause.
  - On conflict the error now: names the owning daemon by pid when recorded; states the owner is alive and that this is **not** a stale socket — a held flock is released by the OS when its process exits, so the conflict branch structurally proves a live owner — and says not to delete it; explains that ZeroCode supervises its daemon and restarts it when killed, so quit ZeroCode to stop that daemon; and gives safe recovery for a standalone daemon (SIGTERM the pid, or `zeroclaw service stop` for a managed service).
  - `ErrorKind` stays `AddrInUse`, so daemon startup-failure handling and its existing tests are unchanged.
- **Scope boundary:** Unix only — the Windows named-pipe path has no lifecycle lock (its `first_pipe_instance` conflict is a different surface). No change to lock acquisition order, trust checks, socket cleanup, or the stale-socket takeover path.
- **Blast radius:** the ownership-conflict error path in `crates/zeroclaw-runtime/src/rpc/local.rs`, plus lock-file content that only this new code reads.
- **Linked issue(s):** Fixes #10178. Related #9846 (the ownership guard this diagnoses).
- **Labels:** `bug`, `daemon`, `distinguished contributor`, `risk:medium`, `runtime`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the issue's exact repro shows the delta.
- **Interface(s) exercised:** `cli` (`zeroclaw daemon` startup).
- **Setup / preconditions:** ZeroCode running with its managed daemon (or any running daemon on a config dir).
- **Steps to run:** `zeroclaw daemon --ephemeral --config-dir <same-config-dir>`.
- **Expected on this branch (after):** startup fails with `another ZeroClaw daemon (pid N) is already running and owns the local IPC endpoint at <path>. The owner is alive — this is not a stale socket, so do not delete it. If ZeroCode is running, it supervises its daemon and restarts it when killed; quit ZeroCode to stop that daemon. Stop a standalone daemon with SIGTERM (`kill <pid>`), or `zeroclaw service stop` if it runs as a managed service.`
- **Prior behavior on `master` (before):** `Error: binding local IPC endpoint: local IPC endpoint lifecycle is already owned at <path>` with no owner, no situation, no recovery path.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI; `zeroclaw-runtime` lib tests run the whole `rpc::local` suite on the default features.
- **Known CI coverage gap, if any:** none for this surface (the change is inside the unix `platform` module CI already tests).
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings` — no warnings.
  - `cargo test -p zeroclaw-runtime --lib rpc::local` —
    ```
    test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 3791 filtered out; finished in 0.08s
    ```
    including the new `endpoint_lock_conflict_names_live_owner_and_recovery_path`, which acquires the lock, attempts a second acquire, and asserts the error keeps `ErrorKind::AddrInUse` while naming the recorded owner pid, the live-owner/stale-socket distinction, ZeroCode supervision, and the recovery command — and no longer leaks the "lifecycle lock" mechanism wording.
- **Beyond CI, what did you manually verify?** The pre-existing contention tests (`stale cleanup`, `guard cleanup`, `symlinked entry`) still pass unchanged, confirming lock semantics and the AddrInUse contract are untouched; the daemon-startup ownership test in `daemon/mod.rs` asserts on the error kind only, so it is unaffected. Not verified: a live ZeroCode supervision loop (covered descriptively; the error text is exactly what that scenario needs).
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — the pid is written to the existing 0600 lock file in the daemon's own 0700 data dir, after the existing trust checks.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — a local pid in an owner-only file and an error shown to the same operator.
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — lock-file content was previously unused; old daemons' empty lock files degrade to the message without a pid clause.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk single-commit change: `git revert <sha>` restores the previous message; stray pid content in existing lock files is ignored by the old code and truncated by the next owner.
