### PR TITLE
fix(runtime): keep detailed tool output when a short error is also set

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -4114,6 +4114,9 @@ mod tests {
         assert!(outcome.error_reason.is_none());
     }
 
+    // Success path only. The failure arms of `execute_one_tool` do scrub the
+    // model-visible `output` (they fold in a tool's detailed error body); see
+    // the failure-output tests in `agent::tool_execution::tests`.
     #[tokio::test]
     async fn execute_one_tool_keeps_data_path_raw_and_scrubs_only_observer() {
         struct CapturingResults {

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -583,8 +583,11 @@ pub(crate) async fn execute_tools_sequential(
 
 #[cfg(test)]
 mod tests {
-    use super::{ToolDispatchContext, execute_one_tool, resolved_tool_provenance};
+    use super::{
+        Observer, ObserverEvent, ToolDispatchContext, execute_one_tool, resolved_tool_provenance,
+    };
     use crate::observability::noop::NoopObserver;
+    use crate::observability::traits::ObserverMetric;
     use crate::tools::ActivatedToolSet;
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -779,8 +782,23 @@ mod tests {
 
     /// Fake tool that always fails, with an `error` distinct from `output` —
     /// mirrors `http_request`'s pattern of a short status in `error` plus a
-    /// detailed body in `output`.
+    /// structured, detailed body in `output` built via
+    /// `ToolOutput::json_with_text`, the same constructor
+    /// `http_request.rs` uses for every 4xx/5xx response
+    /// (`crates/zeroclaw-tools/src/http_request.rs:672-680`).
     struct FailingToolWithDetailedOutput;
+
+    fn failing_tool_body_data() -> serde_json::Value {
+        serde_json::json!({
+            "status": 400,
+            "reason": "Bad Request",
+            "headers": "",
+            "body": {
+                "message": "the api-version needs the -preview suffix",
+                "typeKey": "VssInvalidPreviewVersionException",
+            },
+        })
+    }
 
     #[async_trait]
     impl zeroclaw_api::attribution::Attributable for FailingToolWithDetailedOutput {
@@ -812,7 +830,10 @@ mod tests {
         ) -> anyhow::Result<crate::tools::ToolResult> {
             Ok(crate::tools::ToolResult {
                 success: false,
-                output: "Response Body: the api-version needs the -preview suffix".into(),
+                output: zeroclaw_api::tool::ToolOutput::json_with_text(
+                    failing_tool_body_data(),
+                    "Response Body: the api-version needs the -preview suffix",
+                ),
                 error: Some("HTTP 400".into()),
             })
         }
@@ -909,6 +930,13 @@ mod tests {
             Some("HTTP 400"),
             "error_reason stays the short, raw reason for other consumers"
         );
+        assert_eq!(
+            outcome.output_data,
+            Some(failing_tool_body_data()),
+            "structured output_data (the shape http_request.rs actually produces via \
+             ToolOutput::json_with_text) must survive the failure path, not just the \
+             display text"
+        );
     }
 
     #[tokio::test]
@@ -938,6 +966,489 @@ mod tests {
         assert_eq!(
             outcome.output, "Error: old_string not found in file",
             "tools with empty output must keep the exact pre-existing message shape"
+        );
+    }
+
+    /// The production-boundary case #10357 explicitly requires: the real
+    /// `http_request` tool against a live 4xx response, run through
+    /// `execute_one_tool`, proving the response body it builds via
+    /// `ToolOutput::json_with_text` (`http_request.rs:661-680`) reaches the
+    /// agent-visible outcome rather than being replaced by the bare
+    /// `"HTTP 400"` `error`. Mirrors the real-world Azure DevOps repro from
+    /// the issue (a `-preview` api-version 400 response).
+    #[tokio::test]
+    async fn execute_one_tool_preserves_http_request_400_body_from_real_producer() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("loopback bind must succeed");
+        let port = listener.local_addr().unwrap().port();
+
+        let body = serde_json::json!({
+            "message": "The requested version \"7.1\" of the resource is under preview. \
+                The -preview flag must be supplied in the api-version for such requests.",
+            "typeKey": "VssInvalidPreviewVersionException",
+        })
+        .to_string();
+
+        zeroclaw_spawn::spawn!(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept must succeed");
+            let mut request = Vec::new();
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let mut buffer = [0_u8; 1024];
+                let read = stream
+                    .read(&mut buffer)
+                    .await
+                    .expect("read must not error before headers complete");
+                assert!(read > 0, "client closed before completing request headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let response = format!(
+                "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write must succeed");
+        });
+
+        let http_tool = zeroclaw_tools::http_request::HttpRequestTool::new(
+            Arc::new(zeroclaw_config::policy::SecurityPolicy {
+                autonomy: AutonomyLevel::Supervised,
+                ..zeroclaw_config::policy::SecurityPolicy::default()
+            }),
+            vec!["127.0.0.1".into()],
+            1_000_000,
+            5,
+            true,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("HttpRequestTool::new must succeed with a valid allowlist");
+
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(http_tool)];
+        let meta = test_turn_meta();
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            execute_one_tool(
+                "http_request",
+                serde_json::json!({
+                    "url": format!("http://127.0.0.1:{port}/_apis/connectionData?api-version=7.1"),
+                    "method": "GET",
+                }),
+                None,
+                ToolDispatchContext {
+                    tools_registry: &tools,
+                    activated_tools: None,
+                    excluded_tools: &[],
+                    model_switch_callback: None,
+                },
+                &meta,
+                &NoopObserver,
+                None,
+                None,
+                None,
+            ),
+        )
+        .await
+        .expect("execute_one_tool must not hang against the loopback server")
+        .expect("execute_one_tool should return an outcome for the real http_request tool");
+
+        assert!(!outcome.success);
+        assert!(
+            outcome.output.contains("HTTP 400"),
+            "the short error must still be present: {}",
+            outcome.output
+        );
+        assert!(
+            outcome
+                .output
+                .contains("The -preview flag must be supplied"),
+            "the real response body from http_request must reach the agent, not just \
+             the bare status: {}",
+            outcome.output
+        );
+        let output_data = outcome
+            .output_data
+            .expect("http_request's structured body must survive the failure path");
+        assert_eq!(
+            output_data["status"], 400,
+            "structured data must carry the real status code: {output_data}"
+        );
+        assert_eq!(
+            output_data["body"]["typeKey"], "VssInvalidPreviewVersionException",
+            "structured data must carry the parsed JSON body http_request produced: {output_data}"
+        );
+    }
+
+    /// Fake tool whose detailed `output` is plain text with no structured
+    /// `data` attached — the shape of a shell-like tool, as distinct from
+    /// `http_request`'s `json_with_text`. Guards the branch that appends
+    /// distinct plain text without ever synthesizing an `output_data`.
+    struct FailingToolWithPlainTextOutput;
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolWithPlainTextOutput {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool-plain-text"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolWithPlainTextOutput {
+        fn name(&self) -> &str {
+            "failing_tool_plain_text"
+        }
+
+        fn description(&self) -> &str {
+            "Always fails with a plain-text detailed output and no structured data, \
+             for regression testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: "stdout: connection refused while reaching upstream".into(),
+                error: Some("exit code 1".into()),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_appends_plain_text_output_without_data() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithPlainTextOutput)];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "failing_tool_plain_text",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(!outcome.success);
+        assert!(
+            outcome.output.contains("exit code 1"),
+            "the short error must still be present: {}",
+            outcome.output
+        );
+        assert!(
+            outcome
+                .output
+                .contains("connection refused while reaching upstream"),
+            "plain-text detailed output (no structured data) must still reach the agent, \
+             not just tools that happen to use json_with_text: {}",
+            outcome.output
+        );
+        assert_eq!(
+            outcome.output_data, None,
+            "a tool that never declared structured data must not gain output_data \
+             from this code path"
+        );
+    }
+
+    /// Fake tool whose `output` text is byte-identical to its `error` —
+    /// guards against re-introducing duplication like
+    /// `"Error: HTTP 400\n\nHTTP 400"`.
+    struct FailingToolWithOutputIdenticalToError;
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolWithOutputIdenticalToError {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool-identical-output"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolWithOutputIdenticalToError {
+        fn name(&self) -> &str {
+            "failing_tool_identical_output"
+        }
+
+        fn description(&self) -> &str {
+            "Always fails with output text identical to its error, for regression testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: "HTTP 400".into(),
+                error: Some("HTTP 400".into()),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_does_not_duplicate_output_identical_to_error() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithOutputIdenticalToError)];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "failing_tool_identical_output",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(!outcome.success);
+        assert_eq!(
+            outcome.output, "Error: HTTP 400",
+            "output text identical to error must not be duplicated: {}",
+            outcome.output
+        );
+    }
+
+    /// Fake tool that fails with `error: None` and only `output` set — the
+    /// exact fallback line the original bug lived on
+    /// (`r.error.unwrap_or_else(|| r.output.into_string())`). No existing
+    /// test exercised the `None` arm of that closure post-fix.
+    struct FailingToolWithNoErrorField;
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolWithNoErrorField {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool-no-error-field"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolWithNoErrorField {
+        fn name(&self) -> &str {
+            "failing_tool_no_error_field"
+        }
+
+        fn description(&self) -> &str {
+            "Always fails with only `output` set and `error: None`, for regression testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: "validation failed: field 'name' is required".into(),
+                error: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_error_none_falls_back_to_output_text() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithNoErrorField)];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "failing_tool_no_error_field",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(!outcome.success);
+        assert_eq!(
+            outcome.output, "Error: validation failed: field 'name' is required",
+            "with error: None, the pre-existing fallback to r.output must be preserved \
+             verbatim and not duplicated: {}",
+            outcome.output
+        );
+        assert_eq!(
+            outcome.error_reason.as_deref(),
+            Some("validation failed: field 'name' is required"),
+            "error_reason must fall back to the output text when the tool never set error"
+        );
+    }
+
+    /// Captures the last `ObserverEvent::ToolCall.result` seen, so tests can
+    /// assert on exactly what the observer/telemetry path receives — as
+    /// distinct from what `ToolExecutionOutcome.output` sends to the model.
+    struct RecordingObserver {
+        last_result: Mutex<Option<String>>,
+    }
+
+    impl RecordingObserver {
+        fn new() -> Self {
+            Self {
+                last_result: Mutex::new(None),
+            }
+        }
+
+        fn last_result(&self) -> Option<String> {
+            self.last_result.lock().unwrap().clone()
+        }
+    }
+
+    impl Observer for RecordingObserver {
+        fn record_event(&self, event: &ObserverEvent) {
+            if let ObserverEvent::ToolCall { result, .. } = event {
+                *self.last_result.lock().unwrap() = result.clone();
+            }
+        }
+
+        fn record_metric(&self, _metric: &ObserverMetric) {}
+
+        fn name(&self) -> &str {
+            "recording-test-observer"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// Fake tool whose detailed `output` embeds a credential-shaped string,
+    /// mirroring a server that echoes back a bad `Authorization` header or
+    /// API key in its error body.
+    struct FailingToolWithSecretInOutput;
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolWithSecretInOutput {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool-secret"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolWithSecretInOutput {
+        fn name(&self) -> &str {
+            "failing_tool_secret"
+        }
+
+        fn description(&self) -> &str {
+            "Always fails with a credential-shaped string in its detailed output, \
+             for regression testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: "Response Body: API_KEY=sk-1234567890abcdef was rejected".into(),
+                error: Some("HTTP 401".into()),
+            })
+        }
+    }
+
+    /// Pins the exact boundary Audacity88's review asked the PR description
+    /// to state accurately: `scrub_credentials` runs on the observer/
+    /// telemetry event, but the raw combined text still reaches
+    /// `ToolExecutionOutcome.output` (and therefore the model) unscrubbed.
+    #[tokio::test]
+    async fn execute_one_tool_scrubs_credentials_for_observer_but_not_for_model() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithSecretInOutput)];
+        let meta = test_turn_meta();
+        let observer = RecordingObserver::new();
+        let outcome = execute_one_tool(
+            "failing_tool_secret",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &observer,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(!outcome.success);
+        assert!(
+            outcome.output.contains("sk-1234567890abcdef"),
+            "the raw model-visible output is not credential-scrubbed today — pinning \
+             this fact keeps the PR description's security claim accurate: {}",
+            outcome.output
+        );
+
+        let observer_result = observer
+            .last_result()
+            .expect("the ToolCall event must carry a result for a failed call");
+        assert!(
+            !observer_result.contains("sk-1234567890abcdef"),
+            "the observer/telemetry event must be credential-scrubbed: {observer_result}"
+        );
+        assert!(
+            observer_result.contains("[REDACTED]"),
+            "expected scrub_credentials' redaction marker in the observer event: \
+             {observer_result}"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -111,15 +111,21 @@ fn unavailable_tool_outcome(
 // ── Outcome ──────────────────────────────────────────────────────────────
 
 pub struct ToolExecutionOutcome {
+    /// Text handed to the model and persisted to provider history. The
+    /// success path carries raw bytes; the failure paths of `execute_one_tool`
+    /// fold a tool's detailed error body (which can reflect a token or signed
+    /// URL) into this text and credential-scrub it before storing it here.
     pub output: String,
     /// Structured output when the tool declared one (`ToolOutput::data`).
     /// Feeds SOP step capture and data-flow surfaces; the LLM sees only
-    /// `output`.
+    /// `output`. Stored raw — consumers scrub at their own rendering boundary.
     pub output_data: Option<serde_json::Value>,
     pub success: bool,
-    /// Raw failure text on the data path. Credential scrubbing is a rendering
+    /// Raw, unscrubbed failure text for trusted in-process consumers (SOP step
+    /// capture, data-flow surfaces). Credential scrubbing is a rendering
     /// concern applied at each human-facing surface (observer events,
-    /// post-execution log line, CLI progress), never stored pre-scrubbed here.
+    /// post-execution log line, CLI progress) and, unlike this field, on the
+    /// model-visible `output`.
     pub error_reason: Option<String>,
     pub duration: Duration,
     /// Cryptographic HMAC receipt proving this tool actually executed.
@@ -379,20 +385,31 @@ pub(crate) async fn execute_one_tool(
                     } else {
                         reason.clone()
                     };
+                    // Folding the tool's detailed `output` into the
+                    // model-visible text is a credential-egress boundary: a
+                    // failing remote call can echo a token or signed URL in
+                    // its error body, and before this fold that body was
+                    // discarded. Scrub the combined text once and share it
+                    // with both the model-bound outcome and the observer
+                    // event. `error_reason` and `output_data` stay raw for
+                    // trusted in-process consumers (SOP step capture,
+                    // data-flow surfaces) that scrub at their own rendering
+                    // boundary.
+                    let model_visible = scrub_credentials(&full_output);
                     observer.record_event(&ObserverEvent::ToolCall {
                         tool: call_name.to_string(),
                         tool_call_id: tool_call_id_owned.clone(),
                         duration,
                         success: false,
                         arguments: Some(full_args.clone()),
-                        result: Some(scrub_credentials(&full_output)),
+                        result: Some(model_visible.clone()),
                         channel: Some(meta.channel_name.to_string()),
                         agent_alias: meta.agent_alias.map(|s| s.to_string()),
                         parent_agent_alias: meta.parent_agent_alias.map(|s| s.to_string()),
                         turn_id: Some(meta.turn_id.to_string()),
                     });
                     Ok(ToolExecutionOutcome {
-                        output: format!("Error: {full_output}"),
+                        output: format!("Error: {model_visible}"),
                         success: false,
                         error_reason: Some(reason),
                         duration,
@@ -418,20 +435,26 @@ pub(crate) async fn execute_one_tool(
                     format!("tool error: {call_name}")
                 );
                 let reason = format!("Error executing {call_name}: {e}");
+                // Same model-visible egress boundary as the
+                // `Ok(success = false)` arm above: a tool error can embed a
+                // redirect URL with a signed query string. Scrub the
+                // model-bound text; keep `error_reason` raw for trusted
+                // in-process consumers.
+                let model_visible = scrub_credentials(&reason);
                 observer.record_event(&ObserverEvent::ToolCall {
                     tool: call_name.to_string(),
                     tool_call_id: tool_call_id_owned.clone(),
                     duration,
                     success: false,
                     arguments: Some(full_args.clone()),
-                    result: Some(scrub_credentials(&reason)),
+                    result: Some(model_visible.clone()),
                     channel: Some(meta.channel_name.to_string()),
                     agent_alias: meta.agent_alias.map(|s| s.to_string()),
                     parent_agent_alias: meta.parent_agent_alias.map(|s| s.to_string()),
                     turn_id: Some(meta.turn_id.to_string()),
                 });
                 Ok(ToolExecutionOutcome {
-                    output: reason.clone(),
+                    output: model_visible,
                     success: false,
                     error_reason: Some(reason),
                     duration,
@@ -1402,12 +1425,16 @@ mod tests {
         }
     }
 
-    /// Pins the exact boundary Audacity88's review asked the PR description
-    /// to state accurately: `scrub_credentials` runs on the observer/
-    /// telemetry event, but the raw combined text still reaches
-    /// `ToolExecutionOutcome.output` (and therefore the model) unscrubbed.
+    /// Regression for the second Core Team review (`CHANGES_REQUESTED`):
+    /// folding a tool's detailed failure body into the model-visible text is a
+    /// credential-egress boundary. A failing remote call can echo a token or
+    /// signed URL in its error body, and before this fold that body was
+    /// discarded. The combined text must be credential-scrubbed before it is
+    /// stored in `ToolExecutionOutcome.output` (and forwarded to the model /
+    /// provider history), matching the scrub the observer event already
+    /// applied — while the useful non-secret diagnostic still survives.
     #[tokio::test]
-    async fn execute_one_tool_scrubs_credentials_for_observer_but_not_for_model() {
+    async fn execute_one_tool_scrubs_credential_from_model_visible_failure_output() {
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithSecretInOutput)];
         let meta = test_turn_meta();
         let observer = RecordingObserver::new();
@@ -1432,23 +1459,668 @@ mod tests {
 
         assert!(!outcome.success);
         assert!(
-            outcome.output.contains("sk-1234567890abcdef"),
-            "the raw model-visible output is not credential-scrubbed today — pinning \
-             this fact keeps the PR description's security claim accurate: {}",
+            !outcome.output.contains("sk-1234567890abcdef"),
+            "the model-visible failure output must be credential-scrubbed: {}",
             outcome.output
+        );
+        assert!(
+            outcome.output.contains("[REDACTED]"),
+            "expected the redaction marker in the model-visible output: {}",
+            outcome.output
+        );
+        assert!(
+            outcome.output.contains("HTTP 401") && outcome.output.contains("was rejected"),
+            "scrubbing must not destroy the useful error context: {}",
+            outcome.output
+        );
+        assert_eq!(
+            outcome.error_reason.as_deref(),
+            Some("HTTP 401"),
+            "error_reason keeps the short, raw reason for trusted in-process consumers"
         );
 
         let observer_result = observer
             .last_result()
             .expect("the ToolCall event must carry a result for a failed call");
         assert!(
-            !observer_result.contains("sk-1234567890abcdef"),
-            "the observer/telemetry event must be credential-scrubbed: {observer_result}"
+            !observer_result.contains("sk-1234567890abcdef")
+                && observer_result.contains("[REDACTED]"),
+            "the observer/telemetry event stays scrubbed too: {observer_result}"
+        );
+    }
+
+    /// Fake failing tool with a caller-supplied `ToolOutput` and `error`, so a
+    /// single test can drive every `error`/`output` combination the failure
+    /// arm branches on.
+    struct ConfigurableFailingTool {
+        output: zeroclaw_api::tool::ToolOutput,
+        error: Option<String>,
+    }
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for ConfigurableFailingTool {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-configurable-failing-tool"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for ConfigurableFailingTool {
+        fn name(&self) -> &str {
+            "configurable_failing_tool"
+        }
+
+        fn description(&self) -> &str {
+            "Fails with a caller-supplied output/error, for failure-path scrubbing tests"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: self.output.clone(),
+                error: self.error.clone(),
+            })
+        }
+    }
+
+    /// Every `error`/`output` shape the failure arm branches on, each carrying
+    /// a credential-shaped value that must not survive into the model-visible
+    /// `outcome.output` while its surrounding non-secret diagnostic must.
+    ///
+    /// Coverage inventory for the model/provider-history egress of a failed
+    /// tool's content (the only two runtime sites that carry tool-supplied
+    /// text into `ToolExecutionOutcome.output`):
+    ///   - `Ok(ToolResult { success: false, .. })` arm — this test + the
+    ///     real-`http_request` test below.
+    ///   - `Err(e)` arm — `execute_one_tool_err_branch_scrubs_model_visible_credential`.
+    /// Every other outcome constructor (`unavailable`/`unknown tool`, dedup,
+    /// hook-cancel, approval-deny, interrupted) builds `output` from a static
+    /// template or an operator-controlled string, never remote content.
+    #[tokio::test]
+    async fn execute_one_tool_scrubs_model_visible_credential_across_failure_shapes() {
+        use zeroclaw_api::tool::ToolOutput;
+
+        struct Case {
+            name: &'static str,
+            output: ToolOutput,
+            error: Option<&'static str>,
+            secret: &'static str,
+            keep: &'static str,
+            secret_in_error_reason: bool,
+        }
+
+        let cases = vec![
+            Case {
+                name: "concat: credential in the detailed body",
+                output: ToolOutput::text("response body: token=sk-AAAA1111BBBB2222 rejected"),
+                error: Some("HTTP 400"),
+                secret: "sk-AAAA1111BBBB2222",
+                keep: "rejected",
+                secret_in_error_reason: false,
+            },
+            Case {
+                name: "concat: credential in the short error",
+                output: ToolOutput::text("consult the docs for the -preview suffix"),
+                error: Some("blocked: api_key=sk-CCCC3333DDDD4444"),
+                secret: "sk-CCCC3333DDDD4444",
+                keep: "-preview suffix",
+                secret_in_error_reason: true,
+            },
+            Case {
+                name: "error set, output empty",
+                output: ToolOutput::default(),
+                error: Some("auth failed: password=hunter2-aaaaaaaa invalid"),
+                secret: "hunter2-aaaaaaaa",
+                keep: "auth failed",
+                secret_in_error_reason: true,
+            },
+            Case {
+                name: "output text identical to error",
+                output: ToolOutput::text("token=sk-EEEE5555FFFF6666"),
+                error: Some("token=sk-EEEE5555FFFF6666"),
+                secret: "sk-EEEE5555FFFF6666",
+                keep: "token=",
+                secret_in_error_reason: true,
+            },
+            Case {
+                name: "error: None, fall back to output text",
+                output: ToolOutput::text("validation failed: secret=sk-GGGG7777HHHH8888"),
+                error: None,
+                secret: "sk-GGGG7777HHHH8888",
+                keep: "validation failed",
+                secret_in_error_reason: true,
+            },
+            Case {
+                name: "json-only output (display text is the JSON)",
+                output: ToolOutput::json(serde_json::json!({
+                    "apikey": "sk-IIII9999JJJJ0000",
+                    "hint": "add the -preview suffix",
+                })),
+                error: Some("HTTP 403"),
+                secret: "sk-IIII9999JJJJ0000",
+                keep: "-preview suffix",
+                secret_in_error_reason: false,
+            },
+        ];
+
+        for case in cases {
+            let tools: Vec<Box<dyn Tool>> = vec![Box::new(ConfigurableFailingTool {
+                output: case.output.clone(),
+                error: case.error.map(|e| e.to_string()),
+            })];
+            let meta = test_turn_meta();
+            let observer = RecordingObserver::new();
+            let outcome = execute_one_tool(
+                "configurable_failing_tool",
+                serde_json::json!({}),
+                None,
+                ToolDispatchContext {
+                    tools_registry: &tools,
+                    activated_tools: None,
+                    excluded_tools: &[],
+                    model_switch_callback: None,
+                },
+                &meta,
+                &observer,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("execute_one_tool should return an outcome for a failing tool");
+
+            assert!(!outcome.success, "[{}]", case.name);
+            assert!(
+                !outcome.output.contains(case.secret),
+                "[{}] model-visible output leaked the raw credential: {}",
+                case.name,
+                outcome.output
+            );
+            assert!(
+                outcome.output.contains("[REDACTED]"),
+                "[{}] model-visible output is missing the redaction marker: {}",
+                case.name,
+                outcome.output
+            );
+            assert!(
+                outcome.output.contains(case.keep),
+                "[{}] the non-secret diagnostic did not survive scrubbing: {}",
+                case.name,
+                outcome.output
+            );
+
+            let observer_result = observer
+                .last_result()
+                .expect("the ToolCall event must carry a result for a failed call");
+            assert!(
+                !observer_result.contains(case.secret),
+                "[{}] observer event leaked the raw credential: {observer_result}",
+                case.name
+            );
+
+            if case.secret_in_error_reason {
+                assert!(
+                    outcome
+                        .error_reason
+                        .as_deref()
+                        .is_some_and(|reason| reason.contains(case.secret)),
+                    "[{}] error_reason must stay raw for trusted in-process consumers: {:?}",
+                    case.name,
+                    outcome.error_reason
+                );
+            }
+        }
+    }
+
+    /// Fake tool whose `execute` returns `Err`, exercising the `Err(e)` arm of
+    /// `execute_one_tool` (as distinct from `Ok(ToolResult { success: false })`).
+    /// A tool error can embed a redirect URL with a signed query string.
+    struct FailingToolReturningErr {
+        message: &'static str,
+    }
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolReturningErr {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool-returning-err"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolReturningErr {
+        fn name(&self) -> &str {
+            "failing_tool_returning_err"
+        }
+
+        fn description(&self) -> &str {
+            "Returns Err from execute, for failure-path scrubbing tests"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Err(anyhow::Error::msg(self.message))
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_err_branch_scrubs_model_visible_credential() {
+        for (message, secret, keep) in [
+            (
+                "connect failed for https://cb.example/r?token=abcd1234efgh5678ijkl",
+                "abcd1234efgh5678ijkl",
+                "connect failed",
+            ),
+            (
+                "upstream rejected api_key=sk-DEADBEEF12345678",
+                "sk-DEADBEEF12345678",
+                "upstream rejected",
+            ),
+        ] {
+            let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolReturningErr { message })];
+            let meta = test_turn_meta();
+            let observer = RecordingObserver::new();
+            let outcome = execute_one_tool(
+                "failing_tool_returning_err",
+                serde_json::json!({}),
+                None,
+                ToolDispatchContext {
+                    tools_registry: &tools,
+                    activated_tools: None,
+                    excluded_tools: &[],
+                    model_switch_callback: None,
+                },
+                &meta,
+                &observer,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("execute_one_tool must still return an outcome when the tool errors");
+
+            assert!(!outcome.success);
+            assert!(
+                !outcome.output.contains(secret),
+                "Err-branch model-visible output leaked a credential: {}",
+                outcome.output
+            );
+            assert!(
+                outcome.output.contains("[REDACTED]"),
+                "Err-branch output missing the redaction marker: {}",
+                outcome.output
+            );
+            assert!(
+                outcome.output.contains(keep)
+                    && outcome
+                        .output
+                        .contains("Error executing failing_tool_returning_err"),
+                "Err-branch output lost its diagnostic shape: {}",
+                outcome.output
+            );
+            let observer_result = observer
+                .last_result()
+                .expect("the ToolCall event must carry a result for a failed call");
+            assert!(
+                !observer_result.contains(secret),
+                "Err-branch observer event leaked a credential: {observer_result}"
+            );
+        }
+    }
+
+    /// Production-boundary companion to
+    /// `execute_one_tool_preserves_http_request_400_body_from_real_producer`:
+    /// the real `http_request` tool against a 4xx response whose JSON body
+    /// reflects a credential. The reflected token must not reach the
+    /// model-visible outcome; the actionable message must; and the structured
+    /// `output_data` (which never reaches the model) deliberately keeps the
+    /// raw parsed body for trusted consumers.
+    #[tokio::test]
+    async fn execute_one_tool_real_http_request_scrubs_credential_in_400_body() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("loopback bind must succeed");
+        let port = listener.local_addr().unwrap().port();
+
+        let body = serde_json::json!({
+            "message": "The supplied token is invalid; request a new one.",
+            "token": "ghs_aAbBcCdDeEfFgGhHiIjJkKlLmMnN",
+        })
+        .to_string();
+
+        zeroclaw_spawn::spawn!(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept must succeed");
+            let mut request = Vec::new();
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let mut buffer = [0_u8; 1024];
+                let read = stream
+                    .read(&mut buffer)
+                    .await
+                    .expect("read must not error before headers complete");
+                assert!(read > 0, "client closed before completing request headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let response = format!(
+                "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write must succeed");
+        });
+
+        let http_tool = zeroclaw_tools::http_request::HttpRequestTool::new(
+            Arc::new(zeroclaw_config::policy::SecurityPolicy {
+                autonomy: AutonomyLevel::Supervised,
+                ..zeroclaw_config::policy::SecurityPolicy::default()
+            }),
+            vec!["127.0.0.1".into()],
+            1_000_000,
+            5,
+            true,
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("HttpRequestTool::new must succeed with a valid allowlist");
+
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(http_tool)];
+        let meta = test_turn_meta();
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            execute_one_tool(
+                "http_request",
+                serde_json::json!({
+                    "url": format!("http://127.0.0.1:{port}/_apis/connectionData?api-version=7.1"),
+                    "method": "GET",
+                }),
+                None,
+                ToolDispatchContext {
+                    tools_registry: &tools,
+                    activated_tools: None,
+                    excluded_tools: &[],
+                    model_switch_callback: None,
+                },
+                &meta,
+                &NoopObserver,
+                None,
+                None,
+                None,
+            ),
+        )
+        .await
+        .expect("execute_one_tool must not hang against the loopback server")
+        .expect("execute_one_tool should return an outcome for the real http_request tool");
+
+        assert!(!outcome.success);
+        assert!(
+            outcome.output.contains("HTTP 400"),
+            "the short status must survive: {}",
+            outcome.output
         );
         assert!(
-            observer_result.contains("[REDACTED]"),
-            "expected scrub_credentials' redaction marker in the observer event: \
-             {observer_result}"
+            outcome.output.contains("The supplied token is invalid"),
+            "the actionable message must survive scrubbing: {}",
+            outcome.output
+        );
+        assert!(
+            !outcome.output.contains("ghs_aAbBcCdDeEfFgGhHiIjJkKlLmMnN"),
+            "the reflected token must be scrubbed from the model-visible output: {}",
+            outcome.output
+        );
+        assert!(
+            outcome.output.contains("[REDACTED]"),
+            "expected the redaction marker: {}",
+            outcome.output
+        );
+
+        let data = outcome
+            .output_data
+            .expect("http_request builds structured data even on a 4xx");
+        assert_eq!(
+            data["body"]["token"], "ghs_aAbBcCdDeEfFgGhHiIjJkKlLmMnN",
+            "structured output_data does not reach the model and stays raw for trusted \
+             consumers (which scrub at their own boundary): {data}"
+        );
+    }
+
+    /// Characterization: `scrub_credentials` is a shared best-effort scrubber
+    /// keyed off `name<sep>value` pairs. It does not cover `Authorization:
+    /// Bearer <token>` (the space after `Bearer` breaks the value match). This
+    /// gap predates this change; pinning it keeps the PR's security claim
+    /// precise and makes any future tightening of the regex a visible change.
+    #[tokio::test]
+    async fn failure_output_scrub_leaves_bearer_prefixed_token_but_still_runs() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(ConfigurableFailingTool {
+            output: zeroclaw_api::tool::ToolOutput::text(
+                "upstream said: Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig ; \
+                 api_key=sk-CATCHME01234567",
+            ),
+            error: Some("HTTP 401".into()),
+        })];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "configurable_failing_tool",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(
+            outcome.output.contains("eyJhbGciOiJIUzI1NiJ9.payload.sig"),
+            "known gap: Bearer-prefixed tokens are not covered by the shared scrubber: {}",
+            outcome.output
+        );
+        assert!(
+            !outcome.output.contains("sk-CATCHME01234567") && outcome.output.contains("[REDACTED]"),
+            "the scrubber still runs: the adjacent api_key pair is redacted: {}",
+            outcome.output
+        );
+    }
+
+    /// Characterization: signed-URL query parameters (`sig=`,
+    /// `X-Amz-Signature=`) are not credential key names in the shared
+    /// scrubber, so they pass through. Pre-existing gap; pinned for the same
+    /// reason as the Bearer case above.
+    #[tokio::test]
+    async fn failure_output_scrub_leaves_signed_url_query_params_but_still_runs() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(ConfigurableFailingTool {
+            output: zeroclaw_api::tool::ToolOutput::text(
+                "redirect target: \
+                 https://acct.blob.core.windows.net/c/b?sig=aBcD1234eFgH5678iJkL&se=2026 ; \
+                 token=sk-CATCHME01234567",
+            ),
+            error: Some("HTTP 400".into()),
+        })];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "configurable_failing_tool",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(
+            outcome.output.contains("sig=aBcD1234eFgH5678iJkL"),
+            "known gap: signed-URL params are not covered by the shared scrubber: {}",
+            outcome.output
+        );
+        assert!(
+            !outcome.output.contains("sk-CATCHME01234567") && outcome.output.contains("[REDACTED]"),
+            "the scrubber still runs: the adjacent token pair is redacted: {}",
+            outcome.output
+        );
+    }
+
+    /// End-to-end: a failed tool whose detailed body carries a credential must
+    /// reach the model's tool-result message scrubbed, in both the native
+    /// (`role=tool`) and the prompt-mode (`[Tool results]`) history shapes —
+    /// the actual "text sent to the model / provider history".
+    #[tokio::test]
+    async fn failed_tool_credential_is_scrubbed_in_provider_history() {
+        use crate::agent::loop_detector::{LoopDetector, LoopDetectorConfig};
+        use crate::agent::turn::history_append::append_tool_round_to_history;
+        use crate::agent::turn::results_collect::collect_tool_results;
+        use std::collections::HashSet;
+        use zeroclaw_providers::ChatMessage;
+
+        let secret = "sk-HISTORY0123456789";
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(ConfigurableFailingTool {
+            output: zeroclaw_api::tool::ToolOutput::text(format!(
+                "response body: api_key={secret} was rejected"
+            )),
+            error: Some("HTTP 401".into()),
+        })];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "configurable_failing_tool",
+            serde_json::json!({}),
+            Some("call-1"),
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+        assert!(
+            !outcome.output.contains(secret),
+            "precondition: outcome.output must already be scrubbed"
+        );
+
+        let tool_calls = vec![ParsedToolCall {
+            name: "configurable_failing_tool".to_string(),
+            arguments: serde_json::json!({}),
+            tool_call_id: Some("call-1".to_string()),
+        }];
+        let ordered = vec![Some((
+            "configurable_failing_tool".to_string(),
+            Some("call-1".to_string()),
+            outcome,
+        ))];
+        let mut history: Vec<ChatMessage> = Vec::new();
+        let mut detector = LoopDetector::new(LoopDetectorConfig::default());
+        let ignore: HashSet<&str> = HashSet::new();
+        let collected = collect_tool_results(
+            ordered,
+            &tool_calls,
+            &mut history,
+            &mut detector,
+            &ignore,
+            0,
+            None,
+            "test-model",
+            0,
+            "turn-test",
+        )
+        .expect("collect_tool_results must succeed");
+
+        assert!(
+            !collected.tool_results.contains(secret)
+                && collected.tool_results.contains("[REDACTED]"),
+            "prompt-mode <tool_result> block must be scrubbed: {}",
+            collected.tool_results
+        );
+        for (_, result) in &collected.individual_results {
+            assert!(
+                !result.contains(secret) && result.contains("[REDACTED]"),
+                "native role=tool content must be scrubbed: {result}"
+            );
+        }
+
+        let native_calls: Vec<zeroclaw_providers::ToolCall> = Vec::new();
+        let mut native_history: Vec<ChatMessage> = Vec::new();
+        append_tool_round_to_history(
+            &mut native_history,
+            "assistant text".to_string(),
+            &native_calls,
+            &collected.individual_results,
+            &collected.tool_results,
+            true,
+        );
+        assert!(
+            native_history.iter().all(|m| !m.content.contains(secret)),
+            "no native history message may carry the raw credential"
+        );
+        assert!(
+            native_history
+                .iter()
+                .any(|m| m.content.contains("[REDACTED]")),
+            "the native tool-result message must carry the scrubbed body"
+        );
+
+        let prompt_results = vec![(None, collected.individual_results[0].1.clone())];
+        let mut prompt_history: Vec<ChatMessage> = Vec::new();
+        append_tool_round_to_history(
+            &mut prompt_history,
+            "assistant text".to_string(),
+            &native_calls,
+            &prompt_results,
+            &collected.tool_results,
+            false,
+        );
+        assert!(
+            prompt_history.iter().all(|m| !m.content.contains(secret)),
+            "no prompt-mode history message may carry the raw credential"
+        );
+        assert!(
+            prompt_history
+                .iter()
+                .any(|m| m.content.contains("[REDACTED]")),
+            "the prompt-mode [Tool results] message must carry the scrubbed body"
         );
     }
 

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -969,8 +969,8 @@ mod tests {
         );
     }
 
