### PR TITLE
docs(mcp): add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -195,18 +195,44 @@ affiliated with xAI or SpaceX.
 
 Run `gbr-agent` on the **host**. Do not copy it into a sandbox. Attach only
 loopback Bot API `http://127.0.0.1:8788` or stdio `gbr-mcp`. Phone is spectator
-+ veto. Never put mailbox keys in ZeroClaw config. ZeroClaw chat channels are
+and veto. Never put mailbox keys in ZeroClaw config. ZeroClaw chat channels are
 not `gbr/1`.
 
-Omission of `mcp_bundles` is not a grant — define the server **and** grant it:
+Loopback limits *network* exposure. It is **not** process authentication.
+Another local process can call `:8788` unless you set `GBR_BOT_REQUIRE_KEY=1`
+and give `gbr-mcp` the matching mailbox key through ZeroClaw secret-managed
+MCP `env` (not a plaintext mailbox key in `config.toml`).
+
+`gbr-mcp` logs tool-call arguments to `~/.gbr/logs/gbr-mcp-YYYY-MM-DD.jsonl`
+at info, default retention 7 days. Secret redaction does not strip ordinary
+inject text. For the safe baseline set `GBR_MCP_LOG_BODIES=0`. Delete or
+disable those logs if you do not want a second persistence surface outside
+ZeroClaw history.
+
+Omission of `mcp_bundles` is not a grant: define the server **and** grant it.
+
+Need **Node.js 20+** (`mcp/gbr-mcp` `engines.node >=20`). Pin GitHub Release
+**v0.6.2** (checksum the installer, then the binary). Do not paste live
+website `curl | bash`. See
+[PINNED-INSTALL.md](https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/v0.6.2/docs/PINNED-INSTALL.md).
+
+Terminal 1 (leave this process running):
 
 ```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version    # need v0.6.0+
-gbr-agent pair && gbr-agent run
+gbr-agent version    # need v0.6.2
+export GBR_BOT_REQUIRE_KEY=1
+gbr-agent pair
+gbr-agent run
+```
 
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+Terminal 2 (MCP install and diagnose; `gbr-agent run` must already be up):
+
+```bash
+git clone --branch v0.6.2 --depth 1 https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp
+node -v    # v20+
+npm install
+export GBR_MCP_LOG_BODIES=0
 node bin/gbr-mcp.js --diagnose
 ```
 
@@ -215,6 +241,8 @@ node bin/gbr-mcp.js --diagnose
 name = "gbr"
 command = "node"
 args = ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+# Put the mailbox key in ZeroClaw secret-managed MCP env, not in this file.
+# env = { GBR_BOT_KEY = "<secret-ref>", GBR_MCP_LOG_BODIES = "0" }
 
 [mcp_bundles.gbr]
 servers = ["gbr"]
@@ -224,11 +252,11 @@ mcp_bundles = ["gbr"]
 ```
 
 Restart the affected session after changing bundles. HTTP without MCP, after
-`gbr-agent run`:
+`gbr-agent run` with `GBR_BOT_REQUIRE_KEY=1`:
 
 ```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
+curl -sS -H "X-GBR-Key: $GBR_BOT_KEY" http://127.0.0.1:8788/health
+curl -sS -H "X-GBR-Key: $GBR_BOT_KEY" http://127.0.0.1:8788/v1/sessions
 ```
 
-Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md
+Docs: [BOT-API.md](https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/v0.6.2/docs/BOT-API.md)

--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -272,6 +272,9 @@ zeroclaw config set mcp.servers.gbr.env.GBR_MAILBOX_KEY
 zeroclaw config set mcp.servers.gbr.env.GBR_MCP_LOG_BODIES 0
 ```
 
+All MCP environment values use ZeroClaw's masked secret prompt, so the
+trailing `0` is not consumed as the value. Enter `0` at that prompt.
+
 Restart the affected session after changing bundles or `env`. HTTP without MCP,
 after `gbr-agent run` with `GBR_BOT_REQUIRE_KEY=1`:
 

--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -242,7 +242,7 @@ name = "gbr"
 command = "node"
 args = ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
 # Put the mailbox key in ZeroClaw secret-managed MCP env, not in this file.
