### PR TITLE
feat(security): canonical principals and shared grant resolution (#8289 stage 2, supersedes #8672 in part)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13853,6 +13853,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "parking_lot",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "strum 0.28.0",

--- a/crates/zeroclaw-api/Cargo.toml
+++ b/crates/zeroclaw-api/Cargo.toml
@@ -14,12 +14,16 @@ async-trait = "0.1"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std", "rc"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
+schemars = { version = "1.2", optional = true }
 strum = "0.28"
 strum_macros = "0.28"
 thiserror = "2.0"
 tokio = { version = "1.50", default-features = false, features = ["sync", "process", "macros", "rt"] }
 tokio-util = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[features]
+schema-export = ["dep:schemars"]
 
 [dev-dependencies]
 parking_lot = "0.12"

--- a/crates/zeroclaw-api/src/grants.rs
+++ b/crates/zeroclaw-api/src/grants.rs
@@ -1,0 +1,432 @@
+//! Resolved authorization grants — the single runtime authorization
+//! vocabulary (RFC #7141).
+//!
+//! The grant vocabulary is resource × verb over enum-typed resource classes,
+//! plus three fine-grain selectors (agent aliases, config write paths, tool
+//! names) and an `admin` short-circuit. Providers never construct these:
+//! the shared principal resolver maps verified claims / roster entries
+//! through configured permission profiles into one merged [`ResolvedGrants`],
+//! re-resolved whenever the authorization-policy generation changes.
+//!
+//! Deny-by-default, Rev 8 semantics: an empty grant set permits nothing,
+//! and an EMPTY SELECTOR LIST GRANTS NO INSTANCES — broad access requires
+//! the explicit [`WILDCARD`] selector or an administrator grant. Every RPC
+//! method and gateway route classifies itself to exactly one
+//! `(Resource, Verb)` pair, so a request either matches a held grant or is
+//! refused — there is no unclassified traffic. Operations with a
+//! fine-grained selector require BOTH the resource-verb grant AND a
+//! matching selector (composition by intersection).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::principal::AgentAlias;
+
+/// The explicit all-instances selector for `allowed_agents`,
+/// `allowed_tools`, and `config_write_paths`. Broad access is always this
+/// explicit token (or `admin`) — never an empty list.
+pub const WILDCARD: &str = "*";
+
+/// Every grantable resource class in the system. One variant per
+/// RPC/gateway-addressable surface; a new surface must add its variant here
+/// and classify its methods before it can be dispatched.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum Resource {
+    /// Daemon status, health, doctor, and handshake surfaces.
+    System,
+    /// Agent chat sessions (create, prompt, list, kill, approve).
+    Sessions,
+    /// Long-term memory entries.
+    Memory,
+    /// Scheduled jobs and their run history.
+    Cron,
+    /// Configuration reads and writes (writes additionally gated by
+    /// [`ResolvedGrants::may_write_config`]).
+    Config,
+    /// Agent roster introspection and lifecycle.
+    Agents,
+    /// Cost and usage accounting.
+    Cost,
+    /// Skill bundles and skill files.
+    Skills,
+    /// Personality documents.
+    Personality,
+    /// Log queries and live subscriptions.
+    Logs,
+    /// Connected TUI enumeration.
+    Tui,
+    /// File attachment and workspace listing.
+    Files,
+    /// Locale catalogs.
+    Locales,
+    /// First-run quickstart flows.
+    Quickstart,
+    /// Messaging channel instances.
+    Channels,
+    /// Model/TTS/transcription provider profiles.
+    Providers,
+    /// Model catalog and routing.
+    Models,
+    /// Peer group membership.
+    PeerGroups,
+    /// Installed plugins and plugin lifecycle.
+    Plugins,
+    /// Direct tool invocation surfaces.
+    Tools,
+    /// Standard Operating Procedure authoring, execution, and decision
+    /// surfaces.
+    Sops,
+}
+
+/// What may be done to a [`Resource`].
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum Verb {
+    Create,
+    Read,
+    Update,
+    Delete,
+    /// Run/trigger semantics distinct from mutation (prompt a session,
+    /// trigger a cron job, execute a skill).
+    Execute,
+}
+
+/// The merged authorization result for one principal: what it may touch and
+/// how. Produced by the shared grant resolver from permission profiles at a
+/// specific authorization-policy generation; consumed by dispatch
+/// classification, the gateway router, and deep resource checks. Never
+/// stored on a `Principal` — consumers re-resolve when the generation
+/// changes.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ResolvedGrants {
+    /// Full access to everything. Short-circuits all other checks. An
+    /// explicit administrator grant dominates the ordinary grant set.
+    #[serde(default)]
+    pub admin: bool,
+    /// Agent aliases this principal may bind or address. Empty = none;
+    /// broad access requires the explicit [`WILDCARD`] entry.
+    #[serde(default)]
+    pub allowed_agents: Vec<AgentAlias>,
+    /// Dotted config path prefixes this principal may write. A trailing
+    /// `.*` grants the subtree; a bare path grants that exact prop; the
+    /// [`WILDCARD`] entry grants every path. Empty = none.
+    #[serde(default)]
+    pub config_write_paths: Vec<String>,
+    /// Tool names this principal may cause an agent to run. Empty = none;
+    /// broad access requires the explicit [`WILDCARD`] entry. (The agent's
+    /// own tool policy still applies on top.)
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    /// Resource-class grants: which verbs are permitted per resource.
+    /// Missing resource = deny.
+    #[serde(default)]
+    pub resources: BTreeMap<Resource, BTreeSet<Verb>>,
+}
+
+impl ResolvedGrants {
+    /// The deny-everything grant set (the `Default`).
+    #[must_use]
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// The allow-everything grant set (admin). Used for the shared-operator
+    /// sentinel so legacy single-operator deployments keep today's
+    /// behaviour.
+    #[must_use]
+    pub fn all() -> Self {
+        Self {
+            admin: true,
+            ..Self::default()
+        }
+    }
+
+    /// Whether this grant set permits `verb` on `resource`.
+    #[must_use]
+    pub fn permits(&self, resource: Resource, verb: Verb) -> bool {
+        if self.admin {
+            return true;
+        }
+        self.resources
+            .get(&resource)
+            .is_some_and(|verbs| verbs.contains(&verb))
+    }
+
+    /// Whether this principal may bind or address the given agent alias.
+    /// An empty selector list grants no agents; broad access requires the
+    /// explicit [`WILDCARD`] entry or `admin`.
+    #[must_use]
+    pub fn may_use_agent(&self, alias: &str) -> bool {
+        if self.admin {
+            return true;
+        }
+        self.allowed_agents
+            .iter()
+            .any(|a| a.as_str() == WILDCARD || a.as_str() == alias)
+    }
+
+    /// Whether this principal may cause the named tool to run. An empty
+    /// selector list grants no tools; broad access requires the explicit
+    /// [`WILDCARD`] entry or `admin`.
+    #[must_use]
+    pub fn may_use_tool(&self, tool: &str) -> bool {
+        if self.admin {
+            return true;
+        }
+        self.allowed_tools
+            .iter()
+            .any(|t| t == WILDCARD || t == tool)
+    }
+
+    /// Whether this principal may write the given dotted config path.
+    /// A granted `foo.*` covers `foo` itself and every descendant; a
+    /// granted bare `foo.bar` covers exactly that prop; the [`WILDCARD`]
+    /// entry covers every path. Empty = none.
+    #[must_use]
+    pub fn may_write_config(&self, path: &str) -> bool {
+        if self.admin {
+            return true;
+        }
+        self.config_write_paths.iter().any(|granted| {
+            if granted == WILDCARD {
+                return true;
+            }
+            if let Some(prefix) = granted.strip_suffix(".*") {
+                path == prefix
+                    || path
+                        .strip_prefix(prefix)
+                        .is_some_and(|rest| rest.starts_with('.'))
+            } else {
+                path == granted
+            }
+        })
+    }
+
+    /// Merge another grant set into this one — the deterministic monotonic
+    /// union used when one identity maps to multiple permission profiles.
+    /// No implicit deny rules, no profile-order precedence; `admin` from
+    /// either side dominates.
+    pub fn merge(&mut self, other: &Self) {
+        self.admin |= other.admin;
+        for alias in &other.allowed_agents {
+            if !self.allowed_agents.contains(alias) {
+                self.allowed_agents.push(alias.clone());
+            }
+        }
+        for path in &other.config_write_paths {
+            if !self.config_write_paths.contains(path) {
+                self.config_write_paths.push(path.clone());
+            }
+        }
+        for tool in &other.allowed_tools {
+            if !self.allowed_tools.contains(tool) {
+                self.allowed_tools.push(tool.clone());
+            }
+        }
+        for (resource, verbs) in &other.resources {
+            self.resources.entry(*resource).or_default().extend(verbs);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grants_with(resource: Resource, verbs: &[Verb]) -> ResolvedGrants {
+        let mut g = ResolvedGrants::none();
+        g.resources
+            .insert(resource, verbs.iter().copied().collect());
+        g
+    }
+
+    #[test]
+    fn default_denies_everything() {
+        let g = ResolvedGrants::none();
+        assert!(!g.permits(Resource::Sessions, Verb::Read));
+        assert!(!g.may_use_agent("main"));
+        assert!(!g.may_write_config("channels.discord"));
+        assert!(!g.may_use_tool("shell"));
+    }
+
+    #[test]
+    fn admin_permits_everything() {
+        let g = ResolvedGrants::all();
+        assert!(g.permits(Resource::Plugins, Verb::Delete));
+        assert!(g.may_use_agent("anything"));
+        assert!(g.may_write_config("security.estop"));
+        assert!(g.may_use_tool("shell"));
+    }
+
+    #[test]
+    fn resource_verb_grants_are_exact() {
+        let g = grants_with(Resource::Sessions, &[Verb::Create, Verb::Read]);
+        assert!(g.permits(Resource::Sessions, Verb::Read));
+        assert!(!g.permits(Resource::Sessions, Verb::Delete));
+        assert!(!g.permits(Resource::Memory, Verb::Read));
+    }
+
+    #[test]
+    fn empty_selector_lists_grant_no_instances() {
+        // Rev 8: "An empty selector grants no instances" — an empty
+        // allowed_tools/allowed_agents/config list never means unrestricted.
+        let mut g = grants_with(Resource::Tools, &[Verb::Execute]);
+        g.resources
+            .insert(Resource::Sessions, [Verb::Create].into());
+        assert!(g.permits(Resource::Tools, Verb::Execute));
+        assert!(
+            !g.may_use_tool("shell"),
+            "resource grant alone is not enough"
+        );
+        assert!(!g.may_use_agent("main"));
+        assert!(!g.may_write_config("channels.discord.token"));
+    }
+
+    #[test]
+    fn broad_access_requires_the_explicit_wildcard() {
+        let mut g = ResolvedGrants::none();
+        g.allowed_tools = vec![WILDCARD.into()];
+        g.allowed_agents = vec![AgentAlias(WILDCARD.into())];
+        g.config_write_paths = vec![WILDCARD.into()];
+        assert!(g.may_use_tool("shell"));
+        assert!(g.may_use_agent("anything"));
+        assert!(g.may_write_config("security.estop"));
+        assert!(!g.admin, "wildcard selectors do not imply admin");
+        assert!(
+            !g.permits(Resource::Sessions, Verb::Read),
+            "selector wildcards never grant resource verbs"
+        );
+    }
+
+    #[test]
+    fn named_selectors_are_exact_allowlists() {
+        let mut g = ResolvedGrants::none();
+        g.allowed_tools = vec!["calculator".into()];
+        g.allowed_agents = vec![AgentAlias("main".into())];
+        assert!(g.may_use_tool("calculator"));
+        assert!(!g.may_use_tool("shell"));
+        assert!(g.may_use_agent("main"));
+        assert!(!g.may_use_agent("ops"));
+    }
+
+    #[test]
+    fn config_path_wildcards_cover_subtree_only() {
+        let mut g = ResolvedGrants::none();
+        g.config_write_paths = vec!["channels.*".into(), "cron.enabled".into()];
+        assert!(g.may_write_config("channels"));
+        assert!(g.may_write_config("channels.discord.main.bot_token"));
+        assert!(!g.may_write_config("channels_config"));
+        assert!(g.may_write_config("cron.enabled"));
+        assert!(!g.may_write_config("cron.max_jobs"));
+        assert!(!g.may_write_config("security.estop"));
+    }
+
+    #[test]
+    fn merge_unions_grants() {
+        let mut a = grants_with(Resource::Sessions, &[Verb::Read]);
+        a.allowed_agents = vec![AgentAlias("main".into())];
+        let mut b = grants_with(Resource::Sessions, &[Verb::Create]);
+        b.resources.insert(Resource::Cron, [Verb::Read].into());
+        b.allowed_agents = vec![AgentAlias("ops".into()), AgentAlias("main".into())];
+        b.allowed_tools = vec!["calculator".into()];
+        a.merge(&b);
+        assert!(a.permits(Resource::Sessions, Verb::Read));
+        assert!(a.permits(Resource::Sessions, Verb::Create));
+        assert!(a.permits(Resource::Cron, Verb::Read));
+        assert_eq!(a.allowed_agents.len(), 2);
+        assert!(a.may_use_tool("calculator"));
+    }
+
+    #[test]
+    fn merge_is_monotonic_and_admin_dominates() {
+        let mut a = ResolvedGrants::none();
+        let before = a.clone();
+        a.merge(&ResolvedGrants::none());
+        assert_eq!(a, before, "merging nothing grants nothing");
+
+        a.merge(&ResolvedGrants::all());
+        assert!(a.admin, "admin from either side dominates");
+        assert!(a.permits(Resource::Sops, Verb::Delete));
+    }
+
+    #[test]
+    fn merge_order_is_irrelevant() {
+        // Deterministic union: profiles compose the same regardless of the
+        // order the resolver encounters them in.
+        let mut a1 = grants_with(Resource::Sessions, &[Verb::Read]);
+        a1.allowed_tools = vec!["calculator".into()];
+        let mut b1 = grants_with(Resource::Cron, &[Verb::Execute]);
+        b1.allowed_tools = vec![WILDCARD.into()];
+
+        let mut ab = a1.clone();
+        ab.merge(&b1);
+        let mut ba = b1.clone();
+        ba.merge(&a1);
+
+        assert_eq!(ab.resources, ba.resources);
+        assert!(ab.may_use_tool("anything") && ba.may_use_tool("anything"));
+        assert_eq!(ab.admin, ba.admin);
+    }
+
+    #[test]
+    fn resource_and_verb_serialize_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Resource::PeerGroups).unwrap(),
+            "\"peer_groups\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Verb::Execute).unwrap(),
+            "\"execute\""
+        );
+        assert_eq!(Resource::PeerGroups.to_string(), "peer_groups");
+        assert_eq!(
+            "peer_groups".parse::<Resource>().unwrap(),
+            Resource::PeerGroups
+        );
+    }
+
+    #[test]
+    fn grants_roundtrip_json() {
+        let mut g = grants_with(Resource::Skills, &[Verb::Read, Verb::Execute]);
+        g.config_write_paths = vec!["agents.*".into()];
+        g.allowed_tools = vec![WILDCARD.into()];
+        let s = serde_json::to_string(&g).unwrap();
+        let back: ResolvedGrants = serde_json::from_str(&s).unwrap();
+        assert_eq!(g, back);
+    }
+}

--- a/crates/zeroclaw-api/src/grants.rs
+++ b/crates/zeroclaw-api/src/grants.rs
@@ -1,5 +1,5 @@
 //! Resolved authorization grants — the single runtime authorization
-//! vocabulary (RFC #7141).
+//! vocabulary (RFC 7141).
 //!
 //! The grant vocabulary is resource × verb over enum-typed resource classes,
 //! plus three fine-grain selectors (agent aliases, config write paths, tool

--- a/crates/zeroclaw-api/src/grants.rs
+++ b/crates/zeroclaw-api/src/grants.rs
@@ -259,8 +259,16 @@ impl ResolvedGrants {
             }
         }
         for (resource, verbs) in &other.resources {
+            // Verb sets are BTreeSet: already deterministic by construction.
             self.resources.entry(*resource).or_default().extend(verbs);
         }
+        // Canonicalize selector order so a merged value is deterministic
+        // regardless of the order profiles were merged in (audit output,
+        // snapshots, and equality all rely on this, even though the membership
+        // checks above are order-insensitive).
+        self.allowed_agents.sort();
+        self.allowed_tools.sort();
+        self.config_write_paths.sort();
     }
 }
 
