### PR TITLE
fix(zerocode): retain ownership of reconnect-spawned daemon children

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -366,6 +366,11 @@ pub async fn run(
     let mut content_area = Rect::default();
     let mut reconnect_last_attempt: Option<std::time::Instant> = None;
     let mut ephemeral_respawn_done = false;
+    // Replacement daemon spawned by this disconnection episode, held until
+    // the answering daemon is verified to be that child (then detached) or
+    // the child exits early (then reaped). Dropping it on TUI exit
+    // terminates a replacement that never became usable.
+    let mut recovery_daemon: Option<crate::SpawnedDaemon> = None;
     let mut needs_intervention = false;
 
     // The live client handle. Reassigned in place on a successful
@@ -593,8 +598,18 @@ pub async fn run(
             if owns_ephemeral && !ephemeral_respawn_done {
                 ephemeral_respawn_done = true;
                 if let crate::ConnectTarget::LocalSocket(socket) = target {
-                    let _ = crate::spawn_ephemeral_daemon(config_dir, socket);
+                    recovery_daemon = crate::spawn_owned_ephemeral_daemon(config_dir, socket).ok();
                 }
+            }
+
+            // Reap an early replacement exit so it cannot linger as a zombie.
+            // The single permitted respawn stays consumed; the user is flagged
+            // just like a replacement that never answers.
+            if let Some(daemon) = recovery_daemon.as_mut()
+                && matches!(daemon.poll_exit(), Ok(Some(_)))
+            {
+                recovery_daemon = None;
+                needs_intervention = true;
             }
 
             {
@@ -612,7 +627,19 @@ pub async fn run(
                         .connect(prev_id.as_deref(), prev_sig.as_deref())
                         .await
                     {
+                        let answering_pid = new_client.server_pid;
                         rpc = Arc::new(new_client);
+                        // Ownership handoff mirrors the initial-start path:
+                        // keep the replacement only if it is the daemon that
+                        // answered (it then manages its own ephemeral
+                        // lifetime); otherwise terminate and reap it so it
+                        // cannot outlive the TUI.
+                        if let Some(mut daemon) = recovery_daemon.take()
+                            && crate::reconcile_spawned_daemon_identity(answering_pid, &mut daemon)
+                                .unwrap_or(false)
+                        {
+                            daemon.detach();
+                        }
                         let resume_chat = (
                             chat_pane.current_session_id().map(String::from),
                             chat_pane.current_agent_alias().map(String::from),

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -901,8 +901,8 @@ mod connection_tests {
         assert!(daemon.try_wait().expect("poll reaped helper").is_some());
     }
 
-    /// Recovery-path regression for #9503: when a different daemon answers
-    /// the reconnect, the spawned replacement must be terminated and reaped
+    /// Recovery-path regression: when a different daemon answers the
+    /// reconnect, the spawned replacement must be terminated and reaped
     /// rather than surviving the TUI.
     #[test]
     fn recovery_handoff_terminates_and_reaps_mismatched_replacement() {

--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -476,18 +476,7 @@ async fn run_until_exit(
     }
 }
 
-pub(crate) fn spawn_ephemeral_daemon(
-    config_dir: &std::path::Path,
-    socket: &std::path::Path,
-) -> anyhow::Result<()> {
-    let mut cmd = ephemeral_daemon_command(config_dir, socket);
-    cmd.stderr(std::process::Stdio::null());
-    cmd.spawn()
-        .map_err(|e| anyhow::Error::msg(format!("failed to spawn daemon: {e}")))?;
-    Ok(())
-}
-
-fn spawn_owned_ephemeral_daemon(
+pub(crate) fn spawn_owned_ephemeral_daemon(
     config_dir: &std::path::Path,
     socket: &std::path::Path,
 ) -> anyhow::Result<SpawnedDaemon> {
@@ -537,7 +526,7 @@ fn configure_ephemeral_daemon_command(
         .env("ZEROCLAW_SOCKET", socket);
 }
 
-struct SpawnedDaemon {
+pub(crate) struct SpawnedDaemon {
     child: std::process::Child,
     stderr: Arc<Mutex<std::collections::VecDeque<u8>>>,
     capture_stderr: Arc<AtomicBool>,
@@ -628,7 +617,7 @@ impl SpawnedDaemon {
         self.child.id()
     }
 
-    fn poll_exit(&mut self) -> anyhow::Result<Option<SpawnedDaemonExit>> {
+    pub(crate) fn poll_exit(&mut self) -> anyhow::Result<Option<SpawnedDaemonExit>> {
         let Some(status) = self.child.try_wait()? else {
             return Ok(None);
         };
@@ -659,7 +648,7 @@ impl SpawnedDaemon {
         sanitize_daemon_stderr(&bytes)
     }
 
-    fn detach(mut self) {
+    pub(crate) fn detach(mut self) {
         self.cleanup_on_drop = false;
         self.capture_stderr.store(false, Ordering::Release);
         self.stderr_done.take();
@@ -724,7 +713,7 @@ fn sanitize_daemon_stderr(bytes: &[u8]) -> String {
     rendered[start..].to_owned()
 }
 
-fn reconcile_spawned_daemon_identity(
+pub(crate) fn reconcile_spawned_daemon_identity(
     server_pid: Option<u32>,
     daemon: &mut SpawnedDaemon,
 ) -> anyhow::Result<bool> {
@@ -910,6 +899,25 @@ mod connection_tests {
 
         assert!(!exit.status.success());
         assert!(daemon.try_wait().expect("poll reaped helper").is_some());
+    }
+
+    /// Recovery-path regression for #9503: when a different daemon answers
+    /// the reconnect, the spawned replacement must be terminated and reaped
+    /// rather than surviving the TUI.
+    #[test]
+    fn recovery_handoff_terminates_and_reaps_mismatched_replacement() {
+        let mut daemon =
+            SpawnedDaemon::spawn(spawned_daemon_helper_command("sleep")).expect("spawn helper");
+        let other_pid = daemon.id().wrapping_add(1);
+
+        let owns = reconcile_spawned_daemon_identity(Some(other_pid), &mut daemon)
+            .expect("mismatch handoff cleans up the replacement");
+
+        assert!(!owns, "a different answering daemon is not our child");
+        assert!(
+            daemon.try_wait().expect("poll reaped helper").is_some(),
+            "the mismatched replacement must be terminated and reaped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The disconnected-recovery loop in `apps/zerocode/src/app.rs` spawned its one replacement daemon through `spawn_ephemeral_daemon`, which dropped the `Child` handle immediately. ZeroCode therefore could not reap an early replacement exit (left a zombie on Unix) and could not terminate a replacement that never accepted a client — the process could survive the TUI, exactly as the issue describes.
  - The recovery path now uses the owned spawn (`SpawnedDaemon`, the ownership type #9334 introduced for the initial auto-start path) and holds it across the disconnected episode, meeting the issue's four expectations:
    - **early exits observed and reaped:** each disconnected tick polls the child; an early exit is reaped and flags `needs_intervention`, and the single permitted respawn stays consumed (one-spawn-per-disconnection preserved);
    - **unusable replacements cleaned up on quit:** the held `SpawnedDaemon`'s drop terminates and reaps a replacement that never became usable when `app::run` returns;
    - **ownership relinquished only after verification:** on reconnect, `reconcile_spawned_daemon_identity` compares the answering daemon's pid with the child, mirroring the initial-start path — our child is detached to manage its own ephemeral lifetime; a different answering daemon means the replacement is terminated and reaped;
    - **one-spawn-per-disconnection preserved:** the `ephemeral_respawn_done` logic is untouched.
  - The now-unused detached helper is removed.
- **Scope boundary:** No change to the initial auto-start lifecycle, reconnect throttling, pane rebuilding, or daemon-side behavior. `SpawnedDaemon` mechanics are unchanged; only visibilities widened to `pub(crate)` for the two methods the recovery path uses.
- **Blast radius:** ZeroCode's disconnected-recovery path for TUI-owned ephemeral daemons.
- **Linked issue(s):** Fixes #9503. Related #9334 (initial-start ownership this extends to recovery).
- **Labels:** `bug`, `distinguished contributor`, `needs-author-action`, `risk:medium`, `zerocode`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the issue's repro is directly observable.
- **Interface(s) exercised:** `tui` (ZeroCode).
- **Setup / preconditions:** start ZeroCode with no pre-existing daemon so it owns an ephemeral daemon.
- **Steps to run:** kill the owned daemon; let recovery spawn its one replacement; then either kill the replacement before reconnect completes and check `ps` for zombies, or quit ZeroCode while the replacement is still unconnected and check for surviving `zeroclaw daemon` processes.
- **Expected on this branch (after):** no zombie remains after an early replacement exit (ZeroCode flags that manual intervention is needed); quitting ZeroCode terminates an unconnected replacement.
- **Prior behavior on `master` (before):** the early-exited replacement stays a zombie while the TUI runs, and an unconnected replacement survives ZeroCode's exit.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI; `zerocode` builds and tests on the default workspace configuration.
- **Known CI coverage gap, if any:** the interactive TUI loop itself is not unit-testable; the decision logic it calls is.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zerocode --all-targets -- -D warnings` — no warnings.
  - `cargo test -p zerocode` —
    ```
    test result: ok. 744 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.34s
    ```
    (plus the isolated subprocess-helper test binaries, all green).
- **Beyond CI, what did you manually verify?** New regression `recovery_handoff_terminates_and_reaps_mismatched_replacement` exercises the recovery handoff's mismatch arm with a real spawned child: a different answering pid must leave the replacement terminated **and reaped** — this used the previously-untested path of `reconcile_spawned_daemon_identity` that recovery now depends on. Early-exit reaping and quit-time cleanup ride on `SpawnedDaemon::poll_exit`/`Drop`, which keep their existing subprocess-helper coverage (`spawned_daemon_cleanup_terminates_and_reaps_running_child`, `spawned_daemon_early_exit_reports_bounded_stderr`). Not verified: a live kill-the-daemon TUI session (no interactive terminal here); the wiring change reuses exactly the flow the initial-start path runs on every cold start.
- **Visual interface changed?** `N/A` — no rendering change; `needs_intervention` reuses the existing disconnected-state presentation.
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — same spawn cadence; the only behavior change is cleanup of processes that previously leaked.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the landed squash commit with `git revert <squash-merge-sha>` and ship that revert through the normal release path; this restores the detached recovery spawn.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** ZeroCode fails to reconnect after daemon loss, reports an unexpected manual-intervention state, or leaves a reconnect-spawned daemon running or as a zombie after the TUI exits.
