### PR TITLE
test(quickstart): make validation assertions locale-independent

### DIFF
--- a/crates/zeroclaw-runtime/src/quickstart/mod.rs
+++ b/crates/zeroclaw-runtime/src/quickstart/mod.rs
@@ -3224,12 +3224,15 @@ mod tests {
             .await
             .expect_err("an existing same-port webhook must be rejected");
 
-        assert!(errors.iter().any(|error| {
-            error.field == "channels[0].fields.port"
-                && error.message
-                    == "webhook port 8090 is already used by enabled webhook `already-active` — \
-                        each enabled webhook needs its own port"
-        }));
+        assert!(
+            errors.iter().any(|error| {
+                error.step == QuickstartStep::Channels
+                    && error.field == "channels[0].fields.port"
+                    && error.message.contains("8090")
+                    && error.message.contains("already-active")
+            }),
+            "localized port conflict must preserve its field and parameters: {errors:?}"
+        );
         let after = std::fs::read_to_string(&config.config_path).unwrap();
         assert_eq!(
             after, before,
@@ -3318,12 +3321,12 @@ mod tests {
 
         assert!(
             errors.iter().any(|error| {
-                error.field == "channels[0].fields.port"
-                    && error.message
-                        == "webhook port 8090 is already used by enabled webhook `existing` — \
-                            each enabled webhook needs its own port"
+                error.step == QuickstartStep::Channels
+                    && error.field == "channels[0].fields.port"
+                    && error.message.contains("8090")
+                    && error.message.contains("existing")
             }),
-            "CLI surface must render the localized conflict string; got {errors:?}"
+            "localized port conflict must preserve its field and parameters; got {errors:?}"
         );
     }
 
@@ -3340,10 +3343,14 @@ mod tests {
         let errors = validate_only_with_surface(&submission, &cfg, Surface::Cli)
             .expect_err("empty webhook secret must be rejected");
 
-        assert!(errors.iter().any(|error| {
-            error.field == "channels[0].fields.secret"
-                && error.message == "Webhook shared secret is required"
-        }));
+        assert!(
+            errors.iter().any(|error| {
+                error.step == QuickstartStep::Channels
+                    && error.field == "channels[0].fields.secret"
+                    && !error.message.trim().is_empty()
+            }),
+            "localized webhook secret validation must preserve its field: {errors:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Replace three Quickstart test assertions that compared localized CLI errors with hard-coded English strings.
  - Keep the assertions focused on the structured Quickstart step/field and semantic values such as the webhook port and conflicting alias.
  - Preserve coverage for duplicate webhook-port validation and required webhook-secret validation under every supported Fluent locale.
- **Scope boundary:** Test-only; no production validation, localization catalog, configuration, or CLI behavior changes.
- **Blast radius:** The Quickstart runtime unit-test suite only. The tests now remain valid when the configured locale is English or a supported non-English locale such as French.
- **Linked issue(s):** Fixes #10264
- **Labels:** `runtime`, `tests`, `follow-up`, `risk:medium`, `quickstart`, `size:XS`, `type:test`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is a test-only change with no useful manual interface path.

### How I tested

- **CI checks relied on and why:** The official ZeroClaw preflight ran the Rust quality and repository test gates for the changed runtime test surface. Formatting, workspace Clippy, and locked Rust tests passed. The focused tests were also run directly under both the default locale and a temporary config containing `locale = "fr"`.
- **Known CI coverage gap, if any:** The local pre-publication parallel runtime gate failed on the pre-existing `tunnel::custom::tests::health_check_with_unreachable_health_url_returns_false` test (`3859 passed; 1 failed; 3 ignored`). That test exists on the validation base and `crates/zeroclaw-runtime/src/tunnel/custom.rs` is not in this diff. Exact-head hosted `Parallel Runtime Test`, `Test`, and `CI Required Gate` have since completed successfully, so no current hosted CI gap remains.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
status: passed

$ git diff --check
status: passed

$ cargo test --locked -p zeroclaw-runtime --lib quickstart
test result: ok. 56 passed; 0 failed

$ env ZEROCLAW_CONFIG_DIR="$FR_CONFIG_DIR" cargo test --locked -p zeroclaw-runtime --lib quickstart
test result: ok. 56 passed; 0 failed

$ cargo test --locked --test architecture user_facing_strings_route_through_fluent
test result: ok. 1 passed; 0 failed

$ bash scripts/ci/parallel_runtime_test_gate.sh
exit: 101
tunnel::custom::tests::health_check_with_unreachable_health_url_returns_false --- FAILED
test result: FAILED. 3859 passed; 1 failed; 3 ignored
```

- **Beyond CI, what did you manually verify?** Confirmed the failing tunnel test is present on the validation base and that the candidate diff changes only `crates/zeroclaw-runtime/src/quickstart/mod.rs`. The French-locale run confirms the three assertions no longer depend on ambient English wording.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No live UI or listener smoke was run because this patch changes only test assertions and does not alter runtime behavior.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback

- **Fast rollback:** Revert commit `2258e43a7` and rerun the normal validation path.
- **Flags or configuration toggles:** None. This is a test-only assertion change.
- **Rollback symptoms:** Roll back if the revised tests stop detecting the structured Quickstart field or semantic webhook parameters they are intended to protect.
