### PR TITLE
fix(hardware): forward probe feature to tool implementations

### DIFF
--- a/crates/zeroclaw-hardware/Cargo.toml
+++ b/crates/zeroclaw-hardware/Cargo.toml
@@ -39,7 +39,7 @@ rppal = { version = "0.22", optional = true }
 default = []
 hardware = ["dep:nusb", "dep:tokio-serial", "dep:dialoguer", "dep:console"]
 peripheral-rpi = ["rppal"]
-probe = ["dep:probe-rs"]
+probe = ["dep:probe-rs", "zeroclaw-tools/probe"]
 # Extends the serial peripheral allow-list with `/tmp/zc-sim-*` for hardware-free
 # local testing (paired with the `esp32_sim` example). Off by default; opt-in.
 #

--- a/tests/component/hardware_probe_feature_graph.rs
+++ b/tests/component/hardware_probe_feature_graph.rs
@@ -1,0 +1,203 @@
+use std::collections::BTreeSet;
+
+fn parse_manifest(source: &str, name: &str) -> toml::Value {
+    toml::from_str(source).unwrap_or_else(|error| panic!("{name} must be valid TOML: {error}"))
+}
+
+fn feature_table<'a>(manifest: &'a toml::Value, name: &str) -> &'a toml::Table {
+    manifest
+        .get("features")
+        .and_then(toml::Value::as_table)
+        .unwrap_or_else(|| panic!("{name} must define a [features] table"))
+}
+
+fn feature_values<'a>(features: &'a toml::Table, feature: &str) -> Vec<&'a str> {
+    features
+        .get(feature)
+        .and_then(toml::Value::as_array)
+        .unwrap_or_else(|| panic!("manifest must define feature {feature}"))
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .unwrap_or_else(|| panic!("feature {feature} must contain only strings"))
+        })
+        .collect()
+}
+
+fn assert_feature_contains(label: &str, values: &[&str], expected: &str) {
+    assert!(
+        values.contains(&expected),
+        "{label} must include {expected}; actual feature values: {values:?}"
+    );
+}
+
+fn root_feature_reachable<'a>(features: &'a toml::Table, seeds: &[&'a str]) -> BTreeSet<&'a str> {
+    let mut reachable = BTreeSet::new();
+    let mut visited_root_features = BTreeSet::new();
+    let mut pending = seeds.to_vec();
+
+    while let Some(feature) = pending.pop() {
+        if !visited_root_features.insert(feature) {
+            continue;
+        }
+        reachable.insert(feature);
+
+        for reference in feature_values(features, feature) {
+            reachable.insert(reference);
+            if !reference.starts_with("dep:")
+                && !reference.contains('/')
+                && features.contains_key(reference)
+            {
+                pending.push(reference);
+            }
+        }
+    }
+
+    reachable
+}
+
+fn distribution_inputs(root: &toml::Value) -> Vec<&str> {
+    let extra_features = root
+        .get("package")
+        .and_then(toml::Value::as_table)
+        .and_then(|package| package.get("metadata"))
+        .and_then(toml::Value::as_table)
+        .and_then(|metadata| metadata.get("zeroclaw"))
+        .and_then(toml::Value::as_table)
+        .and_then(|zeroclaw| zeroclaw.get("dist_extra_features"))
+        .and_then(toml::Value::as_array)
+        .expect("root manifest must define dist_extra_features");
+
+    let mut inputs = vec!["default"];
+    inputs.extend(extra_features.iter().map(|feature| {
+        feature
+            .as_str()
+            .expect("dist_extra_features must contain only strings")
+    }));
+    inputs
+}
+
+fn dependency_feature(reference: &str) -> Option<(&str, &str, bool)> {
+    let (dependency, feature) = reference.split_once('/')?;
+    let (dependency, weak) = match dependency.strip_suffix('?') {
+        Some(dependency) => (dependency, true),
+        None => (dependency, false),
+    };
+    Some((dependency, feature, weak))
+}
+
+fn active_dependencies<'a>(reachable: &BTreeSet<&'a str>) -> BTreeSet<&'a str> {
+    reachable
+        .iter()
+        .copied()
+        .filter_map(|reference| {
+            if let Some(dependency) = reference.strip_prefix("dep:") {
+                return Some(dependency);
+            }
+            dependency_feature(reference)
+                .and_then(|(dependency, _, weak)| (!weak).then_some(dependency))
+        })
+        .collect()
+}
+
+fn probe_boundary_violations<'a>(reachable: &BTreeSet<&'a str>) -> Vec<&'a str> {
+    let active_dependencies = active_dependencies(reachable);
+    reachable
+        .iter()
+        .copied()
+        .filter(|reference| {
+            if matches!(*reference, "hardware" | "probe" | "dep:zeroclaw-hardware") {
+                return true;
+            }
+
+            let Some((dependency, feature, weak)) = dependency_feature(reference) else {
+                return false;
+            };
+            let dependency_feature_is_active = !weak || active_dependencies.contains(dependency);
+            dependency_feature_is_active
+                && ((dependency == "zeroclaw-hardware" && matches!(feature, "hardware" | "probe"))
+                    || (dependency == "zeroclaw-tools" && feature == "probe"))
+        })
+        .collect()
+}
+
+fn assert_probe_boundary(profile: &str, reachable: &BTreeSet<&str>) {
+    let violations = probe_boundary_violations(reachable);
+    assert!(
+        violations.is_empty(),
+        "{profile} must not reach hardware or probe features; original offending reachable \
+         values: {violations:?}; observed reachable values: {reachable:?}"
+    );
+}
+
+#[test]
+fn probe_boundary_applies_weak_dependency_feature_semantics() {
+    let active_weak_edge = BTreeSet::from(["dep:zeroclaw-tools", "zeroclaw-tools?/probe"]);
+    assert_eq!(
+        probe_boundary_violations(&active_weak_edge),
+        vec!["zeroclaw-tools?/probe"]
+    );
+
+    let inactive_weak_edge = BTreeSet::from(["zeroclaw-tools?/probe"]);
+    assert!(probe_boundary_violations(&inactive_weak_edge).is_empty());
+
+    let strong_edge = BTreeSet::from(["zeroclaw-tools/probe"]);
+    assert_eq!(
+        probe_boundary_violations(&strong_edge),
+        vec!["zeroclaw-tools/probe"]
+    );
+}
+
+#[test]
+fn probe_feature_graph_preserves_forwarding_and_distribution_boundaries() {
+    let root = parse_manifest(include_str!("../../Cargo.toml"), "root Cargo.toml");
+    let hardware = parse_manifest(
+        include_str!("../../crates/zeroclaw-hardware/Cargo.toml"),
+        "zeroclaw-hardware Cargo.toml",
+    );
+    let tools = parse_manifest(
+        include_str!("../../crates/zeroclaw-tools/Cargo.toml"),
+        "zeroclaw-tools Cargo.toml",
+    );
+    let root_features = feature_table(&root, "root Cargo.toml");
+    let hardware_features = feature_table(&hardware, "zeroclaw-hardware Cargo.toml");
+    let tools_features = feature_table(&tools, "zeroclaw-tools Cargo.toml");
+
+    let root_hardware = feature_values(root_features, "hardware");
+    assert_feature_contains("root hardware", &root_hardware, "dep:zeroclaw-hardware");
+    assert_feature_contains(
+        "root hardware",
+        &root_hardware,
+        "zeroclaw-hardware/hardware",
+    );
+
+    let root_probe = feature_values(root_features, "probe");
+    assert_feature_contains("root probe", &root_probe, "dep:zeroclaw-hardware");
+    assert_feature_contains("root probe", &root_probe, "zeroclaw-hardware/probe");
+
+    let ci_all_reachable = root_feature_reachable(root_features, &["ci-all"]);
+    for expected in ["hardware", "probe"] {
+        assert!(
+            ci_all_reachable.contains(expected),
+            "root ci-all must reach {expected}; observed reachable values: {ci_all_reachable:?}"
+        );
+    }
+
+    let hardware_probe = feature_values(hardware_features, "probe");
+    assert_feature_contains("zeroclaw-hardware probe", &hardware_probe, "dep:probe-rs");
+    assert_feature_contains(
+        "zeroclaw-hardware probe",
+        &hardware_probe,
+        "zeroclaw-tools/probe",
+    );
+
+    let tools_probe = feature_values(tools_features, "probe");
+    assert_feature_contains("zeroclaw-tools probe", &tools_probe, "dep:probe-rs");
+
+    let default_reachable = root_feature_reachable(root_features, &["default"]);
+    assert_probe_boundary("root default", &default_reachable);
+
+    let distribution_reachable = root_feature_reachable(root_features, &distribution_inputs(&root));
+    assert_probe_boundary("standard distribution", &distribution_reachable);
+}

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -15,6 +15,7 @@ mod direct_cli_terminal_completion;
 mod dockerignore_test;
 mod gateway;
 mod gemini_capabilities;
