### PR TITLE
fix(channels): make Telegram lifecycle tests locale-independent

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -5177,12 +5177,14 @@ mod tests {
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let mock_server = MockServer::start().await;
+        let running_tool_text =
+            crate::util::localized_lifecycle_progress(ProgressEvent::RunningTool);
         Mock::given(method("POST"))
             .and(path_regex(r"/bot[^/]+/editMessageText$"))
             .and(body_json(serde_json::json!({
                 "chat_id": "123",
                 "message_id": 42,
-                "text": "Running tool",
+                "text": running_tool_text,
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "ok": true,
@@ -5285,7 +5287,10 @@ mod tests {
             "only the typed lifecycle event should reach Telegram"
         );
         let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
-        assert_eq!(body["text"], "Running tool");
+        assert_eq!(
+            body["text"],
+            crate::util::localized_lifecycle_progress(ProgressEvent::RunningTool)
+        );
         let raw = String::from_utf8_lossy(&requests[0].body);
         for leaked in [
             "shell",


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Derive the expected Telegram `RunningTool` lifecycle text from the Fluent catalogue in the partial-draft regression test.
  - Use the same locale-aware expectation in the raw-tool-status isolation test.
  - Keep Telegram channel tests reliable when the operator selects a supported non-English locale.
- **Scope boundary:** Test expectations only; no Telegram runtime behavior, locale catalogues, or production APIs change.
- **Blast radius:** `zeroclaw-channels` Telegram unit tests and their locale-sensitive request assertions.
- **Linked issue(s):** Fixes #10303
- **Labels:** `bug`, `channel`, `tests`, `channel:telegram`, `priority:p3`, `risk:low`, `size:XS`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is a test-only change with no user-visible runtime behavior to exercise manually.

### How I tested

- **CI checks relied on and why:** Exact-head hosted CI is green on `03a923e79fe5a2c47792dd7ecbb92d1fcfdc4831`, including formatting, workspace tests, the parallel runtime gate, workspace/platform checks, lint, security, and `CI Required Gate`. The focused and full Telegram unit-test runs below cover the changed expectations directly.
- **Known CI coverage gap, if any:** No material exact-head hosted CI gap remains. The local parallel runtime regression gate failed twice at the unrelated existing test `crates/zeroclaw-runtime/src/tunnel/custom.rs:213` (`tunnel::custom::tests::health_check_with_unreachable_health_url_returns_false`); the exact-head hosted `Parallel Runtime Test` passed, and the changed file is `crates/zeroclaw-channels/src/telegram.rs`.
- **Commands run and tail output:**

  ```text
  $ cargo fmt --all -- --check
  # no output; exit 0

  $ git diff --check
  # no output; exit 0

  $ cargo test --locked -p zeroclaw-channels --lib telegram::tests::update_draft_lifecycle_only_edits_partial_streaming_drafts -- --exact
  test telegram::tests::update_draft_lifecycle_only_edits_partial_streaming_drafts ... ok
  test result: ok. 1 passed; 0 failed

  $ cargo test --locked -p zeroclaw-channels --lib telegram::tests::raw_tool_status_never_reaches_telegram -- --exact
  test telegram::tests::raw_tool_status_never_reaches_telegram ... ok
  test result: ok. 1 passed; 0 failed

  $ cargo test --locked -p zeroclaw-channels --lib telegram::tests
  test result: ok. 232 passed; 0 failed; 2 ignored

  $ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
  # finished successfully; exit 0

  $ cargo test --locked
  # finished successfully; exit 0

  $ bash scripts/ci/parallel_runtime_test_gate.sh
  # failed twice at tunnel::custom::tests::health_check_with_unreachable_health_url_returns_false
  # 3762 passed; 1 failed; 3 ignored in the failing runtime run; exit 101
  ```

  The two focused tests were also rerun with `ZEROCLAW_CONFIG_DIR` pointing to a temporary config containing `locale = "fr"`; each reported `1 passed; 0 failed`.
- **Beyond CI, what did you manually verify?** Confirmed the production path already resolves `ProgressEvent::RunningTool` through the shared Fluent helper, and the patch changes only the two hard-coded test expectations. No runtime or interface behavior was changed.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No additional local command was required after publication; the exact-head hosted matrix supplies the final cross-platform and parallel-runtime checks.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: exact upgrade steps for existing users: N/A

## Rollback

Low-risk test-only change: after merge, run `git revert <landed-squash-sha>`.
