### PR TITLE
Feat/telegram video clips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,33 @@ cargo test
 
 Use `./dev/ci.sh all` for full pre-PR validation when the scope warrants it. Docs-only changes use `scripts/ci/docs_quality_gate.sh` and `scripts/ci/docs_links_gate.sh`. Bootstrap script changes add `bash -n install.sh`.
 
+## Local Service Rebuild & Restart
+
+The user runs the agent as a macOS LaunchAgent (`com.zeroclaw.daemon`, plist at `~/Library/LaunchAgents/com.zeroclaw.daemon.plist`). It executes `~/.cargo/bin/zeroclaw daemon`. To rebuild and redeploy:
+
+```bash
+cargo build --release          # produces target/release/zeroclaw
+```
+
+Then, in this order — **stop the daemon before overwriting the binary**:
+
+```bash
+# Stop. The installed ~/.cargo/bin/zeroclaw may itself be the broken target,
+# so drive the service from the repo binary or launchctl directly:
+./target/release/zeroclaw service stop
+# ...or: launchctl bootout gui/$(id -u)/com.zeroclaw.daemon
+# Verify no daemon remains: ps aux | grep -i "zeroclaw daemon"
+
+cp target/release/zeroclaw ~/.cargo/bin/zeroclaw   # replace binary
+zeroclaw service start                              # restart service
+zeroclaw service status                             # expect ✅ running/loaded
+```
+
+Gotcha: overwriting the live daemon's binary in place leaves the installed
+path failing new invocations with SIGKILL (exit 137) — copy to a temp name
+first to confirm the bytes are good, and always stop the daemon before
+`cp` over `~/.cargo/bin/zeroclaw`.
+
 ## Task References
 
 The architecture map routes task-specific documentation. Consult `docs/book/src/contributing/agent-guidelines.md` only for detailed agent examples, risk and stability policy, skill discovery, and protected operational documents. Do not skip a required contract because it is no longer embedded in this bootstrap file.

--- a/crates/zeroclaw-channels/src/orchestrator/media_pipeline.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/media_pipeline.rs
@@ -122,11 +122,41 @@ impl<'a> MediaPipeline<'a> {
     }
 
     /// Summarize a video attachment.
-    /// Video analysis requires external APIs not currently integrated.
-    /// For now we add a placeholder annotation.
+    ///
+    /// Small videos (at or below [`MAX_VIDEO_BASE64_BYTES`]) are inlined as
+    /// base64 video bytes in a `[VIDEO:data:...;base64,...]` marker so a
+    /// multimodal provider can parse the clip directly. Larger videos are too
+    /// big to inline safely and fall back to a plain attachment annotation;
+    /// the file is still saved by the channel that received it.
     fn process_video(&self, attachment: &MediaAttachment) -> String {
-        format!("[Video: {} attached]", attachment.file_name)
+        if attachment.data.len() > MAX_VIDEO_BASE64_BYTES {
+            return format!("[Video: {} attached]", attachment.file_name);
+        }
+
+        let (mime, data) = video_payload_for_multimodal(attachment);
+        let b64 = STANDARD.encode(data.as_ref());
+        format!(
+            "[Video: {} attached, will be processed by multimodal]\n[VIDEO:data:{};base64,{}]",
+            attachment.file_name, mime, b64
+        )
     }
