### PR TITLE
fix(clippy): replace chunks_exact(2) with as_chunks::<2>() for Rust 1.98

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -7317,7 +7317,7 @@ mod tests {
             Some(ConversationMessage::Chat(message))
                 if message.role == "assistant" && message.content == "done"
         ));
-        for (index, pair) in agent.history[1..63].chunks_exact(2).enumerate() {
+        for (index, pair) in agent.history[1..63].as_chunks::<2>().0.iter().enumerate() {
             let expected_id = format!("trim-history-call-{}", index + 1);
             match pair {
                 [

--- a/crates/zeroclaw-runtime/src/agent/tests.rs
+++ b/crates/zeroclaw-runtime/src/agent/tests.rs
@@ -751,12 +751,9 @@ async fn history_trims_after_max_messages() {
         retained_messages.len(),
         max_history,
     );
-    let mut turns = retained_messages.chunks_exact(2);
-    assert!(
-        turns.remainder().is_empty(),
-        "history must retain whole turns"
-    );
-    assert!(turns.all(|turn| matches!(
+    let (turns, remainder) = retained_messages.as_chunks::<2>();
+    assert!(remainder.is_empty(), "history must retain whole turns");
+    assert!(turns.iter().all(|turn| matches!(
         turn,
         [ConversationMessage::Chat(user), ConversationMessage::Chat(assistant)]
             if user.role == "user" && assistant.role == "assistant"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Rust 1.98.0 introduced the `chunks_exact_to_as_chunks` Clippy lint, which denies `.chunks_exact(N)` when `N` is a compile-time constant and points at the `as_chunks::<N>()` API instead. Two call sites in `zeroclaw-runtime` were flagged, failing the `Lint` job on PR 9527 (the Rust 1.98.0 toolchain bump).
- **Scope boundary:** Test-only. No production code path is touched, and no lint is silenced with an `allow` — both sites move to the suggested API.
- **Blast radius:** Single crate (`zeroclaw-runtime`), two test-only call sites. No other crate, consumer, or runtime behavior is affected.
- **Linked issue(s):** Related #9527
- **Labels:** `agent`, `runtime`, `type:test`, `risk:low`, `size:XS`, `principal contributor`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A — test-only lint fix with no observable behavior change; the `Lint` CI job is the signal.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
```

Both ran clean locally on Rust 1.98.0 (the same version the failing CI job uses).

- **CI checks relied on and why they cover this change:** `Lint` runs `cargo clippy` with `-D warnings` over the workspace including `zeroclaw-runtime`, so it exercises exactly the two changed call sites and is the check that currently fails on 9527. `Check (default features, all targets)` and `Check x86_64-pc-windows-msvc` compile the changed test code, and `MSRV (declared floor)` confirms `as_chunks` is available at the declared floor.
- **Known CI coverage gap, if any:** None. This PR targets current `master` (Rust 1.97), where the new lint is not yet active, so `Lint` here proves no regression rather than the fix; the fix itself is proven by the local 1.98.0 clippy run above and will be confirmed by `Lint` once 9527 lands or rebases onto this.
- **Commands run and tail output:**
  ```
  $ cargo fmt --all -- --check
  (no output — clean)

  $ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 9m 51s
  CLIPPY_EXIT=0
  ```
- **Beyond CI, what did you manually verify?** Read both call sites end to end. `agent.rs` chunks `history[1..63]`, 62 elements, which divides evenly by 2, so discarding the `as_chunks` remainder cannot drop an element. `tests.rs` already asserted `turns.remainder().is_empty()`; the rewrite keeps that invariant as `assert!(remainder.is_empty(), ...)` on the destructured tuple, so a stray odd message still fails the test. I also confirmed `as_chunks::<2>()` compiles on the 1.95.0 toolchain, below the declared MSRV floor of 1.96.0, so this does not raise the floor. I did not run the runtime test suite itself — the two touched assertions are compile-shape changes and `Test` in CI covers execution.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low-risk PR: `git revert <sha>` is the plan.