+mod hardware_probe_feature_graph;
 mod otel_dependency_feature_regression;
 mod plugin_feature_graph;
 mod provider_resolution;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Forward `zeroclaw-hardware/probe` to `zeroclaw-tools/probe` so root builds requesting `hardware,probe` or `ci-all` compile the existing probe-backed hardware tool paths.
  - Add structured manifest regression coverage for the positive root-to-hardware-to-tools closure and the negative default/distribution boundary.
- **Scope boundary:** This PR does not change root defaults, standard distribution features, dependency versions, the lockfile, runtime configuration, APIs, or the existing probe interaction code.
- **Blast radius:** Cargo feature resolution for `zeroclaw-hardware` and `zeroclaw-tools` when probe support is explicitly requested. Default and standard distribution builds remain probe-free.
- **Linked issue(s):** Closes #10282
- **Labels:** `bug`, `type:dependencies`, `risk:medium`, `size:S`, `hardware`, `tests`, `distinguished contributor`

### What this does, simply

ZeroClaw includes three tools that can inspect supported Nucleo boards. Users could already request direct board access when building ZeroClaw, but that request stopped before it reached the tools. Two tools therefore returned only built-in reference data, while memory read could incorrectly say direct probe support was disabled.

This PR completes that existing opt-in connection so the tools use the connected board when direct probe support is requested. It also checks that ordinary builds and standard releases still leave that support out.

