### PR TITLE
chore(ci): remove dead labeler paths and correct moved-file labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -89,7 +89,6 @@
 "channel:cli":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/channels/cli.rs"
           - "crates/zeroclaw-channels/src/cli.rs"
 
 "channel:dingtalk":
@@ -102,9 +101,8 @@
   - changed-files:
       - any-glob-to-any-file:
           - "src/channels/discord.rs"
-          - "src/channels/discord_history.rs"
-          - "crates/zeroclaw-channels/src/discord.rs"
-          - "crates/zeroclaw-channels/src/discord_history.rs"
+          - "crates/zeroclaw-channels/src/discord/**"
+          - "crates/zeroclaw-channels/src/discord_slash_state.rs"
 
 "channel:email":
   - changed-files:
@@ -165,7 +163,7 @@
 "channel:mqtt":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/channels/mqtt.rs"
+          - "crates/zeroclaw-channels/src/orchestrator/mqtt.rs"
 
 "channel:nextcloud-talk":
   - changed-files:
@@ -237,7 +235,6 @@
       - any-glob-to-any-file:
           - "src/channels/wecom.rs"
           - "crates/zeroclaw-channels/src/wecom.rs"
-          - "src/channels/wecom_ws.rs"
           - "crates/zeroclaw-channels/src/wecom_ws.rs"
 
 "channel:whatsapp":
