### PR TITLE
fix(doctor): serialize model-cache refreshes with a cross-process lock

### DIFF
--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -464,6 +464,33 @@ pub fn persist_model_cache(
 
     let cache_path = cache_dir.join(MODEL_CACHE_FILE);
 
+    // Cross-process advisory lock around the whole read-merge-publish
+    // sequence. The publish itself is collision-safe (exclusive temp file +
+    // atomic rename), but without serialization two concurrent refreshes can
+    // both read the same pre-refresh snapshot and the second rename silently
+    // discards the first one's provider entry — the lost-update window left
+    // open by #9075. Blocking (rather than failing) lets overlapping
+    // refreshes complete in sequence; the lock releases when the guard drops.
+    let lock_path = cache_dir.join(format!("{MODEL_CACHE_FILE}.lock"));
+    let cache_lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| {
+            format!(
+                "Failed to open model cache lock file at {}",
+                lock_path.display()
+            )
+        })?;
+    cache_lock.lock().with_context(|| {
+        format!(
+            "Failed to lock model cache for refresh at {}",
+            lock_path.display()
+        )
+    })?;
+
     // Load existing cache, starting fresh only when the file is genuinely
     // absent. A malformed or unreadable existing file is left untouched and
     // reported rather than silently replaced with a single-provider cache.
@@ -2237,6 +2264,45 @@ mod tests {
         assert_eq!(
             canonicalize_provider_ref("openrouter.work"),
             "openrouter.work"
+        );
+    }
+
+    /// Lost-update regression: concurrent refreshes for different providers
+    /// each read-merge-publish the whole cache file, so without the advisory
+    /// lock one publish can silently drop another's entry. Every concurrently
+    /// written provider must survive.
+    #[test]
+    fn persist_model_cache_concurrent_refreshes_keep_every_provider() {
+        let tmp = TempDir::new().unwrap();
+        let config = config_with_install_root(&tmp);
+
+        let providers: Vec<String> = (0..8).map(|i| format!("provider{i}")).collect();
+        std::thread::scope(|scope| {
+            for provider in &providers {
+                let config = &config;
+                scope.spawn(move || {
+                    for round in 0..5 {
+                        persist_model_cache(config, provider, &[format!("m{round}")]).unwrap();
+                    }
+                });
+            }
+        });
+
+        let raw = std::fs::read_to_string(tmp.path().join("state/models_cache.json")).unwrap();
+        let cache: zeroclaw_config::schema::ModelCacheState = serde_json::from_str(&raw).unwrap();
+        let mut cached: Vec<&str> = cache
+            .entries
+            .iter()
+            .map(|e| e.model_provider.as_str())
+            .collect();
+        cached.sort_unstable();
+        let expected: Vec<String> = providers
+            .iter()
+            .map(|p| canonicalize_provider_ref(p))
+            .collect();
+        assert_eq!(
+            cached, expected,
+            "a concurrent refresh must not lose another provider's entry"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -468,8 +468,8 @@ pub fn persist_model_cache(
     // sequence. The publish itself is collision-safe (exclusive temp file +
     // atomic rename), but without serialization two concurrent refreshes can
     // both read the same pre-refresh snapshot and the second rename silently
-    // discards the first one's provider entry — the lost-update window left
-    // open by #9075. Blocking (rather than failing) lets overlapping
+    // discards the first one's provider entry — the lost-update window the
+    // collision-safe publish left open. Blocking (rather than failing) lets overlapping
     // refreshes complete in sequence; the lock releases when the guard drops.
     let lock_path = cache_dir.join(format!("{MODEL_CACHE_FILE}.lock"));
     let cache_lock = std::fs::OpenOptions::new()


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `persist_model_cache` read the shared cache, merged one provider's entry in memory, and re-published the whole file. The publish is collision-safe since #9075 (exclusive temp file + atomic rename), but the read-modify-write window was uncoordinated across processes: two concurrent `zeroclaw models refresh` runs could both read the same pre-refresh snapshot and the later rename silently dropped the earlier run's provider entry — the documented lost-update follow-up this issue tracks.
  - The whole read-merge-publish sequence now holds a **blocking advisory file lock** on `models_cache.json.lock` in the same state directory — the cross-process-advisory-lock option the issue names. Overlapping refreshes complete in sequence; the lock releases when the guard drops (including on process death, since it is an OS file lock).
  - Blocking (rather than failing) keeps `models refresh` UX unchanged for the rare overlap: the second run waits while the first completes the brief local publish transaction.
- **Scope boundary:** No change to the merge semantics, canonicalization, malformed-cache refusal, atomic publish primitive, or any reader. The channel orchestrator remains a production reader of this shared cache; its call to `persist_model_cache` is test-only and joins the real writer and reader for regression coverage.
- **Blast radius:** The model-cache writer used by `zeroclaw models refresh`; channel readers are unchanged.
- **Linked issue(s):** Fixes #9590. Related #9046, #9075 (the collision-safe publish this completes).
- **Labels:** `bug`, `distinguished contributor`, `doctor`, `risk:medium`, `runtime`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the race is timing-dependent by hand; the deterministic multi-thread regression below is the reliable reproduction and shows the A/B against `master` directly.

### How I tested

- **CI checks relied on and why they cover this change:** standard Rust fmt/clippy/test CI; `zeroclaw-runtime` lib tests run the doctor module on default features.
- **Known CI coverage gap, if any:** none for this surface.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings` — no warnings.
  - `cargo test -p zeroclaw-runtime --lib doctor::` —
    ```
    test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 3763 filtered out; finished in 1.26s
    ```
  - The new regression grafted onto `master` (`45e5ce137`), three consecutive runs:
    ```
    test result: FAILED. 0 passed; 1 failed; ... (x3)
    assertion `left == right` failed: a concurrent refresh must not lose another provider's entry
    ```
    (loses provider entries on every unlocked run; passes deterministically with the lock).
- **Beyond CI, what did you manually verify?** The regression uses eight threads with distinct file handles, which contend through the same OS lock primitive as separate processes, so the single-process test models the cross-process race. All pre-existing cache tests — merge/replace, malformed-file refusal, unreadable-file refusal, and the tmp-symlink non-follow regression — still pass unchanged. Not verified: two literal `zeroclaw models refresh` processes racing by hand (timing-dependent, as the issue notes); the lock primitive is the same OS facility the daemon's endpoint lifecycle lock already relies on.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `Yes, narrowly` — creates one persistent lock file beside the cache it guards inside the existing daemon-owned state directory; it contains no user data or secrets.
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — an old binary racing a new one simply doesn't take the lock, matching today's behavior until both sides upgrade.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No` — `File::lock` is already used by the runtime's endpoint lifecycle lock.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit on `master`; the leftover `models_cache.json.lock` file is inert to old code and can remain on disk.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `zeroclaw models refresh` fails with `Failed to open model cache lock file` or `Failed to lock model cache for refresh`, waits unexpectedly while another process owns the lock, or concurrent refreshes again leave a provider entry missing from `data/state/models_cache.json`.