-    /// The production-boundary case #10357 explicitly requires: the real
-    /// `http_request` tool against a live 4xx response, run through
+    /// The production-boundary case the linked issue explicitly requires:
+    /// the real `http_request` tool against a live 4xx response, run through
     /// `execute_one_tool`, proving the response body it builds via
     /// `ToolOutput::json_with_text` (`http_request.rs:661-680`) reaches the
     /// agent-visible outcome rather than being replaced by the bare

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -362,26 +362,42 @@ pub(crate) async fn execute_one_tool(
                         receipt,
                     })
                 } else {
-                    let reason = r.error.unwrap_or_else(|| r.output.into_string());
+                    // A tool can report a short `error` (e.g. "HTTP 400") while
+                    // separately building a richer `output` with the detail an
+                    // agent would need to self-correct (e.g. the full response
+                    // body explaining what was wrong with the request). Only
+                    // `output` reaches the LLM (see `ToolExecutionOutcome::output`
+                    // doc comment), so when both are present and distinct, fold
+                    // the detail into what the agent sees instead of discarding
+                    // it. Tools that already put everything into `error` and
+                    // leave `output` empty (the common case) are unaffected.
+                    let output_text = r.output.as_str().to_string();
+                    let output_data = r.output.into_data();
+                    let reason = r.error.unwrap_or_else(|| output_text.clone());
+                    let full_output = if !output_text.is_empty() && output_text != reason {
+                        format!("{reason}\n\n{output_text}")
+                    } else {
+                        reason.clone()
+                    };
                     observer.record_event(&ObserverEvent::ToolCall {
                         tool: call_name.to_string(),
                         tool_call_id: tool_call_id_owned.clone(),
                         duration,
                         success: false,
                         arguments: Some(full_args.clone()),
-                        result: Some(scrub_credentials(&reason)),
+                        result: Some(scrub_credentials(&full_output)),
                         channel: Some(meta.channel_name.to_string()),
                         agent_alias: meta.agent_alias.map(|s| s.to_string()),
                         parent_agent_alias: meta.parent_agent_alias.map(|s| s.to_string()),
                         turn_id: Some(meta.turn_id.to_string()),
                     });
                     Ok(ToolExecutionOutcome {
-                        output: format!("Error: {reason}"),
+                        output: format!("Error: {full_output}"),
                         success: false,
                         error_reason: Some(reason),
                         duration,
                         receipt: None,
-                        output_data: None,
+                        output_data,
                     })
                 }
             }