### Scope and maintenance tradeoff

The production repair is one feature edge in the manifest that owns the hardware capability. It reuses the existing root profile, hardware crate, tool crate, and `probe` feature instead of adding another dependency, runtime switch, or registration path.

Most of the diff is regression coverage because the contract has several independent parts: root `hardware` and `probe` forwarding, `ci-all` aggregation, hardware-to-tools forwarding, tool-side `probe-rs` activation, and default/distribution exclusion. The test parses the existing manifests as TOML and keeps distribution metadata validation with its current `xtask` owner.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this changes compile-time feature closure rather than the existing physical-probe interaction, so the focused graph regression and feature-specific compile provide the useful signal.

### How I tested

- **CI checks relied on and why they cover this change:** Hosted `Check (all features)`, `Check (no default features)`, `Test`, and `CI Required Gate` passed on the current head. They cover the repaired cross-crate feature closure, the default-off build, focused workspace tests, and the aggregate required status.
- **Known CI coverage gap, if any:** No local `ci-all` build or physical-probe smoke was run. The local minimal feature compile covers the repaired crate closure, and the structured regression proves `ci-all` selects it while default and distribution profiles exclude it.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# exit 0

cargo check --locked -p zeroclaw --lib --no-default-features --features hardware,probe
# Finished successfully in 9m21s

cargo test --locked -p zeroclaw --test component --features hardware,probe hardware_probe_feature_graph
# 2 passed; 0 failed; 223 filtered out

bash scripts/ci/comment_hygiene_gate.sh
# exit 0

git diff --check
# exit 0
```

- **Beyond CI, what did you manually verify?** Confirmed the root, hardware, and tools manifests retain their existing ownership boundaries; default and standard distribution inputs remain probe-free; and current `master` does not change the affected feature contract. I did not exercise physical probe hardware.
- **Visual interface changed?** N/A — no rendered or interactive surface changed.
- **If any command was intentionally skipped, why:** A broad local `ci-all` build was deferred to hosted CI because the focused compile reaches the repaired feature combination directly. A physical-probe smoke would exercise unchanged device code rather than the missing Cargo edge.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: The change restores direct USB/SWD board inspection and bounded memory reads only for builds that explicitly select `hardware,probe`. Peripheral support must also be enabled with configured boards, ordinary tool security and channel exclusion policy still apply, and root defaults and standard distributions remain probe-free.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit.
- **Feature flags or config toggles:** `probe` remains opt-in; builds can omit it to retain the probe-free paths.
- **Observable failure symptoms:** A build requesting `hardware,probe` compiles the tool crate without its `probe` feature, `hardware_memory_read` reports that probe support is missing, or the feature-graph regression fails.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede another PR.

