### PR TITLE
test(cron): anchor missed-run assertion to reference time

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -3319,13 +3319,22 @@ schedule = { kind = "every", every_ms = 300000 }
     fn skip_missed_run_advances_recurring_job_next_run() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp);
+        // Keep the reference one second before a minute boundary so the test
+        // exercises the exact rollover that made the old wall-clock assertion
+        // flaky. The explicit UTC zone keeps the expected occurrence stable
+        // across developer and CI machine timezones.
+        let reference = "2026-08-25T12:34:59Z".parse::<DateTime<Utc>>().unwrap();
+        let schedule = Schedule::Cron {
+            expr: "* * * * *".to_string(),
+            tz: Some("UTC".to_string()),
+        };
 
         // Add a cron job that will be "overdue" — its next_run is set based
         // on the schedule from the current time, so we need to make it past.
-        let job = add_job(&config, "test-agent", "* * * * *", "echo test").unwrap();
+        let job = add_job_with_schedule(&config, "test-agent", &schedule, "echo test").unwrap();
 
         // Force next_run into the past so the job appears overdue.
-        let past = Utc::now() - ChronoDuration::hours(1);
+        let past = reference - ChronoDuration::hours(1);
         with_initialized_connection(&config, |conn| {
             conn.execute(
                 "UPDATE cron_jobs SET next_run = ?1 WHERE id = ?2",
@@ -3338,20 +3347,23 @@ schedule = { kind = "every", every_ms = 300000 }
 
         // Verify it is overdue now.
         assert!(
-            !all_overdue_jobs(&config, Utc::now()).unwrap().is_empty(),
+            !all_overdue_jobs(&config, reference).unwrap().is_empty(),
             "job with past next_run must appear in overdue"
         );
 
         // Skip the missed run.
         let reloaded = get_job(&config, &job.id).unwrap();
-        skip_missed_run(&config, &reloaded, Utc::now()).unwrap();
+        skip_missed_run(&config, &reloaded, reference).unwrap();
 
-        // The job's next_run should now be in the future.
+        // The job's next_run should be the first occurrence after the same
+        // reference instant supplied to skip_missed_run.
         let updated = get_job(&config, &job.id).unwrap();
+        let expected_next_run = "2026-08-25T12:35:00Z".parse::<DateTime<Utc>>().unwrap();
         assert!(
-            updated.next_run > Utc::now(),
+            updated.next_run > reference,
             "skip_missed_run must advance next_run to the future"
         );
+        assert_eq!(updated.next_run, expected_next_run);
         assert!(updated.enabled, "recurring job must stay enabled");
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Anchor the recurring `skip_missed_run` regression test to one explicit reference instant instead of sampling the wall clock during setup and assertion.
  - Fix the test at `12:34:59Z` with a UTC every-minute schedule so it covers the minute-boundary rollover that caused the flake.
  - Assert the exact next occurrence at `12:35:00Z` while retaining the enabled-state regression check.
- **Scope boundary:** Test-only change; production cron scheduling, one-shot skip behavior, and persisted job semantics are unchanged.
- **Blast radius:** `zeroclaw-runtime` cron store unit tests and their deterministic timing coverage.
- **Linked issue(s):** Fixes #10332
- **Labels:** `bug`, `cron`, `runtime`, `risk:low`, `size:XS`, `type:test`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is a deterministic test-only change with no user-visible runtime behavior to exercise manually.

### How I tested

- **CI checks relied on and why:** Exact-head required CI passed, including formatting, workspace Clippy, locked workspace tests, and the Parallel Runtime Test. The focused checks below cover the changed cron store test, the adjacent cron scheduler/type/schedule tests, and the one-shot skip regression.
- **Known CI coverage gap, if any:** None for the changed test. Before publication, the local parallel runtime gate failed at the baseline-existing test `crates/zeroclaw-runtime/src/tunnel/custom.rs:213` (`tunnel::custom::tests::health_check_with_unreachable_health_url_returns_false`); the current exact-head Parallel Runtime Test passes.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
# no output; exit 0

$ git diff --check
# no output; exit 0

$ cargo test --locked -p zeroclaw-runtime --lib cron::store::tests::skip_missed_run_advances_recurring_job_next_run -- --exact
test cron::store::tests::skip_missed_run_advances_recurring_job_next_run ... ok
test result: ok. 1 passed; 0 failed

$ cargo test --locked -p zeroclaw-runtime --lib cron::
test result: ok. 163 passed; 0 failed; 0 ignored

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
# completed successfully; exit 0

$ cargo test --locked
# completed successfully; exit 0

$ bash scripts/ci/parallel_runtime_test_gate.sh
tunnel::custom::tests::health_check_with_unreachable_health_url_returns_false ... FAILED
# 3859 passed; 1 failed; 3 ignored in the failing runtime run; exit 101
```

- **Beyond CI, what did you manually verify?** Confirmed the test uses a fixed UTC boundary instant, asserts the exact next occurrence independently, and preserves the recurring-job enabled assertion plus the adjacent overdue one-shot test. No production code or interface behavior changed.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No additional manual or live testing was needed for this deterministic test-only change. The earlier local parallel runtime failure remains recorded above rather than being treated as a pass; exact-head CI now supplies the passing gate result.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: exact upgrade steps for existing users: N/A

## Rollback

Low-risk test-only change: after merge, run `git revert <landed-squash-sha>`.