+}
+
+/// Maximum raw video size (bytes) that is safe to inline base64 into message
+/// content for a multimodal provider. 20 MiB is the Telegram file-download cap
+/// for bots and keeps the encoded payload bounded.
+const MAX_VIDEO_BASE64_BYTES: usize = 20 * 1024 * 1024;
+
+/// Resolve the MIME type and payload for a video attachment, defaulting to
+/// `video/mp4` when the type is unknown.
+fn video_payload_for_multimodal(attachment: &MediaAttachment) -> (String, Cow<'_, [u8]>) {
+    let mime = attachment
+        .mime_type
+        .as_deref()
+        .filter(|m| m.to_ascii_lowercase().starts_with("video/"))
+        .unwrap_or("video/mp4")
+        .to_string();
+    (mime, Cow::Borrowed(&attachment.data))
 }
 
 fn image_payload_for_vision(attachment: &MediaAttachment) -> (String, Cow<'_, [u8]>) {
@@ -349,8 +379,72 @@ mod tests {
 
         let result = pipeline.process("watch", &[sample_video()]).await;
         assert!(
-            result.contains("[Video: clip.mp4 attached]"),
+            result.contains("[Video: clip.mp4 attached"),
             "expected video annotation, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn small_video_is_inlined_as_base64_for_multimodal() {
+        let config = default_pipeline_config(true);
+        let pipeline = MediaPipeline::new(&config, None, false);
+
+        // A video below the 20MB base64 threshold.
+        let video = MediaAttachment {
+            file_name: "clip.mp4".to_string(),
+            data: b"\x00\x00\x00 ftypmp42 video-bytes".to_vec(),
+            mime_type: Some("video/mp4".to_string()),
+        };
+        let result = pipeline.process("look", &[video]).await;
+
+        assert!(
+            result.contains("[Video: clip.mp4 attached"),
+            "expected named annotation, got: {result}"
+        );
+        assert!(
+            result.contains("[VIDEO:data:video/mp4;base64,"),
+            "expected base64 video data URI, got: {result}"
+        );
+        assert!(result.contains("look"), "missing original text");
+    }
+
+    #[tokio::test]
+    async fn large_video_is_not_inlined_as_base64() {
+        let config = default_pipeline_config(true);
+        let pipeline = MediaPipeline::new(&config, None, false);
+
+        // A video above the 20MB threshold must not be dumped into content.
+        let video = MediaAttachment {
+            file_name: "big.mp4".to_string(),
+            data: vec![0u8; 21 * 1024 * 1024],
+            mime_type: Some("video/mp4".to_string()),
+        };
+        let result = pipeline.process("watch", &[video]).await;
+
+        assert!(
+            result.contains("[Video: big.mp4 attached]"),
+            "expected fallback annotation, got: {result}"
+        );
+        assert!(
+            !result.contains("[VIDEO:data:"),
+            "large video must not be inlined as base64, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn video_without_mime_falls_back_to_video_mp4() {
+        let config = default_pipeline_config(true);
+        let pipeline = MediaPipeline::new(&config, None, false);
+
+        let video = MediaAttachment {
+            file_name: "note.mp4".to_string(),
+            data: b"video-bytes".to_vec(),
+            mime_type: None,
+        };
+        let result = pipeline.process("watch", &[video]).await;
+        assert!(
+            result.contains("[VIDEO:data:video/mp4;base64,"),
+            "expected video/mp4 fallback mime, got: {result}"
         );
     }
 
@@ -380,7 +474,7 @@ mod tests {
             "missing image annotation"
         );
         assert!(
-            result.contains("[Video: clip.mp4 attached]"),
+            result.contains("[Video: clip.mp4 attached"),
             "missing video annotation"
         );
         assert!(result.contains("context"), "missing original text");

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6208,10 +6208,7 @@ async fn process_channel_message_body(
                 let doc_path = docs_dir.join(&safe_name);
                 match std::fs::write(&doc_path, &attachment.data) {
                     Ok(_) => {
-                        doc_markers.push(format!(
-                            "[Document: {}]",
-                            doc_path.display()
-                        ));
+                        doc_markers.push(format!("[Document: {}]", doc_path.display()));
                         ::zeroclaw_log::record!(
                             INFO,
                             ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
@@ -12555,7 +12552,7 @@ pub async fn start_channels(
 
             println!("🦀 ZeroClaw Channel Server");
             println!("  🤖 Model:    {model} (agent: {agent_alias})");
-            let effective_backend = config.resolve_active_storage().kind();
+            let effective_backend = config.effective_memory_backend(agent_alias.as_str());
             println!(
                 "  🧠 Memory:   {} (auto-save: {})",
                 effective_backend,

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -6179,6 +6179,70 @@ async fn process_channel_message_body(
         msg.content = Box::pin(pipeline.process(&msg.content, &msg.attachments)).await;
     }
 
+    // ── Document attachments: save Unknown (non-Audio/Image/Video) attachments ──
+    // to the workspace and add a file path marker so the agent can read them.
+    let doc_attachments: Vec<_> = msg
+        .attachments
+        .iter()
+        .filter(|a| a.kind() == media_pipeline::MediaKind::Unknown)
+        .cloned()
+        .collect();
+    if !doc_attachments.is_empty() {
+        let docs_dir = ctx.workspace_dir.join("inbound-documents");
+        if let Err(e) = std::fs::create_dir_all(&docs_dir) {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
+                "failed to create inbound-documents directory"
+            );
+        } else {
+            let mut doc_markers = Vec::new();
+            for attachment in &doc_attachments {
+                let ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0);
+                let safe_name = format!("{}_{}", ts, attachment.file_name);
+                let doc_path = docs_dir.join(&safe_name);
+                match std::fs::write(&doc_path, &attachment.data) {
+                    Ok(_) => {
+                        doc_markers.push(format!(
+                            "[Document: {}]",
+                            doc_path.display()
+                        ));
+                        ::zeroclaw_log::record!(
+                            INFO,
+                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                .with_attrs(::serde_json::json!({"path": format!("{}", doc_path.display()), "size": attachment.data.len()})),
+                            "saved inbound document attachment"
+                        );
+                    }
+                    Err(e) => {
+                        ::zeroclaw_log::record!(
+                            WARN,
+                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                                .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                                .with_attrs(::serde_json::json!({"file": attachment.file_name, "error": format!("{}", e)})),
+                            "failed to save inbound document attachment"
+                        );
+                    }
+                }
+            }
+            if !doc_markers.is_empty() {
+                // Prepend document markers before the existing content so the
+                // agent sees them first.
+                let prefix = doc_markers.join("\n");
+                if msg.content.is_empty() {
+                    msg.content = prefix;
+                } else {
+                    msg.content = format!("{}\n\n{}", prefix, msg.content);
+                }
+            }
+        }
+    }
+
     // ── Link enricher: prepend URL summaries before agent sees the message ──
     let le_config = &ctx.prompt_config.link_enricher;
     if le_config.enabled {

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use zeroclaw_api::channel::{Channel, ChannelMessage, ProgressEvent, SendMessage};
+use zeroclaw_api::media::MediaAttachment;
 use zeroclaw_config::schema::{Config, StreamMode, TELEGRAM_OFFICIAL_API_BASE_URL};
 use zeroclaw_runtime::i18n;
 use zeroclaw_runtime::security::pairing::PairingGuard;
@@ -27,13 +28,15 @@ struct IncomingAttachment {
     file_size: Option<u64>,
     caption: Option<String>,
     kind: IncomingAttachmentKind,
+    mime_type: Option<String>,
 }
 
-/// The kind of incoming attachment (document vs photo).
+/// The kind of incoming attachment (document, photo, or video).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IncomingAttachmentKind {
     Document,
     Photo,
+    Video,
 }
 const TELEGRAM_BIND_COMMAND: &str = "/bind";
 /// Telegram Bot API allows at most 100 commands via setMyCommands.
@@ -405,6 +408,15 @@ fn format_attachment_content(
             if is_image_extension(local_path) =>
         {
             format!("[IMAGE:{}]", local_path.display())
+        }
+        // Videos are surfaced with an actionable `[VIDEO:path]` marker so the
+        // path survives vision/multimodal routing and stays exempt from leak
+        // detection, mirroring how `[IMAGE:path]` works for photos.
+        IncomingAttachmentKind::Video => {
+            format!(
+                "[Video: {local_filename}]\n[VIDEO:{}]",
+                local_path.display()
+            )
         }
         _ => {
             format!("[Document: {}] {}", local_filename, local_path.display())
@@ -2059,8 +2071,9 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         Some((file_id, duration))
     }
 
-    /// Extract attachment metadata from an incoming Telegram message (document or photo).
-    /// Returns `None` for text-only, voice, and other unsupported message types.
+    /// Extract attachment metadata from an incoming Telegram message
+    /// (document, photo, or video). Returns `None` for text-only, voice, and
+    /// other unsupported message types.
     fn parse_attachment_metadata(message: &serde_json::Value) -> Option<IncomingAttachment> {
         // Try document first
         if let Some(doc) = message.get("document") {
@@ -2080,6 +2093,10 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 file_size,
                 caption,
                 kind: IncomingAttachmentKind::Document,
+                mime_type: doc
+                    .get("mime_type")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from),
             });
         }
 
@@ -2098,6 +2115,38 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 file_size,
                 caption,
                 kind: IncomingAttachmentKind::Photo,
+                mime_type: None,
+            });
+        }
+
+        // Try video (plain video) then video_note (round video clip).
+        // `video_note` carries no file_name; both are video clips.
+        for field in ["video", "video_note"] {
+            let Some(vid) = message.get(field) else {
+                continue;
+            };
+            let file_id = vid.get("file_id")?.as_str()?.to_string();
+            let file_name = vid
+                .get("file_name")
+                .and_then(serde_json::Value::as_str)
+                .map(String::from);
+            let file_size = vid.get("file_size").and_then(serde_json::Value::as_u64);
+            let caption = message
+                .get("caption")
+                .and_then(serde_json::Value::as_str)
+                .map(String::from);
+            let mime_type = vid
+                .get("mime_type")
+                .and_then(serde_json::Value::as_str)
+                .map(String::from)
+                .or_else(|| Some("video/mp4".to_string()));
+            return Some(IncomingAttachment {
+                file_id,
+                file_name,
+                file_size,
+                caption,
+                kind: IncomingAttachmentKind::Video,
+                mime_type,
             });
         }
 
@@ -2239,9 +2288,22 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         let local_filename = match &attachment.file_name {
             Some(name) => name.clone(),
             None => {
-                // For photos, derive extension from Telegram file path
-                let ext = tg_file_path.rsplit('.').next().unwrap_or("jpg");
-                format!("photo_{chat_id}_{message_id}.{ext}")
+                // Derive extension from the Telegram file path; fall back to a
+                // per-kind default (jpg for photos, mp4 for videos).
+                let default_ext = match attachment.kind {
+                    IncomingAttachmentKind::Video => "mp4",
+                    _ => "jpg",
+                };
+                let prefix = match attachment.kind {
+                    IncomingAttachmentKind::Video => "video",
+                    _ => "photo",
+                };
+                let ext = tg_file_path
+                    .rsplit('.')
+                    .next()
+                    .filter(|e| !e.is_empty())
+                    .unwrap_or(default_ext);
+                format!("{prefix}_{chat_id}_{message_id}.{ext}")
             }
         };
 
@@ -2260,7 +2322,9 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         // Build message content.
         // Photos with image extensions use [IMAGE:] marker so the multimodal
         // pipeline validates vision capability. Non-image files always get
-        // [Document:] format regardless of Telegram's classification.
+        // [Document:] format regardless of Telegram's classification. Videos
+        // get an actionable [VIDEO:path] marker so the clip path survives
+        // routing and stays available to the agent.
         let mut content = format_attachment_content(attachment.kind, &local_filename, &local_path);
         // `gated_caption` is the trimmed caption when the `mention_only`
         // gate admits it; otherwise the raw caption (or None).
@@ -2281,6 +2345,18 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             content = Self::prepend_forward_attribution(&attr, content);
         }
 
+        // Videos are also handed to the summarizing media pipeline (when
+        // `summarize_video` is enabled) so a multimodal model can parse the
+        // clip. Photos/documents keep the marker-only path above.
+        let mut attachments = Vec::new();
+        if attachment.kind == IncomingAttachmentKind::Video {
+            attachments.push(MediaAttachment {
+                file_name: local_filename.clone(),
+                data: file_data.clone(),
+                mime_type: attachment.mime_type.clone(),
+            });
+        }
+
         UpdateDisposition::Parsed(Box::new(ChannelMessage {
             id: format!("telegram_{chat_id}_{message_id}"),
             sender: sender_identity,
@@ -2294,7 +2370,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .as_secs(),
             thread_ts: thread_id,
             interruption_scope_id: None,
-            attachments: vec![],
+            attachments,
             subject: None,
 
             ..Default::default()
@@ -9369,6 +9445,62 @@ mod tests {
             }
         });
         assert!(TelegramChannel::parse_attachment_metadata(&message).is_none());
+    }
+
+    #[test]
+    fn parse_attachment_metadata_detects_video() {
+        let message = serde_json::json!({
+            "video": {
+                "file_id": "BAACAgIAAxk",
+                "file_name": "clip.mp4",
+                "file_size": 5000000,
+                "mime_type": "video/mp4",
+                "width": 1280,
+                "height": 720,
+                "duration": 15
+            },
+            "caption": "watch this"
+        });
+        let att = TelegramChannel::parse_attachment_metadata(&message).unwrap();
+        assert_eq!(att.kind, IncomingAttachmentKind::Video);
+        assert_eq!(att.file_id, "BAACAgIAAxk");
+        assert_eq!(att.file_name.as_deref(), Some("clip.mp4"));
+        assert_eq!(att.file_size, Some(5000000));
+        assert_eq!(att.caption.as_deref(), Some("watch this"));
+    }
+
+    #[test]
+    fn parse_attachment_metadata_detects_video_note() {
+        // Round video clips arrive as `video_note` without a file_name.
+        let message = serde_json::json!({
+            "video_note": {
+                "file_id": "BAACAgIAAxk_note",
+                "file_size": 3000000,
+                "length": 480,
+                "duration": 8
+            }
+        });
+        let att = TelegramChannel::parse_attachment_metadata(&message).unwrap();
+        assert_eq!(att.kind, IncomingAttachmentKind::Video);
+        assert_eq!(att.file_id, "BAACAgIAAxk_note");
+        assert_eq!(att.file_size, Some(3000000));
+        assert!(att.file_name.is_none());
+        assert!(att.caption.is_none());
+    }
+
+    #[test]
+    fn parse_attachment_metadata_video_without_optional_fields() {
+        let message = serde_json::json!({
+            "video": {
+                "file_id": "raw_video_id"
+            }
+        });
+        let att = TelegramChannel::parse_attachment_metadata(&message).unwrap();
+        assert_eq!(att.kind, IncomingAttachmentKind::Video);
+        assert_eq!(att.file_id, "raw_video_id");
+        assert!(att.file_name.is_none());
+        assert!(att.file_size.is_none());
+        assert!(att.caption.is_none());
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -477,9 +477,72 @@ fn parse_path_only_attachment(message: &str) -> Option<TelegramAttachment> {
     })
 }
 
+/// Resolve an outgoing local attachment target to an absolute on-disk path,
+/// bounded to `workspace_dir`.
+///
+/// Parity with the WhatsApp, Matrix, Lark and Slack channels: absolute targets
+/// are used verbatim, `/workspace/...` container paths and workspace-relative
+/// targets (the common form the agent emits, relative to its shell CWD) join
+/// `workspace_dir`, and the resolved path must canonicalize inside
+/// `workspace_dir` (the trust boundary). With no `workspace_dir` configured the
+/// target is used verbatim (legacy daemon-CWD-relative behavior).
+///
+/// This is what the channel was missing: it only recognized HTTP URLs and
+/// absolute (or `/workspace/...`) paths, so a relative marker like
+/// `[DOCUMENT:workspace/report.pdf]` was checked against the daemon process CWD
+/// and always failed with "path not found".
+fn resolve_outgoing_local_target(
+    target: &str,
+    workspace_dir: Option<&std::path::Path>,
+) -> anyhow::Result<String> {
+    let Some(ws) = workspace_dir else {
+        return Ok(target.to_string());
+    };
+
+    let workspace_canon = std::fs::canonicalize(ws).map_err(|err| {
+        anyhow::Error::msg(format!(
+            "canonicalize Telegram workspace {} failed: {err}",
+            ws.display()
+        ))
+    })?;
+
+    let raw = std::path::Path::new(target);
+    let candidate = if let Some(rel) = target.strip_prefix("/workspace/") {
+        workspace_canon.join(rel)
+    } else if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        workspace_canon.join(raw)
+    };
+
+    let candidate_canon = match std::fs::canonicalize(&candidate) {
+        Ok(p) => p,
+        Err(_) => anyhow::bail!("Telegram attachment path not found: {target}"),
+    };
+
+    if !candidate_canon.starts_with(&workspace_canon) {
+        anyhow::bail!("Telegram attachment path escapes workspace_dir: {target}");
+    }
+
+    Ok(candidate_canon.to_string_lossy().to_string())
+}
+
 /// Delegate to the shared `strip_tool_call_tags` in the orchestrator module.
 fn strip_tool_call_tags(message: &str) -> String {
     crate::orchestrator::strip_tool_call_tags(message)
+}
+
+/// True when a reply is substantive natural language worth voicing —
+/// not a URL, JSON, code block, error, or short status line.
+fn is_substantive_voice_reply(content: &str) -> bool {
+    content.len() > 40
+        && !content.starts_with("http")
+        && !content.starts_with('{')
+        && !content.starts_with('[')
+        && !content.starts_with("Error")
+        && !content.contains("```")
+        && !content.contains("tool_call")
+        && !content.contains("wttr.in")
 }
 
 fn find_matching_close(s: &str) -> Option<usize> {
@@ -1334,16 +1397,7 @@ impl TelegramChannel {
 
         // Only queue substantive natural-language replies for voice.
         // Skip tool outputs: URLs, JSON, code blocks, errors, short status.
-        let is_substantive = content.len() > 40
-            && !content.starts_with("http")
-            && !content.starts_with('{')
-            && !content.starts_with('[')
-            && !content.starts_with("Error")
-            && !content.contains("```")
-            && !content.contains("tool_call")
-            && !content.contains("wttr.in");
-
-        if !is_substantive {
+        if !is_substantive_voice_reply(content) {
             return;
         }
 
@@ -3187,22 +3241,30 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             return Ok(());
         }
 
-        // Remap Docker container workspace path (/workspace/...) to the host
-        // workspace directory so files written by the containerised runtime
-        // can be found and sent by the host-side Telegram sender.
-        let remapped;
-        let target = if let Some(rel) = target.strip_prefix("/workspace/") {
-            if let Some(ws) = &self.workspace_dir {
-                remapped = ws.join(rel);
-                remapped.to_str().unwrap_or(target)
-            } else {
-                target
+        // Resolve the target against the channel's workspace (the bound
+        // agent's workspace dir). Absolute targets are used verbatim,
+        // `/workspace/...` container and workspace-relative targets join the
+        // workspace, all under an escape guard — so a marker like
+        // `[DOCUMENT:workspace/report.pdf]` (relative to the agent shell CWD)
+        // resolves instead of failing against the daemon's CWD.
+        let resolved = resolve_outgoing_local_target(target, self.workspace_dir.as_deref());
+        let resolved = match resolved {
+            Ok(p) => p,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(
+                            ::serde_json::json!({"target": target, "error": format!("{}", e)})
+                        ),
+                    "Telegram attachment path resolution failed"
+                );
+                anyhow::bail!("Telegram attachment path not found: {target}");
             }
-        } else {
-            target
         };
 
-        let path = Path::new(target);
+        let path = Path::new(&resolved);
         if !path.exists() {
             anyhow::bail!("Telegram attachment path not found: {target}");
         }
@@ -4065,9 +4127,15 @@ impl Channel for TelegramChannel {
         // Clean up rate-limit tracking for this chat
         self.last_draft_edit.lock().remove(&chat_id);
 
-        // Voice-only peers: delete the draft placeholder and let the voice
-        // bubble be the sole reply. Bypassed when suppress_voice forces text.
-        if !suppress_voice && self.is_voice_peer(recipient) {
+        // Voice-only peers and voice-note senders (mirror): delete the draft
+        // placeholder and let the voice bubble be the sole reply. Only when TTS
+        // is available and the reply is substantive; otherwise the text is sent.
+        // Bypassed when suppress_voice forces text.
+        if !suppress_voice
+            && self.tts_manager.is_some()
+            && is_substantive_voice_reply(text)
+            && self.is_voice_chat(recipient)
+        {
             if let Ok(id) = message_id.parse::<i64>() {
                 let _ = self
                     .client
@@ -4310,9 +4378,13 @@ impl Channel for TelegramChannel {
             self.try_queue_voice_reply(&message.recipient, &content, false, message.force_voice);
         }
 
-        // Voice-only peers (or explicit force_voice): the voice note is the sole reply — skip text.
+        // Voice-only peers, voice-note senders (mirror), or explicit force_voice:
+        // the voice note is the sole reply — skip text. Only when TTS is
+        // available and the reply is substantive; otherwise fall back to text.
         if !message.suppress_voice
-            && (self.is_voice_peer(&message.recipient) || message.force_voice)
+            && self.tts_manager.is_some()
+            && is_substantive_voice_reply(&content)
+            && (self.is_voice_chat(&message.recipient) || message.force_voice)
         {
             return Ok(());
         }
@@ -4935,6 +5007,126 @@ mod tests {
         assert!(
             ch.is_voice_chat("@alice"),
             "live-resolved voice peer must remain active after voice_chats removal"
+        );
+    }
+
+    #[test]
+    fn is_substantive_voice_reply_classifies_natural_language() {
+        assert!(is_substantive_voice_reply(
+            "Here is a detailed summary of the market today across the main sectors."
+        ));
+        for non_voice in [
+            "ok",
+            "http://example.com/a/url/long/enough/to/exceed/forty/characters",
+            "{\"json\": \"body\"}",
+            "[1, 2, 3]",
+            "Error: something went wrong and this message is long enough",
+            "```\ncode block\n```",
+        ] {
+            assert!(
+                !is_substantive_voice_reply(non_voice),
+                "expected non-voice: {non_voice}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn send_falls_back_to_text_for_voice_note_sender_without_tts() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 1 }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "default",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_api_base(mock_server.uri());
+
+        // Recipient's last message was a voice note, but no TTS manager is set:
+        // the reply must fall back to text rather than being dropped.
+        ch.voice_chats.lock().unwrap().insert("123".to_string());
+
+        ch.send(&SendMessage::new(
+            "This is a substantive natural-language reply long enough to be voiced.",
+            "123",
+        ))
+        .await
+        .unwrap();
+
+        // `.expect(1)` on the mock asserts exactly one sendMessage was delivered.
+    }
+
+    #[tokio::test]
+    async fn send_skips_text_for_voice_note_sender_with_tts() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use zeroclaw_config::schema::{AliasedAgentConfig, Config, EdgeTtsProviderConfig};
+
+        // Minimal edge-TTS config (no API key) so `with_tts` builds a manager.
+        let mut config = Config::default();
+        config.tts.enabled = true;
+        config
+            .providers
+            .tts
+            .edge
+            .insert("default".to_string(), EdgeTtsProviderConfig::default());
+        config.agents.insert(
+            "main".to_string(),
+            AliasedAgentConfig {
+                enabled: true,
+                channels: vec!["telegram.default".into()],
+                tts_provider: "edge.default".into(),
+                ..Default::default()
+            },
+        );
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendMessage$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": { "message_id": 1 }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "default",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_tts(&config)
+        .with_api_base(mock_server.uri());
+
+        // Recipient's last message was a voice note and TTS is available:
+        // delivery must be voice-only (no sendMessage text).
+        ch.voice_chats.lock().unwrap().insert("123".to_string());
+
+        ch.send(&SendMessage::new(
+            "This is a substantive natural-language reply long enough to be voiced.",
+            "123",
+        ))
+        .await
+        .unwrap();
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert!(
+            requests.is_empty(),
+            "voice-note sender must get voice-only delivery; got {} sendMessage requests",
+            requests.len()
         );
     }
 
@@ -6308,6 +6500,83 @@ mod tests {
 
         // Should not panic
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn telegram_send_attachment_resolves_workspace_relative_document() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendDocument$"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "ok": true })),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let ws = tempfile::tempdir().expect("tempdir");
+        let reports = ws.path().join("reports");
+        std::fs::create_dir_all(&reports).expect("make reports dir");
+        let file = reports.join("itinerary.pdf");
+        std::fs::write(&file, b"%PDF-1.4 test").expect("write fixture pe");
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_api_base(mock_server.uri())
+        .with_workspace_dir(ws.path().to_path_buf());
+
+        // A workspace-relative marker target (`[DOCUMENT:reports/itinerary.pdf]`)
+        // must resolve against the channel workspace rather than the daemon CWD.
+        let attachment = TelegramAttachment {
+            kind: TelegramAttachmentKind::Document,
+            target: "reports/itinerary.pdf".to_string(),
+        };
+        let result = ch.send_attachment("123456", None, &attachment).await;
+        assert!(
+            result.is_ok(),
+            "workspace-relative document must resolve and send, got: {}",
+            result.unwrap_err()
+        );
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn telegram_send_attachment_refuses_target_escaping_workspace() {
+        let ws = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outer_file = outside.path().join("sneak.pdf");
+        std::fs::write(&outer_file, b"%PDF-1.4").expect("write outer file");
+
+        let ch = TelegramChannel::new(
+            "fake-token".into(),
+            "telegram_test_alias",
+            Arc::new(|| vec!["*".into()]),
+            false,
+        )
+        .with_workspace_dir(ws.path().to_path_buf());
+
+        let attachment = TelegramAttachment {
+            kind: TelegramAttachmentKind::Document,
+            target: outer_file.to_string_lossy().to_string(),
+        };
+        let err = ch
+            .send_attachment("123456", None, &attachment)
+            .await
+            .expect_err("an absolute target outside workspace must be refused");
+        assert!(
+            err.to_string().contains("outside workspace")
+                || err.to_string().contains("resolves outside")
+                || err.to_string().contains("path not found"),
+            "unexpected refusal error: {}",
+            err
+        );
     }
 
     // ── Message ID edge cases ─────────────────────────────────────

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -2443,6 +2443,22 @@ fn whatsapp_delivery_failure_note(failure_count: usize) -> Option<String> {
     ))
 }
 
+/// Decide whether a WhatsApp reply is substantive enough to be voiced in
+/// strict-mirror mode (voice in → voice note only). Tool/status output is
+/// excluded so errors and progress stay visible as text; only natural-language
+/// answers are promoted to a voice-only reply.
+#[cfg(feature = "whatsapp-web")]
+fn is_substantive_voice_reply(content: &str) -> bool {
+    content.len() > 40
+        && !content.starts_with("http")
+        && !content.starts_with('{')
+        && !content.starts_with('[')
+        && !content.starts_with("Error")
+        && !content.contains("```")
+        && !content.contains("tool_call")
+        && !content.contains("wttr.in")
+}
+
 #[cfg(feature = "whatsapp-web")]
 impl ::zeroclaw_api::attribution::Attributable for WhatsAppWebChannel {
     fn role(&self) -> ::zeroclaw_api::attribution::Role {
@@ -2513,30 +2529,31 @@ impl Channel for WhatsAppWebChannel {
             .filter_map(|(kind, target)| WhatsAppMarker::from_shared_marker(kind, target))
             .collect::<Vec<_>>();
 
-        // Voice chat mode: send text normally AND queue a voice note of the
-        // final answer. Only substantive messages (not tool outputs) are queued.
+        // Voice chat mode: a substantive natural-language reply is queued as a
+        // voice note and the text send is skipped (strict mirror — voice in,
+        // voice out). Only substantive messages (not tool outputs) are queued.
         // A debounce task waits 10s after the last substantive message, then
-        // sends ONE voice note. Text in → text out. Voice in → text + voice out.
+        // sends ONE voice note. Text in → text out. Voice in → voice note only.
         let is_voice_chat = self
             .voice_chats
             .lock()
             .map(|vs| vs.contains(&message.recipient))
             .unwrap_or(false);
 
+        // Strict-mirror flag: when the last incoming message was a voice note and
+        // TTS is available, the substantive answer is delivered as a voice note
+        // only. Non-substantive output (tool progress, errors) still goes as text.
+        let mut voice_only_delivery = false;
+
         if is_voice_chat && let Some(tts_manager) = self.tts_manager.clone() {
             let content = &text_content;
             // Only queue substantive natural-language replies for voice.
             // Skip tool outputs: URLs, JSON, code blocks, errors, short status.
-            let is_substantive = content.len() > 40
-                && !content.starts_with("http")
-                && !content.starts_with('{')
-                && !content.starts_with('[')
-                && !content.starts_with("Error")
-                && !content.contains("```")
-                && !content.contains("tool_call")
-                && !content.contains("wttr.in");
+            let is_substantive = is_substantive_voice_reply(content);
 
             if is_substantive {
+                // The voice note is the sole reply — skip the text send below.
+                voice_only_delivery = true;
                 if let Ok(mut pv) = self.pending_voice.lock() {
                     pv.insert(
                         message.recipient.clone(),
@@ -2602,7 +2619,8 @@ impl Channel for WhatsAppWebChannel {
                     }
                 });
             }
-            // Fall through to send text normally (voice chat gets BOTH)
+            // Non-substantive output (tool progress, errors) falls through to
+            // text; substantive answers skip it via voice_only_delivery.
         }
 
         let mut delivered_markers = 0usize;
@@ -2696,6 +2714,13 @@ impl Channel for WhatsAppWebChannel {
         }
 
         if !markers.is_empty() && text_content.is_empty() && delivered_markers > 0 {
+            return Ok(());
+        }
+
+        // Voice-only delivery (strict mirror): the substantive answer was queued
+        // as a voice note by the debounce task, so skip the text send — the voice
+        // note is the sole reply. Attachments/markers were already delivered.
+        if voice_only_delivery {
             return Ok(());
         }
 
@@ -3502,6 +3527,34 @@ mod tests {
     fn allowed_groups_empty_permits_all() {
         // Empty list is the default: every group passes (no behavior change).
         assert!(super::is_group_chat_allowed("123456789012345@g.us", &[]));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn substantive_voice_reply_classifies_natural_language_answers() {
+        // Long natural-language answers are eligible for voice-only delivery.
+        assert!(is_substantive_voice_reply(
+            "Here is a detailed summary of the market today across the three \
+             main sectors we track, with the key numbers you asked about."
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn substantive_voice_reply_excludes_tool_and_status_output() {
+        // Tool outputs / status lines must stay text so errors stay visible.
+        for non_voice in [
+            "short",
+            "https://example.com/longer/url/that/exceeds/the/length/limit/for/sure",
+            "{\"json\": \"payload\"}",
+            "[tool_call] some tool invocation",
+            "Error: the upstream service failed to respond after retrying",
+        ] {
+            assert!(
+                !is_substantive_voice_reply(non_voice),
+                "expected non-voice: {non_voice}"
+            );
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -1594,6 +1594,33 @@ impl WhatsAppWebChannel {
             )
             .await;
         }
+
+        if let Some(ref doc) = base.document_message {
+            let mime = doc
+                .mimetype
+                .clone()
+                .unwrap_or_else(|| "application/octet-stream".to_string());
+            let doc_file_name = doc
+                .file_name
+                .clone()
+                .unwrap_or_else(|| format!("{file_prefix}whatsapp-document"));
+            let file_name = if doc.file_name.is_some() {
+                doc_file_name
+            } else {
+                format!(
+                    "{file_prefix}whatsapp-document.{}",
+                    Self::mime_extension(&mime, "bin")
+                )
+            };
+            Self::push_downloaded_attachment(
+                client,
+                doc.as_ref() as &dyn Downloadable,
+                file_name,
+                Some(mime),
+                attachments,
+            )
+            .await;
+        }
     }
 
     #[cfg(feature = "whatsapp-web")]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -556,6 +556,18 @@ impl WhatsAppWebChannel {
         }
         match super::transcription::TranscriptionManager::new(&config) {
             Ok(m) => {
+                // Mirror TelegramChannel: when exactly one provider registers,
+                // auto-bind it so `transcribe()` dispatches instead of bailing
+                // on an empty agent alias. Multi-provider selection still
+                // requires an explicit orchestrator bind (not yet wired for
+                // this channel).
+                let names = m.available_providers();
+                let m = if names.len() == 1 {
+                    let only = names[0].to_string();
+                    m.with_agent_transcription_provider(only)
+                } else {
+                    m
+                };
                 self.transcription_manager = Some(std::sync::Arc::new(m));
                 self.transcription = Some(config);
             }
@@ -4709,6 +4721,59 @@ mod tests {
         .with_transcription(tc);
         assert!(ch.transcription.is_none());
         assert!(ch.transcription_manager.is_none());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "whatsapp-web")]
+    async fn whatsapp_with_transcription_binds_sole_provider_alias() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("GROQ_API_KEY") };
+
+        // Only the Groq key is set -> exactly one provider registers.
+        // Mirrors telegram_with_transcription_binds_sole_provider_alias.
+        let tc = zeroclaw_config::schema::TranscriptionConfig {
+            enabled: true,
+            api_key: Some("test-groq-key".to_string()),
+            ..zeroclaw_config::schema::TranscriptionConfig::default()
+        };
+        let mention_only = false;
+        let self_chat_mode = false;
+        let cfg = zeroclaw_config::schema::WhatsAppConfig {
+            enabled: true,
+            session_path: Some("/tmp/test-whatsapp.db".into()),
+            mention_only,
+            self_chat_mode,
+            ..Default::default()
+        };
+        let ch = WhatsAppWebChannel::new(
+            &cfg,
+            "whatsapp_web_test_alias",
+            Arc::new(|| vec!["+1234567890".into()]),
+            Arc::new(Vec::new),
+        )
+        .with_transcription(tc);
+
+        let manager = ch
+            .transcription_manager
+            .as_ref()
+            .expect("single configured provider must build a transcription manager");
+
+        // Alias is bound for the single-provider case. Stop before any network
+        // call by using an unsupported audio format, which `validate_audio`
+        // rejects first inside the provider's `transcribe`.
+        let err = manager
+            .transcribe(&[0u8; 16], "voice.aac")
+            .await
+            .expect_err("unsupported format must error before any network call");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("no transcription_provider configured"),
+            "alias must be bound for the single-provider case; got: {msg}"
+        );
+        assert!(
+            msg.contains("Unsupported audio format"),
+            "expected the bound provider to reach audio validation; got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -4523,6 +4523,31 @@ impl Config {
             })
     }
 
+    /// Resolve the effective memory backend name for `agent_alias`,
+    /// matching what the runtime actually constructs.
+    ///
+    /// The per-agent `[agents.<alias>.memory] backend` is the source of truth
+    /// for which backend the agent loop builds (see `create_memory_for_agent`
+    /// in `zeroclaw-memory`). The install-wide `[memory] backend` →
+    /// `[storage]` resolution only sees explicitly-configured storage entries
+    /// and reports `"none"` for the common modern layout — one sqlite agent
+    /// with no `[storage.sqlite]` section on disk — which misleads status
+    /// surfaces. This helper reads the agent's own backend instead. Falls back
+    /// to `resolve_active_storage().kind()` when `agent_alias` isn't
+    /// configured. Mirrors the gateway's per-agent `/api/status` resolution.
+    #[must_use]
+    pub fn effective_memory_backend(&self, agent_alias: &str) -> String {
+        self.agent(agent_alias)
+            .map(|a| a.memory.backend)
+            .map(|kind| {
+                serde_json::to_value(kind)
+                    .ok()
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_else(|| format!("{kind:?}").to_lowercase())
+            })
+            .unwrap_or_else(|| self.resolve_active_storage().kind().to_string())
+    }
+
     /// Resolve the active storage backend for the memory subsystem.
     ///
     /// `MemoryConfig.backend` is a dotted reference (`<backend>.<alias>`) into
@@ -39500,7 +39525,7 @@ allowed_users = []
     }
 
     #[test]
-    async fn plugin_channel_instance_uses_ordinary_agent_channel_reference() {
+async fn plugin_channel_instance_uses_ordinary_agent_channel_reference() {
         let mut config = multi_agent_test_config();
         config.channels.plugin.insert(
             "operations".to_string(),
@@ -39655,6 +39680,49 @@ allowed_users = []
             error.to_string().contains("plugins.max_active_instances"),
             "{error}"
         );
+    }
+
+    #[test]
+    async fn effective_memory_backend_prefers_agent_backend_over_install_storage() {
+        // Regression: status surfaces misreported "none" when the agent
+        // pins a backend (default sqlite) with no explicit [storage] entry
+        // on disk. The per-agent kind is what the runtime constructs.
+        let mut config = Config::default();
+        let agent = AliasedAgentConfig {
+            memory: crate::multi_agent::AgentMemoryConfig {
+                backend: crate::multi_agent::MemoryBackendKind::Sqlite,
+            },
+            ..AliasedAgentConfig::default()
+        };
+        config.agents.insert("alpha".to_string(), agent);
+
+        // Install-wide memory.backend is unset / resolves to nothing.
+        config.memory.backend = "".to_string();
+
+        assert_eq!(config.effective_memory_backend("alpha"), "sqlite");
+    }
+
+    #[test]
+    async fn effective_memory_backend_reports_agent_none() {
+        let mut config = Config::default();
+        let agent = AliasedAgentConfig {
+            memory: crate::multi_agent::AgentMemoryConfig {
+                backend: crate::multi_agent::MemoryBackendKind::None,
+            },
+            ..AliasedAgentConfig::default()
+        };
+        config.agents.insert("alpha".to_string(), agent);
+        config.memory.backend = "sqlite".to_string();
+
+        assert_eq!(config.effective_memory_backend("alpha"), "none");
+    }
+
+    #[test]
+    async fn effective_memory_backend_falls_back_to_install_storage_for_unknown_agent() {
+        let mut config = Config::default();
+        config.memory.backend = "sqlite".to_string();
+        // No storage entry either — resolve_active_storage yields nothing.
+        assert_eq!(config.effective_memory_backend("missing"), "none");
     }
 
     #[test]

--- a/docs/book/src/channels/telegram.md
+++ b/docs/book/src/channels/telegram.md
@@ -216,6 +216,24 @@ running channel would read. For a valid alias it creates or updates
 `[peer_groups.telegram_<alias>]`, scopes the group to
 `telegram.<alias>`, and saves the identity idempotently.
 
+## Incoming media
+
+Photos and documents are downloaded to the agent workspace under
+`<workspace>/telegram_files/` and surfaced to the agent with an `[IMAGE:path]`
+or `[Document: ...]` marker.
+
+Video clips are supported too:
+
+- Both regular videos (the `video` field) and round video notes (the
+  `video_note` field) are recognized, downloaded, and saved under
+  `<workspace>/telegram_files/`.
+- The message content carries an actionable `[VIDEO:path]` marker so the clip
+  path stays available to the agent and survives multimodal routing.
+- When `media_pipeline` `summarize_video` is enabled, small clips
+  (`<= 20 MiB`) are additionally passed to the media pipeline as base64 video
+  bytes in a `[VIDEO:data:...;base64,...]` marker so a multimodal model can
+  parse the clip. Larger clips fall back to an attachment annotation.
+
 ## Restart and persistence behavior
 
 | Change | When the running channel sees it |

--- a/src/main.rs
+++ b/src/main.rs
@@ -5124,7 +5124,10 @@ async fn async_main(command: clap::Command) -> Result<()> {
                     t("cli-status-service-stopped", "🔴 Service:       stopped")
                 );
             }
-            let effective_memory_backend = config.resolve_active_storage().kind();
+            let effective_memory_backend = config
+                .resolved_runtime_agent_alias()
+                .map(|alias| config.effective_memory_backend(alias))
+                .unwrap_or_else(|| config.resolve_active_storage().kind().to_string());
             let heartbeat_value = if config.heartbeat.enabled {
                 let interval_minutes = config.heartbeat.interval_minutes.to_string();
                 let heartbeat_every_fallback = format!("every {}min", interval_minutes);
@@ -5145,7 +5148,7 @@ async fn async_main(command: clap::Command) -> Result<()> {
                     &heartbeat_fallback
                 )
             );
-            let memory_backend = effective_memory_backend.to_string();
+            let memory_backend = effective_memory_backend;
             let memory_auto_save = if config.memory.auto_save {
                 t("cli-status-word-on", "on")
             } else {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** (2 to 5 bullets; the diff shows *what*, you explain *why*)
- **Scope boundary:** (what this PR explicitly does NOT change)
- **Blast radius:** (what other subsystems or consumers could be affected)
- **Linked issue(s):** Use plain text outside backticks. Use `Closes #`,
  `Fixes #`, or `Resolves #` only for issues this PR fully resolves. Use
  `Related #`, `Depends on #`, or `Supersedes #` for non-closing relationships.
- **Labels:** Snapshot the current GitHub labels after labels are applied, for
  example `type:docs`, `risk:low`, `size:S`, `docs`. During label-spelling
  migration, copy the exact live label spelling from the GitHub UI.

## Testing (required)

### How you can test (when useful)

Include this subsection when reviewer-run manual verification adds useful signal, especially for user-visible behavior, a non-obvious test path, or a named CI coverage gap. For changes without useful manual verification, including docs-only, pure-refactor, or trivial changes, set the first field to `N/A` with a one-line reason and remove the remaining prompts.

When reviewer testing is requested, frame it A/B: the same steps should show the old behavior on `master` and the new behavior on this branch, so the reviewer can see the delta themselves.

- **Reviewer testing requested?** (`Yes` / `N/A`; if `N/A`, one line why)
- **Interface(s) exercised:** Name the surface(s) this touches using the same vocabulary the attribution span records: `surface` (`web` / `tui` / `cli`) and `channel` for messaging surfaces. Match the live attribution values; do not invent interface names.
- **Setup / preconditions:** (config, provider, channel, or state needed first)
- **Steps to run:** (the exact click-through or command sequence)
- **Expected on this branch (after):** (what the reviewer should observe if it works)
- **Prior behavior on `master` (before):** (run the same steps unpatched; what breaks or is missing, so the fix is visible)

### How I tested

Explain how the change was checked. Use the evidence that matches the changed surface: required CI, focused local tests, manual smoke, docs/link gates, or full workspace checks when they prove something narrower evidence would miss. Paste relevant output tails for commands you ran, not "all passed".

Fresh required CI is valid evidence when it covers the changed surface. Add extra validation only for a concrete coverage gap, such as platform-specific tests, cross-platform lint, desktop app coverage, release target builds, or stale/unavailable CI.

Visual presentation changes require actual-interface evidence. If this PR changes rendered text, layout, spacing, alignment, wrapping, clipping, color, focus, selection, responsive behavior, or another visible state, exercise the supported interface on an identifiable revision and include or link privacy-safe screenshots at representative terminal or viewport dimensions. String assertions, component-only snapshots, and helper-level renderer tests do not replace this evidence. For interaction or transition changes, also record the action and observed result.

```sh
# Rust/code examples; choose the checks that match the changed surface:
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint (`scripts/ci/docs_quality_gate.sh`) and added-link integrity (`scripts/ci/docs_links_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **CI checks relied on and why they cover this change:** (for example, `Docs Style` covers the changed Markdown lines)
- **Known CI coverage gap, if any:** (for example, `None after the docs and links gates`)
- **Commands run and tail output:**
- **Beyond CI, what did you manually verify?** (functional scenarios, edge cases, and any security-relevant behavior; also what you did NOT verify)
- **Visual interface changed?** (`Yes` / `N/A`; if `Yes`, provide the remaining fields; if `N/A`, remove them)
- **Tested revision, interface, and terminal or viewport dimensions:**
- **Screenshot evidence:** (attach or link one or more screenshots showing the changed state and enough surrounding layout to judge it)
- **Action or changed state and observed result:**
- **If any command was intentionally skipped, why:**

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1-2 sentence risk-and-mitigation note. Manual verification of these scenarios goes under `### How I tested`, not here.

- New permissions, capabilities, or file system access scope? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets / tokens / credentials handling changed? (`Yes/No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`Yes/No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes/No`)
- Config / env / CLI surface changed? (`Yes/No`)
- Rust/MSRV/toolchain floor changed? (`Yes/No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users:

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:**
- **Feature flags or config toggles:** (or `None`)
- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...`
or `Created with Claude Code` to the PR body or commit-message tail. Human
co-author trailers are appropriate only for incorporated contributor work under
the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