@@ -366,7 +363,6 @@
 "runtime":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/runtime/**"
           - "crates/zeroclaw-runtime/src/**"
 
 "runtime:wasm":
@@ -417,77 +413,66 @@
 "provider:anthropic":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/anthropic.rs"
           - "crates/zeroclaw-providers/src/anthropic.rs"
 
 "provider:azure-openai":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/azure_openai.rs"
           - "crates/zeroclaw-providers/src/azure_openai.rs"
 
 "provider:bedrock":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/bedrock.rs"
           - "crates/zeroclaw-providers/src/bedrock.rs"
 
 "provider:claude-code":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/claude_code.rs"
-          - "crates/zeroclaw-providers/src/claude_code.rs"
+          - "crates/zeroclaw-tools/src/claude_code.rs"
+          - "crates/zeroclaw-tools/src/claude_code_runner.rs"
+          - "src/tools/claude_code.rs"
+          - "src/tools/claude_code_runner.rs"
 
 "provider:compatible":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/compatible.rs"
           - "crates/zeroclaw-providers/src/compatible.rs"
 
 "provider:copilot":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/copilot.rs"
           - "crates/zeroclaw-providers/src/copilot.rs"
 
 "provider:gemini":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/gemini.rs"
-          - "src/providers/gemini_cli.rs"
           - "crates/zeroclaw-providers/src/gemini.rs"
           - "crates/zeroclaw-providers/src/gemini_cli.rs"
 
 "provider:glm":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/glm.rs"
           - "crates/zeroclaw-providers/src/glm.rs"
 
 "provider:kilocli":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/kilocli.rs"
           - "crates/zeroclaw-providers/src/kilocli.rs"
 
 "provider:ollama":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/ollama.rs"
           - "crates/zeroclaw-providers/src/ollama.rs"
 
 "provider:openai":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/openai.rs"
-          - "src/providers/openai_codex.rs"
           - "crates/zeroclaw-providers/src/openai.rs"
           - "crates/zeroclaw-providers/src/openai_codex.rs"
 
 "provider:openrouter":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/openrouter.rs"
           - "crates/zeroclaw-providers/src/openrouter.rs"
 
 "provider:reliable":
@@ -503,7 +488,6 @@
 "provider:telnyx":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/providers/telnyx.rs"
           - "crates/zeroclaw-providers/src/telnyx.rs"
 
 "service":
@@ -553,12 +537,6 @@
 "tool:cron":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/tools/cron_add.rs"
-          - "src/tools/cron_list.rs"
-          - "src/tools/cron_remove.rs"
-          - "src/tools/cron_run.rs"
-          - "src/tools/cron_runs.rs"
-          - "src/tools/cron_update.rs"
           - "crates/zeroclaw-runtime/src/tools/cron_add.rs"
           - "crates/zeroclaw-runtime/src/tools/cron_common.rs"
           - "crates/zeroclaw-runtime/src/tools/cron_list.rs"
@@ -576,7 +554,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - "src/tools/file_edit.rs"
-          - "src/tools/file_read.rs"
           - "src/tools/file_write.rs"
           - "src/tools/glob_search.rs"
           - "src/tools/content_search.rs"
@@ -625,14 +602,11 @@
 "tool:microsoft365":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/tools/microsoft365/**"
           - "crates/zeroclaw-tools/src/microsoft365/**"
 
 "tool:shell":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/tools/shell.rs"
-          - "src/tools/node_tool.rs"
           - "src/tools/cli_discovery.rs"
           - "crates/zeroclaw-runtime/src/tools/shell.rs"
           - "crates/zeroclaw-gateway/src/node_tool.rs"
@@ -641,11 +615,6 @@
 "tool:sop":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/tools/sop_advance.rs"
-          - "src/tools/sop_approve.rs"
-          - "src/tools/sop_execute.rs"
-          - "src/tools/sop_list.rs"
-          - "src/tools/sop_status.rs"
           - "crates/zeroclaw-runtime/src/tools/sop_advance.rs"
           - "crates/zeroclaw-runtime/src/tools/sop_approve.rs"
           - "crates/zeroclaw-runtime/src/tools/sop_execute.rs"
@@ -667,8 +636,6 @@
 "tool:security":
   - changed-files:
       - any-glob-to-any-file:
-          - "src/tools/security_ops.rs"
-          - "src/tools/verifiable_intent.rs"
           - "crates/zeroclaw-runtime/src/tools/security_ops.rs"
           - "crates/zeroclaw-runtime/src/tools/verifiable_intent.rs"
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - removed 40 paths from `.github/labeler.yml` that do not exist in the tree: `src/providers/*.rs`, `src/tools/*.rs` (moved to `crates/`), `src/runtime/**`, `src/tools/microsoft365/**`, two `src/channels` files
  - the live `crates/` paths were already listed next to the dead ones, so no label loses coverage
  - `channel:mqtt` now points at `crates/zeroclaw-channels/src/orchestrator/mqtt.rs`, `provider:claude-code` at the `claude_code` files in `crates/zeroclaw-tools` and `src/tools` (both would otherwise be left without live patterns)
  - per review: `channel:discord` now covers the live directory module `crates/zeroclaw-channels/src/discord/**` and `crates/zeroclaw-channels/src/discord_slash_state.rs`, and `provider:claude-code` covers the re-export `src/tools/claude_code_runner.rs`
- **Scope boundary:** no live glob removed. `**/*.mdx` kept on purpose, it catches future files.
- **Blast radius:** PR labeling only. No code or CI behavior.
- **Linked issue(s):** None
- **Labels:** `ci`, `risk:low`, `size:XS`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A, config-only. Every removed path is checkable with `ls` or `git ls-files`.

## How I tested

Found the dead paths with my tool (https://github.com/DanielSwift1992/gate), then checked each against the tree.

- **CI checks relied on and why they cover this change:** the labeler workflow parses this file on the next PR event
- **Known CI coverage gap, if any:** None for this config-only diff. No local Cargo command applies: the diff changes no Rust surface.
- **Commands run and tail output:**

```sh
python3 -c "import yaml; yaml.safe_load(open('.github/labeler.yml'))"   # exit 0
git ls-files | grep -c '^src/runtime/'                                  # 0
git ls-files 'crates/zeroclaw-channels/src/discord/*' | head -3
# crates/zeroclaw-channels/src/discord/interaction.rs
# crates/zeroclaw-channels/src/discord/mod.rs
# crates/zeroclaw-channels/src/discord/rest.rs
```

- **Check statuses at this head (3bfca1c):** CI Required Gate green, MSRV green, core jobs green. Surface-specific jobs (Docs Style, Web Permission Tests, Nix) skipped: this config-only diff does not touch those surfaces.
- **Beyond CI, what did you manually verify?** each removed path is absent from the tree, each label still has at least one live pattern, the discord directory module and both claude_code re-exports are covered
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk, `git revert <sha>`.
