### PR TITLE
test(telegram): make the listen hang guards guards again

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -7606,24 +7606,46 @@ mod tests {
             .collect()
     }
 
-    /// Poll `mock_server`'s recorded requests until a main-loop `getUpdates`
-    /// call carrying `offset` shows up, or `timeout` elapses.
-    async fn telegram_wait_for_main_loop_offset(
+    /// Upper bound for the "this must not hang" waits in the `listen` tests.
+    ///
+    /// These guards exist to fail a genuine hang, not to assert how quickly
+    /// the long-poll loop runs. `scripts/ci/parallel_runtime_test_gate.sh`
+    /// runs the suite at 16 threads, and under that contention the previous
+    /// 5s and 10s budgets stopped being hang guards and became scheduling
+    /// assertions. Delivery here is sub-second when it is not hung, and the
+    /// slowest path waits through a real retry sequence that completes well
+    /// inside this bound, so ordinary runner load cannot reach it.
+    const LISTEN_HANG_GUARD: Duration = Duration::from_secs(30);
+
+    /// Wait until a main-loop `getUpdates` call carrying `offset` shows up.
+    ///
+    /// Panics with the offsets actually observed. This replaced a `bool`
+    /// return that every caller asserted as "the offset never advanced",
+    /// which is a claim a deadline cannot support: on a loaded runner the
+    /// same `false` means "not yet". `context` names what the offset was
+    /// supposed to move past, so the panic says which step is in question
+    /// without pretending to know why.
+    async fn telegram_expect_main_loop_offset(
         mock_server: &wiremock::MockServer,
         offset: i64,
-        timeout: Duration,
-    ) -> bool {
-        let deadline = tokio::time::Instant::now() + timeout;
+        guard: Duration,
+        context: &str,
+    ) {
+        let deadline = tokio::time::Instant::now() + guard;
         loop {
-            let seen = telegram_main_loop_getupdates_bodies(mock_server)
+            let seen: Vec<i64> = telegram_main_loop_getupdates_bodies(mock_server)
                 .await
                 .iter()
-                .any(|b| b.get("offset").and_then(serde_json::Value::as_i64) == Some(offset));
-            if seen {
-                return true;
+                .filter_map(|b| b.get("offset").and_then(serde_json::Value::as_i64))
+                .collect();
+            if seen.contains(&offset) {
+                return;
             }
             if tokio::time::Instant::now() >= deadline {
-                return false;
+                panic!(
+                    "main loop did not request offset {offset} ({context}) within \
+                     {guard:?}; observed offsets {seen:?}"
+                );
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
@@ -7686,7 +7708,7 @@ mod tests {
         let listen_ch = ch.clone();
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
-        let msg = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the attachment message")
             .expect("channel closed before delivering the attachment message");
@@ -7710,10 +7732,13 @@ mod tests {
             );
         }
 
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid + 1, Duration::from_secs(5)).await,
-            "offset never advanced past the update once its retry succeeded"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid + 1,
+            LISTEN_HANG_GUARD,
+            "past the update whose retry succeeded",
+        )
+        .await;
 
         handle.abort();
     }
@@ -7748,7 +7773,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let handle = zeroclaw_spawn::spawn!(async move { ch.listen(tx).await });
 
-        let first = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let first = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for first message")
             .expect("channel closed before first message");
@@ -7758,7 +7783,7 @@ mod tests {
         // `tx.send` observes a closed channel.
         drop(rx);
 
-        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+        let result = tokio::time::timeout(LISTEN_HANG_GUARD, handle)
             .await
             .expect("listen() task timed out")
             .expect("listen() task panicked");
@@ -7820,7 +7845,7 @@ mod tests {
         let listen_ch = ch.clone();
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
-        let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the authorized message")
             .expect("channel closed before delivering the authorized message");
@@ -7835,11 +7860,13 @@ mod tests {
             "unexpected extra message delivered: {extra:?}"
         );
 
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid2 + 1, Duration::from_secs(5))
-                .await,
-            "offset never advanced past the unauthorized update to the next expected value"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid2 + 1,
+            LISTEN_HANG_GUARD,
+            "past the unauthorized update to the next expected value",
+        )
+        .await;
 
         handle.abort();
     }
@@ -7912,13 +7939,13 @@ mod tests {
         let listen_ch = ch.clone();
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
-        let first_message = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let first_message = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the first message")
             .expect("channel closed before delivering the first message");
         assert_eq!(first_message.content, "first");
 
-        let recovered = tokio::time::timeout(Duration::from_secs(15), rx.recv())
+        let recovered = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the recovered attachment")
             .expect("channel closed before delivering the recovered attachment");
@@ -7927,7 +7954,7 @@ mod tests {
             "the failed update must recover before the later update, got: {}",
             recovered.content
         );
-        let third_message = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let third_message = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the later message")
             .expect("channel closed before delivering the later message");
@@ -7942,11 +7969,13 @@ mod tests {
             retry_polls >= 4,
             "expected retries beyond the former three-attempt budget at the blocked offset, got {retry_polls}"
         );
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid3 + 1, Duration::from_secs(5))
-                .await,
-            "offset never advanced past the ordered batch after recovery"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid3 + 1,
+            LISTEN_HANG_GUARD,
+            "past the ordered batch after recovery",
+        )
+        .await;
 
         handle.abort();
     }
