### PR TITLE
fix(tests): compare Discord save paths with Path, not a "/" substring

### DIFF
--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -4309,12 +4309,24 @@ mod tests {
         let saved = media[0]
             .marker_target()
             .expect("a saved attachment must record the target it rendered");
-        assert!(
-            saved.contains("discord_files/"),
+        // The recorded target is a native filesystem path, so the separator is
+        // `\` on Windows and `/` elsewhere. Walk it as a `Path` instead of
+        // matching a `/`-joined substring, which only ever held on Unix — and
+        // which made the save-name check below compare the whole path.
+        let saved_path = std::path::Path::new(saved);
+        assert_eq!(
+            saved_path
+                .parent()
+                .and_then(|dir| dir.file_name())
+                .and_then(|dir| dir.to_str()),
+            Some("discord_files"),
             "expected a workspace save path, got: {saved}"
         );
         assert_ne!(
-            saved.rsplit('/').next().unwrap_or(saved),
+            saved_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(saved),
             media[0].file_name,
             "the save name must differ from the sender name, or this test proves nothing"
         );


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `saved_attachment_marker_joins_to_its_envelope_through_the_pipeline` asserted `saved.contains("discord_files/")` on a value built from a native `PathBuf` (`workspace_dir.join("discord_files")`). On Windows the separator is `\`, so the substring never matched and the test failed in CI. The same assumption made the next assertion (`saved.rsplit('/')`) return the whole path instead of the file name, so the "save name must differ from sender name" check compared a full path to a bare name and passed for the wrong reason.
- **Scope boundary:** Test-only. Does not touch `save_attachment_bytes_to_workspace` or any other production path; the saved attachment path stays a native `PathBuf` because the agent later opens it.
- **Blast radius:** Single test in `crates/zeroclaw-channels/src/discord/mod.rs`. No other tests or runtime code reference this assertion pattern.
- **Linked issue(s):** None.
- **Labels:** `channel`, `channel:discord`, `tests`, `type:test`, `risk:low`, `size:XS`, `principal contributor`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A — test-only change, verified by CI below.

### How I tested

`cargo fmt --all -- --check` ran locally and passed (no diff).

Compile and test execution were left to CI rather than a local build, given local build times. The Windows leg that originally surfaced this failure (`platform-tests.yml`) is `workflow_dispatch`/schedule-gated and not part of the default PR check set, so I dispatched it manually against this branch to get direct before/after signal on the failing test:

- Run: https://github.com/NiuBlibing/zeroclaw/actions/runs/32805918431 (dispatched on head `8181be39f`)
- Result: **success** — `Format`, `Platform Test (macOS)`, `Platform Test (Windows)` all passed, confirming `saved_attachment_marker_joins_to_its_envelope_through_the_pipeline` now passes on Windows.

Default PR CI also passed, including the Windows check target:
- `Format` — pass
- `Check x86_64-pc-windows-msvc` — pass
- `Check (all features)`, `Check (default features, all targets)`, `Check (no default features)`, `Check (32-bit)`, `Check (plugins cranelift backend)` — pass
- `Build x86_64-unknown-linux-gnu`, `Check aarch64-apple-darwin` — pass
- `CI Required Gate` — pass

- **CI checks relied on and why they cover this change:** `Check x86_64-pc-windows-msvc` compiles the changed test on the Windows target; the manually dispatched `platform-tests.yml` Windows job actually executes it, which is the only way to reproduce the original failure.
- **Known CI coverage gap, if any:** None — the manual dispatch closes the gap that the default PR trigger doesn't run `platform-tests.yml` for changes outside that workflow file.
- **Commands run and tail output:**
  ```
  $ cargo fmt --all -- --check
  (no output — clean)
  ```
- **Beyond CI, what did you manually verify?** Read the two related assertions end-to-end against `save_attachment_bytes_to_workspace` to confirm the fix addresses the real save-path shape (native `PathBuf`) rather than papering over the symptom.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low-risk PR: `git revert <sha>` is the plan.