@@ -759,6 +775,170 @@ mod tests {
             "Tool not available in this turn: extract_text"
         );
         assert_eq!(invocations.load(Ordering::SeqCst), 0);
+    }
+
+    /// Fake tool that always fails, with an `error` distinct from `output` —
+    /// mirrors `http_request`'s pattern of a short status in `error` plus a
+    /// detailed body in `output`.
+    struct FailingToolWithDetailedOutput;
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolWithDetailedOutput {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolWithDetailedOutput {
+        fn name(&self) -> &str {
+            "failing_tool"
+        }
+
+        fn description(&self) -> &str {
+            "Always fails with error + detailed output, for regression testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: "Response Body: the api-version needs the -preview suffix".into(),
+                error: Some("HTTP 400".into()),
+            })
+        }
+    }
+
+    /// Fake tool that fails with only `error` set and empty `output` — the
+    /// common case (e.g. `file_edit`, blocked shell commands) that must keep
+    /// behaving exactly as before this change.
+    struct FailingToolWithNoOutput;
+
+    #[async_trait]
+    impl zeroclaw_api::attribution::Attributable for FailingToolWithNoOutput {
+        fn role(&self) -> zeroclaw_api::attribution::Role {
+            zeroclaw_api::attribution::Role::System
+        }
+        fn alias(&self) -> &str {
+            "test-failing-tool-no-output"
+        }
+    }
+
+    #[async_trait]
+    impl Tool for FailingToolWithNoOutput {
+        fn name(&self) -> &str {
+            "failing_tool_no_output"
+        }
+
+        fn description(&self) -> &str {
+            "Always fails with only error set, for regression testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}, "required": []})
+        }
+
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: false,
+                output: zeroclaw_api::tool::ToolOutput::default(),
+                error: Some("old_string not found in file".into()),
+            })
+        }
+    }
+
+    fn test_turn_meta() -> crate::agent::turn::TurnMeta<'static> {
+        crate::agent::turn::TurnMeta {
+            parent_agent_alias: None,
+            agent_alias: None,
+            turn_id: "test-turn-id",
+            channel_name: "test",
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_includes_detailed_output_alongside_short_error() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithDetailedOutput)];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "failing_tool",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(!outcome.success);
+        assert!(
+            outcome.output.contains("HTTP 400"),
+            "the short error must still be present: {}",
+            outcome.output
+        );
+        assert!(
+            outcome
+                .output
+                .contains("the api-version needs the -preview suffix"),
+            "the tool's detailed output must reach the agent, not just the bare status: {}",
+            outcome.output
+        );
+        assert_eq!(
+            outcome.error_reason.as_deref(),
+            Some("HTTP 400"),
+            "error_reason stays the short, raw reason for other consumers"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_one_tool_error_only_output_is_unchanged() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(FailingToolWithNoOutput)];
+        let meta = test_turn_meta();
+        let outcome = execute_one_tool(
+            "failing_tool_no_output",
+            serde_json::json!({}),
+            None,
+            ToolDispatchContext {
+                tools_registry: &tools,
+                activated_tools: None,
+                excluded_tools: &[],
+                model_switch_callback: None,
+            },
+            &meta,
+            &NoopObserver,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("execute_one_tool should return an outcome for a failing tool");
+
+        assert!(!outcome.success);
+        assert_eq!(
+            outcome.output, "Error: old_string not found in file",
+            "tools with empty output must keep the exact pre-existing message shape"
+        );
     }
 
     use super::should_execute_tools_in_parallel;

