### PR TITLE
fix(providers): simplify structured upstream errors

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -3841,7 +3841,10 @@ mod tests {
         let error =
             streaming_api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, &body).to_string();
 
-        assert_eq!(error, format!("500 Internal Server Error: {message}"));
+        assert_eq!(
+            error,
+            format!("ModelProvider error: 500 Internal Server Error: {message}")
+        );
     }
 
     fn make_model_provider(

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -242,8 +242,44 @@ fn apply_auth_to_request(
     }
 }
 
+fn structured_api_error_message(value: &serde_json::Value) -> Option<String> {
+    let object = value.as_object()?;
+
+    let nested_message = object.get("error").and_then(|error| match error {
+        serde_json::Value::Object(_) => structured_api_error_message(error),
+        serde_json::Value::String(error) => serde_json::from_str(error)
+            .ok()
+            .and_then(|nested| structured_api_error_message(&nested)),
+        _ => None,
+    });
+    if let Some(message) = nested_message {
+        return Some(message);
+    }
+
+    for key in ["message", "detail"] {
+        if let Some(message) = object
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|message| !message.is_empty())
+        {
+            return Some(message.to_string());
+        }
+    }
+
+    object
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .map(str::to_string)
+}
+
 fn streaming_api_error(status: reqwest::StatusCode, body: &str) -> StreamError {
-    let sanitized = super::sanitize_api_error(body);
+    let message = serde_json::from_str(body)
+        .ok()
+        .and_then(|value| structured_api_error_message(&value));
+    let sanitized = super::sanitize_api_error(message.as_deref().unwrap_or(body));
     StreamError::ModelProvider(format!("{status}: {sanitized}"))
 }
 
@@ -3782,6 +3818,29 @@ mod tests {
         assert!(error.contains("[REDACTED]"));
         assert!(!error.contains(secret));
         assert!(error.chars().count() <= 550);
+    }
+
+    #[test]
+    fn streaming_api_error_extracts_message_from_stringified_error_envelope() {
+        let message = "anthropic error: Message: fetch failed Cause: AggregateError Name: TypeError";
+        let body = serde_json::json!({
+            "status": "failure",
+            "message": message,
+            "error": serde_json::json!({
+                "message": message,
+                "type": "APIError",
+                "code": "500",
+            })
+            .to_string(),
+            "error_origin_level": "api_error",
+            "provider": "anthropic",
+        })
+        .to_string();
+
+        let error = streaming_api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, &body)
+            .to_string();
+
+        assert_eq!(error, format!("500 Internal Server Error: {message}"));
     }
 
     fn make_model_provider(

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -3822,7 +3822,8 @@ mod tests {
 
     #[test]
     fn streaming_api_error_extracts_message_from_stringified_error_envelope() {
-        let message = "anthropic error: Message: fetch failed Cause: AggregateError Name: TypeError";
+        let message =
+            "anthropic error: Message: fetch failed Cause: AggregateError Name: TypeError";
         let body = serde_json::json!({
             "status": "failure",
             "message": message,
@@ -3837,8 +3838,8 @@ mod tests {
         })
         .to_string();
 
-        let error = streaming_api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, &body)
-            .to_string();
+        let error =
+            streaming_api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, &body).to_string();
 
         assert_eq!(error, format!("500 Internal Server Error: {message}"));
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Extract a concise message from common compatible-provider JSON error envelopes before formatting streaming non-2xx failures.
- **What changed and why:** Preserve the existing HTTP status, secret scrubbing, length bound, and raw-body fallback while avoiding duplicated stringified nested JSON.
- **What changed and why:** Add a unit regression for the nested envelope reported in #10224.
- **Scope boundary:** This PR does not change non-streaming error handling, provider routing, retry behavior, telemetry schemas, or log attributes.
- **Blast radius:** Only the human-readable error text returned by OpenAI-compatible streaming requests after a non-success HTTP status.
- **Linked issue(s):** Fixes #10224
- **Labels:** `provider`, `provider:compatible`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the deterministic unit regression exercises the reported envelope without requiring a live custom provider.

### How I tested

- **CI checks relied on and why they cover this change:** The required Quality Gate on head `02b7e372267e91af453fdd22c6e3a02b0331df81` passed Format, Lint/Clippy, the full workspace Test job, MSRV, Linux/macOS/Windows and feature-matrix checks, Security, Semgrep, and the final CI Required Gate. The Test job directly executed the new `zeroclaw-providers` regression.
- **Known CI coverage gap, if any:** None for the changed Rust surface after the required CI completed successfully.
- **Commands run and tail output:**

  ```sh
  git diff --check upstream/master...HEAD
  # exit 0, no output
  ```

- **Beyond CI, what did you manually verify?** Compared the helper against the exact nested JSON shape from #10224 and verified unknown response shapes still use the existing sanitized raw-body fallback. I did not exercise a live provider endpoint.
- **Visual interface changed?** N/A — no rendered interface changed.
- **If any command was intentionally skipped, why:** Local `cargo test` and `cargo fmt` were skipped because `cargo` is not installed on the host; the required CI subsequently ran and passed both formatting and the complete workspace test job on the final head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes` — structured message selection now occurs before the existing sanitizer; every selected message and raw fallback still passes through the same secret scrubber and 500-character bound.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: A structured upstream error may contain sensitive text. The change retains `sanitize_api_error` as the single final formatting gate, and the existing secret-redaction test continues to cover that boundary.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge SHA>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Compatible-provider streaming failures lose the concise message or return the full escaped JSON envelope again; inspect `model_provider stream emitted an error event` records.