@@ -8025,7 +8054,7 @@ mod tests {
         let listen_ch = ch.clone();
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
-        let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the authorized message")
             .expect("channel closed before delivering the authorized message");
@@ -8039,11 +8068,13 @@ mod tests {
             "unexpected extra message delivered: {extra:?}"
         );
 
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid2 + 1, Duration::from_secs(5))
-                .await,
-            "offset never advanced past the unauthorized update"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid2 + 1,
+            LISTEN_HANG_GUARD,
+            "past the unauthorized update",
+        )
+        .await;
 
         handle.abort();
     }
@@ -8117,7 +8148,7 @@ mod tests {
         let listen_ch = ch.clone();
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
-        let msg = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out waiting for the queued attachment message")
             .expect("channel closed before delivering the queued attachment message");
@@ -8140,10 +8171,13 @@ mod tests {
             "offset must have stayed at 0 (unadvanced by the probe) for exactly one main-loop retry"
         );
 
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid + 1, Duration::from_secs(5)).await,
-            "offset never advanced past the queued update once its retry succeeded"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid + 1,
+            LISTEN_HANG_GUARD,
+            "past the queued update whose retry succeeded",
+        )
+        .await;
 
         // The queued update must be delivered exactly once, never twice.
         let extra = tokio::time::timeout(Duration::from_millis(300), rx.recv()).await;
@@ -8238,11 +8272,13 @@ mod tests {
         // A callback is terminal for inbound processing, so the offset must
         // advance past the whole batch; waiting on that also guarantees every
         // answerCallbackQuery has been posted before we inspect them.
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, last_uid + 1, Duration::from_secs(5))
-                .await,
-            "offset never advanced past the callback batch"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            last_uid + 1,
+            LISTEN_HANG_GUARD,
+            "past the callback batch",
+        )
+        .await;
 
         let ack_texts: Vec<String> = mock_server
             .received_requests()
@@ -8589,17 +8625,19 @@ mod tests {
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
         // The update behind the permanently rejected one must arrive.
-        let msg = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out: a permanently rejected file id head-of-line blocked the batch")
             .expect("channel closed before delivering the update behind the rejected one");
         assert_eq!(msg.content, "i am behind the bad one");
 
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid_good + 1, Duration::from_secs(5))
-                .await,
-            "offset never advanced past the permanently rejected update"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid_good + 1,
+            LISTEN_HANG_GUARD,
+            "past the permanently rejected update",
+        )
+        .await;
 
         handle.abort();
     }