-# env = { GBR_BOT_KEY = "<secret-ref>", GBR_MCP_LOG_BODIES = "0" }
+# env = { GBR_MAILBOX_KEY = "<secret-ref>", GBR_MCP_LOG_BODIES = "0" }
 
 [mcp_bundles.gbr]
 servers = ["gbr"]
@@ -255,8 +255,8 @@ Restart the affected session after changing bundles. HTTP without MCP, after
 `gbr-agent run` with `GBR_BOT_REQUIRE_KEY=1`:
 
 ```bash
-curl -sS -H "X-GBR-Key: $GBR_BOT_KEY" http://127.0.0.1:8788/health
-curl -sS -H "X-GBR-Key: $GBR_BOT_KEY" http://127.0.0.1:8788/v1/sessions
+curl -sS -H "X-GBR-Key: $GBR_MAILBOX_KEY" http://127.0.0.1:8788/health
+curl -sS -H "X-GBR-Key: $GBR_MAILBOX_KEY" http://127.0.0.1:8788/v1/sessions
 ```
 
 Docs: [BOT-API.md](https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/v0.6.2/docs/BOT-API.md)

--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -185,3 +185,50 @@ treated as **untrusted**: it is provenance-wrapped, secret-scrubbed, and
 length-bounded before entering context. Access to `mcp_resources` / `mcp_prompts`
 and to specific servers is governed by your agent's tool access policy (risk
 profile), and narrows correctly when delegating to subagents.