--- a/crates/zeroclaw-runtime/src/agent/turn/redact.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/redact.rs
@@ -1,6 +1,10 @@
 //! Credential redaction for the rendering layer (logs, observer events, and
-//! UI-facing turn events). This never runs on the data path: tool results fed
-//! back to the model and signed by HMAC receipts always carry raw bytes.
+//! UI-facing turn events). The success data path is untouched: a successful
+//! tool result fed back to the model and signed by an HMAC receipt carries
+//! raw bytes. The one data-path exception is the failure arms of
+//! `execute_one_tool`, which fold a tool's detailed error body into the
+//! model-visible text and scrub that combined string first, so a reflected
+//! token in a 4xx/5xx body is not forwarded to the model provider.
 
 use regex::Regex;
 use std::sync::LazyLock;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `execute_one_tool`'s failure branch built the agent-facing message with
    `r.error.unwrap_or_else(|| r.output.into_string())`, which only falls back
    to `r.output` when `r.error` is `None`.
  - Any tool that always populates `error` on failure (e.g. `http_request` on
    every 4xx/5xx response) never reached that fallback, so a richer `output`
    it had already computed (full response body, headers, parsed JSON) was
    silently discarded. `output_data` was also hardcoded to `None` on this
    path regardless of what the tool returned.
  - The agent ends up seeing only `"Error: HTTP 400"` instead of the response
    body that explains what was actually wrong and how to fix it, so it
    cannot self-correct and exhausts retries on errors the tool already had
    enough information to resolve.
  - This PR appends the tool's `output`/`output_data` to the failure outcome
    whenever it carries content beyond the short `error` string.
  - Because that fold is a new credential-egress boundary (a failing remote
    call can reflect a token or signed URL in its error body, and before
    this PR that body was discarded), the combined model-visible text is
    run through the shared `scrub_credentials` scrubber before it is stored
    in `ToolExecutionOutcome.output`, in both the `Ok(success = false)` and
    the `Err(e)` arms of `execute_one_tool`. `error_reason` and
    `output_data` stay raw for trusted in-process consumers.
