### PR TITLE
fix(gateway): redact duplicate idempotency keys from logs

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -2837,6 +2837,18 @@ fn idempotency_storage_key(namespace: Option<&str>, idempotency_key: &str) -> St
     key
 }
 
+/// Emit duplicate telemetry without copying caller-controlled key material
+/// into the log pipeline. The key remains available to the replay store; only
+/// its presence is useful and safe at this observability boundary.
+fn record_duplicate_idempotency_log(_idempotency_key: &str) {
+    ::zeroclaw_log::record!(
+        INFO,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_attrs(::serde_json::json!({"idempotency_key_present": true})),
+        "webhook duplicate ignored"
+    );
+}
+
 fn check_webhook_idempotency(
     state: &AppState,
     headers: &HeaderMap,
@@ -2852,12 +2864,7 @@ fn check_webhook_idempotency(
         return None;
     }
 
-    ::zeroclaw_log::record!(
-        INFO,
-        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-            .with_attrs(::serde_json::json!({"idempotency_key": idempotency_key})),
-        "webhook duplicate ignored"
-    );
+    record_duplicate_idempotency_log(idempotency_key);
     Some((
         StatusCode::OK,
         Json(serde_json::json!({
@@ -8391,6 +8398,41 @@ path = "{trigger_path}"
         let store = IdempotencyStore::new(Duration::from_secs(300), 100);
         assert!(store.record_if_new("rapid"));
         assert!(!store.record_if_new("rapid"));
+    }
+
+    #[test]
+    fn duplicate_idempotency_log_omits_caller_key() {
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut receiver = zeroclaw_log::subscribe_or_install();
+        while receiver.try_recv().is_ok() {}
+
+        let raw_key = "caller-sensitive-id";
+        record_duplicate_idempotency_log(raw_key);
+
+        let event = loop {
+            match receiver.try_recv() {
+                Ok(value)
+                    if value.get("message").and_then(|message| message.as_str())
+                        == Some("webhook duplicate ignored") =>
+                {
+                    break value;
+                }
+                Ok(_) => continue,
+                Err(error) => panic!("duplicate log event was not broadcast: {error}"),
+            }
+        };
+        zeroclaw_log::clear_broadcast_hook();
+
+        assert_eq!(
+            event["attributes"]["idempotency_key_present"],
+            serde_json::Value::Bool(true)
+        );
+        assert!(event["attributes"].get("idempotency_key").is_none());
+        assert!(
+            !event.to_string().contains(raw_key),
+            "caller-controlled idempotency key must not enter structured logs"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -2840,7 +2840,7 @@ fn idempotency_storage_key(namespace: Option<&str>, idempotency_key: &str) -> St
 /// Emit duplicate telemetry without copying caller-controlled key material
 /// into the log pipeline. The key remains available to the replay store; only
 /// its presence is useful and safe at this observability boundary.
-fn record_duplicate_idempotency_log(_idempotency_key: &str) {
+fn record_duplicate_idempotency_log() {
     ::zeroclaw_log::record!(
         INFO,
         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -2864,7 +2864,7 @@ fn check_webhook_idempotency(
         return None;
     }
 
-    record_duplicate_idempotency_log(idempotency_key);
+    record_duplicate_idempotency_log();
     Some((
         StatusCode::OK,
         Json(serde_json::json!({
@@ -8408,7 +8408,7 @@ path = "{trigger_path}"
         while receiver.try_recv().is_ok() {}
 
         let raw_key = "caller-sensitive-id";
-        record_duplicate_idempotency_log(raw_key);
+        record_duplicate_idempotency_log();
 
         let event = loop {
             match receiver.try_recv() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Stop copying caller-controlled `X-Idempotency-Key` values into duplicate-request structured logs.
  - Record only `idempotency_key_present: true` at the observability boundary while keeping the full key for replay-store lookup and duplicate suppression.
  - Keep request handling, replay behavior, namespaces, authentication, routing, and storage semantics unchanged.
- **Scope boundary:** This PR changes duplicate-request telemetry only. It does not change idempotency matching, replay-store keys, duplicate responses, authentication, routing, storage, or request handling.
- **Blast radius:** The shared duplicate-log helper in `zeroclaw-gateway` is used by the webhook and SOP webhook paths. Operators and log consumers will see the presence boolean instead of the raw caller-controlled key.
- **Linked issue(s):** Related #10249
- **Labels:** `bug`, `gateway`, `domain:security`, `risk:high`, `size:XS`, `needs-maintainer-review`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` - no manual interface path adds signal beyond the deterministic gateway and log-capture tests.

### How I tested

- **CI checks relied on and why they cover this change:** The current hosted status rollup reports successful path-label and PR-title checks. No hosted build, test, or lint result is claimed for this exact head. Local package and workspace-shaped checks below cover the changed gateway helper, its Rust dependencies, and the repository feature selection used by CI.
- **Known CI coverage gap, if any:** No known code-coverage gap for the shared redaction helper. The route-level `/webhook` and `/sop/*` duplicate callers share this helper but are not each instrumented with a separate log-capture assertion. A broader all-features check could not complete because the `embedded-web` build script requires generated web assets; the repository `ci-all` checks do not enable that feature. A full workspace `nextest` attempt timed out before producing a result.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` - passed.
  - `cargo test --locked -p zeroclaw-gateway --lib duplicate_idempotency_log_omits_caller_key -- --nocapture` - 1 passed.
  - `cargo test --locked -p zeroclaw-gateway --lib idempotency -- --nocapture` - 16 passed.
  - `cargo nextest run --locked -p zeroclaw-gateway --lib --no-fail-fast` - 463 passed, 0 skipped.
  - `cargo check --locked --workspace --exclude zeroclaw-desktop --features ci-all` - passed.
  - `cargo check --locked --workspace --exclude zeroclaw-desktop --all-targets` - passed.
  - `cargo check --locked --workspace --exclude zeroclaw-desktop --no-default-features` - passed.
  - `cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings` - passed.
  - Review follow-up: `cargo test --locked -p zeroclaw-gateway --lib --quiet` - 463 passed; `cargo clippy --locked -p zeroclaw-gateway -p zeroclaw-config --all-targets --no-deps -- -D warnings` - passed; `cargo check --locked --workspace --exclude zeroclaw-desktop --features ci-all` - passed.
  - `git diff --check origin/master...HEAD` - passed.
- **Beyond CI, what did you manually verify?** The full key remains only in the existing replay-store flow before the observability boundary; the zero-argument logging helper emits a structured event containing `idempotency_key_present: true`, with no `idempotency_key` attribute and no raw test value. The shared helper is called from the existing webhook and SOP webhook duplicate paths. No live daemon or visual interface test is applicable.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** Package-level all-features validation was not claimed because the `embedded-web` build script requires generated web assets not present in this checkout. Full workspace `cargo nextest` was not claimed because the command timed out before reaching a result; the changed crate's complete 463-test run passed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes` — caller-controlled idempotency-key material is no longer copied into duplicate structured logs; the full value remains confined to replay-store lookup and duplicate suppression.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`. The observability boundary is tightened by excluding caller-controlled idempotency key material from structured logs while preserving the existing in-memory replay-store behavior.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After squash merge, copy the landed commit SHA from PR #10256's merged event and run `git revert <landed-squash-sha>`.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Duplicate telemetry unexpectedly lacks the `idempotency_key_present` attribute, or log consumers fail because they still require the intentionally removed raw `idempotency_key` field.