@@ -386,12 +394,14 @@ mod tests {
 
     #[test]
     fn merge_order_is_irrelevant() {
-        // Deterministic union: profiles compose the same regardless of the
-        // order the resolver encounters them in.
+        // Deterministic union AS A VALUE: reverse-order merges must produce
+        // equal selector vectors and serialization, not just equal membership.
         let mut a1 = grants_with(Resource::Sessions, &[Verb::Read]);
-        a1.allowed_tools = vec!["calculator".into()];
+        a1.allowed_tools = vec!["shell".into(), "calculator".into()];
+        a1.config_write_paths = vec!["security".into()];
         let mut b1 = grants_with(Resource::Cron, &[Verb::Execute]);
-        b1.allowed_tools = vec![WILDCARD.into()];
+        b1.allowed_tools = vec!["memory".into()];
+        b1.config_write_paths = vec!["users".into(), "oidc".into()];
 
         let mut ab = a1.clone();
         ab.merge(&b1);
@@ -399,8 +409,13 @@ mod tests {
         ba.merge(&a1);
 
         assert_eq!(ab.resources, ba.resources);
-        assert!(ab.may_use_tool("anything") && ba.may_use_tool("anything"));
         assert_eq!(ab.admin, ba.admin);
+        // The canonicalization fix: full selector values are order-independent.
+        assert_eq!(ab.allowed_tools, ba.allowed_tools);
+        assert_eq!(ab.allowed_agents, ba.allowed_agents);
+        assert_eq!(ab.config_write_paths, ba.config_write_paths);
+        assert_eq!(ab.allowed_tools, vec!["calculator", "memory", "shell"]);
+        assert_eq!(ab.config_write_paths, vec!["oidc", "security", "users"]);
     }
 
     #[test]

--- a/crates/zeroclaw-api/src/lib.rs
+++ b/crates/zeroclaw-api/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agent;
 pub mod attribution;
 pub mod channel;
 pub mod elicitation;
+pub mod grants;
 pub mod hook;
 pub mod ingress;
 pub mod jsonrpc;

--- a/crates/zeroclaw-api/src/principal.rs
+++ b/crates/zeroclaw-api/src/principal.rs
@@ -105,7 +105,7 @@ impl From<&str> for PrincipalId {
 
 /// An agent alias a principal may bind at session start. Newtype so it never
 /// gets confused with an arbitrary `String` in grant checks.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct AgentAlias(pub String);
 
 impl AgentAlias {
@@ -429,10 +429,11 @@ impl Principal {
     /// sentinel. A2A distinct-principal routing keys on this.
     #[must_use]
     pub fn is_authenticated(&self) -> bool {
-        !matches!(
-            self.auth_method,
-            AuthMethod::None | AuthMethod::SharedOperator
-        )
+        // Subject-based, not method-based: the shared operator is identified by
+        // its canonical PrincipalId sentinel, so `shared_operator(Native)` (a
+        // supported shape) is never mistaken for a distinct authenticated
+        // identity regardless of the auth method recorded.
+        self.auth_method != AuthMethod::None && self.id.as_str() != PrincipalId::SHARED_OPERATOR
     }
 }
 
@@ -518,6 +519,22 @@ mod tests {
         assert_eq!(p.actor, ActorKind::Human);
         assert_eq!(p.trust_domain, "native");
         assert!(!p.is_authenticated());
+    }
+
+    #[test]
+    fn shared_operator_via_native_method_is_not_authenticated() {
+        // The exact shape the native provider emits: SharedOperator subject
+        // with AuthMethod::Native. is_authenticated keys on the canonical id,
+        // not the method, so a native pairing bearer is never mistaken for a
+        // distinct authenticated identity.
+        let identity = AuthenticatedIdentity::shared_operator(AuthMethod::Native);
+        let p = Principal::from_identity(&identity);
+        assert_eq!(p.id.as_str(), PrincipalId::SHARED_OPERATOR);
+        assert_eq!(p.auth_method, AuthMethod::Native);
+        assert!(
+            !p.is_authenticated(),
+            "native shared operator must not read as a distinct authenticated identity"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-api/src/principal.rs
+++ b/crates/zeroclaw-api/src/principal.rs
@@ -1,4 +1,4 @@
-//! The RFC #7141 identity contract: what an auth provider outputs
+//! The RFC 7141 identity contract: what an auth provider outputs
 //! ([`AuthenticatedIdentity`]) and what the shared resolver turns it into
 //! (the canonical [`Principal`]).
 //!

--- a/crates/zeroclaw-api/src/principal.rs
+++ b/crates/zeroclaw-api/src/principal.rs
@@ -1,20 +1,89 @@
-//! The authenticated subject — the single `Principal` every gateway/RPC/ACP
-//! connection carries once an [`crate`] auth provider has verified a credential.
+//! The RFC #7141 identity contract: what an auth provider outputs
+//! ([`AuthenticatedIdentity`]) and what the shared resolver turns it into
+//! (the canonical [`Principal`]).
+//!
+//! Three stages, three vocabularies (Rev 8):
+//!
+//! 1. A provider verifies ONE credential and emits an [`AuthenticatedIdentity`]
+//!    — provenance, subject, actor kind, verified claims, expiry/revalidation
+//!    metadata. Providers never emit grants.
+//! 2. The shared resolver (in `zeroclaw-runtime`) maps that identity to a
+//!    canonical [`PrincipalId`] and the currently-configured permission
+//!    profiles. Claims are mapping *inputs*, never runtime grants.
+//! 3. Dispatch/gateway/storage surfaces consume the resolved [`Principal`]
+//!    plus its separately-resolved [`crate::grants::ResolvedGrants`]. Grants
+//!    are NOT stored on the `Principal`: they are re-resolved from current
+//!    policy at the authorization-generation boundary, so a profile or
+//!    mapping change affects established connections without reconnect.
 
 use serde::{Deserialize, Serialize};
 
-/// Stable, opaque subject id. The audit `Actor`, the approval-routing key, the
-/// provenance origin, and (A2A) the peer join key. For an OIDC user this equals
-/// the IdP `sub`; for the shared-bearer / trusted-local path it is the sentinel
-/// [`PrincipalId::SHARED_OPERATOR`].
+/// Canonical, globally-unambiguous principal identifier. The durable ownership
+/// key for sessions, private memory, approvals, and audit attribution.
+///
+/// Composition is injective per identity class (see the constructors): an OIDC
+/// identity is keyed by validated issuer AND subject — never by subject alone
+/// and never by a config alias, so renaming an `[oidc.<alias>]` entry cannot
+/// re-key principals, and two issuers cannot collide on a shared `sub`.
+/// String equality across classes never links accounts.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PrincipalId(pub String);
 
+/// Escape `%` and `:` so a component can never smuggle the `:` join
+/// separator — this is what makes the composed ids injective.
+fn encode_component(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '%' => out.push_str("%25"),
+            ':' => out.push_str("%3A"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 impl PrincipalId {
-    /// Sentinel id for the single-operator / trusted-local path (no distinct IdP
-    /// principal). Lets callers treat "trusted, but anonymous operator" as a real
-    /// `Principal` instead of branching on `Option`.
+    /// Sentinel id for the single-operator / trusted-local path (no distinct
+    /// identity source). Lets callers treat "trusted, but anonymous operator"
+    /// as a real `Principal` instead of branching on `Option`.
     pub const SHARED_OPERATOR: &'static str = "shared-operator";
+
+    #[must_use]
+    pub fn shared_operator() -> Self {
+        Self(Self::SHARED_OPERATOR.to_owned())
+    }
+
+    /// Canonical id for an OIDC human identity: validated issuer + `sub`.
+    #[must_use]
+    pub fn for_oidc(issuer: &str, subject: &str) -> Self {
+        Self(format!(
+            "oidc:{}:{}",
+            encode_component(issuer),
+            encode_component(subject)
+        ))
+    }
+
+    /// Canonical id for an OIDC service principal: validated issuer + the
+    /// stable verified client identity (introspected `client_id` or an
+    /// equivalent provider-defined client subject). Never a human-subject
+    /// mapping.
+    #[must_use]
+    pub fn for_service(issuer: &str, client_id: &str) -> Self {
+        Self(format!(
+            "svc:{}:{}",
+            encode_component(issuer),
+            encode_component(client_id)
+        ))
+    }
+
+    /// Canonical id for a local roster identity: the durable
+    /// `[users.<name>]` principal id (NOT the display name — renaming a
+    /// roster entry must preserve this id or migrate ownership atomically).
+    #[must_use]
+    pub fn for_roster(roster_principal_id: &str) -> Self {
+        Self(format!("user:{}", encode_component(roster_principal_id)))
+    }
 
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -34,8 +103,8 @@ impl From<&str> for PrincipalId {
     }
 }
 
-/// An agent alias a principal may bind at session start. Newtype so it never gets
-/// confused with an arbitrary `String` in grant checks.
+/// An agent alias a principal may bind at session start. Newtype so it never
+/// gets confused with an arbitrary `String` in grant checks.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AgentAlias(pub String);
 
@@ -46,6 +115,20 @@ impl AgentAlias {
     }
 }
 
+/// What kind of actor an identity represents. Human and service identities
+/// stay distinct end-to-end: a service principal never inherits interactive
+/// browser sessions or private user memory because claims have similar names.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ActorKind {
+    /// An interactive human user (or the shared operator).
+    #[default]
+    Human,
+    /// A headless service principal (`client_credentials`).
+    Service,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -53,119 +136,292 @@ pub enum AuthMethod {
     /// No authentication performed (default; an unbound connection).
     #[default]
     None,
-    /// Explicitly-trusted connection with no distinct IdP principal — today's
-    /// shared pairing bearer / trusted-local stdio. Carries the
+    /// Explicitly-trusted connection with no distinct identity — the
+    /// shared pairing bearer / trusted-local stdio path. Carries the
     /// [`PrincipalId::SHARED_OPERATOR`] sentinel.
     SharedOperator,
-    /// External OpenID Connect IdP (RFCheadline provider).
+    /// External OpenID Connect IdP (the RFC's headline provider).
     Oidc,
-    /// Challenge-response against a registered SSH public key.
+    /// Challenge-response against a registered SSH public key
+    /// (separately-tracked extension; reserved here so the wire label is
+    /// stable).
     SshKey,
     /// Local Unix-socket / named-pipe peer credential (`SO_PEERCRED`).
     Peercred,
-    /// The existing `PairingGuard` bearer token (continuity / operator bootstrap).
+    /// The existing `PairingGuard` bearer token (continuity / operator
+    /// bootstrap).
     Native,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct Principal {
-    pub id: PrincipalId,
-    /// Human/account identifier from the identity source (e.g. OIDC `sub`).
-    /// Equals `id.0` for a real user; sentinel for [`AuthMethod::SharedOperator`].
-    pub user_id: String,
-    /// Coarse roles the identity source asserted (drives `IamPolicy` mapping).
-    #[serde(default)]
-    pub roles: Vec<String>,
-    /// Fine-grained scopes/capabilities granted this session.
-    #[serde(default)]
-    pub scopes: Vec<String>,
-    /// How this principal authenticated.
-    #[serde(default)]
-    pub auth_method: AuthMethod,
-    /// Whether a second factor was completed (drives any step-up policy).
-    #[serde(default)]
-    pub mfa_verified: bool,
-    /// Session expiry, UNIX seconds; `0` = no expiry.
-    #[serde(default)]
-    pub expires_at: u64,
-    /// Agent aliases this principal MAY bind at `session/new`. Empty + no roles ⇒
-    /// the [`AuthMethod::SharedOperator`] fallback ("any configured alias",
-    /// today's behaviour).
-    #[serde(default)]
-    pub allowed_aliases: Vec<AgentAlias>,
+impl AuthMethod {
+    /// Wire/audit label for the method — the `<type>` half of the
+    /// `<type>.<alias>` provider attribution composite.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::SharedOperator => "shared_operator",
+            Self::Oidc => "oidc",
+            Self::SshKey => "ssh-key",
+            Self::Peercred => "peercred",
+            Self::Native => "native",
+        }
+    }
 }
 
-impl Principal {
+/// The verified subject of an [`AuthenticatedIdentity`]. Each variant carries
+/// exactly the fields its canonical [`PrincipalId`] is composed from, so a
+/// provider cannot construct an ambiguous or cross-class identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IdentitySubject {
+    /// Explicitly-trusted shared operator (native pairing token, or the
+    /// daemon's own uid on the local socket). Trusted, but NOT a distinct
+    /// authenticated identity.
+    SharedOperator,
+    /// An OIDC human identity. `issuer` is the VALIDATED `iss`; `subject`
+    /// the validated `sub`.
+    Oidc { issuer: String, subject: String },
+    /// An OIDC service principal. `client_id` is the stable verified client
+    /// identity from the validated token/introspection response.
+    Service { issuer: String, client_id: String },
+    /// A local roster identity: the durable `[users.<name>]` principal id
+    /// the credential mapped to through explicit configuration.
+    Roster { principal_id: String },
+}
+
+impl IdentitySubject {
+    /// The canonical principal id this subject resolves to. One composition
+    /// rule, owned here — providers and the resolver cannot disagree.
     #[must_use]
-    pub fn shared_operator() -> Self {
-        Self {
-            id: PrincipalId(PrincipalId::SHARED_OPERATOR.to_owned()),
-            user_id: PrincipalId::SHARED_OPERATOR.to_owned(),
-            roles: Vec::new(),
-            scopes: Vec::new(),
-            auth_method: AuthMethod::SharedOperator,
-            mfa_verified: false,
-            expires_at: 0,
-            allowed_aliases: Vec::new(),
+    pub fn principal_id(&self) -> PrincipalId {
+        match self {
+            Self::SharedOperator => PrincipalId::shared_operator(),
+            Self::Oidc { issuer, subject } => PrincipalId::for_oidc(issuer, subject),
+            Self::Service { issuer, client_id } => PrincipalId::for_service(issuer, client_id),
+            Self::Roster { principal_id } => PrincipalId::for_roster(principal_id),
         }
     }
 
-    /// Construct an authenticated principal with the given subject id and method.
-    /// Grants default to empty; attach claims via the `with_*` builder setters.
-    /// This is the construction path other crates (the providers) must use because
-    /// the struct is `#[non_exhaustive]`.
+    /// The actor kind this subject implies.
     #[must_use]
-    pub fn new(
-        id: impl Into<PrincipalId>,
-        user_id: impl Into<String>,
-        auth_method: AuthMethod,
-    ) -> Self {
-        Self {
-            id: id.into(),
-            user_id: user_id.into(),
-            roles: Vec::new(),
-            scopes: Vec::new(),
-            auth_method,
-            mfa_verified: false,
-            expires_at: 0,
-            allowed_aliases: Vec::new(),
+    pub fn actor_kind(&self) -> ActorKind {
+        match self {
+            Self::Service { .. } => ActorKind::Service,
+            _ => ActorKind::Human,
         }
     }
 
-    /// Attach the role claims the identity source asserted.
+    /// The trust domain recorded on the resolved principal: the validated
+    /// issuer for OIDC identities, `local` for roster identities, `native`
+    /// for the shared operator.
     #[must_use]
-    pub fn with_roles(mut self, roles: Vec<String>) -> Self {
-        self.roles = roles;
+    pub fn trust_domain(&self) -> &str {
+        match self {
+            Self::SharedOperator => "native",
+            Self::Oidc { issuer, .. } | Self::Service { issuer, .. } => issuer,
+            Self::Roster { .. } => "local",
+        }
+    }
+
+    /// A human-readable, non-authoritative display identifier (OIDC `sub`,
+    /// roster principal id, service `client_id`).
+    #[must_use]
+    pub fn display_id(&self) -> &str {
+        match self {
+            Self::SharedOperator => PrincipalId::SHARED_OPERATOR,
+            Self::Oidc { subject, .. } => subject,
+            Self::Service { client_id, .. } => client_id,
+            Self::Roster { principal_id } => principal_id,
+        }
+    }
+}
+
+/// What an auth provider outputs after verifying ONE credential: identity and
+/// evidence, never grants. Handshake-scoped and server-side only — this type
+/// is deliberately not serializable, and its `Debug` never prints claim
+/// values (claims may carry personal data).
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct AuthenticatedIdentity {
+    /// The verified subject.
+    pub subject: IdentitySubject,
+    /// How the credential was verified.
+    pub method: AuthMethod,
+    /// The configured provider alias that verified it (e.g. `corp` for
+    /// `[oidc.corp]`). `None` for providers with no config alias.
+    pub provider_alias: Option<String>,
+    /// Verified claims, as mapping INPUTS for the shared resolver's explicit
+    /// claim-to-profile mapping. Empty for local/native identities. Never
+    /// retained on the resolved [`Principal`].
+    pub claims: serde_json::Map<String, serde_json::Value>,
+    /// Whether the identity source attested a completed second factor.
+    pub mfa_verified: bool,
+    /// Credential expiry (UNIX seconds). `None` = the provider imposes none.
+    pub expires_at: Option<u64>,
+    /// Provider-specific revalidation deadline (UNIX seconds): the moment
+    /// after which the next privileged operation must revalidate or fail
+    /// closed. `None` = no revalidation requirement beyond `expires_at`.
+    pub revalidate_by: Option<u64>,
+}
+
+impl AuthenticatedIdentity {
+    /// Construct with empty claims and no expiry. Providers attach evidence
+    /// via the `with_*` builders (the struct is `#[non_exhaustive]`).
+    #[must_use]
+    pub fn new(subject: IdentitySubject, method: AuthMethod) -> Self {
+        Self {
+            subject,
+            method,
+            provider_alias: None,
+            claims: serde_json::Map::new(),
+            mfa_verified: false,
+            expires_at: None,
+            revalidate_by: None,
+        }
+    }
+
+    /// The trusted shared operator (native pairing / same-uid local peer).
+    #[must_use]
+    pub fn shared_operator(method: AuthMethod) -> Self {
+        Self::new(IdentitySubject::SharedOperator, method)
+    }
+
+    #[must_use]
+    pub fn with_provider_alias(mut self, alias: impl Into<String>) -> Self {
+        self.provider_alias = Some(alias.into());
         self
     }
 
-    /// Attach the scope claims granted this session.
     #[must_use]
-    pub fn with_scopes(mut self, scopes: Vec<String>) -> Self {
-        self.scopes = scopes;
+    pub fn with_claims(mut self, claims: serde_json::Map<String, serde_json::Value>) -> Self {
+        self.claims = claims;
         self
     }
 
-    /// Mark MFA as completed.
     #[must_use]
     pub fn with_mfa_verified(mut self, mfa_verified: bool) -> Self {
         self.mfa_verified = mfa_verified;
         self
     }
 
-    /// Set the session expiry (UNIX seconds; `0` = none).
     #[must_use]
     pub fn with_expires_at(mut self, expires_at: u64) -> Self {
-        self.expires_at = expires_at;
+        self.expires_at = Some(expires_at);
         self
     }
 
-    /// Attach the agent aliases this principal may bind.
     #[must_use]
-    pub fn with_allowed_aliases(mut self, allowed_aliases: Vec<AgentAlias>) -> Self {
-        self.allowed_aliases = allowed_aliases;
+    pub fn with_revalidate_by(mut self, revalidate_by: u64) -> Self {
+        self.revalidate_by = Some(revalidate_by);
         self
+    }
+
+    /// The audit label for the verifying provider: `<type>.<alias>` when a
+    /// config alias exists, else the bare method label.
+    #[must_use]
+    pub fn provider_label(&self) -> String {
+        match &self.provider_alias {
+            Some(alias) => format!("{}.{alias}", self.method.as_str()),
+            None => self.method.as_str().to_owned(),
+        }
+    }
+}
+
+impl std::fmt::Debug for AuthenticatedIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthenticatedIdentity")
+            .field("subject", &self.subject)
+            .field("method", &self.method)
+            .field("provider_alias", &self.provider_alias)
+            // Claim VALUES may carry personal data; keys are enough for debug.
+            .field(
+                "claims",
+                &self.claims.keys().cloned().collect::<Vec<String>>(),
+            )
+            .field("mfa_verified", &self.mfa_verified)
+            .field("expires_at", &self.expires_at)
+            .field("revalidate_by", &self.revalidate_by)
+            .finish()
+    }
+}
+
+/// The canonical resolved principal: the single non-secret record every
+/// dispatch/audit/isolation surface consumes.
+///
+/// Deliberately carries NO grants and NO raw claims: effective grants are
+/// resolved from current permission-profile configuration by the shared
+/// resolver and re-resolved when the authorization-policy generation
+/// changes, so this record can be held for a connection's lifetime without
+/// becoming a stale authorization snapshot.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Principal {
+    /// Canonical ownership/audit key.
+    pub id: PrincipalId,
+    /// Human-readable, non-authoritative display identifier (OIDC `sub`,
+    /// roster principal id, service `client_id`). Never an ownership key.
+    pub display_id: String,
+    /// Human or service actor.
+    #[serde(default)]
+    pub actor: ActorKind,
+    /// How this principal authenticated.
+    #[serde(default)]
+    pub auth_method: AuthMethod,
+    /// The `<alias>` of the configured provider entry that authenticated
+    /// this principal, when one exists (audit attribution).
+    #[serde(default)]
+    pub provider_alias: Option<String>,
+    /// The trust domain of the identity source (validated issuer URL,
+    /// `local`, or `native`).
+    #[serde(default)]
+    pub trust_domain: String,
+    /// Whether a second factor was completed.
+    #[serde(default)]
+    pub mfa_verified: bool,
+    /// Credential expiry (UNIX seconds), when the provider imposes one.
+    #[serde(default)]
+    pub expires_at: Option<u64>,
+    /// Provider revalidation deadline (UNIX seconds), when one applies.
+    #[serde(default)]
+    pub revalidate_by: Option<u64>,
+}
+
+impl Principal {
+    /// The single construction path: every `Principal` derives from a
+    /// provider-verified [`AuthenticatedIdentity`], so no caller can invent
+    /// a principal with an inconsistent id/actor/trust-domain combination.
+    #[must_use]
+    pub fn from_identity(identity: &AuthenticatedIdentity) -> Self {
+        Self {
+            id: identity.subject.principal_id(),
+            display_id: identity.subject.display_id().to_owned(),
+            actor: identity.subject.actor_kind(),
+            auth_method: identity.method,
+            provider_alias: identity.provider_alias.clone(),
+            trust_domain: identity.subject.trust_domain().to_owned(),
+            mfa_verified: identity.mfa_verified,
+            expires_at: identity.expires_at,
+            revalidate_by: identity.revalidate_by,
+        }
+    }
+
+    /// The trusted shared-operator sentinel (no distinct identity source).
+    #[must_use]
+    pub fn shared_operator() -> Self {
+        Self::from_identity(&AuthenticatedIdentity::shared_operator(
+            AuthMethod::SharedOperator,
+        ))
+    }
+
+    /// The audit label for the verifying provider: `<type>.<alias>` when a
+    /// config alias exists, else the bare method label.
+    #[must_use]
+    pub fn auth_provider_label(&self) -> String {
+        match &self.provider_alias {
+            Some(alias) => format!("{}.{alias}", self.auth_method.as_str()),
+            None => self.auth_method.as_str().to_owned(),
+        }
     }
 
     /// `true` once a *distinct* identity source authenticated this principal —
@@ -180,10 +436,11 @@ impl Principal {
     }
 }
 
-/// Why a credential was rejected. Fail-closed: any ambiguity ⇒ a `Denied` variant,
-/// never a silent allow.
+/// Why a credential was rejected. Fail-closed: any ambiguity ⇒ a `Denied`
+/// variant, never a silent allow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DenyReason {
     /// No credential was presented.
     NoCredential,
@@ -193,42 +450,48 @@ pub enum DenyReason {
     TokenExpired,
     /// A second factor is required and was not satisfied.
     MfaRequired,
+    /// The credential authenticated but its claims/roster entry map to no
+    /// permission profile, so the principal would hold no grants at all.
+    NotEntitled,
     /// The principal is not entitled to the requested agent alias.
     AliasNotEntitled,
+    /// No provider matches the requested provider selection.
+    UnknownProvider,
     /// The provider/config is misconfigured (fail closed, do not allow).
     Misconfigured,
 }
 
-/// The single result every auth surface returns. Misroute/timeout/malformed ⇒
-/// [`AuthOutcome::Denied`], NEVER a silent allow.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// The single result every credential verification returns. Misroute,
+/// timeout, or malformed input ⇒ [`AuthOutcome::Denied`], NEVER a silent
+/// allow. Once a provider was selected for a credential, its denial is
+/// authoritative: there is no fallback to another provider or to broader
+/// authority.
+#[derive(Clone, Debug)]
 pub enum AuthOutcome {
-    /// A distinct identity source authenticated the caller.
-    Authenticated(Principal),
-    /// An explicitly-trusted connection with no distinct IdP principal — carries
-    /// the [`Principal::shared_operator`] sentinel so callers never branch on
-    /// `Option`.
-    Trusted(Principal),
+    /// The selected provider verified the credential into an identity.
+    /// Whether that identity is a *distinct* authenticated principal or the
+    /// trusted shared operator is carried by [`IdentitySubject`].
+    Verified(AuthenticatedIdentity),
     /// The credential was rejected.
     Denied { reason: DenyReason },
 }
 
 impl AuthOutcome {
-    /// The bound principal if the outcome allows the connection (authenticated or
-    /// trusted), else `None`.
+    /// The verified identity if the outcome allows the connection, else
+    /// `None`.
     #[must_use]
-    pub fn principal(&self) -> Option<&Principal> {
+    pub fn identity(&self) -> Option<&AuthenticatedIdentity> {
         match self {
-            Self::Authenticated(p) | Self::Trusted(p) => Some(p),
+            Self::Verified(identity) => Some(identity),
             Self::Denied { .. } => None,
         }
     }
 
-    /// Whether the connection is allowed to proceed at all (still subject to
-    /// per-method grant checks downstream).
+    /// Whether the connection may proceed at all (still subject to grant
+    /// resolution and per-method checks downstream).
     #[must_use]
     pub fn is_allowed(&self) -> bool {
-        matches!(self, Self::Authenticated(_) | Self::Trusted(_))
+        matches!(self, Self::Verified(_))
     }
 }
 
@@ -236,45 +499,143 @@ impl AuthOutcome {
 mod tests {
     use super::*;
 
+    fn oidc_identity() -> AuthenticatedIdentity {
+        AuthenticatedIdentity::new(
+            IdentitySubject::Oidc {
+                issuer: "https://sso.example.com/realms/main".into(),
+                subject: "alice".into(),
+            },
+            AuthMethod::Oidc,
+        )
+        .with_provider_alias("corp")
+    }
+
     #[test]
     fn shared_operator_is_trusted_but_not_authenticated() {
         let p = Principal::shared_operator();
         assert_eq!(p.id.as_str(), PrincipalId::SHARED_OPERATOR);
         assert_eq!(p.auth_method, AuthMethod::SharedOperator);
+        assert_eq!(p.actor, ActorKind::Human);
+        assert_eq!(p.trust_domain, "native");
         assert!(!p.is_authenticated());
     }
 
     #[test]
-    fn a_real_principal_is_authenticated() {
-        let p = Principal {
-            id: PrincipalId::from("alice"),
-            user_id: "alice".to_owned(),
-            roles: vec!["operator".to_owned()],
-            scopes: vec![],
-            auth_method: AuthMethod::Oidc,
-            mfa_verified: true,
-            expires_at: 0,
-            allowed_aliases: vec![AgentAlias("main".to_owned())],
-        };
+    fn oidc_principal_is_keyed_by_issuer_and_subject() {
+        let p = Principal::from_identity(&oidc_identity());
+        assert_eq!(
+            p.id.as_str(),
+            "oidc:https%3A//sso.example.com/realms/main:alice"
+        );
+        assert_eq!(p.display_id, "alice");
+        assert_eq!(p.trust_domain, "https://sso.example.com/realms/main");
         assert!(p.is_authenticated());
     }
 
     #[test]
-    fn auth_outcome_allow_and_principal_accessors() {
-        let ok = AuthOutcome::Trusted(Principal::shared_operator());
+    fn principal_id_composition_is_injective_across_colon_boundaries() {
+        // The classic splice: ("a:b", "c") must not equal ("a", "b:c").
+        let left = PrincipalId::for_oidc("a:b", "c");
+        let right = PrincipalId::for_oidc("a", "b:c");
+        assert_ne!(left, right);
+
+        // Percent signs in components cannot fake an escape sequence.
+        let literal = PrincipalId::for_oidc("a%3A", "c");
+        let colon = PrincipalId::for_oidc("a:", "c");
+        assert_ne!(literal, colon);
+    }
+
+    #[test]
+    fn same_subject_under_different_issuers_are_distinct_principals() {
+        let a = PrincipalId::for_oidc("https://idp-a.example.com", "alice");
+        let b = PrincipalId::for_oidc("https://idp-b.example.com", "alice");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn provider_alias_does_not_affect_the_principal_id() {
+        let with_alias = Principal::from_identity(&oidc_identity());
+        let mut identity = oidc_identity();
+        identity.provider_alias = Some("renamed".into());
+        let renamed = Principal::from_identity(&identity);
+        assert_eq!(
+            with_alias.id, renamed.id,
+            "alias is audit-only, not identity"
+        );
+    }
+
+    #[test]
+    fn service_and_human_identities_never_collide() {
+        let human = PrincipalId::for_oidc("https://idp.example.com", "svc-1");
+        let service = PrincipalId::for_service("https://idp.example.com", "svc-1");
+        assert_ne!(human, service);
+
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Service {
+                issuer: "https://idp.example.com".into(),
+                client_id: "svc-1".into(),
+            },
+            AuthMethod::Oidc,
+        );
+        let p = Principal::from_identity(&identity);
+        assert_eq!(p.actor, ActorKind::Service);
+        assert!(p.is_authenticated());
+    }
+
+    #[test]
+    fn roster_ids_are_prefixed_and_escaped() {
+        assert_eq!(PrincipalId::for_roster("bob").as_str(), "user:bob");
+        assert_eq!(
+            PrincipalId::for_roster("b:ob").as_str(),
+            "user:b%3Aob",
+            "a roster id cannot smuggle a separator"
+        );
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "bob".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        let p = Principal::from_identity(&identity);
+        assert_eq!(p.trust_domain, "local");
+        assert!(p.is_authenticated());
+    }
+
+    #[test]
+    fn auth_outcome_allow_and_identity_accessors() {
+        let ok = AuthOutcome::Verified(oidc_identity());
         assert!(ok.is_allowed());
-        assert!(ok.principal().is_some());
+        assert!(ok.identity().is_some());
 
         let no = AuthOutcome::Denied {
             reason: DenyReason::NoCredential,
         };
         assert!(!no.is_allowed());
-        assert!(no.principal().is_none());
+        assert!(no.identity().is_none());
+    }
+
+    #[test]
+    fn every_deny_reason_is_not_allowed() {
+        for reason in [
+            DenyReason::NoCredential,
+            DenyReason::BadCredential,
+            DenyReason::TokenExpired,
+            DenyReason::MfaRequired,
+            DenyReason::NotEntitled,
+            DenyReason::AliasNotEntitled,
+            DenyReason::UnknownProvider,
+            DenyReason::Misconfigured,
+        ] {
+            let outcome = AuthOutcome::Denied { reason };
+            assert!(!outcome.is_allowed());
+            assert!(outcome.identity().is_none());
+        }
     }
 
     #[test]
     fn principal_roundtrips_through_json() {
-        let p = Principal::shared_operator();
+        let p =
+            Principal::from_identity(&oidc_identity().with_mfa_verified(true).with_expires_at(42));
         let s = serde_json::to_string(&p).expect("serialize");
         let back: Principal = serde_json::from_str(&s).expect("deserialize");
         assert_eq!(p, back);
@@ -287,49 +648,44 @@ mod tests {
     }
 
     #[test]
-    fn authenticated_outcome_is_allowed_and_exposes_principal() {
-        // Existing tests cover Trusted and Denied but not the Authenticated arm.
-        let outcome = AuthOutcome::Authenticated(Principal::shared_operator());
-        assert!(outcome.is_allowed());
-        assert!(outcome.principal().is_some());
+    fn provider_label_prefers_configured_alias() {
+        let labeled = Principal::from_identity(&oidc_identity());
+        assert_eq!(labeled.auth_provider_label(), "oidc.corp");
+        let bare = Principal::from_identity(&AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "bob".into(),
+            },
+            AuthMethod::Peercred,
+        ));
+        assert_eq!(bare.auth_provider_label(), "peercred");
     }
 
     #[test]
-    fn none_auth_method_is_not_authenticated() {
-        let mut p = Principal::shared_operator();
-        p.auth_method = AuthMethod::None;
-        assert!(!p.is_authenticated());
+    fn identity_debug_never_prints_claim_values() {
+        let mut claims = serde_json::Map::new();
+        claims.insert(
+            "email".into(),
+            serde_json::Value::String("alice@example.com".into()),
+        );
+        let identity = oidc_identity().with_claims(claims);
+        let dbg = format!("{identity:?}");
+        assert!(dbg.contains("email"), "claim keys are shown");
+        assert!(
+            !dbg.contains("alice@example.com"),
+            "claim values must never appear in debug output"
+        );
     }
 
     #[test]
-    fn builder_methods_set_fields() {
-        let p = Principal::shared_operator()
-            .with_roles(vec!["admin".to_owned()])
-            .with_scopes(vec!["read".to_owned(), "write".to_owned()])
+    fn identity_evidence_flows_onto_the_principal() {
+        let identity = oidc_identity()
             .with_mfa_verified(true)
-            .with_expires_at(42)
-            .with_allowed_aliases(vec![AgentAlias("bot".to_owned())]);
-        assert_eq!(p.roles, vec!["admin".to_owned()]);
-        assert_eq!(p.scopes.len(), 2);
+            .with_expires_at(1000)
+            .with_revalidate_by(500);
+        let p = Principal::from_identity(&identity);
         assert!(p.mfa_verified);
-        assert_eq!(p.expires_at, 42);
-        assert_eq!(p.allowed_aliases.len(), 1);
-        assert_eq!(p.allowed_aliases[0].as_str(), "bot");
-    }
-
-    #[test]
-    fn every_deny_reason_is_not_allowed() {
-        for reason in [
-            DenyReason::NoCredential,
-            DenyReason::BadCredential,
-            DenyReason::TokenExpired,
-            DenyReason::MfaRequired,
-            DenyReason::AliasNotEntitled,
-            DenyReason::Misconfigured,
-        ] {
-            let outcome = AuthOutcome::Denied { reason };
-            assert!(!outcome.is_allowed());
-            assert!(outcome.principal().is_none());
-        }
+        assert_eq!(p.expires_at, Some(1000));
+        assert_eq!(p.revalidate_by, Some(500));
+        assert_eq!(identity.provider_label(), "oidc.corp");
     }
 }

--- a/crates/zeroclaw-config/Cargo.toml
+++ b/crates/zeroclaw-config/Cargo.toml
@@ -64,7 +64,7 @@ tokio = { version = "1.50", features = ["rt-multi-thread", "macros"] }
 # schema-export and clap are the only defaults. All channel schema types
 # compile unconditionally; channel feature flags live in zeroclaw-channels only.
 default = ["schema-export", "clap"]
-schema-export = ["dep:schemars"]
+schema-export = ["dep:schemars", "zeroclaw-api/schema-export"]
 clap = ["dep:clap"]
 memory-postgres = ["dep:postgres"]
 # Test-only fault-injection hooks (post-replace sync failure). Enabled by

--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -236,7 +236,14 @@ pub fn migrate_to_current_resilient(input: &str) -> Config {
 /// a malformed one to its `Default` may grant a broader posture than intended.
 /// Salvage still drops them (so the daemon boots) but logs ERROR and reports
 /// them in [`ResilientLoad::dropped_security`] for exposure gating.
-pub const SECURITY_CRITICAL_KEYS: &[&str] = &["security", "risk_profiles", "peer_groups"];
+pub const SECURITY_CRITICAL_KEYS: &[&str] = &[
+    "security",
+    "risk_profiles",
+    "peer_groups",
+    "users",
+    "oidc",
+    "permission_profiles",
+];
 
 pub const WHOLE_CONFIG_SENTINEL: &str = "<entire-config>";
 
@@ -3040,6 +3047,27 @@ from_address = "a@example.com"
         assert!(
             migrate_to_current(raw).is_err(),
             "strict path must surface the defect for repair tooling"
+        );
+    }
+
+    #[test]
+    fn broken_users_roster_is_reported_as_security_degraded() {
+        // A malformed [users] roster salvaged to an empty roster is
+        // indistinguishable from an intentional no-roster config, which
+        // re-opens the shared-operator fallback. It must surface as a
+        // security-critical drop so exposure gating can react.
+        let raw = r#"
+schema_version = 3
+
+[users.alice]
+uid = "not-an-integer"
+permission_profiles = ["operator"]
+"#;
+        let load = migrate_to_current_salvaged(raw);
+        assert!(
+            load.dropped_security.iter().any(|p| p == "users"),
+            "malformed [users] must be a security-critical drop, got: {:?}",
+            load.dropped_security
         );
     }
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -13030,16 +13030,17 @@ impl OidcConfig {
                 ),
             }
         }
-        if self.claim_path.trim().is_empty() {
+        if self.profile_map.is_empty() && self.service_profile_map.is_empty() {
+            anyhow::bail!(
+                "oidc.{alias} requires profile_map or service_profile_map: map at least one \
+                 verified identity value to a permission profile or every identity from this issuer \
+                 will be denied"
+            );
+        }
+        if !self.profile_map.is_empty() && self.claim_path.trim().is_empty() {
             anyhow::bail!(
                 "oidc.{alias}.claim_path is required: set the dotted path to the \
                  claim carrying role/group values (e.g. `realm_access.roles` or `groups`)"
-            );
-        }
-        if self.profile_map.is_empty() {
-            anyhow::bail!(
-                "oidc.{alias}.profile_map is required: map at least one claim value to a \
-                 permission profile or every identity from this issuer will be denied"
             );
         }
         Ok(())
@@ -26248,6 +26249,32 @@ mod tests {
         config
             .validate()
             .expect("a service map naming a configured profile is valid");
+    }
+
+    #[::core::prelude::v1::test]
+    fn oidc_service_only_profile_map_does_not_require_a_claim_path() {
+        let mut config = auth_config();
+        let oidc = config.oidc.get_mut("corp").unwrap();
+        oidc.claim_path.clear();
+        oidc.profile_map.clear();
+        oidc.service_profile_map
+            .insert("worker".to_string(), "operator".to_string());
+
+        config
+            .validate()
+            .expect("a service-only OIDC map naming a configured profile is valid");
+    }
+
+    #[::core::prelude::v1::test]
+    fn oidc_requires_a_human_or_service_profile_map() {
+        let mut config = auth_config();
+        let oidc = config.oidc.get_mut("corp").unwrap();
+        oidc.profile_map.clear();
+        oidc.service_profile_map.clear();
+
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("profile_map"), "got: {err}");
+        assert!(err.contains("service_profile_map"), "got: {err}");
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -489,6 +489,29 @@ pub struct Config {
     #[nested]
     pub risk_profiles: HashMap<String, RiskProfileConfig>,
 
+    /// OIDC trust relationships (`[oidc.<alias>]`). Each entry names one
+    /// issuer whose identities this daemon accepts and how their verified
+    /// claims map to permission profiles. Any standards-compliant IdP
+    /// works; there is no per-vendor configuration.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[nested]
+    pub oidc: HashMap<String, OidcConfig>,
+
+    /// Local user roster (`[users.<name>]`) for credential-to-principal
+    /// mapping of local auth providers (peer credentials today). OIDC
+    /// identities are NOT listed here; they are keyed by issuer + subject.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[nested]
+    pub users: HashMap<String, UserConfig>,
+
+    /// Named permission profiles (`[permission_profiles.<alias>]`): the
+    /// single runtime authorization vocabulary. OIDC claim mappings and
+    /// user roster entries resolve here; deny-by-default — anything a
+    /// profile does not grant is refused.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[nested]
+    pub permission_profiles: HashMap<String, PermissionProfileConfig>,
+
     /// Named runtime/LLM execution profiles (`[runtime_profiles.<alias>]`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     #[nested]
@@ -12895,6 +12918,207 @@ fn is_valid_env_var_name(name: &str) -> bool {
     chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
+// ── Inbound authentication & principals (#7141) ──────────────────
+
+/// Validates the operator-chosen names used by the auth sections: OIDC
+/// aliases (which become the `oidc.<alias>` provider selection key) and
+/// roster entry names / durable principal ids. Conservative charset so the
+/// composed keys stay unambiguous in logs, TOML paths, and principal ids.
+fn is_valid_auth_section_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    name.len() <= 64 && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+/// One OIDC trust relationship (`[oidc.<alias>]`) — the identity-mapping
+/// half consumed by the shared principal resolver.
+///
+/// The alias is an operator-chosen handle (it appears in logs and audit
+/// attribution as `oidc.<alias>` and selects the provider during the
+/// handshake), never part of principal identity: canonical identity is
+/// keyed by the validated issuer plus token subject, so renaming an alias
+/// cannot re-key principals or link accounts across issuers.
+///
+/// Token-verification settings (validation mode, audience, client secrets,
+/// lifetimes) ship with the OIDC provider slice; this entry carries what
+/// the resolver needs to map verified claims to permission profiles.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "oidc"]
+#[serde(default)]
+pub struct OidcConfig {
+    /// Issuer URL exactly as it appears in validated token `iss` claims
+    /// (e.g. `https://sso.example.com/realms/main`).
+    pub issuer: String,
+    /// Dotted path to the verified claim holding this deployment's
+    /// role/group values (e.g. `realm_access.roles`, `groups`). Must be
+    /// set explicitly: the daemon refuses to guess where grants live in a
+    /// token.
+    pub claim_path: String,
+    /// Maps a claim value found at `claim_path` to a
+    /// `[permission_profiles.<alias>]` name. Claim values with no mapping
+    /// grant nothing; an identity mapping to no profile at all is denied.
+    pub profile_map: HashMap<String, String>,
+}
+
+impl OidcConfig {
+    pub fn validate(&self, alias: &str) -> Result<()> {
+        if !is_valid_auth_section_name(alias) {
+            anyhow::bail!(
+                "oidc alias {alias:?} is invalid: expected [A-Za-z0-9][A-Za-z0-9_-]* (max 64 chars)"
+            );
+        }
+        if self.issuer.trim().is_empty() {
+            anyhow::bail!("oidc.{alias}.issuer is required");
+        }
+        if !self.issuer.starts_with("https://") && !self.issuer.starts_with("http://") {
+            anyhow::bail!("oidc.{alias}.issuer must be an http(s) URL");
+        }
+        if self.claim_path.trim().is_empty() {
+            anyhow::bail!(
+                "oidc.{alias}.claim_path is required: set the dotted path to the \
+                 claim carrying role/group values (e.g. `realm_access.roles` or `groups`)"
+            );
+        }
+        if self.profile_map.is_empty() {
+            anyhow::bail!(
+                "oidc.{alias}.profile_map is required: map at least one claim value to a \
+                 permission profile or every identity from this issuer will be denied"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// One local roster identity (`[users.<name>]`) for the local auth
+/// providers (peer credentials today; SSH keys and passwords are
+/// separately tracked extensions).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "user"]
+#[serde(default)]
+pub struct UserConfig {
+    /// Durable principal identifier for this entry; defaults to the entry
+    /// name. Ownership of sessions, memory, approvals, and audit trails
+    /// keys on this id, NOT on the entry name — so to rename the entry
+    /// without orphaning its data, set `principal_id` to the original id
+    /// in the same edit. Changing an entry's effective principal id
+    /// creates a new principal that owns nothing.
+    pub principal_id: Option<String>,
+    /// Unix uid accepted for this user over the local socket (peer
+    /// credential). Required today: it is the only roster credential the
+    /// accepted provider set supports.
+    pub uid: Option<u32>,
+    /// The `[permission_profiles.<alias>]` entries granting this user's
+    /// permissions, merged by deterministic union. Required; a user with
+    /// no profile cannot authenticate.
+    pub permission_profiles: Vec<String>,
+}
+
+impl UserConfig {
+    /// The durable principal id this entry resolves to (explicit
+    /// `principal_id`, else the entry name).
+    #[must_use]
+    pub fn effective_principal_id<'a>(&'a self, name: &'a str) -> &'a str {
+        self.principal_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .unwrap_or(name)
+    }
+
+    pub fn validate(&self, name: &str) -> Result<()> {
+        if !is_valid_auth_section_name(name) {
+            anyhow::bail!(
+                "users entry name {name:?} is invalid: expected [A-Za-z0-9][A-Za-z0-9_-]* (max 64 chars)"
+            );
+        }
+        if let Some(id) = self.principal_id.as_deref().map(str::trim)
+            && !id.is_empty()
+            && !is_valid_auth_section_name(id)
+        {
+            anyhow::bail!(
+                "users.{name}.principal_id {id:?} is invalid: expected [A-Za-z0-9][A-Za-z0-9_-]* (max 64 chars)"
+            );
+        }
+        if self.uid.is_none() {
+            anyhow::bail!(
+                "users.{name}.uid is required: the peer-credential provider is the only \
+                 supported roster credential today, and an entry with no credential can \
+                 never authenticate"
+            );
+        }
+        if self.permission_profiles.iter().all(|p| p.trim().is_empty()) {
+            anyhow::bail!(
+                "users.{name}.permission_profiles is required: a user with no permission \
+                 profile holds no grants and cannot authenticate"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// One named grant set (`[permission_profiles.<alias>]`).
+///
+/// Profiles are the single authorization vocabulary: OIDC `profile_map`
+/// values and `[users.<name>].permission_profiles` both resolve here. A
+/// profile grants exactly what it lists; everything else is denied.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "permission_profile"]
+#[serde(default)]
+pub struct PermissionProfileConfig {
+    /// Grant everything. When true all other fields are irrelevant.
+    pub admin: bool,
+    /// Agent aliases holders of this profile may bind or address. Empty
+    /// grants NO agents; grant every agent with the explicit `"*"` entry.
+    pub allowed_agents: Vec<String>,
+    /// Dotted config path prefixes holders may write. A trailing `.*`
+    /// grants the subtree (e.g. `channels.*`); a bare path grants that
+    /// exact prop; `"*"` grants every path. Empty grants NO paths.
+    pub config_write_paths: Vec<String>,
+    /// Tool names holders may cause an agent to run. Empty grants NO
+    /// tools — broad access requires the explicit `"*"` entry. (Note this
+    /// differs from risk-profile `allowed_tools`, where empty means
+    /// unconstrained: permission profiles are deny-by-default. The
+    /// agent's own risk-profile policy still applies on top.)
+    pub allowed_tools: Vec<String>,
+    /// Resource-class grants: for each resource kind, the verbs
+    /// permitted. Resources: `system`, `sessions`, `memory`, `cron`,
+    /// `config`, `agents`, `cost`, `skills`, `personality`, `logs`,
+    /// `tui`, `files`, `locales`, `quickstart`, `channels`, `providers`,
+    /// `models`, `peer_groups`, `plugins`, `tools`, `sops`. Verbs:
+    /// `create`, `read`, `update`, `delete`, `execute`. An unlisted
+    /// resource is denied.
+    pub grants: HashMap<zeroclaw_api::grants::Resource, Vec<zeroclaw_api::grants::Verb>>,
+}
+
+impl PermissionProfileConfig {
+    /// Compile this profile into the runtime grant shape.
+    #[must_use]
+    pub fn resolve(&self) -> zeroclaw_api::grants::ResolvedGrants {
+        use zeroclaw_api::principal::AgentAlias;
+        let mut resolved = zeroclaw_api::grants::ResolvedGrants::none();
+        resolved.admin = self.admin;
+        resolved.allowed_agents = self
+            .allowed_agents
+            .iter()
+            .map(|a| AgentAlias(a.clone()))
+            .collect();
+        resolved.config_write_paths = self.config_write_paths.clone();
+        resolved.allowed_tools = self.allowed_tools.clone();
+        for (resource, verbs) in &self.grants {
+            resolved
+                .resources
+                .insert(*resource, verbs.iter().copied().collect());
+        }
+        resolved
+    }
+}
+
 // ── Profiles & Bundles ───────────────────────────────────────────
 
 /// Named risk/autonomy profile (`[risk_profiles.<alias>]`).
@@ -19402,6 +19626,9 @@ impl Default for Config {
             delegate: DelegateToolConfig::default(),
             agents: HashMap::new(),
             risk_profiles: HashMap::new(),
+            oidc: HashMap::new(),
+            users: HashMap::new(),
+            permission_profiles: HashMap::new(),
             runtime_profiles: HashMap::new(),
             skill_bundles: HashMap::new(),
             knowledge_bundles: HashMap::new(),
@@ -21990,6 +22217,94 @@ impl Config {
                     anyhow::bail!(
                         "risk_profiles.{profile_alias}.shell_env_passthrough[{i}] is invalid ({env_name}); expected [A-Za-z_][A-Za-z0-9_]*"
                     );
+                }
+            }
+        }
+
+        // Inbound authentication & principals (#7141): each auth section
+        // must be internally valid, reference only configured entries, and
+        // map credentials and principal ids unambiguously. Keys are sorted
+        // so the first error reported is deterministic.
+        {
+            let mut oidc_aliases: Vec<&String> = self.oidc.keys().collect();
+            oidc_aliases.sort();
+            for alias in oidc_aliases {
+                let oidc = &self.oidc[alias];
+                oidc.validate(alias)?;
+                let mut claim_values: Vec<&String> = oidc.profile_map.keys().collect();
+                claim_values.sort();
+                for claim_value in claim_values {
+                    let profile = &oidc.profile_map[claim_value];
+                    if !self.permission_profiles.contains_key(profile) {
+                        validation_bail!(
+                            DanglingReference,
+                            format!("oidc.{alias}.profile_map"),
+                            "oidc.{alias}.profile_map[{claim_value:?}] names permission profile {profile:?} but [permission_profiles.{profile}] is not configured",
+                        );
+                    }
+                }
+            }
+
+            let mut user_names: Vec<&String> = self.users.keys().collect();
+            user_names.sort();
+            let mut uid_owners: HashMap<u32, &str> = HashMap::new();
+            let mut principal_owners: HashMap<&str, &str> = HashMap::new();
+            for name in user_names {
+                let user = &self.users[name];
+                user.validate(name)?;
+                for profile in &user.permission_profiles {
+                    let trimmed = profile.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if !self.permission_profiles.contains_key(trimmed) {
+                        validation_bail!(
+                            DanglingReference,
+                            format!("users.{name}.permission_profiles"),
+                            "users.{name}.permission_profiles names {trimmed:?} but [permission_profiles.{trimmed}] is not configured",
+                        );
+                    }
+                }
+                // A uid maps a kernel-reported peer to exactly one
+                // principal; two entries claiming one uid would make
+                // authentication ambiguous.
+                if let Some(uid) = user.uid
+                    && let Some(other) = uid_owners.insert(uid, name.as_str())
+                {
+                    validation_bail!(
+                        ValidationFailed,
+                        format!("users.{name}.uid"),
+                        "users.{name}.uid = {uid} is already mapped by users.{other}; a uid must resolve to exactly one principal",
+                    );
+                }
+                // Two entries resolving to one durable principal id would
+                // silently link accounts and merge their owned data.
+                let principal_id = user.effective_principal_id(name);
+                if let Some(other) = principal_owners.insert(principal_id, name.as_str()) {
+                    validation_bail!(
+                        ValidationFailed,
+                        format!("users.{name}.principal_id"),
+                        "users.{name} resolves to principal id {principal_id:?} which users.{other} already uses; principal ids must be unique",
+                    );
+                }
+            }
+
+            let mut profile_aliases: Vec<&String> = self.permission_profiles.keys().collect();
+            profile_aliases.sort();
+            for alias in profile_aliases {
+                let profile = &self.permission_profiles[alias];
+                for agent in &profile.allowed_agents {
+                    let trimmed = agent.trim();
+                    if trimmed.is_empty() || trimmed == "*" {
+                        continue;
+                    }
+                    if !self.agents.contains_key(trimmed) {
+                        validation_bail!(
+                            DanglingReference,
+                            format!("permission_profiles.{alias}.allowed_agents"),
+                            "permission_profiles.{alias}.allowed_agents names {trimmed:?} but [agents.{trimmed}] is not configured (use \"*\" for every agent)",
+                        );
+                    }
                 }
             }
         }
@@ -25752,6 +26067,245 @@ mod tests {
         assert_eq!(AmqpConfig::default().dispatch, SopDispatch::AgentLoop);
     }
 
+    // ── Inbound auth config sections (#7141 / #8289 Stage 2) ─────────
+
+    fn auth_operator_profile() -> PermissionProfileConfig {
+        PermissionProfileConfig {
+            allowed_agents: vec!["*".to_string()],
+            allowed_tools: vec!["calculator".to_string()],
+            grants: HashMap::from([(
+                zeroclaw_api::grants::Resource::Sessions,
+                vec![
+                    zeroclaw_api::grants::Verb::Create,
+                    zeroclaw_api::grants::Verb::Read,
+                ],
+            )]),
+            ..PermissionProfileConfig::default()
+        }
+    }
+
+    fn auth_config() -> Config {
+        let mut config = Config::default();
+        config
+            .permission_profiles
+            .insert("operator".to_string(), auth_operator_profile());
+        config.users.insert(
+            "alice".to_string(),
+            UserConfig {
+                uid: Some(1000),
+                permission_profiles: vec!["operator".to_string()],
+                ..UserConfig::default()
+            },
+        );
+        config.oidc.insert(
+            "corp".to_string(),
+            OidcConfig {
+                issuer: "https://sso.example.com/realms/main".to_string(),
+                claim_path: "realm_access.roles".to_string(),
+                profile_map: HashMap::from([(
+                    "zeroclaw-operators".to_string(),
+                    "operator".to_string(),
+                )]),
+            },
+        );
+        config
+    }
+
+    #[::core::prelude::v1::test]
+    fn auth_sections_valid_config_passes_validation() {
+        auth_config().validate().expect("valid auth config");
+    }
+
+    #[::core::prelude::v1::test]
+    fn oidc_dangling_profile_map_reference_fails() {
+        let mut config = auth_config();
+        config
+            .oidc
+            .get_mut("corp")
+            .unwrap()
+            .profile_map
+            .insert("admins".to_string(), "missing".to_string());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("oidc.corp.profile_map"), "got: {err}");
+        assert!(err.contains("missing"), "got: {err}");
+    }
+
+    #[::core::prelude::v1::test]
+    fn oidc_requires_issuer_claim_path_and_profile_map() {
+        for strip in ["issuer", "claim_path", "profile_map"] {
+            let mut config = auth_config();
+            let oidc = config.oidc.get_mut("corp").unwrap();
+            match strip {
+                "issuer" => oidc.issuer.clear(),
+                "claim_path" => oidc.claim_path.clear(),
+                _ => oidc.profile_map.clear(),
+            }
+            let err = config.validate().unwrap_err().to_string();
+            assert!(
+                err.contains(strip),
+                "stripping {strip} must fail, got: {err}"
+            );
+        }
+    }
+
+    #[::core::prelude::v1::test]
+    fn oidc_alias_charset_is_enforced() {
+        let mut config = auth_config();
+        let entry = config.oidc.remove("corp").unwrap();
+        config.oidc.insert("bad.alias".to_string(), entry);
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("bad.alias"), "got: {err}");
+    }
+
+    #[::core::prelude::v1::test]
+    fn users_dangling_profile_reference_fails() {
+        let mut config = auth_config();
+        config
+            .users
+            .get_mut("alice")
+            .unwrap()
+            .permission_profiles
+            .push("missing".to_string());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("users.alice.permission_profiles"),
+            "got: {err}"
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn users_without_uid_fail_closed_at_load() {
+        let mut config = auth_config();
+        config.users.get_mut("alice").unwrap().uid = None;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("users.alice.uid"), "got: {err}");
+    }
+
+    #[::core::prelude::v1::test]
+    fn users_duplicate_uid_is_ambiguous_and_fails() {
+        let mut config = auth_config();
+        config.users.insert(
+            "bob".to_string(),
+            UserConfig {
+                uid: Some(1000),
+                permission_profiles: vec!["operator".to_string()],
+                ..UserConfig::default()
+            },
+        );
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("uid must resolve to exactly one principal")
+                || err.contains("already mapped"),
+            "got: {err}"
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn users_duplicate_principal_id_fails() {
+        // An explicit principal_id colliding with another entry's effective
+        // id would silently link two accounts and merge their owned data.
+        let mut config = auth_config();
+        config.users.insert(
+            "bob".to_string(),
+            UserConfig {
+                principal_id: Some("alice".to_string()),
+                uid: Some(2000),
+                permission_profiles: vec!["operator".to_string()],
+            },
+        );
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("principal ids must be unique"), "got: {err}");
+    }
+
+    #[::core::prelude::v1::test]
+    fn users_rename_with_pinned_principal_id_is_stable() {
+        let mut config = auth_config();
+        let mut entry = config.users.remove("alice").unwrap();
+        entry.principal_id = Some("alice".to_string());
+        config.users.insert("alice-renamed".to_string(), entry);
+        config.validate().expect("rename with pinned id is valid");
+        assert_eq!(
+            config.users["alice-renamed"].effective_principal_id("alice-renamed"),
+            "alice",
+            "the durable principal id survives the display rename"
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn permission_profile_allowed_agents_must_exist_or_be_wildcard() {
+        let mut config = auth_config();
+        config
+            .permission_profiles
+            .get_mut("operator")
+            .unwrap()
+            .allowed_agents = vec!["ghost".to_string()];
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("permission_profiles.operator.allowed_agents"),
+            "got: {err}"
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn permission_profile_resolves_to_deny_by_default_grants() {
+        use zeroclaw_api::grants::{Resource, Verb};
+        let resolved = auth_operator_profile().resolve();
+        assert!(!resolved.admin);
+        assert!(resolved.permits(Resource::Sessions, Verb::Read));
+        assert!(!resolved.permits(Resource::Sessions, Verb::Delete));
+        assert!(!resolved.permits(Resource::Config, Verb::Update));
+        assert!(resolved.may_use_agent("anything"), "wildcard entry");
+        assert!(resolved.may_use_tool("calculator"));
+        assert!(!resolved.may_use_tool("shell"), "selector is an allowlist");
+        assert!(
+            !resolved.may_write_config("channels.discord"),
+            "empty config paths grant nothing"
+        );
+
+        let empty = PermissionProfileConfig::default().resolve();
+        assert!(
+            !empty.may_use_tool("calculator"),
+            "empty profile grants nothing"
+        );
+        assert!(!empty.permits(Resource::System, Verb::Read));
+    }
+
+    #[::core::prelude::v1::test]
+    fn auth_sections_roundtrip_from_toml() {
+        let toml_src = r#"
+[permission_profiles.operator]
+allowed_agents = ["*"]
+allowed_tools = ["calculator"]
+
+[permission_profiles.operator.grants]
+sessions = ["create", "read"]
+tools = ["execute"]
+
+[users.alice]
+uid = 1000
+permission_profiles = ["operator"]
+
+[oidc.corp]
+issuer = "https://sso.example.com/realms/main"
+claim_path = "realm_access.roles"
+
+[oidc.corp.profile_map]
+zeroclaw-operators = "operator"
+"#;
+        let config: Config = toml::from_str(toml_src).expect("auth sections parse");
+        config.validate().expect("parsed auth config validates");
+        let resolved = config.permission_profiles["operator"].resolve();
+        assert!(resolved.permits(
+            zeroclaw_api::grants::Resource::Tools,
+            zeroclaw_api::grants::Verb::Execute
+        ));
+        assert_eq!(
+            config.oidc["corp"].profile_map["zeroclaw-operators"],
+            "operator"
+        );
+        assert_eq!(config.users["alice"].uid, Some(1000));
+    }
+
     #[test]
     async fn filesystem_validate_requires_path() {
         let cfg = FilesystemConfig {
@@ -28317,6 +28871,9 @@ auto_save = true
                 backend: ObservabilityBackend::Log,
                 ..ObservabilityConfig::default()
             },
+            oidc: HashMap::new(),
+            users: HashMap::new(),
+            permission_profiles: HashMap::new(),
             risk_profiles: {
                 let mut m = HashMap::new();
                 m.insert(
@@ -29417,6 +29974,9 @@ default_temperature = 0.7
             delegate: DelegateToolConfig::default(),
             agents: HashMap::new(),
             risk_profiles: HashMap::new(),
+            oidc: HashMap::new(),
+            users: HashMap::new(),
+            permission_profiles: HashMap::new(),
             runtime_profiles: HashMap::new(),
             skill_bundles: HashMap::new(),
             knowledge_bundles: HashMap::new(),

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12962,6 +12962,14 @@ pub struct OidcConfig {
     /// `[permission_profiles.<alias>]` name. Claim values with no mapping
     /// grant nothing; an identity mapping to no profile at all is denied.
     pub profile_map: HashMap<String, String>,
+    /// Maps a SERVICE client's verified `client_id` to a
+    /// `[permission_profiles.<alias>]` name. Service principals resolve ONLY
+    /// through this map, never `profile_map`, so a machine credential cannot
+    /// inherit a human profile from similarly-named claims. A service
+    /// `client_id` with no entry here is authenticated but entitled to nothing
+    /// (fail closed).
+    #[serde(default)]
+    pub service_profile_map: HashMap<String, String>,
 }
 
 impl OidcConfig {
@@ -12974,8 +12982,53 @@ impl OidcConfig {
         if self.issuer.trim().is_empty() {
             anyhow::bail!("oidc.{alias}.issuer is required");
         }
-        if !self.issuer.starts_with("https://") && !self.issuer.starts_with("http://") {
-            anyhow::bail!("oidc.{alias}.issuer must be an http(s) URL");
+        // Require TLS for the issuer: the OIDC discovery, JWKS, and
+        // introspection documents fetched from it are trusted to verify
+        // tokens, so a plaintext issuer lets an on-path attacker forge
+        // them (and, for enrollment, capture the client secret). Loopback
+        // is the sole exception, for local IdP development and the test
+        // harness where there is no network to intercept.
+        {
+            // The resolver compares the configured issuer byte-for-byte with
+            // the verified token issuer, so validation must accept exactly the
+            // value that comparison will use: surrounding whitespace would
+            // pass a trimmed URL check here and then never match. OpenID
+            // Connect Discovery §3 also excludes query and fragment components
+            // from an issuer identifier, so a decorated value is rejected
+            // rather than allowed through on its scheme alone.
+            if self.issuer != self.issuer.trim() {
+                anyhow::bail!("oidc.{alias}.issuer must not have surrounding whitespace");
+            }
+            // Parse structurally: a prefix check accepts lookalike hosts like
+            // `http://localhost.attacker.example`. Require https, or http only
+            // when the host is EXACTLY a loopback name (local IdP dev / tests).
+            let issuer = self.issuer.as_str();
+            let url = match url::Url::parse(issuer) {
+                Ok(url) => url,
+                Err(e) => anyhow::bail!("oidc.{alias}.issuer is not a valid URL: {e}"),
+            };
+            if url.query().is_some() || url.fragment().is_some() {
+                anyhow::bail!(
+                    "oidc.{alias}.issuer must not carry a query or fragment: OpenID Connect \
+                     Discovery issuer identifiers exclude them"
+                );
+            }
+            match url.scheme() {
+                "https" => {}
+                "http" => {
+                    let host = url.host_str().unwrap_or_default();
+                    let is_loopback = matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1");
+                    if !is_loopback {
+                        anyhow::bail!(
+                            "oidc.{alias}.issuer must be an https URL (http is allowed only for \
+                             an exact loopback host: localhost, 127.0.0.1, or ::1)"
+                        );
+                    }
+                }
+                other => anyhow::bail!(
+                    "oidc.{alias}.issuer must be an http(s) URL, got scheme '{other}'"
+                ),
+            }
         }
         if self.claim_path.trim().is_empty() {
             anyhow::bail!(
@@ -13103,13 +13156,30 @@ impl PermissionProfileConfig {
         use zeroclaw_api::principal::AgentAlias;
         let mut resolved = zeroclaw_api::grants::ResolvedGrants::none();
         resolved.admin = self.admin;
+        // Normalize selectors: trim surrounding whitespace and drop empties.
+        // Validation trims when checking existence, but the compiled selector
+        // must match too, so `" main "` cannot validate and then never match.
         resolved.allowed_agents = self
             .allowed_agents
             .iter()
-            .map(|a| AgentAlias(a.clone()))
+            .map(|a| a.trim())
+            .filter(|a| !a.is_empty())
+            .map(|a| AgentAlias(a.to_string()))
             .collect();
-        resolved.config_write_paths = self.config_write_paths.clone();
-        resolved.allowed_tools = self.allowed_tools.clone();
+        resolved.config_write_paths = self
+            .config_write_paths
+            .iter()
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .map(str::to_string)
+            .collect();
+        resolved.allowed_tools = self
+            .allowed_tools
+            .iter()
+            .map(|t| t.trim())
+            .filter(|t| !t.is_empty())
+            .map(str::to_string)
+            .collect();
         for (resource, verbs) in &self.grants {
             resolved
                 .resources
@@ -22243,6 +22313,21 @@ impl Config {
                         );
                     }
                 }
+                // Service mappings reference profiles too: a dangling target
+                // must fail here at load time, not surface later as a
+                // Misconfigured denial when the service first resolves.
+                let mut client_ids: Vec<&String> = oidc.service_profile_map.keys().collect();
+                client_ids.sort();
+                for client_id in client_ids {
+                    let profile = &oidc.service_profile_map[client_id];
+                    if !self.permission_profiles.contains_key(profile) {
+                        validation_bail!(
+                            DanglingReference,
+                            format!("oidc.{alias}.service_profile_map"),
+                            "oidc.{alias}.service_profile_map[{client_id:?}] names permission profile {profile:?} but [permission_profiles.{profile}] is not configured",
+                        );
+                    }
+                }
             }
 
             let mut user_names: Vec<&String> = self.users.keys().collect();
@@ -26106,6 +26191,7 @@ mod tests {
                     "zeroclaw-operators".to_string(),
                     "operator".to_string(),
                 )]),
+                ..OidcConfig::default()
             },
         );
         config
@@ -26131,6 +26217,40 @@ mod tests {
     }
 
     #[::core::prelude::v1::test]
+    fn oidc_dangling_service_profile_map_reference_fails() {
+        // A dangling service target must fail at validation, not surface
+        // later as a Misconfigured denial when the service first resolves.
+        let mut config = auth_config();
+        config
+            .oidc
+            .get_mut("corp")
+            .unwrap()
+            .service_profile_map
+            .insert("worker".to_string(), "missing".to_string());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("oidc.corp.service_profile_map"), "got: {err}");
+        assert!(err.contains("missing"), "got: {err}");
+
+        // A service mapping that names a configured profile round-trips.
+        let mut config = auth_config();
+        let existing = config.oidc["corp"]
+            .profile_map
+            .values()
+            .next()
+            .cloned()
+            .expect("auth_config maps at least one claim value");
+        config
+            .oidc
+            .get_mut("corp")
+            .unwrap()
+            .service_profile_map
+            .insert("worker".to_string(), existing);
+        config
+            .validate()
+            .expect("a service map naming a configured profile is valid");
+    }
+
+    #[::core::prelude::v1::test]
     fn oidc_requires_issuer_claim_path_and_profile_map() {
         for strip in ["issuer", "claim_path", "profile_map"] {
             let mut config = auth_config();
@@ -26146,6 +26266,90 @@ mod tests {
                 "stripping {strip} must fail, got: {err}"
             );
         }
+    }
+
+    #[::core::prelude::v1::test]
+    fn oidc_issuer_must_be_https_except_loopback() {
+        // Plaintext issuer over the network is rejected: discovery/JWKS/
+        // introspection are the token-verification root of trust.
+        let mut config = auth_config();
+        config.oidc.get_mut("corp").unwrap().issuer = "http://sso.corp".to_string();
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("https"),
+            "http issuer must be refused, got: {err}"
+        );
+
+        // Loopback stays allowed for local IdP dev and the test harness.
+        for loopback in [
+            "http://127.0.0.1:8080/realms/main",
+            "http://localhost:8080",
+            "http://[::1]:8080",
+        ] {
+            let mut ok = auth_config();
+            ok.oidc.get_mut("corp").unwrap().issuer = loopback.to_string();
+            assert!(
+                ok.validate().is_ok(),
+                "loopback issuer {loopback} must be accepted"
+            );
+        }
+
+        // Lookalike hosts must NOT count as loopback: the url::Url parse
+        // (vs a string prefix) rejects these cleartext issuers.
+        for lookalike in [
+            "http://localhost.attacker.example/realms/main",
+            "http://127.0.0.1.attacker.example",
+            "http://not-localhost:8080",
+            "ftp://sso.corp",
+        ] {
+            let mut bad = auth_config();
+            bad.oidc.get_mut("corp").unwrap().issuer = lookalike.to_string();
+            assert!(
+                bad.validate().is_err(),
+                "lookalike/invalid issuer {lookalike} must be rejected"
+            );
+        }
+
+        // The resolver compares the configured issuer byte-for-byte with the
+        // verified token issuer, so validation must accept exactly that value:
+        // surrounding whitespace would pass a trimmed check and then never
+        // match. OpenID Connect Discovery excludes query and fragment from an
+        // issuer identifier, so decorated values are refused too.
+        for decorated in [
+            " https://sso.example.com ",
+            "https://sso.example.com ",
+            "https://sso.example.com?tenant=x",
+            "https://sso.example.com#fragment",
+        ] {
+            let mut bad = auth_config();
+            bad.oidc.get_mut("corp").unwrap().issuer = decorated.to_string();
+            assert!(
+                bad.validate().is_err(),
+                "issuer {decorated:?} with whitespace/query/fragment must be rejected"
+            );
+        }
+        let mut clean = auth_config();
+        clean.oidc.get_mut("corp").unwrap().issuer = "https://sso.example.com".to_string();
+        assert!(
+            clean.validate().is_ok(),
+            "a plain https issuer must still be accepted"
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn permission_profile_resolve_normalizes_agent_selectors() {
+        // A whitespace-padded selector must normalize so it actually matches
+        // (`" main "` validated but never matched before); empties are dropped.
+        let profile = PermissionProfileConfig {
+            allowed_agents: vec![" main ".to_string(), "   ".to_string()],
+            ..PermissionProfileConfig::default()
+        };
+        let resolved = profile.resolve();
+        assert!(
+            resolved.may_use_agent("main"),
+            "trimmed selector must match"
+        );
+        assert_eq!(resolved.allowed_agents.len(), 1, "whitespace-only dropped");
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12918,7 +12918,7 @@ fn is_valid_env_var_name(name: &str) -> bool {
     chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
-// ── Inbound authentication & principals (#7141) ──────────────────
+// ── Inbound authentication & principals (RFC 7141) ──────────────
 
 /// Validates the operator-chosen names used by the auth sections: OIDC
 /// aliases (which become the `oidc.<alias>` provider selection key) and
@@ -22221,7 +22221,7 @@ impl Config {
             }
         }
 
-        // Inbound authentication & principals (#7141): each auth section
+        // Inbound authentication & principals (RFC 7141): each auth section
         // must be internally valid, reference only configured entries, and
         // map credentials and principal ids unambiguously. Keys are sorted
         // so the first error reported is deterministic.
@@ -26067,7 +26067,7 @@ mod tests {
         assert_eq!(AmqpConfig::default().dispatch, SopDispatch::AgentLoop);
     }
 
-    // ── Inbound auth config sections (#7141 / #8289 Stage 2) ─────────
+    // ── Inbound auth config sections (RFC 7141 stage 2) ─────────────
 
     fn auth_operator_profile() -> PermissionProfileConfig {
         PermissionProfileConfig {

--- a/crates/zeroclaw-config/src/sections.rs
+++ b/crates/zeroclaw-config/src/sections.rs
@@ -116,6 +116,7 @@ pub fn humanize_section_key(key: &str) -> String {
         "providers.models" => return "Model providers".to_string(),
         "providers.tts" => return "TTS providers".to_string(),
         "providers.transcription" => return "Transcription providers".to_string(),
+        "oidc" => return "OIDC".to_string(),
         _ => {}
     }
     let mut s = key.replace(['_', '-', '.'], " ");

--- a/crates/zeroclaw-runtime/src/security/auth_provider.rs
+++ b/crates/zeroclaw-runtime/src/security/auth_provider.rs
@@ -1,4 +1,4 @@
-//! RFC #7141 inbound authentication seam: the [`AuthProvider`] trait + a
+//! RFC 7141 inbound authentication seam: the [`AuthProvider`] trait + a
 //! default-deny [`ProviderRegistry`] with EXPLICIT provider selection.
 //!
 //! Each provider verifies ONE credential kind (OIDC token, peer uid, native

--- a/crates/zeroclaw-runtime/src/security/auth_provider.rs
+++ b/crates/zeroclaw-runtime/src/security/auth_provider.rs
@@ -195,7 +195,7 @@ impl ProviderRegistry {
                 reason: DenyReason::BadCredential,
             };
         }
-        provider.verify(credential).await
+        bind_provenance(provider.as_ref(), provider.verify(credential).await)
     }
 
     /// Route a transport-intrinsic credential (today: the kernel-supplied
@@ -228,7 +228,44 @@ impl ProviderRegistry {
                 reason: DenyReason::Misconfigured,
             };
         }
-        provider.verify(credential).await
+        bind_provenance(provider.as_ref(), provider.verify(credential).await)
+    }
+}
+
+/// Bind the selected provider to the identity it returns: reject a `Verified`
+/// outcome whose method, subject class, or provider alias does not match the
+/// provider the handshake selected. RFC 7141's trusted-provenance boundary must
+/// not depend on every provider implementation being correct — a miswired
+/// provider registered under one name cannot borrow another method, another
+/// issuer's profile mapping, or the shared-operator sentinel.
+fn bind_provenance(provider: &dyn AuthProvider, outcome: AuthOutcome) -> AuthOutcome {
+    use zeroclaw_api::principal::{AuthMethod, IdentitySubject};
+    let AuthOutcome::Verified(identity) = &outcome else {
+        return outcome;
+    };
+    let method_ok = identity.method == provider.method();
+    let subject_ok = matches!(
+        (identity.method, &identity.subject),
+        (AuthMethod::Native, IdentitySubject::SharedOperator)
+            | (AuthMethod::Peercred, IdentitySubject::SharedOperator)
+            | (AuthMethod::Peercred, IdentitySubject::Roster { .. })
+            | (AuthMethod::Oidc, IdentitySubject::Oidc { .. })
+            | (AuthMethod::Oidc, IdentitySubject::Service { .. })
+            | (AuthMethod::SharedOperator, IdentitySubject::SharedOperator)
+    );
+    // An `oidc.<alias>` provider must return that same alias: the resolver
+    // selects the issuer/profile mapping from `provider_alias`, so a mismatch
+    // could borrow a different issuer's mapping.
+    let alias_ok = match provider.name().strip_prefix("oidc.") {
+        Some(expected) => identity.provider_alias.as_deref() == Some(expected),
+        None => true,
+    };
+    if method_ok && subject_ok && alias_ok {
+        outcome
+    } else {
+        AuthOutcome::Denied {
+            reason: DenyReason::Misconfigured,
+        }
     }
 }
 
@@ -320,6 +357,86 @@ mod tests {
                 },
             }
         }
+    }
+
+    /// A miswired provider whose verify() returns an identity that does not
+    /// match its declared provenance (method / subject class / alias). Used to
+    /// prove `bind_provenance` rejects such a Verified outcome.
+    struct Miswired {
+        bad: AuthenticatedIdentity,
+    }
+
+    #[async_trait]
+    impl AuthProvider for Miswired {
+        fn name(&self) -> &str {
+            "oidc.corp"
+        }
+        fn method(&self) -> AuthMethod {
+            AuthMethod::Oidc
+        }
+        fn accepts(&self, credential: &Credential) -> bool {
+            matches!(credential, Credential::Bearer(_))
+        }
+        async fn verify(&self, _credential: &Credential) -> AuthOutcome {
+            AuthOutcome::Verified(self.bad.clone())
+        }
+    }
+
+    async fn miswired_is_denied(bad: AuthenticatedIdentity) {
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(Miswired { bad })).unwrap();
+        let out = reg.resolve_named("oidc.corp", &bearer("x")).await;
+        assert!(
+            matches!(
+                out,
+                AuthOutcome::Denied {
+                    reason: DenyReason::Misconfigured
+                }
+            ),
+            "bind_provenance must reject a mismatched identity"
+        );
+    }
+
+    #[tokio::test]
+    async fn provenance_rejects_method_mismatch() {
+        // oidc.corp returns a Native-method identity.
+        miswired_is_denied(
+            AuthenticatedIdentity::new(
+                IdentitySubject::Oidc {
+                    issuer: "https://sso".into(),
+                    subject: "s".into(),
+                },
+                AuthMethod::Native,
+            )
+            .with_provider_alias("corp"),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn provenance_rejects_shared_operator_from_oidc_provider() {
+        // A non-native provider returning the shared-operator sentinel.
+        miswired_is_denied(
+            AuthenticatedIdentity::shared_operator(AuthMethod::Oidc).with_provider_alias("corp"),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn provenance_rejects_oidc_alias_mismatch() {
+        // oidc.corp returns an identity claiming a different alias, which the
+        // resolver would use to pick another issuer's mapping.
+        miswired_is_denied(
+            AuthenticatedIdentity::new(
+                IdentitySubject::Oidc {
+                    issuer: "https://sso".into(),
+                    subject: "s".into(),
+                },
+                AuthMethod::Oidc,
+            )
+            .with_provider_alias("other"),
+        )
+        .await;
     }
 
     fn bearer(token: &str) -> Credential {

--- a/crates/zeroclaw-runtime/src/security/auth_provider.rs
+++ b/crates/zeroclaw-runtime/src/security/auth_provider.rs
@@ -1,24 +1,33 @@
-//! RFC inbound authentication seam: the [`AuthProvider`] trait + a
-//! default-deny [`ProviderRegistry`].
+//! RFC #7141 inbound authentication seam: the [`AuthProvider`] trait + a
+//! default-deny [`ProviderRegistry`] with EXPLICIT provider selection.
 //!
-//! Each provider verifies ONE credential kind (OIDC token, SSH signature, peer
-//! uid, native pairing bearer) and emits a uniform
-//! [`zeroclaw_api::principal::Principal`] carrying the identity / claim inputs
-//! (the resolved ZeroClaw grants are added additively in the later
-//! IamPolicy-wiring step, not in this slice). Dispatch,
-//! audit, and per-principal isolation read that `Principal` and never see the
-//! credential, so they are provider-agnostic.
+//! Each provider verifies ONE credential kind (OIDC token, peer uid, native
+//! pairing bearer, …) and emits a uniform
+//! [`zeroclaw_api::principal::AuthenticatedIdentity`] — identity and evidence
+//! only. Grants are resolved separately by the shared principal resolver from
+//! the current permission-profile configuration, so providers cannot carry an
+//! authorization vocabulary and cannot snapshot policy.
+//!
+//! Credential routing is explicit and unambiguous (Rev 8): the handshake
+//! names the intended provider ([`ProviderRegistry::resolve_named`]) unless
+//! the credential format securely identifies it
+//! ([`ProviderRegistry::route_transport`] for kernel-supplied peer
+//! credentials). A credential is never offered to every configured provider,
+//! and once a provider was selected its denial is authoritative — there is no
+//! fallback to another provider or to broader authority.
 //!
 //! NOTE — name distinction: this `AuthProvider` (an *inbound auth* trait) is
 //! unrelated to [`zeroclaw_providers::auth`]'s `AuthProvider` enum, which names
 //! *outbound LLM-provider* OAuth kinds. They live in different crates and never
 //! coexist in one import scope.
 //!
-//! This module is the foundational seam: it has no production call sites yet (the
-//! registry is empty until providers are constructed at gateway/RPC boot in a
-//! later phase), so it changes no runtime behaviour. Default-deny means an empty
-//! registry rejects everything — wiring it on is a deliberate, later step.
+//! This module is the foundational seam: it has no production call sites yet
+//! (the registry is empty until providers are constructed at gateway/RPC boot
+//! in a later phase), so it changes no runtime behaviour. Default-deny means
+//! an empty registry rejects everything — wiring it on is a deliberate, later
+//! step.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -43,7 +52,7 @@ use zeroclaw_api::principal::{AuthMethod, AuthOutcome, DenyReason};
 pub enum Credential {
     /// No credential was presented.
     None,
-    /// A bearer token (native pairing token, or an OIDC access/ID token).
+    /// A bearer token (native pairing token, or an OIDC access token).
     Bearer(String),
     /// An SSH challenge signature over a server-issued nonce.
     SshSignature {
@@ -51,8 +60,20 @@ pub enum Credential {
         nonce: Vec<u8>,
         signature: Vec<u8>,
     },
-    /// A local transport peer credential (Unix-socket uid).
+    /// A local transport peer credential (Unix-socket uid). Kernel-supplied:
+    /// the transport, not the client, constructs this arm.
     Peercred { uid: u32 },
+}
+
+impl Credential {
+    /// Whether the credential's FORMAT securely identifies its provider
+    /// class without the client naming one: today only the kernel-supplied
+    /// peer credential qualifies. A bearer string identifies nothing by
+    /// itself — routing it requires an explicit provider selection.
+    #[must_use]
+    pub fn is_transport_intrinsic(&self) -> bool {
+        matches!(self, Self::Peercred { .. })
+    }
 }
 
 impl std::fmt::Debug for Credential {
@@ -75,34 +96,40 @@ impl std::fmt::Debug for Credential {
 
 /// An RFC authentication provider: verifies one credential kind and emits a
 /// uniform [`AuthOutcome`]. Implementations live beside their identity source
-/// (e.g. `oidc` next to the IdP introspection code, `native` over `PairingGuard`).
+/// (e.g. `oidc` next to the token-verification code, `native` over
+/// `PairingGuard`).
 ///
-/// Fail-closed contract: `verify` returns [`AuthOutcome::Denied`] for anything it
-/// cannot positively authenticate — never a silent allow.
+/// Fail-closed contract: `verify` returns [`AuthOutcome::Denied`] for anything
+/// it cannot positively authenticate — never a silent allow. Providers verify
+/// credentials into identities; they never resolve or attach grants.
 #[async_trait]
 pub trait AuthProvider: Send + Sync {
-    /// Stable provider name = its config key (e.g. `"oidc"`, `"native"`,
-    /// `"ssh-key"`). Used for enumeration and diagnostics.
+    /// Stable provider name = its config selection key (e.g. `"native"`,
+    /// `"peercred"`, `"oidc.corp"` for `[oidc.corp]`). Unique within a
+    /// registry; the handshake selects a provider by this name.
     fn name(&self) -> &str;
 
     /// The [`AuthMethod`] this provider attests on success (also what it
     /// advertises in the handshake).
     fn method(&self) -> AuthMethod;
 
-    /// Whether this provider can attempt the given credential kind. Lets the
-    /// registry skip providers that don't apply without burning a `verify`.
+    /// Whether this provider can attempt the given credential kind. Used to
+    /// reject a mis-kinded credential before `verify`, and to route
+    /// transport-intrinsic credentials — never to try one credential across
+    /// providers.
     fn accepts(&self, credential: &Credential) -> bool;
 
-    /// Verify the credential and resolve grants. Fail-closed.
+    /// Verify the credential into an identity. Fail-closed.
     async fn verify(&self, credential: &Credential) -> AuthOutcome;
 }
 
-/// The configured set of providers, consulted in order. **Default-deny**: if no
-/// provider accepts-and-authenticates the credential, the outcome is
-/// [`AuthOutcome::Denied`]. An empty registry rejects everything.
+/// The configured set of providers, selected by name. **Default-deny**: an
+/// empty registry rejects everything, an unknown selection rejects, a
+/// mis-kinded credential rejects, and a selected provider's denial is final.
 #[derive(Default)]
 pub struct ProviderRegistry {
     providers: Vec<Arc<dyn AuthProvider>>,
+    by_name: HashMap<String, usize>,
 }
 
 impl ProviderRegistry {
@@ -111,9 +138,17 @@ impl ProviderRegistry {
         Self::default()
     }
 
-    /// Register a provider (boot-time wiring).
-    pub fn register(&mut self, provider: Arc<dyn AuthProvider>) {
+    /// Register a provider (boot-time wiring). Provider names are the
+    /// selection keys, so a duplicate is ambiguous routing — refused rather
+    /// than silently shadowed.
+    pub fn register(&mut self, provider: Arc<dyn AuthProvider>) -> anyhow::Result<()> {
+        let name = provider.name().to_owned();
+        if self.by_name.contains_key(&name) {
+            anyhow::bail!("auth provider name {name:?} is already registered");
+        }
+        self.by_name.insert(name, self.providers.len());
         self.providers.push(provider);
+        Ok(())
     }
 
     /// `true` if no provider is configured (default-deny will reject all).
@@ -129,66 +164,89 @@ impl ProviderRegistry {
     }
 
     /// The configured provider names, in registration order — the enumeration
-    /// surface exposes over RPC (no hardcoded provider lists).
+    /// surface exposed over RPC (no hardcoded provider lists). These are the
+    /// valid `resolve_named` selections.
     #[must_use]
     pub fn names(&self) -> Vec<&str> {
         self.providers.iter().map(|p| p.name()).collect()
     }
 
-    /// Resolve a presented credential to an [`AuthOutcome`], **default-deny and
-    /// authoritative-deny**.
+    /// Verify `credential` against the EXPLICITLY selected provider.
     ///
-    /// The first accepting provider that authenticates wins. The key safety rule:
-    /// a provider that *accepts* a credential but rejects it with a **specific**
-    /// [`DenyReason`] (anything other than the generic [`DenyReason::BadCredential`]
-    /// — e.g. [`DenyReason::MfaRequired`], [`DenyReason::TokenExpired`],
-    /// [`DenyReason::Misconfigured`], [`DenyReason::AliasNotEntitled`]) is
-    /// **authoritative**: that outcome is returned immediately so a later,
-    /// more broadly-`accept`ing provider can NOT authenticate the same presented
-    /// credential past it (e.g. an OIDC provider returning `MfaRequired` for a
-    /// bearer token can't be bypassed by a later catch-all bearer provider). Only
-    /// the generic `BadCredential` ("not my credential / wrong secret") lets the
-    /// registry fall through to the next accepting provider. `None` is denied
-    /// before any provider runs. An empty registry denies everything.
-    pub async fn resolve(&self, credential: &Credential) -> AuthOutcome {
+    /// Fail-closed and authoritative: an unknown name, a missing credential,
+    /// or a credential kind the selected provider does not accept is denied;
+    /// and whatever the selected provider decides is final — a denial can
+    /// never fall through to another provider that would have accepted the
+    /// same credential (Rev 8: "failure is authoritative once a method and
+    /// provider have been selected").
+    pub async fn resolve_named(&self, name: &str, credential: &Credential) -> AuthOutcome {
         if matches!(credential, Credential::None) {
             return AuthOutcome::Denied {
                 reason: DenyReason::NoCredential,
             };
         }
-        for provider in &self.providers {
-            if provider.accepts(credential) {
-                match provider.verify(credential).await {
-                    allowed @ (AuthOutcome::Authenticated(_) | AuthOutcome::Trusted(_)) => {
-                        return allowed;
-                    }
-                    // Specific deny = authoritative; only generic BadCredential
-                    // lets a later accepting provider try the same credential.
-                    AuthOutcome::Denied { reason } if reason != DenyReason::BadCredential => {
-                        return AuthOutcome::Denied { reason };
-                    }
-                    AuthOutcome::Denied { .. } => {}
-                }
-            }
+        let Some(provider) = self.by_name.get(name).map(|i| &self.providers[*i]) else {
+            return AuthOutcome::Denied {
+                reason: DenyReason::UnknownProvider,
+            };
+        };
+        if !provider.accepts(credential) {
+            return AuthOutcome::Denied {
+                reason: DenyReason::BadCredential,
+            };
         }
-        AuthOutcome::Denied {
-            reason: DenyReason::BadCredential,
+        provider.verify(credential).await
+    }
+
+    /// Route a transport-intrinsic credential (today: the kernel-supplied
+    /// peer uid) to the ONE provider that handles its kind.
+    ///
+    /// This is not a fallback scan: a credential whose format does not
+    /// securely identify its provider (any bearer, any signature) is denied
+    /// here — it must go through [`Self::resolve_named`]. Zero accepting
+    /// providers deny; more than one accepting provider is ambiguous wiring
+    /// and denies as misconfigured rather than picking silently.
+    pub async fn route_transport(&self, credential: &Credential) -> AuthOutcome {
+        if matches!(credential, Credential::None) {
+            return AuthOutcome::Denied {
+                reason: DenyReason::NoCredential,
+            };
         }
+        if !credential.is_transport_intrinsic() {
+            return AuthOutcome::Denied {
+                reason: DenyReason::UnknownProvider,
+            };
+        }
+        let mut accepting = self.providers.iter().filter(|p| p.accepts(credential));
+        let Some(provider) = accepting.next() else {
+            return AuthOutcome::Denied {
+                reason: DenyReason::UnknownProvider,
+            };
+        };
+        if accepting.next().is_some() {
+            return AuthOutcome::Denied {
+                reason: DenyReason::Misconfigured,
+            };
+        }
+        provider.verify(credential).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zeroclaw_api::principal::Principal;
+    use zeroclaw_api::principal::{AuthenticatedIdentity, IdentitySubject};
 
     /// A trivial provider that accepts one fixed bearer token.
-    struct FixedBearer(&'static str);
+    struct FixedBearer {
+        name: &'static str,
+        token: &'static str,
+    }
 
     #[async_trait]
     impl AuthProvider for FixedBearer {
         fn name(&self) -> &str {
-            "fixed-bearer"
+            self.name
         }
         fn method(&self) -> AuthMethod {
             AuthMethod::Native
@@ -198,9 +256,9 @@ mod tests {
         }
         async fn verify(&self, credential: &Credential) -> AuthOutcome {
             match credential {
-                Credential::Bearer(t) if t == self.0 => {
-                    AuthOutcome::Trusted(Principal::shared_operator())
-                }
+                Credential::Bearer(t) if t == self.token => AuthOutcome::Verified(
+                    AuthenticatedIdentity::shared_operator(AuthMethod::Native),
+                ),
                 _ => AuthOutcome::Denied {
                     reason: DenyReason::BadCredential,
                 },
@@ -208,48 +266,14 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn empty_registry_is_default_deny() {
-        let reg = ProviderRegistry::new();
-        assert!(reg.is_empty());
-        let out = reg.resolve(&Credential::Bearer("anything".into())).await;
-        assert!(!out.is_allowed());
-    }
-
-    #[tokio::test]
-    async fn no_credential_is_denied() {
-        let mut reg = ProviderRegistry::new();
-        reg.register(Arc::new(FixedBearer("secret")));
-        let out = reg.resolve(&Credential::None).await;
-        assert!(matches!(
-            out,
-            AuthOutcome::Denied {
-                reason: DenyReason::NoCredential
-            }
-        ));
-    }
-
-    #[tokio::test]
-    async fn matching_provider_authenticates() {
-        let mut reg = ProviderRegistry::new();
-        reg.register(Arc::new(FixedBearer("secret")));
-        assert_eq!(reg.advertised_methods(), vec![AuthMethod::Native]);
-        assert_eq!(reg.names(), vec!["fixed-bearer"]);
-
-        let ok = reg.resolve(&Credential::Bearer("secret".into())).await;
-        assert!(ok.is_allowed());
-
-        let bad = reg.resolve(&Credential::Bearer("wrong".into())).await;
-        assert!(!bad.is_allowed());
-    }
-
-    /// A provider that accepts any bearer but always rejects with a specific reason.
+    /// A provider that accepts any bearer but always rejects with a specific
+    /// reason.
     struct AlwaysMfa;
 
     #[async_trait]
     impl AuthProvider for AlwaysMfa {
         fn name(&self) -> &str {
-            "always-mfa"
+            "oidc.corp"
         }
         fn method(&self) -> AuthMethod {
             AuthMethod::Oidc
@@ -264,27 +288,146 @@ mod tests {
         }
     }
 
+    /// A trivial peercred provider mapping one uid to a roster identity.
+    struct FixedPeercred {
+        name: &'static str,
+        uid: u32,
+    }
+
+    #[async_trait]
+    impl AuthProvider for FixedPeercred {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn method(&self) -> AuthMethod {
+            AuthMethod::Peercred
+        }
+        fn accepts(&self, credential: &Credential) -> bool {
+            matches!(credential, Credential::Peercred { .. })
+        }
+        async fn verify(&self, credential: &Credential) -> AuthOutcome {
+            match credential {
+                Credential::Peercred { uid } if *uid == self.uid => {
+                    AuthOutcome::Verified(AuthenticatedIdentity::new(
+                        IdentitySubject::Roster {
+                            principal_id: "bob".into(),
+                        },
+                        AuthMethod::Peercred,
+                    ))
+                }
+                _ => AuthOutcome::Denied {
+                    reason: DenyReason::BadCredential,
+                },
+            }
+        }
+    }
+
+    fn bearer(token: &str) -> Credential {
+        Credential::Bearer(token.into())
+    }
+
     #[tokio::test]
-    async fn resolve_preserves_specific_deny_reason() {
-        let mut reg = ProviderRegistry::new();
-        reg.register(Arc::new(AlwaysMfa));
-        // A matching provider that rejects with MfaRequired must NOT be flattened
-        // to the generic BadCredential fallback.
-        let out = reg.resolve(&Credential::Bearer("tok".into())).await;
+    async fn empty_registry_is_default_deny() {
+        let reg = ProviderRegistry::new();
+        assert!(reg.is_empty());
+        let out = reg.resolve_named("native", &bearer("anything")).await;
         assert!(matches!(
             out,
             AuthOutcome::Denied {
-                reason: DenyReason::MfaRequired
+                reason: DenyReason::UnknownProvider
+            }
+        ));
+        let routed = reg
+            .route_transport(&Credential::Peercred { uid: 1000 })
+            .await;
+        assert!(!routed.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn no_credential_is_denied() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "secret",
+        }))
+        .unwrap();
+        let out = reg.resolve_named("native", &Credential::None).await;
+        assert!(matches!(
+            out,
+            AuthOutcome::Denied {
+                reason: DenyReason::NoCredential
+            }
+        ));
+        let routed = reg.route_transport(&Credential::None).await;
+        assert!(matches!(
+            routed,
+            AuthOutcome::Denied {
+                reason: DenyReason::NoCredential
             }
         ));
     }
 
     #[tokio::test]
-    async fn resolve_falls_back_to_bad_credential_when_no_provider_accepts() {
+    async fn named_selection_verifies_and_enumerates() {
         let mut reg = ProviderRegistry::new();
-        reg.register(Arc::new(FixedBearer("secret")));
-        // No provider accepts a Peercred credential → generic BadCredential.
-        let out = reg.resolve(&Credential::Peercred { uid: 1000 }).await;
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "secret",
+        }))
+        .unwrap();
+        assert_eq!(reg.advertised_methods(), vec![AuthMethod::Native]);
+        assert_eq!(reg.names(), vec!["native"]);
+
+        let ok = reg.resolve_named("native", &bearer("secret")).await;
+        assert!(ok.is_allowed());
+
+        let bad = reg.resolve_named("native", &bearer("wrong")).await;
+        assert!(!bad.is_allowed());
+
+        let unknown = reg.resolve_named("oidc.corp", &bearer("secret")).await;
+        assert!(matches!(
+            unknown,
+            AuthOutcome::Denied {
+                reason: DenyReason::UnknownProvider
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn selected_provider_denial_is_authoritative_no_fallback() {
+        // Rev 8: once a provider is selected, its denial is final. A second
+        // registered provider that WOULD accept the same bearer must never be
+        // consulted.
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(AlwaysMfa)).unwrap();
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "tok",
+        }))
+        .unwrap();
+        let out = reg.resolve_named("oidc.corp", &bearer("tok")).await;
+        assert!(
+            matches!(
+                out,
+                AuthOutcome::Denied {
+                    reason: DenyReason::MfaRequired
+                }
+            ),
+            "the same credential must not be re-tried against the native provider"
+        );
+    }
+
+    #[tokio::test]
+    async fn mis_kinded_credential_for_selected_provider_is_denied() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "secret",
+        }))
+        .unwrap();
+        let out = reg
+            .resolve_named("native", &Credential::Peercred { uid: 1000 })
+            .await;
         assert!(matches!(
             out,
             AuthOutcome::Denied {
@@ -293,24 +436,86 @@ mod tests {
         ));
     }
 
-    /// Regression (review): a provider that accepts a credential and rejects
-    /// it with a SPECIFIC reason (MfaRequired) must not be bypassed by a later
-    /// provider that would authenticate the same credential.
     #[tokio::test]
-    async fn specific_deny_is_not_bypassed_by_a_later_provider() {
+    async fn duplicate_provider_name_is_refused() {
         let mut reg = ProviderRegistry::new();
-        reg.register(Arc::new(AlwaysMfa)); // accepts Bearer → MfaRequired
-        reg.register(Arc::new(FixedBearer("tok"))); // would Trust Bearer("tok")
-        let out = reg.resolve(&Credential::Bearer("tok".into())).await;
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "a",
+        }))
+        .unwrap();
+        let err = reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "b",
+        }));
         assert!(
-            matches!(
-                out,
-                AuthOutcome::Denied {
-                    reason: DenyReason::MfaRequired
-                }
-            ),
-            "a later provider must not authenticate past an authoritative MfaRequired"
+            err.is_err(),
+            "duplicate selection keys are ambiguous routing"
         );
+    }
+
+    #[tokio::test]
+    async fn transport_routing_reaches_the_single_peercred_provider() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "secret",
+        }))
+        .unwrap();
+        reg.register(Arc::new(FixedPeercred {
+            name: "peercred",
+            uid: 1000,
+        }))
+        .unwrap();
+        let ok = reg
+            .route_transport(&Credential::Peercred { uid: 1000 })
+            .await;
+        assert!(ok.is_allowed());
+        let bad = reg.route_transport(&Credential::Peercred { uid: 1 }).await;
+        assert!(!bad.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn transport_routing_never_scans_bearers() {
+        // A bearer format identifies no provider: routing it without an
+        // explicit selection would be credential spraying.
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(FixedBearer {
+            name: "native",
+            token: "secret",
+        }))
+        .unwrap();
+        let out = reg.route_transport(&bearer("secret")).await;
+        assert!(matches!(
+            out,
+            AuthOutcome::Denied {
+                reason: DenyReason::UnknownProvider
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn ambiguous_transport_routing_fails_closed() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(Arc::new(FixedPeercred {
+            name: "peercred",
+            uid: 1000,
+        }))
+        .unwrap();
+        reg.register(Arc::new(FixedPeercred {
+            name: "peercred-2",
+            uid: 1000,
+        }))
+        .unwrap();
+        let out = reg
+            .route_transport(&Credential::Peercred { uid: 1000 })
+            .await;
+        assert!(matches!(
+            out,
+            AuthOutcome::Denied {
+                reason: DenyReason::Misconfigured
+            }
+        ));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/security/auth_provider.rs
+++ b/crates/zeroclaw-runtime/src/security/auth_provider.rs
@@ -143,6 +143,19 @@ impl ProviderRegistry {
     /// than silently shadowed.
     pub fn register(&mut self, provider: Arc<dyn AuthProvider>) -> anyhow::Result<()> {
         let name = provider.name().to_owned();
+        // An OIDC provider derives its authorization mapping from the `<alias>`
+        // in its `oidc.<alias>` name, so the registry enforces that canonical
+        // shape here rather than trusting each provider to honor the convention.
+        // Without this, an OIDC-method provider registered under a noncanonical
+        // name would slip past the alias-provenance boundary in
+        // `bind_provenance` and borrow an arbitrary issuer's profile mapping.
+        if provider.method() == AuthMethod::Oidc
+            && name.strip_prefix("oidc.").is_none_or(str::is_empty)
+        {
+            anyhow::bail!(
+                "OIDC auth provider must be registered under a canonical `oidc.<alias>` name, got {name:?}"
+            );
+        }
         if self.by_name.contains_key(&name) {
             anyhow::bail!("auth provider name {name:?} is already registered");
         }
@@ -253,12 +266,20 @@ fn bind_provenance(provider: &dyn AuthProvider, outcome: AuthOutcome) -> AuthOut
             | (AuthMethod::Oidc, IdentitySubject::Service { .. })
             | (AuthMethod::SharedOperator, IdentitySubject::SharedOperator)
     );
-    // An `oidc.<alias>` provider must return that same alias: the resolver
-    // selects the issuer/profile mapping from `provider_alias`, so a mismatch
-    // could borrow a different issuer's mapping.
-    let alias_ok = match provider.name().strip_prefix("oidc.") {
-        Some(expected) => identity.provider_alias.as_deref() == Some(expected),
-        None => true,
+    // An OIDC provider's alias carries authority: the resolver selects the
+    // issuer/profile mapping from `provider_alias`. Key this on the METHOD, not
+    // the name — an OIDC-method provider must carry a canonical `oidc.<alias>`
+    // name AND return that same alias, so it cannot dodge the check by
+    // registering under a noncanonical name (which `register` also refuses).
+    // Non-OIDC methods carry no alias authority, so nothing to bind there.
+    let alias_ok = if provider.method() == AuthMethod::Oidc {
+        matches!(
+            provider.name().strip_prefix("oidc."),
+            Some(expected)
+                if !expected.is_empty() && identity.provider_alias.as_deref() == Some(expected)
+        )
+    } else {
+        true
     };
     if method_ok && subject_ok && alias_ok {
         outcome
@@ -437,6 +458,84 @@ mod tests {
             .with_provider_alias("other"),
         )
         .await;
+    }
+
+    /// An OIDC-*method* provider registered under a NONCANONICAL name (one with
+    /// no `oidc.<alias>` prefix), returning a valid-looking OIDC identity with an
+    /// arbitrary alias. Proves both halves of the fix: the registry refuses it,
+    /// and `bind_provenance` denies it independently by keying on the method.
+    struct NoncanonicalOidc {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl AuthProvider for NoncanonicalOidc {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn method(&self) -> AuthMethod {
+            AuthMethod::Oidc
+        }
+        fn accepts(&self, credential: &Credential) -> bool {
+            matches!(credential, Credential::Bearer(_))
+        }
+        async fn verify(&self, _credential: &Credential) -> AuthOutcome {
+            AuthOutcome::Verified(
+                AuthenticatedIdentity::new(
+                    IdentitySubject::Oidc {
+                        issuer: "https://sso".into(),
+                        subject: "s".into(),
+                    },
+                    AuthMethod::Oidc,
+                )
+                .with_provider_alias("corp"),
+            )
+        }
+    }
+
+    #[test]
+    fn register_rejects_noncanonical_oidc_provider_name() {
+        let mut reg = ProviderRegistry::new();
+        // An OIDC-method provider under a noncanonical name is refused at the
+        // registry boundary — otherwise it would skip alias provenance and
+        // borrow an arbitrary issuer's authorization mapping.
+        let err = reg
+            .register(Arc::new(NoncanonicalOidc { name: "custom" }))
+            .unwrap_err();
+        assert!(err.to_string().contains("canonical"), "{err}");
+        // An empty alias is equally noncanonical.
+        assert!(
+            reg.register(Arc::new(NoncanonicalOidc { name: "oidc." }))
+                .is_err()
+        );
+        // The canonical `oidc.<alias>` form is accepted.
+        reg.register(Arc::new(NoncanonicalOidc { name: "oidc.corp" }))
+            .unwrap();
+    }
+
+    #[test]
+    fn bind_provenance_denies_a_noncanonical_oidc_provider() {
+        // Defense in depth: even if a noncanonical-named OIDC provider bypassed
+        // `register`, bind_provenance keys the alias check on the METHOD and
+        // denies it, so an OIDC method can never carry alias authority under a
+        // name that dodges the `oidc.` prefix.
+        let provider = NoncanonicalOidc { name: "custom" };
+        let outcome = AuthOutcome::Verified(
+            AuthenticatedIdentity::new(
+                IdentitySubject::Oidc {
+                    issuer: "https://sso".into(),
+                    subject: "s".into(),
+                },
+                AuthMethod::Oidc,
+            )
+            .with_provider_alias("corp"),
+        );
+        assert!(matches!(
+            bind_provenance(&provider, outcome),
+            AuthOutcome::Denied {
+                reason: DenyReason::Misconfigured
+            }
+        ));
     }
 
     fn bearer(token: &str) -> Credential {

--- a/crates/zeroclaw-runtime/src/security/mod.rs
+++ b/crates/zeroclaw-runtime/src/security/mod.rs
@@ -24,6 +24,7 @@ pub mod otp;
 pub mod pairing;
 pub mod playbook;
 pub mod policy;
+pub mod principal_resolver;
 pub mod prompt_guard;
 #[cfg(target_os = "macos")]
 pub mod seatbelt;

--- a/crates/zeroclaw-runtime/src/security/principal_resolver.rs
+++ b/crates/zeroclaw-runtime/src/security/principal_resolver.rs
@@ -45,8 +45,11 @@ pub struct ResolvedPrincipal {
 pub struct OidcMapping {
     pub issuer: String,
     pub claim_path: String,
-    /// Claim value → permission-profile alias.
+    /// Claim value -> permission-profile alias (human OIDC subjects).
     pub profile_map: HashMap<String, String>,
+    /// Verified service client_id -> permission-profile alias. Service
+    /// principals resolve ONLY through this map, never `profile_map`.
+    pub service_profile_map: HashMap<String, String>,
 }
 
 /// One compiled authorization policy: everything the resolver needs at one
@@ -62,6 +65,11 @@ pub struct ResolverPolicy {
     /// it. Keyed by the EFFECTIVE principal id (`principal_id` override or
     /// entry name), which is what a local provider binds.
     pub roster: HashMap<String, Vec<String>>,
+    /// Set when two `[users]` entries resolved to the SAME effective
+    /// principal id: the roster cannot deterministically say which grants
+    /// win, so it is emptied (fail closed) and this flag lets the reload
+    /// path refuse to install the invalid replacement.
+    pub roster_conflict: bool,
 }
 
 impl ResolverPolicy {
@@ -85,28 +93,44 @@ impl ResolverPolicy {
                         issuer: entry.issuer.clone(),
                         claim_path: entry.claim_path.clone(),
                         profile_map: entry.profile_map.clone(),
+                        service_profile_map: entry.service_profile_map.clone(),
                     },
                 )
             })
             .collect();
-        let roster = config
-            .users
-            .iter()
-            .map(|(name, user)| {
-                (
-                    user.effective_principal_id(name).to_owned(),
-                    user.permission_profiles
-                        .iter()
-                        .map(|p| p.trim().to_owned())
-                        .filter(|p| !p.is_empty())
-                        .collect(),
-                )
-            })
-            .collect();
+        // Build the roster explicitly so a duplicate effective principal id
+        // is a deterministic rejection, not a HashMap insert whose winner
+        // depends on iteration order. Config validation already rejects this,
+        // but the compiler must not silently install a corrupted roster if it
+        // ever receives an unvalidated config.
+        let mut roster: HashMap<String, Vec<String>> = HashMap::new();
+        let mut roster_conflict = false;
+        for (name, user) in &config.users {
+            let pid = user.effective_principal_id(name).to_owned();
+            let profiles: Vec<String> = user
+                .permission_profiles
+                .iter()
+                .map(|p| p.trim().to_owned())
+                .filter(|p| !p.is_empty())
+                .collect();
+            if roster.insert(pid, profiles).is_some() {
+                roster_conflict = true;
+            }
+        }
+        if roster_conflict {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                "Two [users] entries share an effective principal_id; rejecting the whole roster (fail closed) rather than authorizing one arbitrarily. Repair the duplicate principal_id/entry name."
+            );
+            roster.clear();
+        }
         Self {
             profiles,
             oidc,
             roster,
+            roster_conflict,
         }
     }
 }
@@ -179,10 +203,23 @@ impl PrincipalResolver {
         state.1
     }
 
-    /// Re-compile from a validated config and install (see
-    /// [`Self::replace_policy`]).
+    /// Re-compile from config and install (see [`Self::replace_policy`]) —
+    /// UNLESS the new policy is invalid (a duplicate effective principal id).
+    /// An invalid replacement is rejected: the current policy stays installed
+    /// and the generation does NOT advance, so established connections keep
+    /// resolving against the last valid policy until the config is repaired.
     pub fn replace_from_config(&self, config: &Config) -> u64 {
-        self.replace_policy(ResolverPolicy::from_config(config))
+        let policy = ResolverPolicy::from_config(config);
+        if policy.roster_conflict {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure),
+                "Refusing to install an authorization policy with a duplicate effective principal_id; keeping the previous policy. Repair the [users] roster and reload."
+            );
+            return self.generation();
+        }
+        self.replace_policy(policy)
     }
 
     /// Map a provider-verified identity to its canonical principal and the
@@ -222,11 +259,10 @@ impl PrincipalResolver {
                 };
                 Self::merge_profiles(policy, profile_aliases.iter().map(String::as_str))
             }
-            IdentitySubject::Oidc { issuer, .. } | IdentitySubject::Service { issuer, .. } => {
+            IdentitySubject::Oidc { issuer, .. } => {
                 // The provider alias names which [oidc.<alias>] mapping
-                // applies; the VALIDATED issuer must agree with that
-                // entry, so a mis-wired provider cannot borrow another
-                // issuer's mapping.
+                // applies; the VALIDATED issuer must agree with that entry,
+                // so a mis-wired provider cannot borrow another issuer's map.
                 let Some(alias) = identity.provider_alias.as_deref() else {
                     return Err(DenyReason::Misconfigured);
                 };
@@ -238,8 +274,7 @@ impl PrincipalResolver {
                 }
                 let values = claim_values(&identity.claims, &mapping.claim_path);
                 // Sort mapped aliases so multi-profile composition is
-                // deterministic regardless of claim ordering; drop
-                // duplicates so one profile merges once.
+                // deterministic regardless of claim ordering; drop duplicates.
                 let mut mapped: Vec<&str> = values
                     .iter()
                     .filter_map(|value| mapping.profile_map.get(value))
@@ -253,6 +288,27 @@ impl PrincipalResolver {
                     return Err(DenyReason::NotEntitled);
                 }
                 Self::merge_profiles(policy, mapped.into_iter())
+            }
+            IdentitySubject::Service { issuer, client_id } => {
+                // Service principals are actor-qualified: they resolve ONLY
+                // through service_profile_map keyed by the verified client_id,
+                // never the human profile_map, so a machine credential cannot
+                // inherit a human profile from similarly-named claims.
+                let Some(alias) = identity.provider_alias.as_deref() else {
+                    return Err(DenyReason::Misconfigured);
+                };
+                let Some(mapping) = policy.oidc.get(alias) else {
+                    return Err(DenyReason::Misconfigured);
+                };
+                if mapping.issuer != *issuer {
+                    return Err(DenyReason::Misconfigured);
+                }
+                // No explicit service mapping => authenticated, entitled to
+                // nothing (fail closed).
+                let Some(profile) = mapping.service_profile_map.get(client_id) else {
+                    return Err(DenyReason::NotEntitled);
+                };
+                Self::merge_profiles(policy, std::iter::once(profile.as_str()))
             }
             // IdentitySubject is #[non_exhaustive]: an identity class this
             // resolver does not recognize maps to nothing (fail closed).
@@ -317,6 +373,10 @@ mod tests {
                     ("zeroclaw-readers".to_string(), "reader".to_string()),
                     ("zeroclaw-ops".to_string(), "ops".to_string()),
                 ]),
+                service_profile_map: HashMap::from([(
+                    "reporting-batch".to_string(),
+                    "ops".to_string(),
+                )]),
             },
         );
 
@@ -330,6 +390,7 @@ mod tests {
             profiles,
             oidc,
             roster,
+            roster_conflict: false,
         }
     }
 
@@ -508,7 +569,33 @@ mod tests {
     }
 
     #[test]
-    fn service_identity_resolves_to_a_service_principal() {
+    fn service_identity_resolves_through_the_service_map() {
+        // A service whose verified client_id is in service_profile_map
+        // resolves to that service profile (keyed by client_id, NOT claims).
+        let resolver = PrincipalResolver::new(policy());
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Service {
+                issuer: "https://sso.example.com/realms/main".into(),
+                client_id: "reporting-batch".into(),
+            },
+            AuthMethod::Oidc,
+        )
+        .with_provider_alias("corp");
+        let resolved = resolver
+            .resolve(&identity)
+            .expect("mapped service resolves");
+        assert_eq!(resolved.principal.actor, ActorKind::Service);
+        assert_eq!(
+            resolved.principal.id.as_str(),
+            "svc:https%3A//sso.example.com/realms/main:reporting-batch"
+        );
+        assert!(resolved.grants.permits(Resource::Cron, Verb::Execute));
+    }
+
+    #[test]
+    fn service_without_a_service_mapping_is_denied() {
+        // A service client_id absent from service_profile_map is authenticated
+        // but entitled to nothing — even carrying claims a human would map on.
         let resolver = PrincipalResolver::new(policy());
         let claims = serde_json::json!({ "realm_access": { "roles": ["zeroclaw-ops"] } });
         let serde_json::Value::Object(claims) = claims else {
@@ -517,19 +604,101 @@ mod tests {
         let identity = AuthenticatedIdentity::new(
             IdentitySubject::Service {
                 issuer: "https://sso.example.com/realms/main".into(),
-                client_id: "reporting-batch".into(),
+                client_id: "unmapped-client".into(),
             },
             AuthMethod::Oidc,
         )
         .with_provider_alias("corp")
         .with_claims(claims);
-        let resolved = resolver.resolve(&identity).expect("service resolves");
-        assert_eq!(resolved.principal.actor, ActorKind::Service);
-        assert_eq!(
-            resolved.principal.id.as_str(),
-            "svc:https%3A//sso.example.com/realms/main:reporting-batch"
+        assert!(matches!(
+            resolver.resolve(&identity),
+            Err(DenyReason::NotEntitled)
+        ));
+    }
+
+    #[test]
+    fn identical_claims_resolve_differently_for_human_and_service() {
+        // The core RFC 7141 guarantee: the SAME claims give a human its mapped
+        // profile but do NOT leak that profile to a service (which resolves by
+        // client_id through service_profile_map, and is denied without one).
+        let resolver = PrincipalResolver::new(policy());
+        let claims = serde_json::json!({ "realm_access": { "roles": ["zeroclaw-ops"] } });
+        let serde_json::Value::Object(claims) = claims else {
+            unreachable!()
+        };
+        let human = AuthenticatedIdentity::new(
+            IdentitySubject::Oidc {
+                issuer: "https://sso.example.com/realms/main".into(),
+                subject: "alice".into(),
+            },
+            AuthMethod::Oidc,
+        )
+        .with_provider_alias("corp")
+        .with_claims(claims.clone());
+        let human_grants = resolver.resolve(&human).expect("human resolves").grants;
+        assert!(human_grants.permits(Resource::Cron, Verb::Execute));
+
+        let service = AuthenticatedIdentity::new(
+            IdentitySubject::Service {
+                issuer: "https://sso.example.com/realms/main".into(),
+                client_id: "unmapped-client".into(),
+            },
+            AuthMethod::Oidc,
+        )
+        .with_provider_alias("corp")
+        .with_claims(claims);
+        assert!(
+            matches!(resolver.resolve(&service), Err(DenyReason::NotEntitled)),
+            "identical claims must not grant a service the human profile"
         );
-        assert!(resolved.grants.permits(Resource::Cron, Verb::Execute));
+    }
+
+    #[test]
+    fn duplicate_effective_principal_id_rejects_the_roster() {
+        use zeroclaw_config::schema::UserConfig;
+        let mut config = Config::default();
+        for (name, uid, profile) in [("alice", 1u32, "reader"), ("bob", 2u32, "ops")] {
+            config.users.insert(
+                name.to_string(),
+                UserConfig {
+                    principal_id: Some("shared".to_string()),
+                    uid: Some(uid),
+                    permission_profiles: vec![profile.to_string()],
+                },
+            );
+        }
+        let policy = ResolverPolicy::from_config(&config);
+        assert!(
+            policy.roster_conflict,
+            "duplicate effective id flags conflict"
+        );
+        assert!(
+            policy.roster.is_empty(),
+            "a conflicting roster is emptied (fail closed), never overwritten by iteration order"
+        );
+    }
+
+    #[test]
+    fn reload_with_duplicate_principal_id_keeps_the_old_policy() {
+        use zeroclaw_config::schema::UserConfig;
+        let resolver = PrincipalResolver::new(policy());
+        let before = resolver.generation();
+        let mut bad = Config::default();
+        for (name, uid) in [("alice", 1u32), ("bob", 2u32)] {
+            bad.users.insert(
+                name.to_string(),
+                UserConfig {
+                    principal_id: Some("dup".to_string()),
+                    uid: Some(uid),
+                    permission_profiles: vec![],
+                },
+            );
+        }
+        let after = resolver.replace_from_config(&bad);
+        assert_eq!(
+            after, before,
+            "an invalid replacement must not install or advance the generation"
+        );
     }
 
     #[test]
@@ -612,6 +781,7 @@ mod tests {
                 issuer: "https://sso.example.com".to_string(),
                 claim_path: "groups".to_string(),
                 profile_map: HashMap::from([("ops".to_string(), "operator".to_string())]),
+                ..OidcConfig::default()
             },
         );
         config.validate().expect("valid");

--- a/crates/zeroclaw-runtime/src/security/principal_resolver.rs
+++ b/crates/zeroclaw-runtime/src/security/principal_resolver.rs
@@ -1,4 +1,4 @@
-//! The RFC #7141 shared principal resolver: ONE place that maps a
+//! The RFC 7141 shared principal resolver: ONE place that maps a
 //! provider-verified [`AuthenticatedIdentity`] to a canonical [`Principal`]
 //! and its currently-configured grants.
 //!

--- a/crates/zeroclaw-runtime/src/security/principal_resolver.rs
+++ b/crates/zeroclaw-runtime/src/security/principal_resolver.rs
@@ -1,0 +1,661 @@
+//! The RFC #7141 shared principal resolver: ONE place that maps a
+//! provider-verified [`AuthenticatedIdentity`] to a canonical [`Principal`]
+//! and its currently-configured grants.
+//!
+//! Providers verify credentials into identities; they never touch this
+//! vocabulary. The resolver owns the explicit claim-to-profile mapping
+//! (`[oidc.<alias>].profile_map`), the local roster
+//! (`[users.<name>]`), and the compiled `[permission_profiles]` — and it
+//! stamps every resolution with the AUTHORIZATION-POLICY GENERATION it was
+//! computed from. Consumers hold the `Principal` for the connection's
+//! lifetime but re-resolve grants whenever [`PrincipalResolver::generation`]
+//! has moved past their stamped value, so removing or narrowing a profile,
+//! mapping, or roster entry affects established connections at the next
+//! privileged operation — no reconnect or daemon restart required.
+//!
+//! Deny-by-default: unmapped identities, unmapped claim values, unknown
+//! roster ids, and any policy inconsistency resolve to a denial, never to
+//! shared-operator or partial access.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use zeroclaw_api::grants::ResolvedGrants;
+use zeroclaw_api::principal::{AuthenticatedIdentity, DenyReason, IdentitySubject, Principal};
+use zeroclaw_config::schema::Config;
+
+/// One identity's resolution at a specific policy generation.
+#[derive(Clone, Debug)]
+pub struct ResolvedPrincipal {
+    /// The canonical non-secret principal record (held per connection).
+    pub principal: Principal,
+    /// The effective grants at `generation`. Never cached past a
+    /// generation change.
+    pub grants: ResolvedGrants,
+    /// The authorization-policy generation these grants were resolved
+    /// from. Compare against [`PrincipalResolver::generation`] before the
+    /// next privileged operation; if it moved, re-resolve.
+    pub generation: u64,
+}
+
+/// The identity-mapping half of one `[oidc.<alias>]` trust relationship.
+#[derive(Clone, Debug, Default)]
+pub struct OidcMapping {
+    pub issuer: String,
+    pub claim_path: String,
+    /// Claim value → permission-profile alias.
+    pub profile_map: HashMap<String, String>,
+}
+
+/// One compiled authorization policy: everything the resolver needs at one
+/// generation. Immutable once installed; a config change installs a new
+/// policy (and bumps the generation) rather than mutating this one.
+#[derive(Clone, Debug, Default)]
+pub struct ResolverPolicy {
+    /// Compiled `[permission_profiles.<alias>]` grant sets.
+    pub profiles: HashMap<String, ResolvedGrants>,
+    /// `[oidc.<alias>]` identity mappings, by alias.
+    pub oidc: HashMap<String, OidcMapping>,
+    /// Local roster: durable principal id → the profile aliases granted to
+    /// it. Keyed by the EFFECTIVE principal id (`principal_id` override or
+    /// entry name), which is what a local provider binds.
+    pub roster: HashMap<String, Vec<String>>,
+}
+
+impl ResolverPolicy {
+    /// Compile the auth sections of a validated [`Config`]. Dangling
+    /// references were rejected at config load; the resolver still fails
+    /// closed if it meets one at resolve time.
+    #[must_use]
+    pub fn from_config(config: &Config) -> Self {
+        let profiles = config
+            .permission_profiles
+            .iter()
+            .map(|(alias, profile)| (alias.clone(), profile.resolve()))
+            .collect();
+        let oidc = config
+            .oidc
+            .iter()
+            .map(|(alias, entry)| {
+                (
+                    alias.clone(),
+                    OidcMapping {
+                        issuer: entry.issuer.clone(),
+                        claim_path: entry.claim_path.clone(),
+                        profile_map: entry.profile_map.clone(),
+                    },
+                )
+            })
+            .collect();
+        let roster = config
+            .users
+            .iter()
+            .map(|(name, user)| {
+                (
+                    user.effective_principal_id(name).to_owned(),
+                    user.permission_profiles
+                        .iter()
+                        .map(|p| p.trim().to_owned())
+                        .filter(|p| !p.is_empty())
+                        .collect(),
+                )
+            })
+            .collect();
+        Self {
+            profiles,
+            oidc,
+            roster,
+        }
+    }
+}
+
+/// Walk a dotted claim path over a verified-claims document and collect the
+/// values found there as strings. A string claim yields itself; an array
+/// yields its string members; an object yields its KEYS (the shape
+/// Zitadel-style role claims use, where roles are keys of an object).
+fn claim_values(claims: &serde_json::Map<String, serde_json::Value>, path: &str) -> Vec<String> {
+    let mut cursor: Option<&serde_json::Value> = None;
+    for segment in path.split('.') {
+        cursor = match cursor {
+            None => claims.get(segment),
+            Some(value) => value.get(segment),
+        };
+        if cursor.is_none() {
+            return Vec::new();
+        }
+    }
+    match cursor {
+        Some(serde_json::Value::String(s)) => vec![s.clone()],
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect(),
+        Some(serde_json::Value::Object(map)) => map.keys().cloned().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The generation-aware shared resolver. One instance per daemon; the
+/// installed [`ResolverPolicy`] is swapped (never mutated) when the
+/// authorization configuration changes.
+pub struct PrincipalResolver {
+    /// Current policy + the generation it was installed at. One lock so a
+    /// reader can never observe a new policy with an old generation.
+    state: RwLock<(Arc<ResolverPolicy>, u64)>,
+}
+
+impl PrincipalResolver {
+    /// Install the initial policy at generation 1 (0 is never a valid
+    /// stamped generation, so an uninitialized consumer can't look fresh).
+    #[must_use]
+    pub fn new(policy: ResolverPolicy) -> Self {
+        Self {
+            state: RwLock::new((Arc::new(policy), 1)),
+        }
+    }
+
+    /// Convenience: compile and install from a validated config.
+    #[must_use]
+    pub fn from_config(config: &Config) -> Self {
+        Self::new(ResolverPolicy::from_config(config))
+    }
+
+    /// The current authorization-policy generation. Consumers compare
+    /// their stamped [`ResolvedPrincipal::generation`] against this before
+    /// each privileged operation and re-resolve when it moved.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.state.read().1
+    }
+
+    /// Install a new policy, invalidating every previously stamped
+    /// generation. Returns the new generation.
+    pub fn replace_policy(&self, policy: ResolverPolicy) -> u64 {
+        let mut state = self.state.write();
+        state.0 = Arc::new(policy);
+        state.1 += 1;
+        state.1
+    }
+
+    /// Re-compile from a validated config and install (see
+    /// [`Self::replace_policy`]).
+    pub fn replace_from_config(&self, config: &Config) -> u64 {
+        self.replace_policy(ResolverPolicy::from_config(config))
+    }
+
+    /// Map a provider-verified identity to its canonical principal and the
+    /// grants the CURRENT policy assigns it. Fail-closed: any gap —
+    /// unknown roster id, missing mapping, missing profile, provider/alias
+    /// inconsistency — is a denial, never partial or shared-operator
+    /// access.
+    pub fn resolve(
+        &self,
+        identity: &AuthenticatedIdentity,
+    ) -> Result<ResolvedPrincipal, DenyReason> {
+        let (policy, generation) = {
+            let state = self.state.read();
+            (Arc::clone(&state.0), state.1)
+        };
+        let grants = Self::resolve_grants(&policy, identity)?;
+        Ok(ResolvedPrincipal {
+            principal: Principal::from_identity(identity),
+            grants,
+            generation,
+        })
+    }
+
+    fn resolve_grants(
+        policy: &ResolverPolicy,
+        identity: &AuthenticatedIdentity,
+    ) -> Result<ResolvedGrants, DenyReason> {
+        match &identity.subject {
+            // The trusted single-operator path keeps today's full access;
+            // it exists precisely so enforcement can ship without an IdP.
+            IdentitySubject::SharedOperator => Ok(ResolvedGrants::all()),
+            IdentitySubject::Roster { principal_id } => {
+                let Some(profile_aliases) = policy.roster.get(principal_id) else {
+                    // An identity outside the roster holds nothing — it
+                    // never falls back to shared-operator access.
+                    return Err(DenyReason::NotEntitled);
+                };
+                Self::merge_profiles(policy, profile_aliases.iter().map(String::as_str))
+            }
+            IdentitySubject::Oidc { issuer, .. } | IdentitySubject::Service { issuer, .. } => {
+                // The provider alias names which [oidc.<alias>] mapping
+                // applies; the VALIDATED issuer must agree with that
+                // entry, so a mis-wired provider cannot borrow another
+                // issuer's mapping.
+                let Some(alias) = identity.provider_alias.as_deref() else {
+                    return Err(DenyReason::Misconfigured);
+                };
+                let Some(mapping) = policy.oidc.get(alias) else {
+                    return Err(DenyReason::Misconfigured);
+                };
+                if mapping.issuer != *issuer {
+                    return Err(DenyReason::Misconfigured);
+                }
+                let values = claim_values(&identity.claims, &mapping.claim_path);
+                // Sort mapped aliases so multi-profile composition is
+                // deterministic regardless of claim ordering; drop
+                // duplicates so one profile merges once.
+                let mut mapped: Vec<&str> = values
+                    .iter()
+                    .filter_map(|value| mapping.profile_map.get(value))
+                    .map(String::as_str)
+                    .collect();
+                mapped.sort_unstable();
+                mapped.dedup();
+                if mapped.is_empty() {
+                    // Verified, but entitled to nothing: unmapped claims
+                    // grant nothing (Rev 8).
+                    return Err(DenyReason::NotEntitled);
+                }
+                Self::merge_profiles(policy, mapped.into_iter())
+            }
+            // IdentitySubject is #[non_exhaustive]: an identity class this
+            // resolver does not recognize maps to nothing (fail closed).
+            _ => Err(DenyReason::Misconfigured),
+        }
+    }
+
+    /// Union the named profiles (deterministic monotonic merge). A named
+    /// profile missing from the policy is a configuration inconsistency:
+    /// fail closed rather than grant a subset.
+    fn merge_profiles<'a>(
+        policy: &ResolverPolicy,
+        aliases: impl Iterator<Item = &'a str>,
+    ) -> Result<ResolvedGrants, DenyReason> {
+        let mut grants = ResolvedGrants::none();
+        let mut any = false;
+        for alias in aliases {
+            let Some(profile) = policy.profiles.get(alias) else {
+                return Err(DenyReason::Misconfigured);
+            };
+            grants.merge(profile);
+            any = true;
+        }
+        if any {
+            Ok(grants)
+        } else {
+            Err(DenyReason::NotEntitled)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroclaw_api::grants::{Resource, Verb, WILDCARD};
+    use zeroclaw_api::principal::{ActorKind, AuthMethod, PrincipalId};
+
+    fn grants_for(resource: Resource, verbs: &[Verb]) -> ResolvedGrants {
+        let mut g = ResolvedGrants::none();
+        g.resources
+            .insert(resource, verbs.iter().copied().collect());
+        g
+    }
+
+    fn policy() -> ResolverPolicy {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "reader".to_string(),
+            grants_for(Resource::Sessions, &[Verb::Read]),
+        );
+        let mut ops = grants_for(Resource::Cron, &[Verb::Execute]);
+        ops.allowed_tools = vec![WILDCARD.to_string()];
+        profiles.insert("ops".to_string(), ops);
+
+        let mut oidc = HashMap::new();
+        oidc.insert(
+            "corp".to_string(),
+            OidcMapping {
+                issuer: "https://sso.example.com/realms/main".to_string(),
+                claim_path: "realm_access.roles".to_string(),
+                profile_map: HashMap::from([
+                    ("zeroclaw-readers".to_string(), "reader".to_string()),
+                    ("zeroclaw-ops".to_string(), "ops".to_string()),
+                ]),
+            },
+        );
+
+        let mut roster = HashMap::new();
+        roster.insert(
+            "alice".to_string(),
+            vec!["reader".to_string(), "ops".to_string()],
+        );
+
+        ResolverPolicy {
+            profiles,
+            oidc,
+            roster,
+        }
+    }
+
+    fn oidc_identity(roles: serde_json::Value) -> AuthenticatedIdentity {
+        let claims = serde_json::json!({ "realm_access": { "roles": roles } });
+        let serde_json::Value::Object(claims) = claims else {
+            unreachable!()
+        };
+        AuthenticatedIdentity::new(
+            IdentitySubject::Oidc {
+                issuer: "https://sso.example.com/realms/main".into(),
+                subject: "alice".into(),
+            },
+            AuthMethod::Oidc,
+        )
+        .with_provider_alias("corp")
+        .with_claims(claims)
+    }
+
+    #[test]
+    fn shared_operator_resolves_to_admin_grants() {
+        let resolver = PrincipalResolver::new(policy());
+        let resolved = resolver
+            .resolve(&AuthenticatedIdentity::shared_operator(AuthMethod::Native))
+            .expect("shared operator resolves");
+        assert!(resolved.grants.admin);
+        assert_eq!(resolved.principal.id.as_str(), PrincipalId::SHARED_OPERATOR);
+        assert_eq!(resolved.generation, 1);
+    }
+
+    #[test]
+    fn roster_identity_unions_its_profiles() {
+        let resolver = PrincipalResolver::new(policy());
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "alice".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        let resolved = resolver.resolve(&identity).expect("roster resolves");
+        assert_eq!(resolved.principal.id.as_str(), "user:alice");
+        assert!(resolved.principal.is_authenticated());
+        assert!(resolved.grants.permits(Resource::Sessions, Verb::Read));
+        assert!(resolved.grants.permits(Resource::Cron, Verb::Execute));
+        assert!(resolved.grants.may_use_tool("anything"), "ops wildcard");
+        assert!(!resolved.grants.admin);
+        assert!(
+            !resolved.grants.permits(Resource::Config, Verb::Update),
+            "union grants only what the profiles list"
+        );
+    }
+
+    #[test]
+    fn unknown_roster_identity_is_not_entitled() {
+        let resolver = PrincipalResolver::new(policy());
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "mallory".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        assert_eq!(
+            resolver.resolve(&identity).unwrap_err(),
+            DenyReason::NotEntitled,
+            "an unmatched identity never falls back to shared-operator access"
+        );
+    }
+
+    #[test]
+    fn roster_naming_a_missing_profile_fails_closed() {
+        let mut policy = policy();
+        policy
+            .roster
+            .insert("bob".to_string(), vec!["ghost".to_string()]);
+        let resolver = PrincipalResolver::new(policy);
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "bob".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        assert_eq!(
+            resolver.resolve(&identity).unwrap_err(),
+            DenyReason::Misconfigured,
+            "a dangling profile reference denies rather than granting a subset"
+        );
+    }
+
+    #[test]
+    fn oidc_claims_map_through_the_alias_mapping() {
+        let resolver = PrincipalResolver::new(policy());
+        let resolved = resolver
+            .resolve(&oidc_identity(serde_json::json!(["zeroclaw-readers"])))
+            .expect("mapped claim resolves");
+        assert_eq!(
+            resolved.principal.id.as_str(),
+            "oidc:https%3A//sso.example.com/realms/main:alice"
+        );
+        assert!(resolved.grants.permits(Resource::Sessions, Verb::Read));
+        assert!(!resolved.grants.permits(Resource::Cron, Verb::Execute));
+    }
+
+    #[test]
+    fn oidc_multi_profile_union_is_order_independent() {
+        let resolver = PrincipalResolver::new(policy());
+        let ab = resolver
+            .resolve(&oidc_identity(serde_json::json!([
+                "zeroclaw-readers",
+                "zeroclaw-ops"
+            ])))
+            .expect("resolves");
+        let ba = resolver
+            .resolve(&oidc_identity(serde_json::json!([
+                "zeroclaw-ops",
+                "zeroclaw-readers",
+                "zeroclaw-ops"
+            ])))
+            .expect("resolves");
+        assert_eq!(ab.grants, ba.grants, "deterministic monotonic union");
+        assert!(ab.grants.permits(Resource::Sessions, Verb::Read));
+        assert!(ab.grants.permits(Resource::Cron, Verb::Execute));
+    }
+
+    #[test]
+    fn unmapped_claims_grant_nothing() {
+        let resolver = PrincipalResolver::new(policy());
+        assert_eq!(
+            resolver
+                .resolve(&oidc_identity(serde_json::json!(["guests"])))
+                .unwrap_err(),
+            DenyReason::NotEntitled
+        );
+        assert_eq!(
+            resolver
+                .resolve(&oidc_identity(serde_json::json!([])))
+                .unwrap_err(),
+            DenyReason::NotEntitled
+        );
+    }
+
+    #[test]
+    fn zitadel_object_keyed_roles_map() {
+        let resolver = PrincipalResolver::new(policy());
+        let resolved = resolver
+            .resolve(&oidc_identity(serde_json::json!({
+                "zeroclaw-readers": { "276": "org.example.com" }
+            })))
+            .expect("object-keyed roles resolve");
+        assert!(resolved.grants.permits(Resource::Sessions, Verb::Read));
+    }
+
+    #[test]
+    fn issuer_mismatch_with_alias_mapping_fails_closed() {
+        let resolver = PrincipalResolver::new(policy());
+        let mut identity = oidc_identity(serde_json::json!(["zeroclaw-readers"]));
+        identity.subject = IdentitySubject::Oidc {
+            issuer: "https://other-idp.example.com".into(),
+            subject: "alice".into(),
+        };
+        assert_eq!(
+            resolver.resolve(&identity).unwrap_err(),
+            DenyReason::Misconfigured,
+            "a provider cannot borrow another issuer's mapping"
+        );
+    }
+
+    #[test]
+    fn oidc_identity_without_provider_alias_fails_closed() {
+        let resolver = PrincipalResolver::new(policy());
+        let mut identity = oidc_identity(serde_json::json!(["zeroclaw-readers"]));
+        identity.provider_alias = None;
+        assert_eq!(
+            resolver.resolve(&identity).unwrap_err(),
+            DenyReason::Misconfigured
+        );
+    }
+
+    #[test]
+    fn service_identity_resolves_to_a_service_principal() {
+        let resolver = PrincipalResolver::new(policy());
+        let claims = serde_json::json!({ "realm_access": { "roles": ["zeroclaw-ops"] } });
+        let serde_json::Value::Object(claims) = claims else {
+            unreachable!()
+        };
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Service {
+                issuer: "https://sso.example.com/realms/main".into(),
+                client_id: "reporting-batch".into(),
+            },
+            AuthMethod::Oidc,
+        )
+        .with_provider_alias("corp")
+        .with_claims(claims);
+        let resolved = resolver.resolve(&identity).expect("service resolves");
+        assert_eq!(resolved.principal.actor, ActorKind::Service);
+        assert_eq!(
+            resolved.principal.id.as_str(),
+            "svc:https%3A//sso.example.com/realms/main:reporting-batch"
+        );
+        assert!(resolved.grants.permits(Resource::Cron, Verb::Execute));
+    }
+
+    #[test]
+    fn policy_replacement_bumps_the_generation_and_applies_immediately() {
+        let resolver = PrincipalResolver::new(policy());
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "alice".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        let before = resolver.resolve(&identity).expect("resolves");
+        assert_eq!(before.generation, 1);
+        assert!(before.grants.permits(Resource::Cron, Verb::Execute));
+
+        // Narrow alice to the reader profile only.
+        let mut narrowed = policy();
+        narrowed
+            .roster
+            .insert("alice".to_string(), vec!["reader".to_string()]);
+        let new_generation = resolver.replace_policy(narrowed);
+        assert_eq!(new_generation, 2);
+        assert_eq!(resolver.generation(), 2);
+        assert!(
+            before.generation < resolver.generation(),
+            "a stamped resolution is detectably stale after the swap"
+        );
+
+        let after = resolver.resolve(&identity).expect("resolves");
+        assert_eq!(after.generation, 2);
+        assert!(after.grants.permits(Resource::Sessions, Verb::Read));
+        assert!(
+            !after.grants.permits(Resource::Cron, Verb::Execute),
+            "narrowed authorization applies without any reconnect"
+        );
+    }
+
+    #[test]
+    fn removing_a_roster_entry_revokes_at_the_next_resolution() {
+        let resolver = PrincipalResolver::new(policy());
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "alice".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        assert!(resolver.resolve(&identity).is_ok());
+        let mut without = policy();
+        without.roster.remove("alice");
+        resolver.replace_policy(without);
+        assert_eq!(
+            resolver.resolve(&identity).unwrap_err(),
+            DenyReason::NotEntitled
+        );
+    }
+
+    #[test]
+    fn policy_compiles_from_config_sections() {
+        use zeroclaw_config::schema::{OidcConfig, PermissionProfileConfig, UserConfig};
+        let mut config = Config::default();
+        config.permission_profiles.insert(
+            "operator".to_string(),
+            PermissionProfileConfig {
+                allowed_tools: vec!["calculator".to_string()],
+                grants: HashMap::from([(Resource::Sessions, vec![Verb::Read])]),
+                ..PermissionProfileConfig::default()
+            },
+        );
+        config.users.insert(
+            "display-name".to_string(),
+            UserConfig {
+                principal_id: Some("alice".to_string()),
+                uid: Some(1000),
+                permission_profiles: vec!["operator".to_string()],
+            },
+        );
+        config.oidc.insert(
+            "corp".to_string(),
+            OidcConfig {
+                issuer: "https://sso.example.com".to_string(),
+                claim_path: "groups".to_string(),
+                profile_map: HashMap::from([("ops".to_string(), "operator".to_string())]),
+            },
+        );
+        config.validate().expect("valid");
+
+        let resolver = PrincipalResolver::from_config(&config);
+        // The roster keys on the durable principal id, not the entry name.
+        let identity = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "alice".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        let resolved = resolver.resolve(&identity).expect("resolves");
+        assert!(resolved.grants.permits(Resource::Sessions, Verb::Read));
+        assert!(resolved.grants.may_use_tool("calculator"));
+        assert!(!resolved.grants.may_use_tool("shell"));
+
+        let by_name = AuthenticatedIdentity::new(
+            IdentitySubject::Roster {
+                principal_id: "display-name".into(),
+            },
+            AuthMethod::Peercred,
+        );
+        assert_eq!(
+            resolver.resolve(&by_name).unwrap_err(),
+            DenyReason::NotEntitled,
+            "the display name is not an identity once principal_id is pinned"
+        );
+    }
+
+    #[test]
+    fn claim_path_walks_nested_flat_and_missing_shapes() {
+        let claims = serde_json::json!({
+            "realm_access": { "roles": ["a", "b"] },
+            "groups": ["g1"],
+            "plan": "pro",
+        });
+        let serde_json::Value::Object(claims) = claims else {
+            unreachable!()
+        };
+        assert_eq!(claim_values(&claims, "realm_access.roles"), vec!["a", "b"]);
+        assert_eq!(claim_values(&claims, "groups"), vec!["g1"]);
+        assert_eq!(claim_values(&claims, "plan"), vec!["pro"]);
+        assert!(claim_values(&claims, "missing.path").is_empty());
+        assert!(claim_values(&claims, "plan.deeper").is_empty());
+    }
+}

--- a/crates/zeroclaw-runtime/src/security/principal_resolver.rs
+++ b/crates/zeroclaw-runtime/src/security/principal_resolver.rs
@@ -209,6 +209,25 @@ impl PrincipalResolver {
     /// and the generation does NOT advance, so established connections keep
     /// resolving against the last valid policy until the config is repaired.
     pub fn replace_from_config(&self, config: &Config) -> u64 {
+        // Fail closed on a semantically-invalid config. The reload gate upstream
+        // only rejects STRUCTURAL config degradation (a salvage marker), so a
+        // config that parses and survives salvage but fails auth-section
+        // validation — e.g. an OIDC issuer that can never match a token's `iss`,
+        // or a profile referencing a missing grant — must not become live
+        // policy. Keep the previous policy and hold the generation, exactly as
+        // for a duplicate-principal conflict, so live connections keep resolving
+        // against the last valid policy until the config is repaired. This does
+        // not trust the caller to have validated: installation is the boundary.
+        if let Err(e) = config.validate() {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({ "error": format!("{e}") })),
+                "Refusing to install an authorization policy from a config that failed validation; keeping the previous policy. Repair the config and reload."
+            );
+            return self.generation();
+        }
         let policy = ResolverPolicy::from_config(config);
         if policy.roster_conflict {
             ::zeroclaw_log::record!(
@@ -698,6 +717,64 @@ mod tests {
         assert_eq!(
             after, before,
             "an invalid replacement must not install or advance the generation"
+        );
+    }
+
+    /// A known-valid auth config (mirrors `policy_compiles_from_config_sections`).
+    fn valid_auth_config() -> Config {
+        use zeroclaw_config::schema::{OidcConfig, PermissionProfileConfig};
+        let mut config = Config::default();
+        config.permission_profiles.insert(
+            "operator".to_string(),
+            PermissionProfileConfig {
+                allowed_tools: vec!["calculator".to_string()],
+                grants: HashMap::from([(Resource::Sessions, vec![Verb::Read])]),
+                ..PermissionProfileConfig::default()
+            },
+        );
+        config.oidc.insert(
+            "corp".to_string(),
+            OidcConfig {
+                issuer: "https://sso.example.com".to_string(),
+                claim_path: "groups".to_string(),
+                profile_map: HashMap::from([("ops".to_string(), "operator".to_string())]),
+                ..OidcConfig::default()
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn reload_installs_a_valid_config() {
+        let resolver = PrincipalResolver::new(policy());
+        let before = resolver.generation();
+        let good = valid_auth_config();
+        assert!(good.validate().is_ok(), "fixture must be valid");
+        let after = resolver.replace_from_config(&good);
+        assert_eq!(
+            after,
+            before + 1,
+            "a valid replacement installs and advances the generation"
+        );
+    }
+
+    #[test]
+    fn reload_refuses_a_semantically_invalid_config() {
+        let resolver = PrincipalResolver::new(policy());
+        let before = resolver.generation();
+        // Structurally fine, but the OIDC issuer carries a `#fragment` that can
+        // never match a token's `iss` (rejected by OidcConfig::validate). The
+        // structural reload gate would not catch this; the activation gate must.
+        let mut bad = valid_auth_config();
+        bad.oidc.get_mut("corp").unwrap().issuer = "https://sso.example.com#fragment".to_string();
+        assert!(
+            bad.validate().is_err(),
+            "fixture must be semantically invalid"
+        );
+        let after = resolver.replace_from_config(&bad);
+        assert_eq!(
+            after, before,
+            "a semantically-invalid replacement must not install or advance the generation"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Amends the #8063 auth seam to the ratified RFC #7141 Rev 8 identity contract: providers now emit an `AuthenticatedIdentity` (subject, actor kind, verified claims, expiry/revalidation metadata) instead of a grant-bearing `Principal`, and the `ProviderRegistry` requires explicit provider selection — a selected provider's denial is authoritative and a bearer is never scanned across providers.
  - Introduces the single runtime authorization vocabulary (`ResolvedGrants`: resource × verb classes plus agent/tool/config-path selectors) with Rev 8 deny-by-default semantics: an empty selector list grants no instances; broad access requires an explicit `"*"` or an administrator grant.
  - Adds the `[permission_profiles.<alias>]`, `[users.<name>]`, and `[oidc.<alias>]` config sections (identity-mapping half only), with validation that fails closed, deterministically: dangling human and service profile references, ambiguous uid mappings, colliding durable principal ids, and issuers that are not exactly the compared value (surrounding whitespace, query, or fragment). `Config::load_or_init` deliberately tolerates a semantically invalid config so an operator can boot to repair it; the serving-time gate — validation before *initial* policy installation with an actionable error — lands where the resolver first serves, in #10259. This PR's replacement path already refuses a semantically invalid policy and holds the generation.
  - Adds the shared, generation-aware `PrincipalResolver`: one place maps verified identities to canonical principals (`oidc:<issuer>:<sub>`, `svc:<issuer>:<client_id>`, `user:<roster-id>` — injectively encoded, issuer-keyed, alias-independent) and to the grants the *current* policy assigns; every resolution is stamped with the authorization-policy generation so established connections re-resolve after a policy change instead of holding an authorization snapshot.
  - Folds in the review hardening from the CHANGES_REQUESTED passes: provider-provenance binding plus subject-based `is_authenticated` (a mismatched or shared-operator identity from a non-native provider is denied, not authenticated); registration refuses an OIDC-method provider without a canonical `oidc.<alias>` name and alias binding keys on the method, so no provider can borrow another issuer's mapping; explicit service grants via `service_profile_map` (a `client_credentials` identity fails closed rather than inheriting a human profile); `url::Url` exact-loopback issuer parsing (no lookalike-host bypass); and canonicalized `ResolvedGrants::merge` plus trimmed agent selectors so equal predicates compare and serialize equal.
- **Scope:** eight own commits — the six original commits plus the two September 10 repairs (canonical OIDC provider names with method-bound alias provenance; the replacement gate on semantic validation).
- **Scope boundary:** No enforcement changes anywhere — the seam still has zero production call sites, `initialize` and the gateway behave exactly as on `master`. No OIDC token verification (JWT/JWKS/introspection ship as the next slice), no native/peercred providers, no session/memory ownership (#8290), no gateway route enforcement (#6250), no Nevis/`iam_policy` removal, no SSH-key/password providers (#8076 and extensions).
- **Blast radius:** `zeroclaw-api` (principal/grants types — a Rust source break relative to the published `zeroclaw-api` 0.8.5 shape, detailed under Compatibility; publication establishes availability, not that any particular downstream consumer exists), `zeroclaw-runtime/security` (dormant seam + new resolver module), `zeroclaw-config` (three new default-empty sections). Existing configs parse and validate unchanged.
- **Linked issue(s):** Related #8289 (Stage 2 slice), Related #7141 (implements the Rev 8 contract). Supersedes #8672 (Stage 2 scope only; the provider, enforcement, and storage scope follows in stacked slices per the #8289 stage boundaries).
- **Labels:** `enhancement`, `dependencies`, `config`, `runtime`, `security`, `distinguished contributor`, `domain:security`, `needs-author-action`, `risk:medium`, `size:XL`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — library + config surface only; no runtime behavior changes to exercise. The contract is fully covered by unit/contract tests (see below); config behavior is observable via `zeroclaw doctor` on a config using the new sections.

### How I tested

- **CI checks relied on and why they cover this change:** the hosted Quality Gate for the current head `3a0c5d3d91` (run 34666842959) — fmt, clippy `-D warnings`, and the parallel workspace tests cover the changed surface completely, since the change is types, config schema, and an in-crate-tested library module. On the first pass one required job, `Parallel Runtime Test`, hit a timeout in `telegram::tests::media_group_listener_retains_video_context_before_photos_across_polls`, a test master added on 2026-09-11 (`cbd1b0adce`) in a crate this PR does not touch; the failed jobs were re-run and the current result is the one on the checks tab. The advisory Windows nextest job (not a required check) has one failure on the current attempt (run 34666842959 attempt 2, job 103613390719): `publish_contract::published_crates_never_include_files_outside_their_own_directory`, on the unchanged gateway `../../web/dist` include, a file this PR does not touch. Historical note: attempt 1 also failed `agent::loop_::tests::run_tool_call_loop_reuses_fallback_image_cache_across_iterations`; that test passes on attempt 2, so the earlier two-failure statement no longer describes the current result.
- **Known CI coverage gap, if any:** None for this slice beyond the advisory Windows job noted above, which is not a required check.
- **Commands run and tail output:** run locally at exactly this head, `3a0c5d3d91`, on 2026-09-12:

```
$ git checkout 3a0c5d3d91 && cargo check --workspace --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s)   (exit 0, errors=0)
```

  Test execution for this head is the hosted run above; earlier local tails from prior revisions have been removed rather than re-stated against a revision they were not run on.

- **Beyond CI, what did you manually verify?** Contract-level properties are pinned by tests rather than manual checks: principal-id injectivity across colon/percent splices; alias-rename stability of OIDC principal ids; human/service disjointness; empty-selector-denies and wildcard semantics; deterministic multi-profile union under claim reordering; generation bump narrowing/revoking established resolutions without reconnect; roster rename with pinned `principal_id`; duplicate uid / duplicate principal-id rejection; loopback-only cleartext issuers, and issuer whitespace/query/fragment rejection; dangling human and service profile targets; a semantically invalid replacement holding the prior policy and generation; claim-value redaction in `Debug`. NOT verified (out of scope, unimplemented here): any live authentication flow — nothing constructs the registry or resolver in production yet; validation before initial installation is verified in #10259.
- **Visual interface changed?** Yes — one label. `crates/zeroclaw-config/src/sections.rs` now emits an `OIDC` section label, surfaced in the gateway config-sections list and in RPC config-section output.
- **Tested revision, interface, and terminal or viewport dimensions:** `3a0c5d3d91`; the `zerocode` TUI config manager (Config pane, Sections list) connected over the local Unix socket to a `zeroclaw daemon` built from the same revision, on a throwaway `ZEROCLAW_CONFIG_DIR` with default config and no secrets; terminal 120×44, `xterm-256color` with truecolor.
- **Screenshot evidence:** two frames of the actual TUI, nothing retouched. Capture method, for transparency: the interface ran under tmux at 120×44, the pane was dumped with its colour escapes (`tmux capture-pane -e`), and that frame was rendered through a terminal emulator (xterm.js) at 2× so it is exact and legible. First, `OIDC` selected with its section detail open; second, the same list scrolled so `OIDC` sits with the neighbouring new rows (`Permission profiles`, `Users`), with the `Wss` detail showing only defaults.
  <img width="1932" height="1406" alt="oidc_sections_selected" src="https://github.com/user-attachments/assets/a9992239-6c70-4a02-9532-f80af493a3e8" />
  <img width="1932" height="1406" alt="oidc_sections_context" src="https://github.com/user-attachments/assets/ecfe1b8d-4463-48b1-87ef-d3f9a43d287b" />
- **Action or changed state and observed result:** opened the Config pane and moved the cursor down the Sections list. The `OIDC` row renders under the `Other` group together with `Permission profiles` and `Users`; selecting it opens the `oidc` section detail, whose `Fields` box is empty on a default config. No other visual state changes.
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No — `Credential` redaction is unchanged; the new `AuthenticatedIdentity` deliberately does not implement `Serialize` and redacts claim values in `Debug`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No — placeholder identities only (`alice`, `sso.example.com`).
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A for the fields above. What this PR introduces, for the security reviewer: the `ResolvedGrants` resource × verb vocabulary with deny-by-default selectors; the `[permission_profiles]`, `[users]`, and `[oidc.<alias>]` config sections with fail-closed reference validation; and identity *evidence* handling — providers emit an `AuthenticatedIdentity` (no `Serialize`, redacted claim values in `Debug`) and grants never live on `Principal`. Enforcement is **not** activated in this PR: no production code constructs the registry or resolver, so no request is authorized differently than on `master`. Activation is #10259. It *changes the shape* of security-critical types before they gain call sites, which is exactly why it is its own reviewable slice.

## Compatibility (required)

- Backward compatible? Config and defaults: **Yes** — the three new sections are additive and absent by default; existing configs parse, validate, and run unchanged. Rust source: **No** — this changes the published `zeroclaw-api` 0.8.5 `Principal` / `AuthOutcome` shape: `Principal::new`, `user_id`, `roles`, `scopes`, `allowed_aliases` and their builders are removed; `expires_at` becomes `Option<u64>`; the `Authenticated` / `Trusted` outcomes and `principal()` are replaced by `Verified` and `identity()`; `ProviderRegistry::register` now returns a `Result` callers must handle; implicit `resolve` is replaced by explicit `resolve_named` or transport routing. `zeroclaw-api` and the runtime are Experimental-tier components, so a source break is permitted; it is stated here because it is one.
- Config / env / CLI surface changed? Yes — three new optional sections: `[permission_profiles.<alias>]`, `[users.<name>]`, `[oidc.<alias>]`. Purely additive; documented in the schema field docs. No env or CLI changes.
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: config users — none; omitting the new sections is the supported default and preserves today's behavior exactly. Rust callers of `zeroclaw-api` — providers emit verified identity evidence (`AuthenticatedIdentity`) instead of provider-owned grants; consumers resolve current grants through the shared `PrincipalResolver`; field/accessor users adopt `identity()` and the `Verified` outcome; bearer callers select a provider explicitly (`auth_provider`, defaulting to `native`). **Intended release: v0.9.0** (the #8289 program); versioning and release ownership follow the v0.9.0 release owner — this PR does not bump workspace manifests.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` of the eight commits (they revert cleanly in reverse order; no storage or migration side effects).
- **Feature flags or config toggles:** None — nothing activates unless later slices wire the registry/resolver into the handshake.
- **Observable failure symptoms:** none expected at runtime (no call sites). A regression would surface as config-validation failures on load for configs that use the new sections — grep `doctor`/startup output for `permission_profiles`, `users.`, or `oidc.`.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors:
  - #8672 by @singlerider
- Scope materially carried forward: the `Resource`×`Verb`/`ResolvedGrants` grants model and its test structure (with the empty-`allowed_tools`-means-unrestricted behavior corrected to Rev 8 deny-by-default), the `[oidc]`/`[users]`/`[permission_profiles]` config section shapes and dangling-reference validation approach, and the Keycloak/Zitadel-aware claim-path walking. The provider implementations, enrollment client, dispatch classification table, and session-store ownership migration from #8672 are planned for the stacked follow-up slices, where attribution continues.
- `Co-authored-by` trailers added in commit messages for incorporated contributors? Yes — on the two commits that carry #8672 material (`feat(api): add the deny-by-default resolved grants vocabulary`, `feat(config): add oidc, users, and permission_profiles sections`).
- If `No`, why: N/A

## Non-goals

- Landing #8672 as one combined unit (an explicit #8289 non-goal). This PR supersedes its Stage 2 scope; token verification, native/peercred, RPC gate-by-construction, gateway routing, and session/memory ownership land as separate reviewable slices.
- Any enforcement flip: remote WSS behavior, `initialize`, and gateway auth are byte-for-byte today's behavior.

## Design notes for review

- **Grants are not on `Principal`.** #8672 froze `ResolvedGrants` into the principal at handshake time; Rev 8 §establishment semantics and the repo's single-source-of-truth rule both forbid policy snapshots in long-lived handles. Here the resolver stamps each resolution with a policy generation, and `replace_policy` invalidates every stamped generation — the Stage 3 dispatch slice will compare generations before privileged operations.
- **OIDC principals are keyed by validated issuer + subject**, never by the config alias (renaming `[oidc.corp]` → `[oidc.sso]` cannot re-key principals or orphan owned data). The alias is a handshake-selection and audit label only, and the resolver cross-checks the identity's validated issuer against the selected alias's configured issuer, fail-closed.
- **Roster identity is durable by construction:** `[users.<name>].principal_id` pins the ownership key across display renames; validation rejects colliding effective ids and ambiguous uid mappings.
- **Deliberate daemon-uid question for Stage 3 (flagged, not implemented here):** whether the daemon's own uid keeps shared-operator trust once a roster is configured. Default position: yes, explicit and documented, since local host authority underpins the RFC's local-only recovery path — decision recorded before the Stage 3 slice lands.
