### PR TITLE
chore(runtime): remove unused image and indicatif dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4687,19 +4687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width 0.2.2",
- "unit-prefix",
- "web-time",
-]
-
-[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11181,12 +11168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14070,8 +14051,6 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "hostname",
- "image",
- "indicatif",
  "landlock",
  "libc",
  "lru 0.18.2",

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -39,8 +39,6 @@ glob = "0.3"
 hex = "0.4"
 hmac = "0.12"
 hostname = "0.4.2"
-image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
-indicatif = "0.18"
 lru = "0.18.2"
 mime_guess = "2"
 nanohtml2text = "0.2"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Removed the unused `image` and `indicatif` direct dependencies from `zeroclaw-runtime`, then regenerated `Cargo.lock` so it reflects the smaller graph.
- **Scope boundary:** No Rust source, runtime behavior, public API, feature default, or channel implementation changes. This does not implement the broader crate-boundary work in #6864.
- **Blast radius:** Cargo resolution for workspace and `zeroclaw-runtime` builds. `image` remains available through `zeroclaw-channels`, its current consumer.
- **Linked issue(s):** Related #6864
- **Labels:** `type:dependencies`, `risk:low`, `size:XS`, `dependencies`

### What this does, simply

`zeroclaw-runtime` declared two libraries that none of its source files used directly. This PR removes those stale entries so the runtime manifest matches the code it owns, while image handling remains in `zeroclaw-channels`, where it is still used. It does not change how ZeroClaw behaves at runtime.

### Scope and maintenance tradeoff

This is the smallest coherent cleanup: two handwritten manifest deletions and Cargo's corresponding 21-line lockfile cleanup. Keeping or feature-gating unused runtime declarations would preserve unnecessary dependency ownership; broader channel/runtime boundary work remains separate under #6864.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a dependency-manifest cleanup with no user-visible behavior.

### How I tested

- **CI checks relied on and why they cover this change:** Current-head required CI passed, including workspace tests, lint, default/all/no-default feature checks, plugin backends, Linux, macOS, Windows, 32-bit, MSRV, security, Semgrep, and the aggregate `CI Required Gate`.
- **Known CI coverage gap, if any:** No full-workspace local check was run; the focused checks compile the changed runtime package and the supported `agent-runtime` feature profile.
- **Commands run and tail output:**

```sh
$ cargo check -p zeroclaw-runtime
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8m 58s

$ cargo check --locked --no-default-features --features agent-runtime
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 51s
```

- **Beyond CI, what did you manually verify?** Inspected the complete lockfile delta. It removes only the two runtime dependency edges, the now-unreachable `indicatif 0.18.4` and `unit-prefix 0.5.2` package blocks, and keeps `image 0.25.10` reachable through `zeroclaw-channels`. `git diff --check` passes.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** A broad workspace build was skipped because this 23-line deletion-only change is directly covered by the two focused compile profiles and exact lockfile inspection.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low risk; revert the commit if an unexpected downstream dependency assumption appears.
