### PR TITLE
fix(channels): make the filesystem listener cancellation-aware

### DIFF
--- a/crates/zeroclaw-channels/src/filesystem.rs
+++ b/crates/zeroclaw-channels/src/filesystem.rs
@@ -51,10 +51,10 @@ impl FilesystemChannel {
         &self.alias
     }
 
-    async fn watch_and_dispatch(&self) -> anyhow::Result<()> {
+    async fn watch_and_dispatch(&self, tx: &mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
         use zeroclaw_log::Instrument;
         let span = zeroclaw_log::attribution_span!(self);
-        self.watch_and_dispatch_inner().instrument(span).await
+        self.watch_and_dispatch_inner(tx).instrument(span).await
     }
 
     fn compile_globs_or_log(
@@ -72,13 +72,21 @@ impl FilesystemChannel {
         })
     }
 
-    async fn watch_and_dispatch_inner(&self) -> anyhow::Result<()> {
+    async fn watch_and_dispatch_inner(
+        &self,
+        tx: &mpsc::Sender<ChannelMessage>,
+    ) -> anyhow::Result<()> {
         let config = &self.config;
         config.validate()?;
         let include = self.compile_globs_or_log(&config.include, "include")?;
         let exclude = self.compile_globs_or_log(&config.exclude, "exclude")?;
 
-        let (raw_tx, raw_rx) = std::sync::mpsc::channel::<Event>();
+        // Bridge watcher callbacks (which run on notify's own thread) into an
+        // async channel so the listener awaits instead of parking a Tokio
+        // worker in a blocking `recv()`. A blocked worker stalled unrelated
+        // daemon work between filesystem events and made an idle listener
+        // impossible to cancel without a synthetic event.
+        let (raw_tx, raw_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
             if let Ok(event) = res {
                 let _ = raw_tx.send(event);
@@ -102,6 +110,21 @@ impl FilesystemChannel {
 
         zeroclaw_runtime::health::mark_component_ok("filesystem");
 
+        self.dispatch_loop(raw_rx, tx, &include, &exclude).await
+    }
+
+    /// Core event loop, separated from watcher construction so tests can
+    /// drive it with synthetic events. Returns when the event source ends or
+    /// when every receiver of `tx` is gone (supervisor shutdown) — including
+    /// while completely idle.
+    async fn dispatch_loop(
+        &self,
+        mut raw_rx: tokio::sync::mpsc::UnboundedReceiver<Event>,
+        tx: &mpsc::Sender<ChannelMessage>,
+        include: &[glob::Pattern],
+        exclude: &[glob::Pattern],
+    ) -> anyhow::Result<()> {
+        let config = &self.config;
         let enabled_events = parse_event_kinds(&config.events);
         let debounce = Duration::from_millis(config.debounce_ms);
         let settle = Duration::from_millis(config.settle_ms);
@@ -109,9 +132,12 @@ impl FilesystemChannel {
         let mut pending_from: Option<PathBuf> = None;
 
         loop {
-            let event = match raw_rx.recv() {
-                Ok(e) => e,
-                Err(_) => return Ok(()),
+            let event = tokio::select! {
+                maybe_event = raw_rx.recv() => match maybe_event {
+                    Some(event) => event,
+                    None => return Ok(()),
+                },
+                () = tx.closed() => return Ok(()),
             };
 
             let (kind, path, old_path) = match classify(&event, &mut pending_from) {
@@ -128,7 +154,7 @@ impl FilesystemChannel {
 
             let path_str = path.to_string_lossy().to_string();
 
-            if !matches_globs(&path_str, &include, &exclude) {
+            if !matches_globs(&path_str, include, exclude) {
                 continue;
             }
 
@@ -188,8 +214,8 @@ impl Channel for FilesystemChannel {
         false
     }
 
-    async fn listen(&self, _tx: mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
-        self.watch_and_dispatch().await
+    async fn listen(&self, tx: mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
+        self.watch_and_dispatch(&tx).await
     }
 
     fn self_handle(&self) -> Option<String> {
@@ -862,6 +888,86 @@ mod tests {
         assert_eq!(payload["content"], "{\"id\":1}");
     }
 
+    fn test_channel(config: FilesystemConfig, alias: &str) -> FilesystemChannel {
+        use std::sync::Arc;
+        use zeroclaw_runtime::sop::engine::SopEngine;
+
+        let memory = Arc::new(zeroclaw_memory::NoneMemory::new(alias));
+        FilesystemChannel::new(FilesystemChannelConfig {
+            config,
+            alias: alias.into(),
+            engine: Arc::new(Mutex::new(SopEngine::new(Default::default()))),
+            audit: Arc::new(SopAuditLogger::new(memory)),
+        })
+    }
+
+    /// Regression for the blocking `std::sync::mpsc::Receiver::recv()` in the
+    /// listener: an idle filesystem channel must exit promptly when the
+    /// supervisor's message channel closes, without needing a synthetic
+    /// filesystem event to unblock it. Before the async bridge, this test
+    /// hangs until its timeout because the listener parks a runtime worker in
+    /// the blocking receive.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idle_listener_exits_on_shutdown_without_a_filesystem_event() {
+        let watched = tempfile::tempdir().unwrap();
+        let channel = test_channel(
+            FilesystemConfig {
+                paths: vec![watched.path().to_string_lossy().to_string()],
+                ..FilesystemConfig::default()
+            },
+            "fs-idle-cancel",
+        );
+
+        let (tx, rx) = mpsc::channel(1);
+        let listener = ::zeroclaw_spawn::spawn!(async move { channel.listen(tx).await });
+
+        // Close the supervisor side while the watcher is completely idle.
+        drop(rx);
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(10), listener)
+            .await
+            .expect("idle listener must exit promptly on shutdown, not wait for an event")
+            .expect("listener task must not panic");
+        result.expect("shutdown is a clean exit");
+    }
+
+    /// The dispatch loop still processes synthetic watcher events and exits
+    /// cleanly when the event source ends.
+    #[tokio::test]
+    async fn dispatch_loop_delivers_events_then_exits_when_source_ends() {
+        use notify::event::{CreateKind, EventKind};
+
+        let watched = tempfile::tempdir().unwrap();
+        let file = watched.path().join("order-1.json");
+        std::fs::write(&file, b"{}").unwrap();
+
+        let channel = test_channel(
+            FilesystemConfig {
+                paths: vec![watched.path().to_string_lossy().to_string()],
+                settle_ms: 0,
+                ..FilesystemConfig::default()
+            },
+            "fs-loop",
+        );
+
+        let (raw_tx, raw_rx) = tokio::sync::mpsc::unbounded_channel();
+        raw_tx
+            .send(Event::new(EventKind::Create(CreateKind::File)).add_path(file))
+            .unwrap();
+        drop(raw_tx);
+
+        let (tx, _rx) = mpsc::channel(1);
+        let include = compile_globs(&[]).unwrap();
+        let exclude = compile_globs(&[]).unwrap();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            channel.dispatch_loop(raw_rx, &tx, &include, &exclude),
+        )
+        .await
+        .expect("loop must exit once the event source ends")
+        .expect("processing a delivered event is not an error");
+    }
+
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn invalid_glob_rejection_is_span_attributed() {
@@ -888,8 +994,9 @@ mod tests {
             audit: Arc::new(SopAuditLogger::new(memory)),
         });
 
+        let (probe_tx, _probe_rx) = mpsc::channel(1);
         let err = channel
-            .watch_and_dispatch()
+            .watch_and_dispatch(&probe_tx)
             .await
             .expect_err("invalid include glob must fail the listener closed");
         assert!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The filesystem channel listener called blocking `std::sync::mpsc::Receiver::recv()` inside its async loop. While the watcher was idle this parked a Tokio runtime worker without yielding — the live v0.8.4 Alpine reproduction (#9860, linked from the issue) saw dashboard/API requests pend until the *next* filesystem event released the worker — and an idle listener could not be cancelled at all, because its future never reached an await point.
  - Watcher callbacks (which run on notify's own thread) now bridge into a `tokio::sync::mpsc::unbounded_channel`, and the event loop awaits it with `tokio::select!` against `tx.closed()` — the supervisor's message-channel closure. Idle cancellation completes promptly, needs no synthetic event, and no runtime worker is occupied by blocking work — the issue's three behavioral acceptance criteria.
  - The event loop is split into `dispatch_loop` (taking the event receiver and compiled globs) so tests can drive it with synthetic `notify::Event`s deterministically instead of relying on OS watcher latency; watcher construction and path registration are unchanged.
- **Scope boundary:** No change to event classification, debounce/settle behavior, glob filtering, payload building, or SOP dispatch — the loop body is identical, only its wait primitive and its extraction changed. No config surface changed.
- **Blast radius:** the filesystem channel listener lifecycle; every deployment with an enabled filesystem channel stops risking daemon-wide stalls between events.
- **Linked issue(s):** Fixes #9666. Related #9860 (live reproduction).
- **Labels:** `bug`, `channel`, `distinguished contributor`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — #9860's reproduction shows the delta directly.
- **Interface(s) exercised:** `web` (dashboard/API responsiveness while a filesystem channel is idle).
- **Setup / preconditions:** daemon with an enabled `[channels.filesystem.<alias>]` watching any directory (per #9860, reproduced on Alpine v0.8.4).
- **Steps to run:** create one file in the watched directory, then issue dashboard/API requests without further file activity; also stop the daemon while the watcher is idle.
- **Expected on this branch (after):** API requests respond while the watcher is idle; daemon shutdown completes promptly with no filesystem activity.
- **Prior behavior on `master` (before):** requests hang until the next file event; shutdown of an idle listener needs a synthetic event.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI; the filesystem channel is in the default feature set of `zeroclaw-channels`.
- **Known CI coverage gap, if any:** The synthetic normal-delivery test asserts clean loop exit but does not observe the SOP dispatch boundary; strengthening that assertion is tracked separately.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-channels --all-targets -- -D warnings` — no warnings.
  - `cargo test -p zeroclaw-channels --lib` —
    ```
    test result: ok. 1455 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 13.55s
    ```
  - The new idle-shutdown regression grafted onto `master` (45e5ce137):
    ```
    test filesystem::tests::idle_listener_exits_on_shutdown_without_a_filesystem_event ... FAILED
    idle listener must exit promptly on shutdown, not wait for an event: Elapsed(())
    test result: FAILED. 0 passed; 1 failed; ... finished in 10.06s
    ```
    (hangs for the full 10s timeout on `master`; exits immediately on this branch — timeout-bounded, per the issue's acceptance criteria).
- **Beyond CI, what did you manually verify?** The full filesystem test module (22 tests) passes, including the pre-existing span-attribution and payload/security tests. The second new test drives a synthetic create event through `dispatch_loop` and asserts clean exit when the event source ends, but it does not observe whether SOP dispatch occurred; that test-hardening gap is tracked separately. Not verified: a live Alpine container reproduction of #9860 (no Alpine deployment here); the stall mechanism it documents is exactly the blocking receive this removes.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — same events, same dispatch; the unbounded bridge preserves delivery order. (The previous std channel was also unbounded.)
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` of this PR's squash commit.
- **Feature flags or config toggles:** `None`.
- **Observable failure symptoms:** if event delivery regressed, `Filesystem channel: dispatching` log lines stop appearing for real file events; if cancellation regressed, daemon shutdown with an idle filesystem channel hangs again.