@@ -8660,7 +8698,7 @@ mod tests {
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
         // The update is retried, not skipped, and eventually delivered.
-        let msg = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out: a transient failure was wrongly skipped instead of retried")
             .expect("channel closed before delivering the retried attachment");
@@ -8746,7 +8784,7 @@ mod tests {
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
         // The update must survive the 408s and arrive after recovery.
-        let msg = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        let msg = tokio::time::timeout(LISTEN_HANG_GUARD, rx.recv())
             .await
             .expect("timed out: a body-less 408 was acknowledged instead of retried")
             .expect("channel closed: the update behind a 408 was silently consumed");
@@ -9135,10 +9173,13 @@ mod tests {
         let listen_ch = Arc::clone(&ch);
         let handle = zeroclaw_spawn::spawn!(async move { listen_ch.listen(tx).await });
 
-        assert!(
-            telegram_wait_for_main_loop_offset(&mock_server, uid + 1, Duration::from_secs(5)).await,
-            "offset never advanced past the captioned pairing update"
-        );
+        telegram_expect_main_loop_offset(
+            &mock_server,
+            uid + 1,
+            LISTEN_HANG_GUARD,
+            "past the captioned pairing update",
+        )
+        .await;
         assert!(
             tokio::time::timeout(Duration::from_millis(300), rx.recv())
                 .await


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Seventeen `telegram::tests::listen_*` tests used a fixed wall-clock duration as the assertion itself. At the 16 threads `scripts/ci/parallel_runtime_test_gate.sh` runs, the 5s and 10s budgets were reachable by ordinary scheduling delay, so a busy runner failed tests whose subject was working correctly. `Repeat parallel runtime tests` is a required check, so this turned red on PRs that had not caused it.
  - The twelve `tokio::time::timeout` guards now share one named `LISTEN_HANG_GUARD` of 30s, which is the convention the assembly tests already established in #9442. Delivery here is sub-second when it is not hung, and the slowest path waits through a real retry sequence that finishes well inside the bound, so runner load cannot reach it while a genuine deadlock still fails quickly.
  - `telegram_wait_for_main_loop_offset` returned a `bool` that all eight callers asserted as "the offset never advanced". A deadline cannot support that claim, because the same `false` also means "not yet". It becomes `telegram_expect_main_loop_offset`, which panics with the offsets it actually observed plus a caller-supplied phrase naming the step. The message now describes what was seen rather than guessing why.
  - The failure text mattered here, not just the flake. `"a body-less 408 was acknowledged instead of retried"` was printed in runs where nothing was acknowledged and the future simply had not been polled. A message asserting a behavior the test never observed is worse than no message.
- **Scope boundary:** Test-only. No production path changes, and one file. The production `tokio::time::timeout(Duration::from_secs(self.approval_timeout_secs), ...)` at `telegram.rs:4705` is an operator-configured approval window, not a test guard, and is untouched. The short `Duration::from_millis(300)` waits are also left alone on purpose: those assert that nothing further is delivered, so a slow runner makes them more likely to pass rather than fail. No test was deleted, disabled, or had an assertion removed.
- **Blast radius:** `zeroclaw-channels` test code only. The guards get longer, so the worst case for a genuinely hung test is that it now takes 30s to fail instead of 5s. That cost lands only on an actual hang, which is the case the guards exist for.
- **Linked issue(s):** Closes #10251. Related #9429 and #9442, which fixed the same defect class at the sites that existed then.
- **Labels:** `bug`, `channel`, `channel:telegram`, `risk:low`, `size:S`, `type:test`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `channel` (Telegram), test-only
- **Setup / preconditions:** None beyond a checkout. An idle machine will not show the problem, which is the whole difficulty, so the load has to be applied deliberately.
- **Steps to run:** Saturate the cores, oversubscribe the test threads, then stop the spinners.

  ```sh
  for i in $(seq 1 24); do (while :; do :; done) & done
  cargo test --locked -p zeroclaw-channels --lib -- --test-threads=256
  kill %1 %2 %3 ...
  ```
- **Expected on this branch (after):** `1464 passed; 0 failed`, repeatedly.
- **Prior behavior on `master` (before):** `1447 passed; 17 failed`, with the same seventeen `listen_*` names each time.

### How I tested

Ran on the CI-pinned toolchain (`rustup override set 1.96.1`; the repo has no `rust-toolchain.toml`).

The before and after, same machine, same recipe, three runs each. `master` was checked out in a separate worktree with its own toolchain override, because the override is path-bound and a worktree does not inherit it:

```sh
# master (3d7a3b1), 24 spinners, --test-threads=256
test result: FAILED. 1447 passed; 17 failed; 2 ignored     # 3 of 3 runs

# this branch, identical recipe
test result: ok. 1464 passed; 0 failed; 2 ignored          # 3 of 3 runs
```

Unloaded suites:

```sh
$ cargo test --locked -p zeroclaw-channels --lib
test result: ok. 1464 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 21.45s

$ cargo test --locked -p zeroclaw-channels --features "channels-full whatsapp-web channel-wechat channel-nostr" --lib
test result: ok. 2717 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 45.79s
```

The `Lint` job's literal steps rather than `rust_quality_gate.sh`, which does not cover the four that follow Clippy:

```sh
$ cargo fmt --all -- --check
$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
$ cargo test --locked --test architecture tests_that_persist_config_isolate_the_path
test result: ok. 1 passed; 0 failed; 27 filtered out
$ cargo test --locked --test architecture user_facing_strings_route_through_fluent
test result: ok. 1 passed; 0 failed; 27 filtered out
$ bash scripts/ci/comment_hygiene_gate.test.sh && bash scripts/ci/comment_hygiene_gate.sh
58 passed, 0 failed
Comment hygiene gate passed.
```

- **CI checks relied on and why they cover this change:** the workspace Test and Lint jobs cover the changed crate, and `Repeat parallel runtime tests` is the job this change is about. `channel-telegram` is in `default-channels`, so unlike most channel work these tests do run in that gate.
- **Known CI coverage gap, if any:** CI cannot prove the absence of a flake, only that one run passed. That is why the evidence above is a before/after under deliberate load rather than a green run.
- **Commands run and tail output:** above.
- **Beyond CI, what did you manually verify?**

  Raising a timeout can turn a real assertion into one that cannot fail, so the useful question is not whether the tests pass now but whether they still catch what they were written for. Three sabotages of production behavior, each restored afterwards:

  | Sabotage | Tests that failed |
  | --- | --- |
  | `RetryTransient` advances the offset like `SkipPermanent` | `listen_bodyless_408_holds_the_offset_and_later_recovers`, `listen_ordered_batch_recovers_after_extended_transient_failure`, `listen_restart_probe_queued_update_survives_transient_failure_until_delivered`, `listen_retries_transient_download_failure_at_same_offset_then_advances`, `listen_transient_file_failure_still_holds_the_offset` |
  | `is_any_user_allowed` returns `true` for everyone | `listen_acknowledges_unauthorized_voice_update_without_download`, `listen_notifies_unauthorized_document_update_without_download`, `listen_permanent_skip_advances_past_unauthorized_update`, `listen_routes_captioned_bind_on_oversized_document_without_download` |
  | `handle_unauthorized_message` skips the processable-content check | `listen_stays_silent_for_unauthorized_media_the_deployment_cannot_process`, `listen_stays_silent_for_unauthorized_media_the_parsers_would_reject`, `listen_stays_silent_for_unauthorized_update_without_processable_content` |

  Each failed within roughly 12 to 33 seconds, so the longer guard does not make a real regression slow to surface.

  Stated plainly: that is 12 of the 17. Five were not individually demonstrated, because I did not find a single-line inversion that targets them specifically: `listen_callback_approval_ack_uses_fluent_catalogue`, `listen_mid_batch_receiver_drop_never_advances_past_delivered`, `listen_permanently_rejected_file_id_does_not_block_later_updates`, `listen_skips_unauthorized_over_duration_voice_update_without_notice`, and `listen_skips_unauthorized_oversized_document_update_without_notice`. Their assertions are unchanged by this PR; only the guard duration around them moved. I am flagging the gap rather than implying full coverage.

  What I did not verify: nothing was run against the live Telegram API, and the reproduction is macOS on aarch64 rather than the Linux runners. The mechanism is scheduling delay against a fixed deadline, which is not platform-specific, but the exact failure rate on CI hardware will differ.
- **If any command was intentionally skipped, why:** the docs gates were not run because no Markdown changed. `./dev/ci.sh all` was not run; the `Lint` steps are reproduced above and the change is one test module in one crate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`. The touched lines are durations, a constant, and assertion text.
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`. Test-only.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A.

## Rollback (required for medium/high-risk PRs)

Low risk, test-only: `git revert <sha>` restores the previous durations and the `bool` helper. Reverting reintroduces the flake but changes no shipped behavior.
