### PR TITLE
test(runtime): stabilize stale local IPC cleanup test

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/local.rs
+++ b/crates/zeroclaw-runtime/src/rpc/local.rs
@@ -928,6 +928,7 @@ mod tests {
         let sock_path = tmp.path().join("daemon.sock");
         let stale_listener = tokio::net::UnixListener::bind(&sock_path).unwrap();
         drop(stale_listener);
+        wait_for_stale_socket(&sock_path).await;
 
         let stale_metadata = std::fs::symlink_metadata(&sock_path).unwrap();
         let stale_identity = (stale_metadata.dev(), stale_metadata.ino());
@@ -959,6 +960,30 @@ mod tests {
 
         drop(listener);
         drop(guard);
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_stale_socket(path: &std::path::Path) {
+        let started = tokio::time::Instant::now();
+        let timeout = Duration::from_secs(2);
+
+        loop {
+            match tokio::net::UnixStream::connect(path).await {
+                Err(error) if error.kind() == ErrorKind::ConnectionRefused => return,
+                Err(error) if error.kind() == ErrorKind::NotFound => {
+                    panic!("synthetic stale endpoint disappeared before cleanup test: {error}");
+                }
+                Err(error) if started.elapsed() >= timeout => {
+                    panic!("synthetic stale endpoint did not settle before cleanup test: {error}");
+                }
+                Ok(_) if started.elapsed() >= timeout => {
+                    panic!("synthetic stale endpoint stayed reachable before cleanup test");
+                }
+                Ok(_) | Err(_) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
     }
 
     /// Set on the re-executed child so `endpoint_lock_is_held_through_guard_cleanup`


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** The RPC local stale-cleanup serialization test now waits until its synthetic Unix socket is observably stale before it records the socket identity and asserts that a competing startup cannot mutate it. This targets the #10362 same-head fail/pass flake where probing the just-dropped socket returned `Connection reset by peer` instead of the expected stale endpoint state.
- **Scope boundary:** Test-only. No production local IPC socket, endpoint-lock, stale-cleanup, daemon, or RPC behavior changes.
- **Blast radius:** One Unix-only runtime unit test. The helper adds a bounded setup wait before the existing assertion; it does not retry or weaken the assertion itself.
- **Linked issue(s):** Related #9965. Related #10362. Related #10036.
- **Labels:** `bug`, `runtime`, `distinguished contributor`, `risk:low`, `size:XS`, `type:test`

### What this does, simply

ZeroClaw's local service uses a socket file on the machine so other ZeroClaw processes can connect to it. When that file is left behind after the service stops, only the startup process that owns cleanup may replace it. The flaky CI run showed the test sometimes checked this rule before its fake service had fully stopped, so it failed because of teardown timing instead of cleanup ownership.

This PR waits for the fake service file to reach the already-recognized stale state first. After that, the same ownership check runs unchanged: the losing startup must fail before it can replace the leftover file, and the lock owner must still be able to start the service.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` - hosted CI is the useful outer boundary for the 16-thread gate flake; the focused local command below checks the changed test directly.

### How I tested

- **CI checks relied on and why they cover this change:** Current-head hosted PR CI passed, including `Parallel Runtime Test` and `CI Required Gate`. `Parallel Runtime Test` is the relevant outer validation for the same 16-thread cargo-test shape that exposed the #10362 flake.
- **Known CI coverage gap, if any:** None for required hosted PR CI at head `473d965002e3725e1dc1439e429454550cf9bc0e`.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
# pass

cargo test -p zeroclaw-runtime rpc::local::tests::concurrent_stale_start_is_serialized_before_cleanup -- --exact --nocapture
# pass
# test rpc::local::tests::concurrent_stale_start_is_serialized_before_cleanup ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3882 filtered out
```

- **Beyond CI, what did you manually verify?** The change is test-only and keeps the production stale-cleanup path unchanged. I inspected the related #10036 endpoint-lock isolation prior art and kept this fix focused on the distinct stale-socket probe timing seen on #10362.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** Broad local CI-shaped validation was skipped because the hosted PR gate is the relevant outer boundary for the reported flake.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes` - test-only.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: `N/A`

## Rollback (required for medium/high-risk PRs)

Low-risk PRs: `git revert <sha>` is the plan, at the cost of restoring the stale-socket setup flake.
