### PR TITLE
fix(tests): make cron workspace assertion portable

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -2228,7 +2228,7 @@ mod tests {
                                     "type": "function",
                                     "function": {
                                         "name": "shell",
-                                        "arguments": "{\"command\":\"pwd\"}"
+                                        "arguments": "{\"command\":\"cat .cron-workspace-marker\"}"
                                     }
                                 }]
                             }
@@ -2269,12 +2269,20 @@ mod tests {
         let mut security = test_security(&config);
         let scheduler_workspace = tmp.path().join("scheduler-owned-workspace");
         std::fs::create_dir_all(&scheduler_workspace).unwrap();
+        let workspace_marker = "CRON_SCHEDULER_WORKSPACE_MARKER";
+        std::fs::write(
+            scheduler_workspace.join(".cron-workspace-marker"),
+            workspace_marker,
+        )
+        .unwrap();
         security.workspace_dir = scheduler_workspace.clone();
-        let expected_workspace = security.workspace_dir.clone();
-        assert_ne!(expected_workspace, config.agent_workspace_dir(TEST_AGENT));
+        assert_ne!(
+            security.workspace_dir,
+            config.agent_workspace_dir(TEST_AGENT)
+        );
         let mut job = test_job("");
         job.job_type = JobType::Agent;
-        job.prompt = Some("Print the current workspace directory".into());
+        job.prompt = Some("Read the scheduler workspace marker".into());
         job.allowed_tools = Some(vec!["shell".into()]);
         job.uses_memory = false;
 
@@ -2319,9 +2327,8 @@ mod tests {
         );
         for tool_result in tool_results {
             assert!(
-                tool_result.contains(expected_workspace.to_string_lossy().as_ref()),
-                "shell output must come from the scheduler workspace {:?}, got {tool_result:?}",
-                expected_workspace
+                tool_result.contains(workspace_marker),
+                "shell output must contain the scheduler workspace marker, got {tool_result:?}"
             );
         }
 

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -2219,6 +2219,11 @@ mod tests {
                         }))
                         .into_response();
                     }
+                    let shell_command = if cfg!(windows) {
+                        "type .cron-workspace-marker"
+                    } else {
+                        "cat .cron-workspace-marker"
+                    };
                     Json(serde_json::json!({
                         "choices": [{
                             "message": {
@@ -2228,7 +2233,10 @@ mod tests {
                                     "type": "function",
                                     "function": {
                                         "name": "shell",
-                                        "arguments": "{\"command\":\"cat .cron-workspace-marker\"}"
+                                        "arguments": serde_json::json!({
+                                            "command": shell_command
+                                        })
+                                        .to_string()
                                     }
                                 }]
                             }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Replace an absolute working-directory string comparison in the cron scheduler regression test with a marker-file check, and read that marker with the native file command for each platform. Equivalent directories can have different path strings on Windows, and plain `cmd.exe` does not provide the Unix `cat` command.
- **Scope boundary:** This changes one test fixture and assertion only. Scheduler behavior, shell execution, retry handling, concurrency, and production workspace selection are unchanged.
- **Blast radius:** The cron scheduler test module in `zeroclaw-runtime`.
- **Linked issue(s):** Related #7462, Related #7461, Related #10253
- **Labels:** `cron`, `runtime`, `distinguished contributor`, `risk:medium`, `size:XS`, `type:test`

### What this does, simply

When ZeroClaw runs an action on a schedule, it should use the working folder selected for that run, not the agent's normal folder. The old test compared two spellings of that folder, which can differ on Windows. The first marker-file version still tried to read the file with the Unix-only `cat` command, which plain Windows does not provide. The test now reads a unique file from the intended folder with `type` on Windows and `cat` elsewhere. This changes only the test, not how scheduled actions run.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the hosted Windows workflow is the requested platform proof.

### How I tested

- **CI checks relied on and why they cover this change:** Required PR CI passed on current head `6a4ff83651c654278080c1b69e93980f6f162321`. [Scheduled Platform Tests run 32924727023](https://github.com/Audacity88/zeroclaw/actions/runs/32924727023) completed on that same head: Format, Platform Test (Windows), and Platform Test (macOS) all passed.
- **Hosted Windows result:** The repaired `agent_cron_run_keeps_workspace_through_shell_on_retry_and_concurrency` test passed through the default Windows runtime in 0.522 seconds. The full Windows nextest job completed in 349 seconds with 14,104 tests run, 14,104 passed, 21 skipped, and no failures; this directly exercises the Windows-native `type .cron-workspace-marker` path.
- **Known CI coverage gap, if any:** None for this test-only repair. Required CI and current-head hosted Windows and macOS execution passed.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

cargo test --locked -p zeroclaw-runtime cron::scheduler::tests::agent_cron_run_keeps_workspace_through_shell_on_retry_and_concurrency --lib -- --exact --test-threads=16
# test cron::scheduler::tests::agent_cron_run_keeps_workspace_through_shell_on_retry_and_concurrency ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3882 filtered out

git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Verified that the marker exists only in the scheduler-owned workspace, the configured agent workspace remains distinct, and the test still exercises one retry, one repeated run, three concurrent runs, and exactly five successful shell tool results. Verified that the fixture selects `type` on Windows and `cat` elsewhere, and serializes the shell arguments with `serde_json`.
- **Visual interface changed?** N/A; this is a test-only change.
- **If any command was intentionally skipped, why:** Broad workspace Cargo validation was skipped because it would not exercise the Windows shell dialect that caused the remaining portability failure. The focused runtime test and current-head hosted Windows execution are the relevant checks.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Run `git revert <landed squash SHA>` through the normal review path to restore the previous cron workspace assertion fixture.
- **Feature flags or config toggles:** None; this is a test-only change.
- **Observable failure symptoms:** The focused cron regression fails because the shell cannot read the marker file, or the test no longer observes five marker-bearing shell results across retry, repeat, and concurrent runs.
