### PR TITLE
chore(zerocode): remove unused async-trait dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14232,7 +14232,6 @@ name = "zerocode"
 version = "0.8.4"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "clap",
  "crossterm",

--- a/apps/zerocode/Cargo.toml
+++ b/apps/zerocode/Cargo.toml
@@ -33,7 +33,6 @@ inkjet = { version = "0.11", default-features = false, features = [
     "language-hcl", "language-zig", "language-scala", "language-php",
     "language-dart",
 ] }
-async-trait = "0.1"
 crossterm = { version = "0.29", features = ["event-stream"] }
 ratatui = { version = "0.30", default-features = true, features = ["unstable-rendered-line-info"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Removed ZeroCode's unused direct `async-trait` declaration and let Cargo remove only that edge from the `zerocode` package entry in `Cargo.lock`.
- **Scope boundary:** This PR does not change Rust source, features, RPC contracts, the shared `async-trait` package, or any other crate's dependency declaration.
- **Blast radius:** Limited to ZeroCode's direct package graph and generated workspace lockfile metadata. Runtime behavior and the standard ZeroClaw distribution are unchanged.
- **Linked issue(s):** None. This is a standalone cleanup identified by the dependency-footprint audit.
- **Labels:** `dependencies`, `distinguished contributor`, `zerocode`, `risk:low`, `size:XS`, `type:dependencies`

### What this does, simply

ZeroCode is the terminal client that talks to ZeroClaw through RPC. Its manifest still listed `async-trait`, even though no tracked ZeroCode source uses that crate.

This PR removes the redundant declaration and its generated lockfile edge. Other workspace packages still use `async-trait`, so the shared package remains in `Cargo.lock`; this does not remove it from ZeroClaw as a whole or change runtime behavior.

### Scope and maintenance tradeoff

The complete change is two deletion-only lines: one handwritten manifest declaration and one Cargo-generated lockfile entry. It reuses Cargo's existing resolver and adds no new maintenance surface.

Keeping this as an independent cleanup avoids mixing a mechanically verifiable package-graph correction with broader dependency policy or feature-gating work. The measured result is one fewer direct package/version pair in the isolated ZeroCode graph, not a claim of smaller binaries, downloads, or the standard distribution.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This is dependency metadata only; the focused package suite and required CI exercise the relevant build and boundary contracts.

### How I tested

- **CI checks relied on and why they cover this change:** Current-head hosted CI passed, including `CI Required Gate`, the standard Rust build, test, lint, and security matrix, and `Zerocode RPC Boundary` for `apps/zerocode/**` changes.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```text
$ cargo metadata --format-version 1
Generated only the planned deletion from the zerocode dependency list in Cargo.lock.

$ cargo test --locked -p zerocode
test result: ok. 997 passed; 0 failed; 2 ignored

$ bash scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
zerocode gate passed: no zeroclaw-* dependencies.

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check
Passed with no output.
```

- **Beyond CI, what did you manually verify?** Confirmed the final diff contains exactly two deletions, no tracked ZeroCode source uses `async_trait` or `async-trait`, the shared package remains in the lockfile, and 12 other workspace manifests still declare it. No live smoke was run because runtime behavior and user-facing output do not change.
- **Visual interface changed?** N/A. No rendered state changes.
- **If any command was intentionally skipped, why:** Broad local workspace checks were skipped because the focused ZeroCode package suite directly covers this metadata-only change and required CI will cover the aggregate workspace and platform matrix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: `git revert <sha>`.