- **Scope boundary:** Does not change `http_request.rs`'s own error/output
  construction (fixed generically at the runtime fallback level instead, so
  it covers every current and future tool with this shape). Does not touch
  the operator-approval-denial path (`approval_gate.rs`) referenced in
  #9654 — related design principle, different code path, left out of scope
  here.
- **Blast radius:** Any tool whose `ToolResult` sets both `error` and a
  non-empty `output` on failure now has that `output` folded into the
  message the agent and the observer/telemetry event both see. Tools that
  already leave `output` empty on failure (the common case, e.g. `file_edit`,
  blocked shell commands) are unaffected — covered by regression tests.
- **Linked issue(s):** Fixes #10357
- **Labels:** `bug`, `agent`, `runtime`, `domain:security`, `risk:high`, `size:L`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the changed logic is internal
  (`execute_one_tool`'s failure-outcome construction), fully exercised by
  unit tests plus a real-tool production-boundary test, and has no
  user-facing interface surface to click through.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib
```

- `cargo fmt --all -- --check`: clean, no diff.
- `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings`: clean, 0 warnings.
- `cargo test -p zeroclaw-runtime --lib -- agent::tool_execution::tests
  agent::turn::redact agent::turn::results_collect`: 40/40 passed.
  Regression tests, extended after review feedback:
  - `execute_one_tool_includes_detailed_output_alongside_short_error` — the
    fake tool now builds its output via `ToolOutput::json_with_text`, the
    same constructor `http_request.rs` uses for every 4xx/5xx response, and
    the test asserts both the combined text *and* `output_data` survive.
  - `execute_one_tool_preserves_http_request_400_body_from_real_producer` —
    the production-boundary case #10357 requires: runs the real
    `HttpRequestTool` against a live loopback server returning the actual
    Azure DevOps-shaped 400 body from the issue, through `execute_one_tool`,
    and asserts the response body and structured data reach the outcome.
  - `execute_one_tool_appends_plain_text_output_without_data` — a plain-text
    (non-JSON) detailed output is appended without inventing `output_data`.
  - `execute_one_tool_does_not_duplicate_output_identical_to_error` —
    `output` text identical to `error` is not duplicated.
  - `execute_one_tool_error_none_falls_back_to_output_text` — `error: None`
    with only `output` set (the original bug's exact fallback line) behaves
    as before, unchanged.
  - `execute_one_tool_error_only_output_is_unchanged` — a tool with only
    `error` set and empty `output` keeps the pre-existing message shape
    (`"Error: {reason}"`) byte-for-byte.

  Failure-path credential-scrubbing coverage (second review):
  - `execute_one_tool_scrubs_credential_from_model_visible_failure_output`
    — a credential-shaped string in a failed tool's detailed output is
    scrubbed in both the observer event and the model-visible
    `outcome.output`, while the non-secret error context survives.
  - `execute_one_tool_scrubs_model_visible_credential_across_failure_shapes`
    — a table over every `error`/`output` combination the failure arm
    branches on (secret in the body vs. in the short error; empty output;
    output identical to error; `error: None`; json-only output), each
    asserting the secret is redacted from `outcome.output`, the diagnostic
    survives, and `error_reason` stays raw where the secret lived in
    `error`.
  - `execute_one_tool_err_branch_scrubs_model_visible_credential` — the
    `Err(e)` arm (a failed `execute()`, e.g. a redirect URL with a signed
    query string) is scrubbed too.
  - `execute_one_tool_real_http_request_scrubs_credential_in_400_body` —
    the real `HttpRequestTool` against a loopback 400 whose JSON body
    reflects a token: the token is scrubbed from `outcome.output`, the
    actionable message survives, and the structured `output_data` (which
    never reaches the model) keeps the raw parsed body.
  - `failed_tool_credential_is_scrubbed_in_provider_history` — end-to-end
    through `collect_tool_results` + `append_tool_round_to_history`: the
    scrubbed body reaches both the native (`role=tool`) and the
    prompt-mode (`[Tool results]`) history messages.
  - `failure_output_scrub_leaves_bearer_prefixed_token_but_still_runs` /
    `failure_output_scrub_leaves_signed_url_query_params_but_still_runs` —
    characterization pins for the two known gaps of the shared scrubber
    (see Security & Privacy Impact).
- `cargo test -p zeroclaw-runtime --lib` (full crate suite): 3793 passed, 2
  failed, 2 ignored. Both failures are pre-existing and unrelated to this
  change — `cron::scheduler::tests::agent_cron_run_keeps_workspace_through_shell_on_retry_and_concurrency`
  and `tunnel::tests::kill_shared_terminates_and_clears_child` fail on this
  Windows dev machine because they shell out to the Unix `pwd`/`sleep`
  binaries, which don't exist on Windows. Verified these are unaffected by
  this diff by inspection (different modules, no call path through
  `tool_execution.rs`) and expect them to pass on Linux CI.

- **CI checks relied on and why they cover this change:** the standard Rust
  CI job (`cargo fmt`, `cargo clippy -D warnings`, `cargo test`, plus the
  repo's comment-hygiene gate) covers this change directly; it's a pure Rust
  logic change with no docs/desktop/platform-specific surface. See the PR's
  Checks tab for the live run status on the current head rather than relying
  on this description, which can go stale across pushes — an earlier push
  to this branch failed the comment-hygiene gate on an accidental issue
  reference inside a doc comment, fixed in a follow-up commit.
- **Known CI coverage gap, if any:** None expected on Linux CI — the two
  local failures above are Windows-only environment gaps, not gaps in what
  CI itself covers.
- **Commands run and tail output:** see above.
- **Beyond CI, what did you manually verify?** Traced the exact real-world
  repro from #10357 (Azure DevOps `connectionData?api-version=7.1` returning
  HTTP 400 with a JSON body naming the `-preview` fix) against the new
  logic by hand, then additionally verified it end-to-end:
  `execute_one_tool_preserves_http_request_400_body_from_real_producer` runs
  the real `HttpRequestTool` against a live loopback server returning that
  exact body shape, through `execute_one_tool`, confirming the response
  reaches the agent-visible outcome rather than being replaced by the bare
  `"HTTP 400"`.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? **Yes.** Folding a
  failed tool's detailed error body into the model-visible text is a new
  credential-egress boundary (before this PR that body was discarded), so
  the combined string is run through the shared `scrub_credentials`
  scrubber **before** it is stored in `ToolExecutionOutcome.output`, in
  both the `Ok(success = false)` and the `Err(e)` arms of
  `execute_one_tool` — the same scrub the observer event already applied.
  A reflected token in a 4xx/5xx body is therefore redacted before it
  reaches the model / provider history. This is a deliberate, narrow
  departure from the "rendering layer only" contract of
  `agent/turn/redact.rs` (its module doc is updated to record it): the
  fold is a new egress path this PR introduces, distinct from the
  pre-existing success path, which is left unchanged.
  `error_reason` and `output_data` intentionally stay raw — they do not
  reach the model (`ToolExecutionOutcome::output_data` doc: "the LLM sees
  only `output`"), feed only trusted in-process consumers (SOP step
  capture in `sop/executor.rs`, data-flow surfaces), and those consumers
  scrub at their own rendering boundary (`sop/executor.rs`
  `record_step_tool_call` scrubs `output`/`output_data`/`error`;
  `turn/post_exec.rs` and `turn/progress.rs` scrub `error_reason`).
  Known limitations, pre-existing to the shared scrubber and pinned by
  characterization tests so any future tightening is a visible change:
  `Authorization: Bearer <token>` is not redacted (the space after
  `Bearer` breaks its `name<sep>value` match), and signed-URL query
  parameters (`sig=`, `X-Amz-Signature=`) are not redacted (not
  credential key names). Tightening those means changing the shared
  scrubber primitive used by every rendering surface, which is out of
  scope here.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? Yes —
  on the failure path specifically, the tool's `output` (e.g. an HTTP
  response body, which can contain server-controlled content) now reaches
  the model when it differs from `error`, where previously only the short
  `error` string did. Mitigation: the combined model-visible text is
  credential-scrubbed before it is stored (see the credentials answer
  above). The earlier lower-level terminal failure log at
  `tool_execution.rs` still records `r.output` directly, unscrubbed — that
  log predates this PR, is not model-visible, and is not a new regression.
  Covered by
  `execute_one_tool_scrubs_credential_from_model_visible_failure_output`,
  `execute_one_tool_scrubs_model_visible_credential_across_failure_shapes`,
  `execute_one_tool_err_branch_scrubs_model_visible_credential`,
  `execute_one_tool_real_http_request_scrubs_credential_in_400_body`, and
  `failed_tool_credential_is_scrubbed_in_provider_history`.

## Compatibility (required)

- Backward compatible? Yes — no signature/struct changes; `error_reason`
  keeps returning the same short string as before for any other consumers.
  The model-visible failure `output` text can now contain `*[REDACTED]`
  markers where a tool's error body carried a credential-shaped value.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is
  `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the squash-merge commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Failed tool results expose unexpected detail, omit the short error classification, or break consumers of structured failure output.