+
+## Example: Build Remote Agent (`gbr`)
+
+[Build Remote Agent](https://grokbuildremote.com/) is a pairing device: a phone
+app spectates (and can inject into) this ZeroClaw host through free MIT
+`gbr-agent`. Protocol `gbr/1`. Independent product by Linespotting AB. Not
+affiliated with xAI or SpaceX.
+
+Run `gbr-agent` on the **host**. Do not copy it into a sandbox. Attach only
+loopback Bot API `http://127.0.0.1:8788` or stdio `gbr-mcp`. Phone is spectator
++ veto. Never put mailbox keys in ZeroClaw config. ZeroClaw chat channels are
+not `gbr/1`.
+
+Omission of `mcp_bundles` is not a grant — define the server **and** grant it:
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+```toml
+[[mcp.servers]]
+name = "gbr"
+command = "node"
+args = ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+
+[mcp_bundles.gbr]
+servers = ["gbr"]
+
+[agents.assistant]
+mcp_bundles = ["gbr"]
+```
+
+Restart the affected session after changing bundles. HTTP without MCP, after
+`gbr-agent run`:
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md

--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -195,8 +195,8 @@ affiliated with xAI or SpaceX.
 
 Run `gbr-agent` on the **host**. Do not copy it into a sandbox. Attach only
 loopback Bot API `http://127.0.0.1:8788` or stdio `gbr-mcp`. Phone is spectator
-and veto. Never put mailbox keys in ZeroClaw config. ZeroClaw chat channels are
-not `gbr/1`.
+and veto. Never paste mailbox keys as plaintext in `config.toml`. ZeroClaw chat
+channels are not `gbr/1`.
 
 Loopback limits *network* exposure. It is **not** process authentication.
 Another local process can call `:8788` unless you set `GBR_BOT_REQUIRE_KEY=1`
@@ -205,9 +205,9 @@ MCP `env` (not a plaintext mailbox key in `config.toml`).
 
 `gbr-mcp` logs tool-call arguments to `~/.gbr/logs/gbr-mcp-YYYY-MM-DD.jsonl`
 at info, default retention 7 days. Secret redaction does not strip ordinary
-inject text. For the safe baseline set `GBR_MCP_LOG_BODIES=0`. Delete or
-disable those logs if you do not want a second persistence surface outside
-ZeroClaw history.
+inject text. For the safe baseline set `GBR_MCP_LOG_BODIES=0` on the `gbr`
+server `env` in ZeroCode Config. Delete or disable those logs if you do not
+want a second persistence surface outside ZeroClaw history.
 
 Omission of `mcp_bundles` is not a grant: define the server **and** grant it.
 
@@ -225,24 +225,34 @@ gbr-agent pair
 gbr-agent run
 ```
 
-Terminal 2 (MCP install and diagnose; `gbr-agent run` must already be up):
+After pairing, obtain the mailbox key from the phone (Settings -> Bot API) or
+from the host pairing file `~/.gbr/device.json` (`mailbox_key`). The pinned
+`gbr-mcp` client reads `GBR_MAILBOX_KEY` from its options or process
+environment; it does not load that pairing file. With `GBR_BOT_REQUIRE_KEY=1`,
+a fresh shell that omits the key makes unauthorized Bot API requests.
+
+Terminal 2 (MCP install and diagnose; `gbr-agent run` must already be up).
+Paste the key into a silent prompt so the value is not stored in shell history:
 
 ```bash
 git clone --branch v0.6.2 --depth 1 https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
 cd GrokBuildRemote-Agents/mcp/gbr-mcp
 node -v    # v20+
 npm install
+IFS= read -rs GBR_MAILBOX_KEY   # paste key, Enter; no echo, no history
+export GBR_MAILBOX_KEY
 export GBR_MCP_LOG_BODIES=0
 node bin/gbr-mcp.js --diagnose
 ```
+
+The `export` lines above apply only to this diagnostic shell. They do not
+configure the ZeroClaw-spawned `gbr` server. Define the server and grant it:
 
 ```toml
 [[mcp.servers]]
 name = "gbr"
 command = "node"
 args = ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
-# Put the mailbox key in ZeroClaw secret-managed MCP env, not in this file.
-# env = { GBR_MAILBOX_KEY = "<secret-ref>", GBR_MCP_LOG_BODIES = "0" }
 
 [mcp_bundles.gbr]
 servers = ["gbr"]
@@ -251,10 +261,23 @@ servers = ["gbr"]
 mcp_bundles = ["gbr"]
 ```
 
-Restart the affected session after changing bundles. HTTP without MCP, after
-`gbr-agent run` with `GBR_BOT_REQUIRE_KEY=1`:
+Then set both `GBR_MAILBOX_KEY` and `GBR_MCP_LOG_BODIES=0` on that server's
+`env` through ZeroCode Config (`/config` -> `mcp.servers` -> `gbr` -> `env`).
+The mailbox key is a secret field: use the masked prompt (encrypted secrets
+store) or a 1Password `op://vault/item/field` reference. Do not put the raw
+key in `config.toml`. The CLI equivalent is:
+
+```sh
+zeroclaw config set mcp.servers.gbr.env.GBR_MAILBOX_KEY
+zeroclaw config set mcp.servers.gbr.env.GBR_MCP_LOG_BODIES 0
+```
+
+Restart the affected session after changing bundles or `env`. HTTP without MCP,
+after `gbr-agent run` with `GBR_BOT_REQUIRE_KEY=1`:
 
 ```bash
+IFS= read -rs GBR_MAILBOX_KEY
+export GBR_MAILBOX_KEY
 curl -sS -H "X-GBR-Key: $GBR_MAILBOX_KEY" http://127.0.0.1:8788/health
 curl -sS -H "X-GBR-Key: $GBR_MAILBOX_KEY" http://127.0.0.1:8788/v1/sessions
 ```


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add a docs-only example so ZeroClaw can attach to host `gbr-agent` via stdio `gbr-mcp` after `gbr/1` pair.
  - Review round: split `gbr-agent run` from npm/diagnose (run is a long-lived process).
  - Review round: enable `GBR_BOT_REQUIRE_KEY=1` and secret-managed `GBR_MAILBOX_KEY` in MCP env. Loopback is not process authentication.
  - Review round: document `~/.gbr/logs` JSONL and default `GBR_MCP_LOG_BODIES=0` for the safe baseline.
  - Review round: Node.js 20+, pin Agents tag `v0.6.2`, no em dash, no plus-list, no bare URL.
  - Review round: after pair, obtain mailbox key from phone Settings -> Bot API or `~/.gbr/device.json`; `gbr-mcp` does not load the pairing file. Supply `GBR_MAILBOX_KEY` with `read -rs` so the value is not in shell history. Set both `GBR_MAILBOX_KEY` and `GBR_MCP_LOG_BODIES=0` on `mcp.servers` -> `gbr` -> `env` via ZeroCode Config / masked `zeroclaw config set`, then restart the session.
  - Review round: note that MCP `env` `config set` uses the masked secret prompt, so a trailing `0` is not consumed; enter `0` at that prompt.
  - Review round: `npm install --ignore-scripts` (v0.6.2 has no npm lockfile; install-script disable is not runtime-dependency trust). High-risk rollback fields completed.
- **Scope boundary:** Does not add a ZeroClaw crate, runtime, or fourth pair protocol. Does not vendor `gbr-agent`.
- **Blast radius:** Docs book MCP chapter only. Operators who copy the recipe start a host control surface; the recipe now requires local API auth.
- **Linked issue(s):** Related to LinespottingOrg/grok-build-inbox#81 and LinespottingOrg/grok-build-inbox#112 (pairing fleet). No ZeroClaw issue fully resolved.
- **Labels:** `docs`, `domain:security`, `risk:high`, `risk:manual`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A: docs-only Markdown; useful signal is the docs CI gates, not a manual ZeroClaw session.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI on head `2ac7826`: `Docs Style` and `CI Required Gate` succeeded. `docs_quality_gate.sh` covers changed Markdown (em dash, MD004, MD034). `docs_links_gate.sh` covers added links.
- **Known CI coverage gap, if any:** `lychee` HTTP check is optional and may be skipped if not installed; unique external destinations were previously HTTP 200 (grokbuildremote.com, GitHub Agents docs). No new unique destinations in this round.
- **Commands run and tail output:** `npx markdownlint-cli2@0.20.0 docs/book/src/tools/mcp.md` -> Summary: 0 error(s). `DOCS_FILES=docs/book/src/tools/mcp.md bash scripts/ci/docs_quality_gate.sh` -> no prose em-dashes, 0 lint errors. No Cargo.
- **Beyond CI, what did you manually verify?** Recipe now: silent `read -rs` for `GBR_MAILBOX_KEY` before `--diagnose`; ZeroCode Config / `zeroclaw config set mcp.servers.gbr.env.*` for the live server env; CLI example notes that MCP env `config set` still prompts and to enter `0` for `GBR_MCP_LOG_BODIES`; `npm install --ignore-scripts` plus the v0.6.2 no-lockfile trust note; restart after env change. Did not run ZeroClaw or `gbr-agent` on this laptop.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Cargo fmt/clippy/test skipped: Markdown-only. Relying on required Docs Style and CI Required Gate on `2ac7826`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`Yes`) Recipe documents host `gbr-agent` inject into TTYs. Mitigation: host-only, `GBR_BOT_REQUIRE_KEY=1`, no mailbox key in `config.toml`.
- New external network calls? (`Yes`) Optional HTTPS to GitHub Releases for pinned install; relay is existing GBR product, not ZeroClaw runtime.
- Secrets / tokens / credentials handling changed? (`Yes`) Documents mailbox key via ZeroClaw secret-managed MCP env `GBR_MAILBOX_KEY` (masked `config set` / ZeroCode Config `env`).
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: Local Bot API can inject into host terminals. Loopback is not enough; require key. MCP logs can retain inject text; default the recipe to `GBR_MCP_LOG_BODIES=0` on the server `env`.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`) Example only.
- Rust/MSRV/toolchain floor changed? (`No`)

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Stop the `gbr-agent` process and the ZeroClaw session using `gbr`, then revert the landed documentation commit with `git revert <squash-commit-sha>`. Reverting documentation alone does not disable an installed integration.
- **Feature flags or config toggles:** No ZeroClaw feature flag. Remove the affected agent's `gbr` MCP-bundle grant through ZeroCode Config and restart that session before resuming work. Keep `GBR_BOT_REQUIRE_KEY=1` and body logging disabled while the integration remains installed.
- **Observable failure symptoms:** Unexpected terminal input or `gbr_inject` activity, unauthorized Bot API responses during diagnosis, or tool argument bodies appearing under `~/.gbr/logs` despite `GBR_MCP_LOG_BODIES=0`.

---

Addresses review from @Audacity88 (`2ac7826` npm `--ignore-scripts` + rollback fields; earlier mailbox key + ZeroCode Config env) and earlier @IftekharUddin (CHANGES_REQUESTED on 1111798, later addressed).
