### PR TITLE
feat(dev): add deterministic dependency footprint reports

### DIFF
--- a/dev/ci/dependency-footprint.toml
+++ b/dev/ci/dependency-footprint.toml
@@ -1,0 +1,85 @@
+schema_version = 1
+edge_kinds = ["normal", "build"]
+
+[[profiles]]
+id = "foundation"
+package = "zeroclaw"
+mode = "no-default-features"
+
+[[profiles]]
+id = "agent-runtime"
+package = "zeroclaw"
+mode = "features"
+features = ["agent-runtime"]
+
+[[profiles]]
+id = "root-default"
+package = "zeroclaw"
+mode = "defaults"
+
+[[profiles]]
+id = "standard-distribution"
+package = "zeroclaw"
+mode = "selection"
+selection = "dist"
+
+[[profiles]]
+id = "ci-all"
+package = "zeroclaw"
+mode = "features"
+features = ["ci-all"]
+
+[[profiles]]
+id = "hardware-probe"
+package = "zeroclaw"
+mode = "features"
+features = ["agent-runtime", "probe", "zeroclaw-tools/probe"]
+
+[[profiles]]
+id = "channels-minimal"
+package = "zeroclaw-channels"
+mode = "no-default-features"
+
+[[profiles]]
+id = "channels-default"
+package = "zeroclaw-channels"
+mode = "defaults"
+
+[[contracts]]
+id = "hardware-package-present"
+profile = "hardware-probe"
+kind = "package"
+package = "zeroclaw-hardware"
+expect = "present"
+
+[[contracts]]
+id = "hardware-probe-enabled"
+profile = "hardware-probe"
+kind = "feature"
+package = "zeroclaw-hardware"
+feature = "probe"
+expect = "enabled"
+
+[[contracts]]
+id = "tools-probe-enabled"
+profile = "hardware-probe"
+kind = "feature"
+package = "zeroclaw-tools"
+feature = "probe"
+expect = "enabled"
+
+[[contracts]]
+id = "root-default-no-hardware-probe"
+profile = "root-default"
+kind = "feature"
+package = "zeroclaw-hardware"
+feature = "probe"
+expect = "forbidden"
+
+[[contracts]]
+id = "standard-distribution-no-hardware-probe"
+profile = "standard-distribution"
+kind = "feature"
+package = "zeroclaw-hardware"
+feature = "probe"
+expect = "forbidden"

--- a/scripts/ci/dependency_footprint.py
+++ b/scripts/ci/dependency_footprint.py
@@ -8,13 +8,13 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import stat
 import subprocess
 import sys
-import tempfile
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 
 SCHEMA_VERSION = 1
@@ -33,6 +33,12 @@ PACKAGE_FIELD_RE = re.compile(
 
 class ToolError(Exception):
     pass
+
+
+class PreparedOutput(NamedTuple):
+    path: Path
+    parent: Path
+    parent_identity: tuple[int, int]
 
 
 def fail(message: str) -> ToolError:
@@ -549,6 +555,41 @@ def output_identity_exclusions(repo_root: Path, output_path: Path) -> set[bytes]
     return {os.fsencode(relative_text)}
 
 
+def output_parent_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+
+def reject_output_symlink(path: Path, directory_fd: int) -> None:
+    try:
+        metadata = os.stat(path.name, dir_fd=directory_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(metadata.st_mode):
+        raise fail(f"output path is an existing symlink: {path}")
+
+
+def prepare_output(raw_path: str) -> PreparedOutput:
+    path = Path(raw_path).absolute()
+    try:
+        parent = path.parent.resolve()
+        if not parent.exists():
+            raise fail(f"output parent does not exist: {path.parent}")
+        directory_fd = os.open(parent, output_parent_flags())
+        try:
+            reject_output_symlink(path, directory_fd)
+            metadata = os.fstat(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except (OSError, NotImplementedError) as exc:
+        raise fail(f"could not inspect output path {path}: {exc}") from exc
+    return PreparedOutput(path, parent, (metadata.st_dev, metadata.st_ino))
+
+
 def context_from_capture(
     cargo: str,
     repo_root: Path,
@@ -582,37 +623,78 @@ def context_from_capture(
     }
 
 
-def atomic_write(path: Path, value: Any) -> None:
+def atomic_write(output: PreparedOutput, value: Any) -> None:
     text = json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+    directory_fd: int | None = None
+    temporary_fd: int | None = None
+    temporary_name: str | None = None
     try:
-        path.parent.mkdir(parents=False, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            delete=False,
-        ) as handle:
-            temporary = Path(handle.name)
+        current_parent = output.path.parent.resolve(strict=True)
+        if current_parent != output.parent:
+            raise fail(f"output parent changed before write: {output.path.parent}")
+        directory_fd = os.open(current_parent, output_parent_flags())
+        parent_metadata = os.fstat(directory_fd)
+        current_identity = (parent_metadata.st_dev, parent_metadata.st_ino)
+        if current_identity != output.parent_identity:
+            raise fail(f"output parent changed before write: {output.path.parent}")
+        reject_output_symlink(output.path, directory_fd)
+        temporary_flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        for _attempt in range(100):
+            candidate = f".{output.path.name}.{secrets.token_hex(12)}"
+            try:
+                temporary_fd = os.open(candidate, temporary_flags, 0o600, dir_fd=directory_fd)
+            except FileExistsError:
+                continue
+            temporary_name = candidate
+            break
+        if temporary_fd is None or temporary_name is None:
+            raise fail(f"could not create temporary output beside {output.path}")
+        handle = os.fdopen(temporary_fd, "w", encoding="utf-8")
+        temporary_fd = None
+        with handle:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temporary, path)
-    except OSError as exc:
-        try:
-            temporary.unlink(missing_ok=True)
-        except (UnboundLocalError, OSError):
-            pass
-        raise fail(f"could not atomically write {path}: {exc}") from exc
+        os.replace(
+            temporary_name,
+            output.path.name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        temporary_name = None
+    except (OSError, NotImplementedError, TypeError) as exc:
+        raise fail(f"could not atomically write {output.path}: {exc}") from exc
+    finally:
+        if temporary_fd is not None:
+            try:
+                os.close(temporary_fd)
+            except OSError:
+                pass
+        if temporary_name is not None and directory_fd is not None:
+            try:
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            except (FileNotFoundError, OSError, NotImplementedError):
+                pass
+        if directory_fd is not None:
+            try:
+                os.close(directory_fd)
+            except OSError:
+                pass
 
 
 def command_capture(args: argparse.Namespace) -> None:
     policy_path = Path(args.policy).resolve()
     repo_root = Path(args.repo_root).resolve() if args.repo_root else SCRIPT_ROOT
-    output_path = Path(args.output).resolve()
+    output = prepare_output(args.output)
     cargo = require_string(args.cargo, "cargo command")
     policy, digest = load_policy(policy_path)
-    identity_exclusions = output_identity_exclusions(repo_root, output_path)
+    identity_exclusions = output_identity_exclusions(repo_root, output.parent / output.path.name)
     source_identity = git_source_identity(repo_root, identity_exclusions)
     resolved: dict[str, list[str]] = {}
     for profile in policy["profiles"]:
@@ -645,7 +727,7 @@ def command_capture(args: argparse.Namespace) -> None:
         captures[profile["id"]] = run_command(command, repo_root, f"profile {profile['id']}")
     if git_source_identity(repo_root, identity_exclusions) != source_identity:
         raise fail("git source identity: worktree changed during capture")
-    atomic_write(output_path, build_report(policy, digest, context, captures))
+    atomic_write(output, build_report(policy, digest, context, captures))
 
 
 def command_normalize(args: argparse.Namespace) -> None:
@@ -660,7 +742,7 @@ def command_normalize(args: argparse.Namespace) -> None:
             captures[profile["id"]] = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             raise fail(f"profile {profile['id']}: could not read capture: {exc}") from exc
-    atomic_write(Path(args.output).resolve(), build_report(policy, digest, context, captures))
+    atomic_write(prepare_output(args.output), build_report(policy, digest, context, captures))
 
 
 def validate_resolved_inputs(value: Any, label: str) -> None:
@@ -721,6 +803,11 @@ def validate_profile(profile: Any, label: str) -> str:
         normalized_pairs.append((name, version))
     if normalized_pairs != sorted(set(normalized_pairs)):
         raise fail(f"{label}.package_pairs: expected sorted unique pairs")
+    versions_by_name: dict[str, set[str]] = {}
+    for name, version in normalized_pairs:
+        versions_by_name.setdefault(name, set()).add(version)
+    if profile["package"] not in versions_by_name:
+        raise fail(f"{label}.package_pairs: declared package {profile['package']!r} is absent")
 
     enabled = profile["enabled_features"]
     if not isinstance(enabled, list):
@@ -757,9 +844,6 @@ def validate_profile(profile: Any, label: str) -> str:
         raise fail(f"{label}.counts: malformed fields")
     if any(type(counts[key]) is not int or counts[key] < 0 for key in count_keys):
         raise fail(f"{label}.counts: expected non-negative integers")
-    versions_by_name: dict[str, set[str]] = {}
-    for name, version in normalized_pairs:
-        versions_by_name.setdefault(name, set()).add(version)
     expected_counts = {
         "package_pairs": len(normalized_pairs),
         "unique_package_names": len(versions_by_name),
@@ -890,6 +974,30 @@ def command_compare(args: argparse.Namespace) -> None:
             raise fail(f"reports: incompatible inputs for profile {profile_id}")
         before_pairs = {(item["name"], item["version"]) for item in before["package_pairs"]}
         after_pairs = {(item["name"], item["version"]) for item in after["package_pairs"]}
+        before_features = {
+            (item["name"], item["version"]): set(item["features"])
+            for item in before["enabled_features"]
+        }
+        after_features = {
+            (item["name"], item["version"]): set(item["features"])
+            for item in after["enabled_features"]
+        }
+        feature_deltas = [
+            {
+                "name": name,
+                "version": version,
+                "added_features": sorted(
+                    after_features.get((name, version), set())
+                    - before_features.get((name, version), set())
+                ),
+                "removed_features": sorted(
+                    before_features.get((name, version), set())
+                    - after_features.get((name, version), set())
+                ),
+            }
+            for name, version in sorted(before_pairs & after_pairs)
+            if before_features.get((name, version), set()) != after_features.get((name, version), set())
+        ]
         before_counts = before.get("counts")
         after_counts = after.get("counts")
         if not isinstance(before_counts, dict) or not isinstance(after_counts, dict):
@@ -905,6 +1013,7 @@ def command_compare(args: argparse.Namespace) -> None:
                     {"name": name, "version": version}
                     for name, version in sorted(before_pairs - after_pairs)
                 ],
+                "feature_deltas": feature_deltas,
                 "count_deltas": {
                     key: after_counts[key] - before_counts[key]
                     for key in (
@@ -929,7 +1038,7 @@ def command_compare(args: argparse.Namespace) -> None:
         "profiles": deltas,
     }
     if args.output:
-        atomic_write(Path(args.output).resolve(), result)
+        atomic_write(prepare_output(args.output), result)
     else:
         sys.stdout.write(json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True) + "\n")
 

--- a/scripts/ci/dependency_footprint.py
+++ b/scripts/ci/dependency_footprint.py
@@ -115,7 +115,7 @@ def load_policy(path: Path) -> tuple[dict[str, Any], str]:
     if (
         not isinstance(edges, list)
         or len(edges) != 2
-        or any(item not in {"normal", "build"} for item in edges)
+        or any(not isinstance(item, str) or item not in {"normal", "build"} for item in edges)
         or sorted(edges) != ["build", "normal"]
     ):
         raise fail("policy.edge_kinds: expected exactly [\"normal\", \"build\"]")
@@ -366,6 +366,36 @@ def capture_path(raw_dir: Path, profile_id: str) -> Path:
     return existing[0]
 
 
+def normalize_resolved_selections(value: Any, label: str) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        raise fail(f"{label}: expected an object")
+    normalized: dict[str, list[str]] = {}
+    for selection, raw_features in value.items():
+        require_string(selection, f"{label} key", PROFILE_ID_RE)
+        features = require_feature_ref_list(raw_features, f"{label}.{selection}")
+        normalized[selection] = sorted(features)
+    return {selection: normalized[selection] for selection in sorted(normalized)}
+
+
+def require_policy_selection_keys(
+    selections: dict[str, list[str]],
+    policy: dict[str, Any],
+    label: str,
+) -> None:
+    expected = {profile["selection"] for profile in policy["profiles"] if profile["selection"] is not None}
+    actual = set(selections)
+    if actual == expected:
+        return
+    details = []
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing:
+        details.append(f"missing {', '.join(missing)}")
+    if extra:
+        details.append(f"extra {', '.join(extra)}")
+    raise fail(f"{label}: keys do not match supplied policy ({'; '.join(details)})")
+
+
 def load_context(path: Path) -> dict[str, Any]:
     context = load_json(path, "context")
     if not isinstance(context, dict):
@@ -397,15 +427,11 @@ def load_context(path: Path) -> dict[str, Any]:
     lock_digest = context.get("cargo_lock_sha256")
     if not isinstance(lock_digest, str) or re.fullmatch(r"[0-9a-f]{64}", lock_digest) is None:
         raise fail("context.cargo_lock_sha256: malformed digest")
-    selections = context.get("resolved_selections", {})
-    if not isinstance(selections, dict):
-        raise fail("context.resolved_selections: expected an object")
-    normalized: dict[str, list[str]] = {}
-    for selection, features in selections.items():
-        require_string(selection, "context.resolved_selections key", PROFILE_ID_RE)
-        normalized[selection] = require_feature_ref_list(features, f"context.resolved_selections.{selection}")
     result = dict(context)
-    result["resolved_selections"] = normalized
+    result["resolved_selections"] = normalize_resolved_selections(
+        context.get("resolved_selections", {}),
+        "context.resolved_selections",
+    )
     return result
 
 
@@ -440,7 +466,11 @@ def build_report(
     context: dict[str, Any],
     captures: dict[str, str],
 ) -> dict[str, Any]:
-    resolved = context.get("resolved_selections", {})
+    resolved = normalize_resolved_selections(
+        context.get("resolved_selections", {}),
+        "context.resolved_selections",
+    )
+    require_policy_selection_keys(resolved, policy, "context.resolved_selections")
     records: dict[str, dict[str, Any]] = {}
     for profile in policy["profiles"]:
         inputs = profile_inputs(profile, resolved)
@@ -466,7 +496,8 @@ def build_report(
                 "rustc_host",
                 "target",
             )
-        },
+        }
+        | {"resolved_selections": resolved},
         "evidence_units": {
             "cargo_package_name_version_pairs": "measured",
             "binary_bytes": "not measured",
@@ -880,6 +911,7 @@ def validate_report(
         "rustc_version",
         "rustc_host",
         "target",
+        "resolved_selections",
     }
     if not isinstance(context, dict) or set(context) != context_fields:
         raise fail(f"{label}.context: malformed fields")
@@ -895,6 +927,17 @@ def validate_report(
     lock_digest = context["cargo_lock_sha256"]
     if not isinstance(lock_digest, str) or re.fullmatch(r"[0-9a-f]{64}", lock_digest) is None:
         raise fail(f"{label}.context.cargo_lock_sha256: malformed digest")
+    resolved_selections = normalize_resolved_selections(
+        context["resolved_selections"],
+        f"{label}.context.resolved_selections",
+    )
+    if context["resolved_selections"] != resolved_selections:
+        raise fail(f"{label}.context.resolved_selections: expected sorted feature values")
+    require_policy_selection_keys(
+        resolved_selections,
+        expected_policy,
+        f"{label}.context.resolved_selections",
+    )
 
     if report["evidence_units"] != {
         "cargo_package_name_version_pairs": "measured",
@@ -924,7 +967,12 @@ def validate_report(
             raise fail(f"{label}.profiles.{profile['id']}: package or mode does not match supplied policy")
         if inputs["selection"] != expected["selection"]:
             raise fail(f"{label}.profiles.{profile['id']}: selection does not match supplied policy")
-        if expected["mode"] != "selection" and inputs["features"] != sorted(expected["features"]):
+        if expected["mode"] == "selection":
+            if inputs["features"] != resolved_selections[expected["selection"]]:
+                raise fail(
+                    f"{label}.profiles.{profile['id']}: features do not match captured selection"
+                )
+        elif inputs["features"] != sorted(expected["features"]):
             raise fail(f"{label}.profiles.{profile['id']}: features do not match supplied policy")
 
     contracts = report["contracts"]

--- a/scripts/ci/dependency_footprint.py
+++ b/scripts/ci/dependency_footprint.py
@@ -1,0 +1,973 @@
+#!/usr/bin/env python3
+"""Deterministic, local Cargo dependency-footprint capture and comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+SCRIPT_ROOT = Path(__file__).resolve().parents[2]
+PROFILE_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+PACKAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+FEATURE_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_:+./-]*$")
+FEATURE_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_:+.-]*$")
+VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]*$")
+PACKAGE_FIELD_RE = re.compile(
+    r"(?P<name>[A-Za-z0-9][A-Za-z0-9_-]*)"
+    r"\s+v(?P<version>[0-9A-Za-z][0-9A-Za-z.+-]*)"
+    r"(?:\s+\([^\t\r\n]+\))?"
+)
+
+
+class ToolError(Exception):
+    pass
+
+
+def fail(message: str) -> ToolError:
+    return ToolError(message)
+
+
+def reject_unknown(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise fail(f"{label}: unknown field(s): {', '.join(unknown)}")
+
+
+def require_string(value: Any, label: str, pattern: re.Pattern[str] | None = None) -> str:
+    if not isinstance(value, str) or not value:
+        raise fail(f"{label}: expected a non-empty string")
+    if pattern is not None and pattern.fullmatch(value) is None:
+        raise fail(f"{label}: malformed value {value!r}")
+    return value
+
+
+def require_string_list(value: Any, label: str, allow_empty: bool = True) -> list[str]:
+    if not isinstance(value, list) or (not allow_empty and not value):
+        raise fail(f"{label}: expected a {'non-empty ' if not allow_empty else ''}list")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        result.append(require_string(item, f"{label}[{index}]", FEATURE_RE))
+    if len(set(result)) != len(result):
+        raise fail(f"{label}: duplicate values")
+    return result
+
+
+def require_feature_ref(value: Any, label: str) -> str:
+    feature = require_string(value, label, FEATURE_RE)
+    if "/" not in feature:
+        return feature
+    parts = feature.split("/")
+    if len(parts) != 2 or PACKAGE_RE.fullmatch(parts[0]) is None or FEATURE_NAME_RE.fullmatch(parts[1]) is None:
+        raise fail(f"{label}: malformed package/feature reference {feature!r}")
+    return feature
+
+
+def require_feature_ref_list(value: Any, label: str, allow_empty: bool = True) -> list[str]:
+    if not isinstance(value, list) or (not allow_empty and not value):
+        raise fail(f"{label}: expected a {'non-empty ' if not allow_empty else ''}list")
+    result = [require_feature_ref(item, f"{label}[{index}]") for index, item in enumerate(value)]
+    if len(set(result)) != len(result):
+        raise fail(f"{label}: duplicate values")
+    return result
+
+
+def require_stable_context_string(value: Any, label: str) -> str:
+    result = require_string(value, label)
+    if (
+        result.startswith(("/", "\\"))
+        or re.match(r"^[A-Za-z]:[\\/]", result)
+        or any(marker in result for marker in ("/tmp/", "/private/tmp/", "/var/folders/", "CARGO_HOME", "RUSTUP_HOME"))
+    ):
+        raise fail(f"{label}: absolute, temporary, or cache path is not allowed")
+    return result
+
+
+def load_policy(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        raw = path.read_bytes()
+        policy = tomllib.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise fail(f"could not read policy {path}: {exc}") from exc
+    if not isinstance(policy, dict):
+        raise fail("policy: expected a table")
+    reject_unknown(policy, {"schema_version", "edge_kinds", "profiles", "contracts"}, "policy")
+    if type(policy.get("schema_version")) is not int or policy["schema_version"] != SCHEMA_VERSION:
+        raise fail("policy.schema_version: expected 1")
+    edges = policy.get("edge_kinds")
+    if (
+        not isinstance(edges, list)
+        or len(edges) != 2
+        or any(item not in {"normal", "build"} for item in edges)
+        or sorted(edges) != ["build", "normal"]
+    ):
+        raise fail("policy.edge_kinds: expected exactly [\"normal\", \"build\"]")
+    profiles_raw = policy.get("profiles")
+    if not isinstance(profiles_raw, list) or not profiles_raw:
+        raise fail("policy.profiles: expected a non-empty array")
+    profiles: list[dict[str, Any]] = []
+    profile_ids: set[str] = set()
+    for index, raw_profile in enumerate(profiles_raw):
+        label = f"policy.profiles[{index}]"
+        if not isinstance(raw_profile, dict):
+            raise fail(f"{label}: expected a table")
+        reject_unknown(raw_profile, {"id", "package", "mode", "features", "selection"}, label)
+        profile_id = require_string(raw_profile.get("id"), f"{label}.id", PROFILE_ID_RE)
+        if profile_id in profile_ids:
+            raise fail(f"{label}.id: duplicate id {profile_id!r}")
+        profile_ids.add(profile_id)
+        package = require_string(raw_profile.get("package"), f"{label}.package", PACKAGE_RE)
+        mode = require_string(raw_profile.get("mode"), f"{label}.mode")
+        if mode not in {"defaults", "no-default-features", "features", "selection"}:
+            raise fail(f"{label}.mode: incompatible mode {mode!r}")
+        has_features = "features" in raw_profile
+        has_selection = "selection" in raw_profile
+        if mode == "features":
+            if has_selection:
+                raise fail(f"{label}: features mode cannot also set selection")
+            features = require_feature_ref_list(raw_profile.get("features"), f"{label}.features", False)
+        elif has_features:
+            raise fail(f"{label}.features: only valid in features mode")
+        else:
+            features = []
+        if mode == "selection":
+            if not has_selection:
+                raise fail(f"{label}.selection: required in selection mode")
+            selection = require_string(raw_profile.get("selection"), f"{label}.selection", PROFILE_ID_RE)
+        elif has_selection:
+            raise fail(f"{label}.selection: only valid in selection mode")
+        else:
+            selection = None
+        profiles.append(
+            {
+                "id": profile_id,
+                "package": package,
+                "mode": mode,
+                "features": features,
+                "selection": selection,
+            }
+        )
+
+    contracts_raw = policy.get("contracts", [])
+    if not isinstance(contracts_raw, list):
+        raise fail("policy.contracts: expected an array")
+    contracts: list[dict[str, Any]] = []
+    contract_ids: set[str] = set()
+    for index, raw_contract in enumerate(contracts_raw):
+        label = f"policy.contracts[{index}]"
+        if not isinstance(raw_contract, dict):
+            raise fail(f"{label}: expected a table")
+        reject_unknown(raw_contract, {"id", "profile", "kind", "package", "feature", "expect"}, label)
+        contract_id = require_string(raw_contract.get("id"), f"{label}.id", PROFILE_ID_RE)
+        if contract_id in contract_ids:
+            raise fail(f"{label}.id: duplicate id {contract_id!r}")
+        contract_ids.add(contract_id)
+        profile = require_string(raw_contract.get("profile"), f"{label}.profile", PROFILE_ID_RE)
+        if profile not in profile_ids:
+            raise fail(f"{label}.profile: unknown profile {profile!r}")
+        kind = require_string(raw_contract.get("kind"), f"{label}.kind")
+        package = require_string(raw_contract.get("package"), f"{label}.package", PACKAGE_RE)
+        expect = require_string(raw_contract.get("expect"), f"{label}.expect")
+        if kind == "package":
+            if expect not in {"present", "absent"} or "feature" in raw_contract:
+                raise fail(f"{label}: malformed package contract")
+            feature = None
+        elif kind == "feature":
+            if expect not in {"enabled", "forbidden"}:
+                raise fail(f"{label}.expect: expected enabled or forbidden")
+            feature = require_string(raw_contract.get("feature"), f"{label}.feature", FEATURE_NAME_RE)
+        else:
+            raise fail(f"{label}.kind: unknown contract kind {kind!r}")
+        contracts.append(
+            {
+                "id": contract_id,
+                "profile": profile,
+                "kind": kind,
+                "package": package,
+                "feature": feature,
+                "expect": expect,
+            }
+        )
+    normalized = {"schema_version": 1, "edge_kinds": ["normal", "build"], "profiles": profiles, "contracts": contracts}
+    return normalized, hashlib.sha256(raw).hexdigest()
+
+
+def reject_duplicate_json_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON field {key!r}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path, label: str) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle, object_pairs_hook=reject_duplicate_json_pairs)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise fail(f"could not read {label} {path}: {exc}") from exc
+
+
+def run_command_bytes(args: list[str], cwd: Path, label: str) -> bytes:
+    try:
+        completed = subprocess.run(args, cwd=cwd, capture_output=True, check=False)
+    except OSError as exc:
+        raise fail(f"{label}: could not start subprocess: {exc}") from exc
+    if completed.returncode != 0:
+        detail_bytes = completed.stderr.strip() or completed.stdout.strip()
+        detail = detail_bytes.decode("utf-8", errors="replace") if detail_bytes else "no output"
+        raise fail(f"{label}: subprocess failed with status {completed.returncode}: {detail}")
+    return completed.stdout
+
+
+def run_command(args: list[str], cwd: Path, label: str) -> str:
+    output = run_command_bytes(args, cwd, label)
+    try:
+        return output.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise fail(f"{label}: subprocess output is not UTF-8") from exc
+
+
+def resolve_selection(cargo: str, selection: str, repo_root: Path, target: str | None) -> list[str]:
+    command = [
+        cargo,
+        "run",
+        "--locked",
+        "--quiet",
+        "-p",
+        "xtask",
+        "--bin",
+        "generate",
+        "--",
+        "features",
+        "--selection",
+        selection,
+    ]
+    if target:
+        command.extend(["--target", target])
+    output = run_command(command, repo_root, f"selection {selection}")
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise fail(f"selection {selection}: expected one non-empty feature line")
+    return require_feature_ref_list(lines[0].split(","), f"selection {selection}", True)
+
+
+def profile_inputs(profile: dict[str, Any], resolved: dict[str, list[str]]) -> dict[str, Any]:
+    mode = profile["mode"]
+    features = list(profile["features"])
+    selection = profile["selection"]
+    if mode == "selection":
+        if selection not in resolved:
+            raise fail(f"profile {profile['id']}: missing resolved selection {selection!r}")
+        features = list(resolved[selection])
+    return {
+        "mode": mode,
+        "no_default_features": mode != "defaults",
+        "features": sorted(features),
+        "selection": selection,
+    }
+
+
+def parse_feature_field(value: str, label: str) -> list[str]:
+    if not value:
+        return []
+    parts = value.split(",")
+    if any(not part for part in parts):
+        raise fail(f"{label}: malformed enabled feature list")
+    for part in parts:
+        require_string(part, f"{label}.feature", FEATURE_NAME_RE)
+    if len(set(parts)) != len(parts):
+        raise fail(f"{label}: duplicate enabled feature")
+    return parts
+
+
+def parse_tree(raw: str, profile_id: str, root_package: str) -> dict[str, Any]:
+    if not raw.strip():
+        raise fail(f"profile {profile_id}: Cargo output is empty")
+    packages: dict[tuple[str, str], set[str]] = {}
+    for number, line in enumerate(raw.splitlines(), start=1):
+        if not line:
+            continue
+        fields = line.split("\t")
+        if len(fields) != 2:
+            raise fail(f"profile {profile_id}: malformed Cargo tree line {number}: {line!r}")
+        package_field, feature_field = fields
+        if not feature_field.startswith("features:"):
+            raise fail(f"profile {profile_id}: malformed Cargo tree line {number}: {line!r}")
+        feature_field = feature_field.removesuffix(" (*)")
+        match = PACKAGE_FIELD_RE.fullmatch(package_field)
+        if match is None:
+            raise fail(f"profile {profile_id}: malformed Cargo tree line {number}: {line!r}")
+        name = match.group("name")
+        version = match.group("version")
+        if VERSION_RE.fullmatch(version) is None:
+            raise fail(f"profile {profile_id}: malformed package version on line {number}")
+        features = parse_feature_field(
+            feature_field.removeprefix("features:"),
+            f"profile {profile_id} line {number}",
+        )
+        packages.setdefault((name, version), set()).update(features)
+    if not packages:
+        raise fail(f"profile {profile_id}: Cargo output contains no packages")
+    if not any(name == root_package for name, _version in packages):
+        raise fail(f"profile {profile_id}: selected root package {root_package!r} is missing")
+    package_pairs = [{"name": name, "version": version} for name, version in sorted(packages)]
+    enabled_features = [
+        {"name": name, "version": version, "features": sorted(features)}
+        for (name, version), features in sorted(packages.items())
+        if features
+    ]
+    versions_by_name: dict[str, set[str]] = {}
+    for name, version in packages:
+        versions_by_name.setdefault(name, set()).add(version)
+    counts = {
+        "package_pairs": len(package_pairs),
+        "unique_package_names": len(versions_by_name),
+        "duplicate_version_names": sum(len(versions) > 1 for versions in versions_by_name.values()),
+        "enabled_features": sum(len(item["features"]) for item in enabled_features),
+    }
+    return {
+        "package_pairs": package_pairs,
+        "enabled_features": enabled_features,
+        "counts": counts,
+    }
+
+
+def capture_path(raw_dir: Path, profile_id: str) -> Path:
+    candidates = [
+        raw_dir / profile_id,
+        raw_dir / f"{profile_id}.tree",
+        raw_dir / f"{profile_id}.txt",
+        raw_dir / f"{profile_id}.raw",
+    ]
+    existing = [candidate for candidate in candidates if candidate.is_file()]
+    if len(existing) != 1:
+        if not existing:
+            raise fail(f"profile {profile_id}: missing capture in {raw_dir}")
+        raise fail(f"profile {profile_id}: duplicate capture files in {raw_dir}")
+    return existing[0]
+
+
+def load_context(path: Path) -> dict[str, Any]:
+    context = load_json(path, "context")
+    if not isinstance(context, dict):
+        raise fail("context: expected a JSON object")
+    reject_unknown(
+        context,
+        {
+            "git_revision",
+            "git_dirty",
+            "git_worktree_digest_sha256",
+            "cargo_lock_sha256",
+            "cargo_version",
+            "rustc_version",
+            "rustc_host",
+            "target",
+            "resolved_selections",
+        },
+        "context",
+    )
+    for key in ("git_revision", "cargo_version", "rustc_version", "rustc_host", "target"):
+        require_stable_context_string(context.get(key), f"context.{key}")
+    if re.fullmatch(r"[0-9a-fA-F]{7,64}", context["git_revision"]) is None:
+        raise fail("context.git_revision: malformed revision")
+    if type(context.get("git_dirty")) is not bool:
+        raise fail("context.git_dirty: expected a boolean")
+    digest = context.get("git_worktree_digest_sha256")
+    if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise fail("context.git_worktree_digest_sha256: malformed digest")
+    lock_digest = context.get("cargo_lock_sha256")
+    if not isinstance(lock_digest, str) or re.fullmatch(r"[0-9a-f]{64}", lock_digest) is None:
+        raise fail("context.cargo_lock_sha256: malformed digest")
+    selections = context.get("resolved_selections", {})
+    if not isinstance(selections, dict):
+        raise fail("context.resolved_selections: expected an object")
+    normalized: dict[str, list[str]] = {}
+    for selection, features in selections.items():
+        require_string(selection, "context.resolved_selections key", PROFILE_ID_RE)
+        normalized[selection] = require_feature_ref_list(features, f"context.resolved_selections.{selection}")
+    result = dict(context)
+    result["resolved_selections"] = normalized
+    return result
+
+
+def validate_contracts(contracts: list[dict[str, Any]], records: dict[str, dict[str, Any]]) -> list[dict[str, str]]:
+    passing: list[dict[str, str]] = []
+    for contract in contracts:
+        record = records[contract["profile"]]
+        pair_names = {pair["name"] for pair in record["package_pairs"]}
+        feature_set = {
+            (item["name"], feature)
+            for item in record["enabled_features"]
+            for feature in item["features"]
+        }
+        if contract["kind"] == "package":
+            actual = contract["package"] in pair_names
+            expected = contract["expect"] == "present"
+        else:
+            actual = (contract["package"], contract["feature"]) in feature_set
+            expected = contract["expect"] == "enabled"
+        if actual != expected:
+            raise fail(
+                f"contract {contract['id']}: {contract['expect']} assertion failed for "
+                f"{contract['package']}" + (f"/{contract['feature']}" if contract["feature"] else "")
+            )
+        passing.append({"id": contract["id"], "profile": contract["profile"], "status": "passed"})
+    return sorted(passing, key=lambda item: item["id"])
+
+
+def build_report(
+    policy: dict[str, Any],
+    policy_digest: str,
+    context: dict[str, Any],
+    captures: dict[str, str],
+) -> dict[str, Any]:
+    resolved = context.get("resolved_selections", {})
+    records: dict[str, dict[str, Any]] = {}
+    for profile in policy["profiles"]:
+        inputs = profile_inputs(profile, resolved)
+        parsed = parse_tree(captures[profile["id"]], profile["id"], profile["package"])
+        records[profile["id"]] = {
+            "id": profile["id"],
+            "package": profile["package"],
+            "resolved_inputs": inputs,
+            **parsed,
+        }
+    contracts = validate_contracts(policy["contracts"], records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "context": {
+            key: context[key]
+            for key in (
+                "git_revision",
+                "git_dirty",
+                "git_worktree_digest_sha256",
+                "cargo_lock_sha256",
+                "cargo_version",
+                "rustc_version",
+                "rustc_host",
+                "target",
+            )
+        },
+        "evidence_units": {
+            "cargo_package_name_version_pairs": "measured",
+            "binary_bytes": "not measured",
+            "runtime_memory": "not measured",
+        },
+        "policy": {"digest_sha256": policy_digest, "edge_kinds": policy["edge_kinds"]},
+        "profiles": sorted(records.values(), key=lambda item: item["id"]),
+        "contracts": contracts,
+    }
+
+
+def git_source_identity(
+    repo_root: Path,
+    excluded_untracked_paths: set[bytes] | None = None,
+) -> dict[str, Any]:
+    revision = run_command(["git", "rev-parse", "--verify", "HEAD"], repo_root, "git revision").strip()
+    if not re.fullmatch(r"[0-9a-fA-F]{7,64}", revision):
+        raise fail("git revision: malformed output")
+    tracked_diff = run_command_bytes(
+        [
+            "git",
+            "-c",
+            "core.quotePath=true",
+            "diff",
+            "--binary",
+            "--full-index",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
+            "HEAD",
+            "--",
+        ],
+        repo_root,
+        "git tracked diff",
+    )
+    untracked_output = run_command_bytes(
+        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+        repo_root,
+        "git untracked files",
+    )
+    excluded = excluded_untracked_paths or set()
+    untracked_paths = sorted(
+        path for path in untracked_output.split(b"\0") if path and path not in excluded
+    )
+    digest = hashlib.sha256()
+    digest.update(len(tracked_diff).to_bytes(8, "big"))
+    digest.update(tracked_diff)
+    for raw_path in untracked_paths:
+        path = repo_root / os.fsdecode(raw_path)
+        try:
+            metadata = path.lstat()
+            if stat.S_ISREG(metadata.st_mode):
+                kind = b"file"
+                content = path.read_bytes()
+            elif stat.S_ISLNK(metadata.st_mode):
+                kind = b"symlink"
+                content = os.fsencode(os.readlink(path))
+            else:
+                raise fail(f"git source identity: unsupported untracked file type {os.fsdecode(raw_path)!r}")
+        except OSError as exc:
+            raise fail(f"git source identity: could not read untracked file {os.fsdecode(raw_path)!r}: {exc}") from exc
+        for field in (raw_path, kind, (metadata.st_mode & 0o111).to_bytes(2, "big"), content):
+            digest.update(len(field).to_bytes(8, "big"))
+            digest.update(field)
+    return {
+        "git_revision": revision,
+        "git_dirty": bool(tracked_diff or untracked_paths),
+        "git_worktree_digest_sha256": digest.hexdigest(),
+    }
+
+
+def output_identity_exclusions(repo_root: Path, output_path: Path) -> set[bytes]:
+    try:
+        relative = output_path.relative_to(repo_root)
+    except ValueError:
+        return set()
+    relative_text = relative.as_posix()
+    tracked = run_command_bytes(
+        ["git", "--literal-pathspecs", "ls-files", "-z", "--", relative_text],
+        repo_root,
+        "git output ownership",
+    )
+    if tracked:
+        raise fail(f"output path is tracked by Git: {relative_text}")
+    return {os.fsencode(relative_text)}
+
+
+def context_from_capture(
+    cargo: str,
+    repo_root: Path,
+    target: str | None,
+    resolved: dict[str, list[str]],
+    source_identity: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        cargo_lock_digest = hashlib.sha256((repo_root / "Cargo.lock").read_bytes()).hexdigest()
+    except OSError as exc:
+        raise fail(f"Cargo.lock: could not read lockfile: {exc}") from exc
+    cargo_version = run_command([cargo, "--version"], repo_root, "cargo version").strip()
+    rustc_verbose = run_command(["rustc", "--version", "--verbose"], repo_root, "rustc version")
+    rustc_lines = [line.strip() for line in rustc_verbose.splitlines() if line.strip()]
+    rustc_version = next((line for line in rustc_lines if line.startswith("rustc ")), None)
+    rustc_host = next((line.split(":", 1)[1].strip() for line in rustc_lines if line.startswith("host:")), None)
+    if not rustc_version or not rustc_host:
+        raise fail("rustc version: missing version or host")
+    require_stable_context_string(cargo_version, "cargo version")
+    require_stable_context_string(rustc_version, "rustc version")
+    require_stable_context_string(rustc_host, "rustc host")
+    require_stable_context_string(target or rustc_host, "target")
+    return {
+        **source_identity,
+        "cargo_lock_sha256": cargo_lock_digest,
+        "cargo_version": cargo_version,
+        "rustc_version": rustc_version,
+        "rustc_host": rustc_host,
+        "target": target or rustc_host,
+        "resolved_selections": resolved,
+    }
+
+
+def atomic_write(path: Path, value: Any) -> None:
+    text = json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+    try:
+        path.parent.mkdir(parents=False, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            temporary.unlink(missing_ok=True)
+        except (UnboundLocalError, OSError):
+            pass
+        raise fail(f"could not atomically write {path}: {exc}") from exc
+
+
+def command_capture(args: argparse.Namespace) -> None:
+    policy_path = Path(args.policy).resolve()
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else SCRIPT_ROOT
+    output_path = Path(args.output).resolve()
+    cargo = require_string(args.cargo, "cargo command")
+    policy, digest = load_policy(policy_path)
+    identity_exclusions = output_identity_exclusions(repo_root, output_path)
+    source_identity = git_source_identity(repo_root, identity_exclusions)
+    resolved: dict[str, list[str]] = {}
+    for profile in policy["profiles"]:
+        selection = profile["selection"]
+        if selection and selection not in resolved:
+            resolved[selection] = resolve_selection(cargo, selection, repo_root, args.target)
+    context = context_from_capture(cargo, repo_root, args.target, resolved, source_identity)
+    captures: dict[str, str] = {}
+    for profile in policy["profiles"]:
+        inputs = profile_inputs(profile, resolved)
+        command = [
+            cargo,
+            "tree",
+            "--locked",
+            "--edges",
+            ",".join(policy["edge_kinds"]),
+            "--prefix",
+            "none",
+            "--format",
+            "{p}\tfeatures:{f}",
+            "-p",
+            profile["package"],
+        ]
+        if inputs["no_default_features"]:
+            command.append("--no-default-features")
+        if inputs["features"]:
+            command.extend(["--features", ",".join(inputs["features"])])
+        if args.target:
+            command.extend(["--target", args.target])
+        captures[profile["id"]] = run_command(command, repo_root, f"profile {profile['id']}")
+    if git_source_identity(repo_root, identity_exclusions) != source_identity:
+        raise fail("git source identity: worktree changed during capture")
+    atomic_write(output_path, build_report(policy, digest, context, captures))
+
+
+def command_normalize(args: argparse.Namespace) -> None:
+    policy_path = Path(args.policy).resolve()
+    policy, digest = load_policy(policy_path)
+    context = load_context(Path(args.context).resolve())
+    captures: dict[str, str] = {}
+    raw_dir = Path(args.raw_dir).resolve()
+    for profile in policy["profiles"]:
+        path = capture_path(raw_dir, profile["id"])
+        try:
+            captures[profile["id"]] = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise fail(f"profile {profile['id']}: could not read capture: {exc}") from exc
+    atomic_write(Path(args.output).resolve(), build_report(policy, digest, context, captures))
+
+
+def validate_resolved_inputs(value: Any, label: str) -> None:
+    if not isinstance(value, dict):
+        raise fail(f"{label}: expected an object")
+    expected_fields = {"mode", "no_default_features", "features", "selection"}
+    reject_unknown(value, expected_fields, label)
+    if set(value) != expected_fields:
+        raise fail(f"{label}: missing field(s): {', '.join(sorted(expected_fields - set(value)))}")
+    mode = require_string(value["mode"], f"{label}.mode")
+    if mode not in {"defaults", "no-default-features", "features", "selection"}:
+        raise fail(f"{label}.mode: incompatible mode {mode!r}")
+    if type(value["no_default_features"]) is not bool:
+        raise fail(f"{label}.no_default_features: expected a boolean")
+    if value["no_default_features"] != (mode != "defaults"):
+        raise fail(f"{label}: mode and no_default_features disagree")
+    features = require_feature_ref_list(value["features"], f"{label}.features")
+    if features != sorted(features):
+        raise fail(f"{label}.features: expected sorted values")
+    if mode == "features" and not features:
+        raise fail(f"{label}.features: expected a non-empty list")
+    if mode not in {"features", "selection"} and features:
+        raise fail(f"{label}.features: incompatible with mode {mode!r}")
+    if mode == "selection":
+        require_string(value["selection"], f"{label}.selection", PROFILE_ID_RE)
+    elif value["selection"] is not None:
+        raise fail(f"{label}.selection: incompatible with mode {mode!r}")
+
+
+def validate_profile(profile: Any, label: str) -> str:
+    if not isinstance(profile, dict):
+        raise fail(f"{label}: expected an object")
+    expected_fields = {
+        "id",
+        "package",
+        "resolved_inputs",
+        "package_pairs",
+        "enabled_features",
+        "counts",
+    }
+    reject_unknown(profile, expected_fields, label)
+    if set(profile) != expected_fields:
+        raise fail(f"{label}: missing field(s): {', '.join(sorted(expected_fields - set(profile)))}")
+    profile_id = require_string(profile["id"], f"{label}.id", PROFILE_ID_RE)
+    require_string(profile["package"], f"{label}.package", PACKAGE_RE)
+    validate_resolved_inputs(profile["resolved_inputs"], f"{label}.resolved_inputs")
+
+    pairs = profile["package_pairs"]
+    if not isinstance(pairs, list) or not pairs:
+        raise fail(f"{label}.package_pairs: expected a non-empty array")
+    normalized_pairs: list[tuple[str, str]] = []
+    for index, pair in enumerate(pairs):
+        pair_label = f"{label}.package_pairs[{index}]"
+        if not isinstance(pair, dict) or set(pair) != {"name", "version"}:
+            raise fail(f"{pair_label}: malformed package pair")
+        name = require_string(pair["name"], f"{pair_label}.name", PACKAGE_RE)
+        version = require_string(pair["version"], f"{pair_label}.version", VERSION_RE)
+        normalized_pairs.append((name, version))
+    if normalized_pairs != sorted(set(normalized_pairs)):
+        raise fail(f"{label}.package_pairs: expected sorted unique pairs")
+
+    enabled = profile["enabled_features"]
+    if not isinstance(enabled, list):
+        raise fail(f"{label}.enabled_features: expected an array")
+    normalized_enabled: list[tuple[str, str]] = []
+    enabled_count = 0
+    for index, item in enumerate(enabled):
+        item_label = f"{label}.enabled_features[{index}]"
+        if not isinstance(item, dict) or set(item) != {"name", "version", "features"}:
+            raise fail(f"{item_label}: malformed enabled-feature record")
+        name = require_string(item["name"], f"{item_label}.name", PACKAGE_RE)
+        version = require_string(item["version"], f"{item_label}.version", VERSION_RE)
+        features = require_string_list(item["features"], f"{item_label}.features", False)
+        for feature_index, feature in enumerate(features):
+            if FEATURE_NAME_RE.fullmatch(feature) is None:
+                raise fail(f"{item_label}.features[{feature_index}]: malformed value {feature!r}")
+        if features != sorted(features):
+            raise fail(f"{item_label}.features: expected sorted values")
+        if (name, version) not in normalized_pairs:
+            raise fail(f"{item_label}: package pair is absent")
+        normalized_enabled.append((name, version))
+        enabled_count += len(features)
+    if normalized_enabled != sorted(set(normalized_enabled)):
+        raise fail(f"{label}.enabled_features: expected sorted unique package records")
+
+    counts = profile["counts"]
+    count_keys = {
+        "package_pairs",
+        "unique_package_names",
+        "duplicate_version_names",
+        "enabled_features",
+    }
+    if not isinstance(counts, dict) or set(counts) != count_keys:
+        raise fail(f"{label}.counts: malformed fields")
+    if any(type(counts[key]) is not int or counts[key] < 0 for key in count_keys):
+        raise fail(f"{label}.counts: expected non-negative integers")
+    versions_by_name: dict[str, set[str]] = {}
+    for name, version in normalized_pairs:
+        versions_by_name.setdefault(name, set()).add(version)
+    expected_counts = {
+        "package_pairs": len(normalized_pairs),
+        "unique_package_names": len(versions_by_name),
+        "duplicate_version_names": sum(len(versions) > 1 for versions in versions_by_name.values()),
+        "enabled_features": enabled_count,
+    }
+    if counts != expected_counts:
+        raise fail(f"{label}.counts: values do not match profile records")
+    return profile_id
+
+
+def validate_report(
+    report: Any,
+    label: str,
+    expected_policy: dict[str, Any],
+    expected_policy_digest: str,
+) -> dict[str, Any]:
+    if not isinstance(report, dict):
+        raise fail(f"{label}: expected a JSON object")
+    expected_fields = {"schema_version", "context", "evidence_units", "policy", "profiles", "contracts"}
+    reject_unknown(report, expected_fields, label)
+    if set(report) != expected_fields:
+        raise fail(f"{label}: missing field(s): {', '.join(sorted(expected_fields - set(report)))}")
+    if type(report["schema_version"]) is not int or report["schema_version"] != SCHEMA_VERSION:
+        raise fail(f"{label}: incompatible schema version")
+
+    context = report["context"]
+    context_fields = {
+        "git_revision",
+        "git_dirty",
+        "git_worktree_digest_sha256",
+        "cargo_lock_sha256",
+        "cargo_version",
+        "rustc_version",
+        "rustc_host",
+        "target",
+    }
+    if not isinstance(context, dict) or set(context) != context_fields:
+        raise fail(f"{label}.context: malformed fields")
+    for key in ("git_revision", "cargo_version", "rustc_version", "rustc_host", "target"):
+        require_stable_context_string(context[key], f"{label}.context.{key}")
+    if re.fullmatch(r"[0-9a-fA-F]{7,64}", context["git_revision"]) is None:
+        raise fail(f"{label}.context.git_revision: malformed revision")
+    if type(context["git_dirty"]) is not bool:
+        raise fail(f"{label}.context.git_dirty: expected a boolean")
+    digest = context["git_worktree_digest_sha256"]
+    if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise fail(f"{label}.context.git_worktree_digest_sha256: malformed digest")
+    lock_digest = context["cargo_lock_sha256"]
+    if not isinstance(lock_digest, str) or re.fullmatch(r"[0-9a-f]{64}", lock_digest) is None:
+        raise fail(f"{label}.context.cargo_lock_sha256: malformed digest")
+
+    if report["evidence_units"] != {
+        "cargo_package_name_version_pairs": "measured",
+        "binary_bytes": "not measured",
+        "runtime_memory": "not measured",
+    }:
+        raise fail(f"{label}: malformed evidence units")
+    policy_record = report["policy"]
+    if not isinstance(policy_record, dict) or set(policy_record) != {"digest_sha256", "edge_kinds"}:
+        raise fail(f"{label}.policy: malformed fields")
+    if policy_record["edge_kinds"] != expected_policy["edge_kinds"]:
+        raise fail(f"{label}.policy.edge_kinds: incompatible edge kinds")
+    if policy_record["digest_sha256"] != expected_policy_digest:
+        raise fail(f"{label}.policy.digest_sha256: does not match supplied policy")
+
+    profiles = report["profiles"]
+    if not isinstance(profiles, list) or not profiles:
+        raise fail(f"{label}.profiles: expected a non-empty array")
+    profile_ids = [validate_profile(profile, f"{label}.profiles[{index}]") for index, profile in enumerate(profiles)]
+    expected_profiles = {profile["id"]: profile for profile in expected_policy["profiles"]}
+    if profile_ids != sorted(expected_profiles):
+        raise fail(f"{label}.profiles: ids do not match supplied policy")
+    for profile in profiles:
+        expected = expected_profiles[profile["id"]]
+        inputs = profile["resolved_inputs"]
+        if profile["package"] != expected["package"] or inputs["mode"] != expected["mode"]:
+            raise fail(f"{label}.profiles.{profile['id']}: package or mode does not match supplied policy")
+        if inputs["selection"] != expected["selection"]:
+            raise fail(f"{label}.profiles.{profile['id']}: selection does not match supplied policy")
+        if expected["mode"] != "selection" and inputs["features"] != sorted(expected["features"]):
+            raise fail(f"{label}.profiles.{profile['id']}: features do not match supplied policy")
+
+    contracts = report["contracts"]
+    if not isinstance(contracts, list):
+        raise fail(f"{label}.contracts: expected an array")
+    proven_contracts = validate_contracts(
+        expected_policy["contracts"],
+        {profile["id"]: profile for profile in profiles},
+    )
+    if contracts != proven_contracts:
+        raise fail(f"{label}.contracts: records do not match supplied policy")
+    return report
+
+
+def command_compare(args: argparse.Namespace) -> None:
+    policy, policy_digest = load_policy(Path(args.policy).resolve())
+    left = validate_report(
+        load_json(Path(args.before).resolve(), "left report"),
+        "left report",
+        policy,
+        policy_digest,
+    )
+    right = validate_report(
+        load_json(Path(args.after).resolve(), "right report"),
+        "right report",
+        policy,
+        policy_digest,
+    )
+    if left["schema_version"] != right["schema_version"]:
+        raise fail("reports: incompatible schemas")
+    if left["policy"] != right["policy"] or left["evidence_units"] != right["evidence_units"]:
+        raise fail("reports: incompatible policy or evidence units")
+    compatibility_context = ("cargo_version", "rustc_version", "rustc_host", "target")
+    if any(left["context"][key] != right["context"][key] for key in compatibility_context):
+        raise fail("reports: incompatible toolchain or target context")
+    if left["contracts"] != right["contracts"]:
+        raise fail("reports: incompatible contract results")
+    left_profiles = {profile["id"]: profile for profile in left["profiles"]}
+    right_profiles = {profile["id"]: profile for profile in right["profiles"]}
+    if set(left_profiles) != set(right_profiles):
+        raise fail("reports: incompatible profile sets")
+    deltas: list[dict[str, Any]] = []
+    for profile_id in sorted(left_profiles):
+        before = left_profiles[profile_id]
+        after = right_profiles[profile_id]
+        if before["package"] != after["package"] or before["resolved_inputs"] != after["resolved_inputs"]:
+            raise fail(f"reports: incompatible inputs for profile {profile_id}")
+        before_pairs = {(item["name"], item["version"]) for item in before["package_pairs"]}
+        after_pairs = {(item["name"], item["version"]) for item in after["package_pairs"]}
+        before_counts = before.get("counts")
+        after_counts = after.get("counts")
+        if not isinstance(before_counts, dict) or not isinstance(after_counts, dict):
+            raise fail(f"reports: profile {profile_id} has malformed counts")
+        deltas.append(
+            {
+                "id": profile_id,
+                "added_package_pairs": [
+                    {"name": name, "version": version}
+                    for name, version in sorted(after_pairs - before_pairs)
+                ],
+                "removed_package_pairs": [
+                    {"name": name, "version": version}
+                    for name, version in sorted(before_pairs - after_pairs)
+                ],
+                "count_deltas": {
+                    key: after_counts[key] - before_counts[key]
+                    for key in (
+                        "package_pairs",
+                        "unique_package_names",
+                        "duplicate_version_names",
+                        "enabled_features",
+                    )
+                },
+            }
+        )
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "context": {
+            "before": left["context"],
+            "after": right["context"],
+            "changed_fields": sorted(
+                key for key in left["context"] if left["context"][key] != right["context"][key]
+            ),
+        },
+        "policy": left["policy"],
+        "profiles": deltas,
+    }
+    if args.output:
+        atomic_write(Path(args.output).resolve(), result)
+    else:
+        sys.stdout.write(json.dumps(result, ensure_ascii=True, indent=2, sort_keys=True) + "\n")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    capture = commands.add_parser("capture")
+    capture.add_argument("--policy", default=str(SCRIPT_ROOT / "dev/ci/dependency-footprint.toml"))
+    capture.add_argument("--output", required=True)
+    capture.add_argument("--repo-root")
+    capture.add_argument("--target")
+    capture.add_argument("--cargo", default=os.environ.get("CARGO", "cargo"))
+    capture.set_defaults(function=command_capture)
+    normalize = commands.add_parser("normalize")
+    normalize.add_argument("--policy", required=True)
+    normalize.add_argument("--raw-dir", required=True)
+    normalize.add_argument("--context", required=True)
+    normalize.add_argument("--output", required=True)
+    normalize.set_defaults(function=command_normalize)
+    compare = commands.add_parser("compare")
+    compare.add_argument("before")
+    compare.add_argument("after")
+    compare.add_argument("--policy", default=str(SCRIPT_ROOT / "dev/ci/dependency-footprint.toml"))
+    compare.add_argument("--output")
+    compare.set_defaults(function=command_compare)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parser().parse_args(argv)
+        args.function(args)
+    except ToolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/dependency_footprint.sh
+++ b/scripts/ci/dependency_footprint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+case "${1:-}" in
+    capture|normalize|compare)
+        exec python3 "${script_dir}/dependency_footprint.py" "$@"
+        ;;
+    *)
+        exec python3 "${script_dir}/dependency_footprint.py" capture "$@"
+        ;;
+esac

--- a/scripts/ci/dependency_footprint.test.sh
+++ b/scripts/ci/dependency_footprint.test.sh
@@ -71,6 +71,9 @@ assert type(report["context"]["git_dirty"]) is bool
 assert len(report["context"]["git_worktree_digest_sha256"]) == 64
 assert len(report["context"]["cargo_lock_sha256"]) == 64
 assert "/fixture/checkout" not in json.dumps(report)
+assert report["context"]["resolved_selections"] == {
+    "dist": ["agent-runtime", "channel-matrix"]
+}
 PY
 
 replace_text "$test_root/raw-b/foundation.tree" 'dep-crate v1.0.0' 'dep-crate v1.1.0'
@@ -253,6 +256,75 @@ set -e
 [[ "$status" -ne 0 ]] || fail "boolean report schema was accepted"
 assert_contains "$test_root/boolean-schema.err" 'incompatible schema version'
 
+cp "$test_root/report-a.json" "$test_root/missing-resolved-selection.json"
+python3 - "$test_root/missing-resolved-selection.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["context"]["resolved_selections"].pop("dist")
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare \
+    "$test_root/missing-resolved-selection.json" \
+    "$test_root/report-a.json" \
+    2>"$test_root/missing-resolved-selection.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "report missing policy-referenced resolved selection was accepted"
+assert_contains "$test_root/missing-resolved-selection.err" 'keys do not match supplied policy (missing dist)'
+
+cp "$test_root/report-a.json" "$test_root/extra-resolved-selection.json"
+python3 - "$test_root/extra-resolved-selection.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["context"]["resolved_selections"]["extra"] = ["synthetic-feature"]
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare \
+    "$test_root/extra-resolved-selection.json" \
+    "$test_root/report-a.json" \
+    2>"$test_root/extra-resolved-selection.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "report with an extra resolved selection was accepted"
+assert_contains "$test_root/extra-resolved-selection.err" 'keys do not match supplied policy (extra extra)'
+
+for side in left right; do
+    cp "$test_root/report-a.json" "$test_root/selection-input-mismatch-${side}.json"
+done
+python3 - \
+    "$test_root/selection-input-mismatch-left.json" \
+    "$test_root/selection-input-mismatch-right.json" <<'PY'
+import json
+import pathlib
+import sys
+
+for value in sys.argv[1:]:
+    path = pathlib.Path(value)
+    report = json.loads(path.read_text(encoding="utf-8"))
+    profile = next(item for item in report["profiles"] if item["id"] == "standard-distribution")
+    profile["resolved_inputs"]["features"] = ["not-real"]
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare \
+    "$test_root/selection-input-mismatch-left.json" \
+    "$test_root/selection-input-mismatch-right.json" \
+    2>"$test_root/selection-input-mismatch.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "selection profile with mismatched resolved inputs was accepted"
+assert_contains "$test_root/selection-input-mismatch.err" 'features do not match captured selection'
+
 fake_cargo="$test_root/fake-cargo"
 cat >"$fake_cargo" <<'SH'
 #!/usr/bin/env bash
@@ -353,9 +425,13 @@ python3 - "$test_root/capture-a.json" <<'PY'
 import json
 import sys
 
-context = json.load(open(sys.argv[1], encoding="utf-8"))["context"]
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+context = report["context"]
 assert type(context["git_dirty"]) is bool
 assert len(context["git_worktree_digest_sha256"]) == 64
+assert context["resolved_selections"] == {
+    "dist": ["agent-runtime", "channel-matrix"]
+}
 PY
 assert_contains "$test_root/fake-cargo.log" 'run --locked --quiet -p xtask --bin generate -- features --selection dist'
 run_fake_capture "$test_root/capture-target.json" 'aarch64-unknown-linux-gnu'
@@ -618,6 +694,24 @@ status=$?
 set -e
 [[ "$status" -ne 0 ]] || fail "boolean policy schema was accepted"
 assert_contains "$test_root/boolean-policy.err" 'expected 1'
+
+cp "$fixture_root/policy.toml" "$test_root/malformed-edge-kinds.toml"
+replace_text \
+    "$test_root/malformed-edge-kinds.toml" \
+    'edge_kinds = ["normal", "build"]' \
+    'edge_kinds = [[], "build"]'
+set +e
+bash "$tool" normalize \
+    --policy "$test_root/malformed-edge-kinds.toml" \
+    --raw-dir "$fixture_root/raw" \
+    --context "$fixture_root/context.json" \
+    --output "$test_root/should-not-exist.json" \
+    2>"$test_root/malformed-edge-kinds.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "malformed policy edge kinds were accepted"
+assert_contains "$test_root/malformed-edge-kinds.err" 'error: policy.edge_kinds: expected exactly'
+! grep -Fq 'Traceback' "$test_root/malformed-edge-kinds.err" || fail "malformed policy emitted a Python traceback"
 
 printf '%s\n' '{"old": true}' > "$test_root/atomic.json"
 printf '%s\n' 'not a Cargo package line' > "$test_root/raw-b/foundation.tree"

--- a/scripts/ci/dependency_footprint.test.sh
+++ b/scripts/ci/dependency_footprint.test.sh
@@ -297,8 +297,8 @@ import json
 import sys
 
 context = json.load(open(sys.argv[1], encoding="utf-8"))["context"]
-assert context["git_dirty"] is True
-assert context["git_worktree_digest_sha256"] != "0" * 64
+assert type(context["git_dirty"]) is bool
+assert len(context["git_worktree_digest_sha256"]) == 64
 PY
 assert_contains "$test_root/fake-cargo.log" 'run --locked --quiet -p xtask --bin generate -- features --selection dist'
 run_fake_capture "$test_root/capture-target.json" 'aarch64-unknown-linux-gnu'
@@ -322,7 +322,9 @@ python3 - "$in_repo_output" <<'PY'
 import json
 import sys
 
-assert json.load(open(sys.argv[1], encoding="utf-8"))["context"]["git_dirty"] is False
+context = json.load(open(sys.argv[1], encoding="utf-8"))["context"]
+assert context["git_dirty"] is False
+assert len(context["git_worktree_digest_sha256"]) == 64
 PY
 cp "$source_repo/tracked.txt" "$test_root/tracked-before.txt"
 set +e

--- a/scripts/ci/dependency_footprint.test.sh
+++ b/scripts/ci/dependency_footprint.test.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tool="${script_dir}/dependency_footprint.sh"
+fixture_root="${script_dir}/fixtures/dependency-footprint"
+policy="${script_dir}/../../dev/ci/dependency-footprint.toml"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    grep -Fq -- "$expected" "$file" || fail "missing ${expected} in ${file}"
+}
+
+replace_text() {
+    python3 - "$1" "$2" "$3" <<'PY'
+import pathlib
+import sys
+
+path, old, new = sys.argv[1:]
+value = pathlib.Path(path).read_text(encoding="utf-8")
+if old not in value:
+    raise SystemExit(f"missing replacement text in {path}")
+pathlib.Path(path).write_text(value.replace(old, new), encoding="utf-8")
+PY
+}
+
+run_normalize() {
+    local raw_dir="$1"
+    local output="$2"
+    bash "$tool" normalize \
+        --policy "$fixture_root/policy.toml" \
+        --raw-dir "$raw_dir" \
+        --context "$fixture_root/context.json" \
+        --output "$output"
+}
+
+cmp -s "$policy" "$fixture_root/policy.toml" || fail "fixture policy drifted from production policy"
+cp -R "$fixture_root/raw" "$test_root/raw-a"
+cp -R "$fixture_root/raw" "$test_root/raw-b"
+run_normalize "$test_root/raw-a" "$test_root/report-a.json"
+run_normalize "$test_root/raw-a" "$test_root/report-a-rerun.json"
+cmp -s "$test_root/report-a.json" "$test_root/report-a-rerun.json" || fail "normalization was not deterministic"
+
+python3 - "$test_root/report-a.json" <<'PY'
+import json
+import sys
+
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+assert report["evidence_units"]["cargo_package_name_version_pairs"] == "measured"
+assert report["evidence_units"]["binary_bytes"] == "not measured"
+assert report["evidence_units"]["runtime_memory"] == "not measured"
+foundation = next(item for item in report["profiles"] if item["id"] == "foundation")
+assert foundation["counts"]["duplicate_version_names"] == 1
+dep_v2 = next(
+    item
+    for item in foundation["enabled_features"]
+    if item["name"] == "dep-crate" and item["version"] == "2.0.0"
+)
+assert dep_v2["features"] == ["__rustls", "feature-a"]
+assert report["contracts"]
+assert type(report["context"]["git_dirty"]) is bool
+assert len(report["context"]["git_worktree_digest_sha256"]) == 64
+assert len(report["context"]["cargo_lock_sha256"]) == 64
+assert "/fixture/checkout" not in json.dumps(report)
+PY
+
+replace_text "$test_root/raw-b/foundation.tree" 'dep-crate v1.0.0' 'dep-crate v1.1.0'
+run_normalize "$test_root/raw-b" "$test_root/report-b.json"
+bash "$tool" compare "$test_root/report-a.json" "$test_root/report-b.json" --output "$test_root/delta.json"
+assert_contains "$test_root/delta.json" '"version": "1.1.0"'
+assert_contains "$test_root/delta.json" '"version": "1.0.0"'
+
+cp "$test_root/report-b.json" "$test_root/lockfile-change.json"
+python3 - "$test_root/lockfile-change.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["context"]["cargo_lock_sha256"] = "2" * 64
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+bash "$tool" compare "$test_root/report-a.json" "$test_root/lockfile-change.json" \
+    --output "$test_root/lockfile-delta.json"
+python3 - "$test_root/lockfile-delta.json" <<'PY'
+import json
+import sys
+
+context = json.load(open(sys.argv[1], encoding="utf-8"))["context"]
+assert context["changed_fields"] == ["cargo_lock_sha256"]
+assert context["before"]["cargo_lock_sha256"] == "1" * 64
+assert context["after"]["cargo_lock_sha256"] == "2" * 64
+PY
+
+cp "$test_root/report-b.json" "$test_root/context-mismatch.json"
+python3 - "$test_root/context-mismatch.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["context"]["target"] = "aarch64-unknown-linux-gnu"
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare "$test_root/report-a.json" "$test_root/context-mismatch.json" 2>"$test_root/context-mismatch.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "incompatible target context was accepted"
+assert_contains "$test_root/context-mismatch.err" 'incompatible toolchain or target context'
+
+cp "$test_root/report-a.json" "$test_root/malformed-report.json"
+python3 - "$test_root/malformed-report.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["profiles"][0]["counts"]["package_pairs"] += 1
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare "$test_root/malformed-report.json" "$test_root/report-a.json" 2>"$test_root/malformed-report.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "malformed report counts were accepted"
+assert_contains "$test_root/malformed-report.err" 'values do not match profile records'
+
+cp "$test_root/report-a.json" "$test_root/stripped-contract.json"
+python3 - "$test_root/stripped-contract.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["contracts"].pop()
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare "$test_root/stripped-contract.json" "$test_root/report-a.json" 2>"$test_root/stripped-contract.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "stripped contract record was accepted"
+assert_contains "$test_root/stripped-contract.err" 'records do not match supplied policy'
+
+cp "$test_root/report-a.json" "$test_root/false-contract.json"
+python3 - "$test_root/false-contract.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+profile = next(item for item in report["profiles"] if item["id"] == "hardware-probe")
+profile["enabled_features"] = [
+    item for item in profile["enabled_features"] if item["name"] != "zeroclaw-tools"
+]
+profile["counts"]["enabled_features"] -= 1
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare "$test_root/false-contract.json" "$test_root/report-a.json" 2>"$test_root/false-contract.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "false passing contract record was accepted"
+assert_contains "$test_root/false-contract.err" 'contract tools-probe-enabled'
+
+cp "$test_root/report-a.json" "$test_root/boolean-schema.json"
+python3 - "$test_root/boolean-schema.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+report["schema_version"] = True
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare "$test_root/boolean-schema.json" "$test_root/report-a.json" 2>"$test_root/boolean-schema.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "boolean report schema was accepted"
+assert_contains "$test_root/boolean-schema.err" 'incompatible schema version'
+
+fake_cargo="$test_root/fake-cargo"
+cat >"$fake_cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%q ' "$@" >>"$FAKE_CARGO_LOG"
+printf '\n' >>"$FAKE_CARGO_LOG"
+
+if [[ "${1:-}" == "--version" ]]; then
+    printf '%s\n' 'cargo 1.90.0 (fixture)'
+    exit 0
+fi
+
+if [[ "${1:-}" == "run" ]]; then
+    expected=(run --locked --quiet -p xtask --bin generate -- features --selection dist)
+    if [[ -n "${FAKE_EXPECT_TARGET:-}" ]]; then
+        expected+=(--target "$FAKE_EXPECT_TARGET")
+    fi
+    [[ "$#" -eq "${#expected[@]}" && "$*" == "${expected[*]}" ]] || exit 91
+    printf '%s\n' "${FAKE_CARGO_SELECTION_OUTPUT:-agent-runtime,channel-matrix}"
+    exit 0
+fi
+
+[[ "${1:-}" == "tree" ]] || exit 93
+shift
+package=""
+features=""
+edges=""
+prefix=""
+format=""
+target=""
+locked=false
+no_default=false
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --locked) locked=true; shift ;;
+        --no-default-features) no_default=true; shift ;;
+        --edges) edges="$2"; shift 2 ;;
+        --prefix) prefix="$2"; shift 2 ;;
+        --format) format="$2"; shift 2 ;;
+        --features) features="$2"; shift 2 ;;
+        --target) target="$2"; shift 2 ;;
+        -p) package="$2"; shift 2 ;;
+        *) exit 94 ;;
+    esac
+done
+[[ "$locked" == true ]] || exit 95
+[[ "$edges" == "normal,build" && "$prefix" == "none" ]] || exit 96
+[[ "$format" == $'{p}\tfeatures:{f}' ]] || exit 97
+[[ "$target" == "${FAKE_EXPECT_TARGET:-}" ]] || exit 98
+case "${package}|${no_default}|${features}" in
+    'zeroclaw|true|') profile=foundation ;;
+    'zeroclaw|true|agent-runtime') profile=agent-runtime ;;
+    'zeroclaw|false|') profile=root-default ;;
+    'zeroclaw|true|agent-runtime,channel-matrix') profile=standard-distribution ;;
+    'zeroclaw|true|ci-all') profile=ci-all ;;
+    'zeroclaw|true|agent-runtime,probe,zeroclaw-tools/probe') profile=hardware-probe ;;
+    'zeroclaw-channels|true|') profile=channels-minimal ;;
+    'zeroclaw-channels|false|') profile=channels-default ;;
+    *) exit 99 ;;
+esac
+[[ "$profile" != "${FAKE_CARGO_FAIL_PROFILE:-}" ]] || exit 100
+cat "$FAKE_CARGO_FIXTURE_ROOT/raw/${profile}.tree"
+SH
+chmod +x "$fake_cargo"
+touch "$test_root/fake-cargo.log"
+
+run_fake_capture() {
+    local output="$1"
+    local target="${2:-}"
+    local selection_output="${3:-agent-runtime,channel-matrix}"
+    local fail_profile="${4:-}"
+    local repo_root="${5:-}"
+    local -a args=(--output "$output")
+    if [[ -n "$target" ]]; then
+        args+=(--target "$target")
+    fi
+    if [[ -n "$repo_root" ]]; then
+        args+=(--repo-root "$repo_root")
+    fi
+    (
+        cd "$test_root"
+        CARGO="$fake_cargo" \
+            FAKE_CARGO_FIXTURE_ROOT="$fixture_root" \
+            FAKE_CARGO_LOG="$test_root/fake-cargo.log" \
+            FAKE_CARGO_SELECTION_OUTPUT="$selection_output" \
+            FAKE_CARGO_FAIL_PROFILE="$fail_profile" \
+            FAKE_EXPECT_TARGET="$target" \
+            bash "$tool" "${args[@]}"
+    )
+}
+
+for suffix in a b; do
+    run_fake_capture "$test_root/capture-${suffix}.json"
+done
+cmp -s "$test_root/capture-a.json" "$test_root/capture-b.json" || fail "capture was not deterministic"
+python3 - "$test_root/capture-a.json" <<'PY'
+import json
+import sys
+
+context = json.load(open(sys.argv[1], encoding="utf-8"))["context"]
+assert context["git_dirty"] is True
+assert context["git_worktree_digest_sha256"] != "0" * 64
+PY
+assert_contains "$test_root/fake-cargo.log" 'run --locked --quiet -p xtask --bin generate -- features --selection dist'
+run_fake_capture "$test_root/capture-target.json" 'aarch64-unknown-linux-gnu'
+assert_contains "$test_root/fake-cargo.log" '--target aarch64-unknown-linux-gnu'
+
+source_repo="$test_root/source-repo"
+git init -q "$source_repo"
+printf '%s\n' 'fixture source' >"$source_repo/tracked.txt"
+printf '%s\n' 'version = 4' >"$source_repo/Cargo.lock"
+git -C "$source_repo" add Cargo.lock tracked.txt
+git -C "$source_repo" \
+    -c user.name='Dependency Footprint Fixture' \
+    -c user.email='fixture@example.invalid' \
+    commit -qm 'fixture source'
+in_repo_output="$source_repo/report.json"
+run_fake_capture "$in_repo_output" '' 'agent-runtime,channel-matrix' '' "$source_repo"
+cp "$in_repo_output" "$test_root/in-repo-first.json"
+run_fake_capture "$in_repo_output" '' 'agent-runtime,channel-matrix' '' "$source_repo"
+cmp -s "$test_root/in-repo-first.json" "$in_repo_output" || fail "in-repo output changed its source identity"
+python3 - "$in_repo_output" <<'PY'
+import json
+import sys
+
+assert json.load(open(sys.argv[1], encoding="utf-8"))["context"]["git_dirty"] is False
+PY
+cp "$source_repo/tracked.txt" "$test_root/tracked-before.txt"
+set +e
+run_fake_capture \
+    "$source_repo/tracked.txt" \
+    '' \
+    'agent-runtime,channel-matrix' \
+    '' \
+    "$source_repo" \
+    2>"$test_root/tracked-output.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "tracked output path was accepted"
+assert_contains "$test_root/tracked-output.err" 'output path is tracked by Git'
+cmp -s "$source_repo/tracked.txt" "$test_root/tracked-before.txt" || fail "tracked output was modified"
+
+set +e
+run_fake_capture "$test_root/bad-selection.json" '' $'agent-runtime\nchannel-matrix' 2>"$test_root/bad-selection.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "multiline selection output was accepted"
+assert_contains "$test_root/bad-selection.err" 'expected one non-empty feature line'
+
+set +e
+run_fake_capture \
+    "$test_root/subprocess-failure.json" \
+    '' \
+    'agent-runtime,channel-matrix' \
+    'foundation' \
+    2>"$test_root/subprocess-failure.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "failed Cargo subprocess was accepted"
+assert_contains "$test_root/subprocess-failure.err" 'subprocess failed with status 100'
+
+printf '%s\n' 'not a Cargo package line' > "$test_root/raw-a/foundation.tree"
+set +e
+run_normalize "$test_root/raw-a" "$test_root/should-not-exist.json" 2>"$test_root/malformed.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "malformed tree was accepted"
+assert_contains "$test_root/malformed.err" 'malformed Cargo tree line'
+
+for whitespace in leading trailing; do
+    cp -R "$fixture_root/raw" "$test_root/raw-feature-${whitespace}"
+    if [[ "$whitespace" == leading ]]; then
+        replacement=$'dep-crate v2.0.0\tfeatures: __rustls,feature-a (*)'
+    else
+        replacement=$'dep-crate v2.0.0\tfeatures:__rustls,feature-a '
+    fi
+    replace_text \
+        "$test_root/raw-feature-${whitespace}/foundation.tree" \
+        $'dep-crate v2.0.0\tfeatures:__rustls,feature-a (*)' \
+        "$replacement"
+    set +e
+    run_normalize \
+        "$test_root/raw-feature-${whitespace}" \
+        "$test_root/feature-${whitespace}.json" \
+        2>"$test_root/feature-${whitespace}.err"
+    status=$?
+    set -e
+    [[ "$status" -ne 0 ]] || fail "${whitespace} feature whitespace was accepted"
+    assert_contains "$test_root/feature-${whitespace}.err" 'malformed value'
+done
+
+rm "$test_root/raw-a/channels-default.tree"
+set +e
+run_normalize "$test_root/raw-a" "$test_root/should-not-exist.json" 2>"$test_root/missing.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "missing capture was accepted"
+assert_contains "$test_root/missing.err" 'missing capture'
+
+cp -R "$fixture_root/raw" "$test_root/raw-duplicate"
+cp "$fixture_root/raw/channels-default.tree" "$test_root/raw-duplicate/channels-default.txt"
+set +e
+run_normalize "$test_root/raw-duplicate" "$test_root/should-not-exist.json" 2>"$test_root/duplicate.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "duplicate capture files were accepted"
+assert_contains "$test_root/duplicate.err" 'duplicate capture files'
+
+cp -R "$fixture_root/raw" "$test_root/raw-truncated"
+replace_text \
+    "$test_root/raw-truncated/hardware-probe.tree" \
+    $'zeroclaw v0.8.4\tfeatures:agent-runtime,probe' \
+    $'other-root v0.8.4\tfeatures:agent-runtime,probe'
+set +e
+run_normalize "$test_root/raw-truncated" "$test_root/should-not-exist.json" 2>"$test_root/truncated.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "capture without selected root was accepted"
+assert_contains "$test_root/truncated.err" 'selected root package'
+
+cp -R "$fixture_root/raw" "$test_root/raw-forwarding"
+replace_text \
+    "$test_root/raw-forwarding/hardware-probe.tree" \
+    $'zeroclaw-tools v0.8.4\tfeatures:probe' \
+    $'zeroclaw-tools v0.8.4\tfeatures:'
+set +e
+run_normalize "$test_root/raw-forwarding" "$test_root/should-not-exist.json" 2>"$test_root/forwarding.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "hardware-to-tools forwarding failure was accepted"
+assert_contains "$test_root/forwarding.err" 'tools-probe-enabled'
+
+cp "$fixture_root/policy.toml" "$test_root/unknown-policy.toml"
+printf '%s\n' 'unexpected = true' >>"$test_root/unknown-policy.toml"
+set +e
+bash "$tool" normalize \
+    --policy "$test_root/unknown-policy.toml" \
+    --raw-dir "$fixture_root/raw" \
+    --context "$fixture_root/context.json" \
+    --output "$test_root/should-not-exist.json" \
+    2>"$test_root/unknown-policy.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "unknown policy field was accepted"
+assert_contains "$test_root/unknown-policy.err" 'unknown field'
+
+cp "$fixture_root/policy.toml" "$test_root/boolean-schema.toml"
+replace_text "$test_root/boolean-schema.toml" 'schema_version = 1' 'schema_version = true'
+set +e
+bash "$tool" normalize \
+    --policy "$test_root/boolean-schema.toml" \
+    --raw-dir "$fixture_root/raw" \
+    --context "$fixture_root/context.json" \
+    --output "$test_root/should-not-exist.json" \
+    2>"$test_root/boolean-policy.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "boolean policy schema was accepted"
+assert_contains "$test_root/boolean-policy.err" 'expected 1'
+
+printf '%s\n' '{"old": true}' > "$test_root/atomic.json"
+printf '%s\n' 'not a Cargo package line' > "$test_root/raw-b/foundation.tree"
+set +e
+run_normalize "$test_root/raw-b" "$test_root/atomic.json" 2>"$test_root/atomic.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "atomic failure input was accepted"
+cmp -s "$test_root/atomic.json" <(printf '%s\n' '{"old": true}') || fail "failed write replaced destination"
+
+echo "dependency footprint fixture tests: pass"

--- a/scripts/ci/dependency_footprint.test.sh
+++ b/scripts/ci/dependency_footprint.test.sh
@@ -74,10 +74,46 @@ assert "/fixture/checkout" not in json.dumps(report)
 PY
 
 replace_text "$test_root/raw-b/foundation.tree" 'dep-crate v1.0.0' 'dep-crate v1.1.0'
+replace_text "$test_root/raw-b/foundation.tree" 'dep-crate v2.0.0' 'dep-crate v2.1.0'
 run_normalize "$test_root/raw-b" "$test_root/report-b.json"
 bash "$tool" compare "$test_root/report-a.json" "$test_root/report-b.json" --output "$test_root/delta.json"
 assert_contains "$test_root/delta.json" '"version": "1.1.0"'
 assert_contains "$test_root/delta.json" '"version": "1.0.0"'
+python3 - "$test_root/delta.json" <<'PY'
+import json
+import sys
+
+delta = json.load(open(sys.argv[1], encoding="utf-8"))
+foundation = next(item for item in delta["profiles"] if item["id"] == "foundation")
+assert foundation["feature_deltas"] == []
+PY
+
+cp -R "$fixture_root/raw" "$test_root/raw-feature-delta"
+replace_text \
+    "$test_root/raw-feature-delta/foundation.tree" \
+    $'dep-crate v2.0.0\tfeatures:__rustls,feature-a (*)' \
+    $'dep-crate v2.0.0\tfeatures:__rustls,feature-b (*)'
+run_normalize "$test_root/raw-feature-delta" "$test_root/report-feature-delta.json"
+bash "$tool" compare \
+    "$test_root/report-a.json" \
+    "$test_root/report-feature-delta.json" \
+    --output "$test_root/feature-delta.json"
+python3 - "$test_root/feature-delta.json" <<'PY'
+import json
+import sys
+
+delta = json.load(open(sys.argv[1], encoding="utf-8"))
+foundation = next(item for item in delta["profiles"] if item["id"] == "foundation")
+assert foundation["count_deltas"]["enabled_features"] == 0
+assert foundation["feature_deltas"] == [
+    {
+        "name": "dep-crate",
+        "version": "2.0.0",
+        "added_features": ["feature-b"],
+        "removed_features": ["feature-a"],
+    }
+]
+PY
 
 cp "$test_root/report-b.json" "$test_root/lockfile-change.json"
 python3 - "$test_root/lockfile-change.json" <<'PY'
@@ -137,6 +173,27 @@ status=$?
 set -e
 [[ "$status" -ne 0 ]] || fail "malformed report counts were accepted"
 assert_contains "$test_root/malformed-report.err" 'values do not match profile records'
+
+cp "$test_root/report-a.json" "$test_root/missing-root.json"
+python3 - "$test_root/missing-root.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+report = json.loads(path.read_text(encoding="utf-8"))
+profile = next(item for item in report["profiles"] if item["id"] == "foundation")
+profile["package_pairs"] = [pair for pair in profile["package_pairs"] if pair["name"] != profile["package"]]
+profile["counts"]["package_pairs"] -= 1
+profile["counts"]["unique_package_names"] -= 1
+path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+bash "$tool" compare "$test_root/missing-root.json" "$test_root/report-a.json" 2>"$test_root/missing-root.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "report without declared root package was accepted"
+assert_contains "$test_root/missing-root.err" 'declared package'
 
 cp "$test_root/report-a.json" "$test_root/stripped-contract.json"
 python3 - "$test_root/stripped-contract.json" <<'PY'
@@ -340,6 +397,109 @@ set -e
 [[ "$status" -ne 0 ]] || fail "tracked output path was accepted"
 assert_contains "$test_root/tracked-output.err" 'output path is tracked by Git'
 cmp -s "$source_repo/tracked.txt" "$test_root/tracked-before.txt" || fail "tracked output was modified"
+
+source_repo_link="$test_root/source-repo-link"
+ln -s "$source_repo" "$source_repo_link"
+set +e
+run_fake_capture \
+    "$source_repo_link/tracked.txt" \
+    '' \
+    'agent-runtime,channel-matrix' \
+    '' \
+    "$source_repo" \
+    2>"$test_root/symlinked-parent-output.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "tracked output through a symlinked parent was accepted"
+assert_contains "$test_root/symlinked-parent-output.err" 'output path is tracked by Git'
+cmp -s "$source_repo/tracked.txt" "$test_root/tracked-before.txt" || fail "tracked output through a symlinked parent was modified"
+
+external_sentinel="$test_root/external-sentinel.json"
+printf '%s\n' 'sentinel' >"$external_sentinel"
+symlink_output="$source_repo/symlink-report.json"
+ln -s "$external_sentinel" "$symlink_output"
+git -C "$source_repo" add symlink-report.json
+git -C "$source_repo" \
+    -c user.name='Dependency Footprint Fixture' \
+    -c user.email='fixture@example.invalid' \
+    commit -qm 'fixture symlink output'
+cp "$external_sentinel" "$test_root/external-sentinel-before.txt"
+set +e
+run_fake_capture \
+    "$symlink_output" \
+    '' \
+    'agent-runtime,channel-matrix' \
+    '' \
+    "$source_repo" \
+    2>"$test_root/symlink-output.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "tracked symlink output was accepted"
+assert_contains "$test_root/symlink-output.err" 'output path is an existing symlink'
+cmp -s "$external_sentinel" "$test_root/external-sentinel-before.txt" || fail "external symlink target was modified"
+
+normalize_symlink_output="$test_root/normalize-symlink.json"
+ln -s "$external_sentinel" "$normalize_symlink_output"
+set +e
+run_normalize "$test_root/raw-a" "$normalize_symlink_output" 2>"$test_root/normalize-symlink.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "normalize accepted a symlink output"
+assert_contains "$test_root/normalize-symlink.err" 'output path is an existing symlink'
+cmp -s "$external_sentinel" "$test_root/external-sentinel-before.txt" || fail "normalize modified an external symlink target"
+
+compare_symlink_output="$test_root/compare-symlink.json"
+ln -s "$external_sentinel" "$compare_symlink_output"
+set +e
+bash "$tool" compare \
+    "$test_root/report-a.json" \
+    "$test_root/report-b.json" \
+    --output "$compare_symlink_output" \
+    2>"$test_root/compare-symlink.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "compare accepted a symlink output"
+assert_contains "$test_root/compare-symlink.err" 'output path is an existing symlink'
+cmp -s "$external_sentinel" "$test_root/external-sentinel-before.txt" || fail "compare modified an external symlink target"
+
+python3 - "$script_dir/dependency_footprint.py" "$test_root" <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+module_path = pathlib.Path(sys.argv[1])
+test_root = pathlib.Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("dependency_footprint", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+parent = test_root / "prepared-output-parent"
+moved_parent = test_root / "prepared-output-parent-moved"
+parent.mkdir()
+output = module.prepare_output(str(parent / "report.json"))
+parent.rename(moved_parent)
+parent.mkdir()
+try:
+    module.atomic_write(output, {"unexpected": True})
+except module.ToolError as exc:
+    assert "output parent changed before write" in str(exc)
+else:
+    raise AssertionError("replaced output parent was accepted")
+assert not (parent / "report.json").exists()
+assert not (moved_parent / "report.json").exists()
+PY
+
+set +e
+run_normalize \
+    "$test_root/raw-a" \
+    "$test_root/missing-output-parent/report.json" \
+    2>"$test_root/missing-output-parent.err"
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || fail "normalize created a missing output parent"
+assert_contains "$test_root/missing-output-parent.err" 'output parent does not exist'
+[[ ! -e "$test_root/missing-output-parent" ]] || fail "failed output created its missing parent"
 
 set +e
 run_fake_capture "$test_root/bad-selection.json" '' $'agent-runtime\nchannel-matrix' 2>"$test_root/bad-selection.err"

--- a/scripts/ci/fixtures/dependency-footprint/context.json
+++ b/scripts/ci/fixtures/dependency-footprint/context.json
@@ -1,0 +1,13 @@
+{
+  "cargo_version": "cargo 1.90.0",
+  "cargo_lock_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "git_dirty": false,
+  "git_revision": "432d36e13f0a596c1e59a50fd985bad8cc2cac96",
+  "git_worktree_digest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "resolved_selections": {
+    "dist": ["agent-runtime", "channel-matrix"]
+  },
+  "rustc_host": "x86_64-apple-darwin",
+  "rustc_version": "rustc 1.90.0 (dummy 2026-01-01)",
+  "target": "x86_64-apple-darwin"
+}

--- a/scripts/ci/fixtures/dependency-footprint/policy.toml
+++ b/scripts/ci/fixtures/dependency-footprint/policy.toml
@@ -1,0 +1,85 @@
+schema_version = 1
+edge_kinds = ["normal", "build"]
+
+[[profiles]]
+id = "foundation"
+package = "zeroclaw"
+mode = "no-default-features"
+
+[[profiles]]
+id = "agent-runtime"
+package = "zeroclaw"
+mode = "features"
+features = ["agent-runtime"]
+
+[[profiles]]
+id = "root-default"
+package = "zeroclaw"
+mode = "defaults"
+
+[[profiles]]
+id = "standard-distribution"
+package = "zeroclaw"
+mode = "selection"
+selection = "dist"
+
+[[profiles]]
+id = "ci-all"
+package = "zeroclaw"
+mode = "features"
+features = ["ci-all"]
+
+[[profiles]]
+id = "hardware-probe"
+package = "zeroclaw"
+mode = "features"
+features = ["agent-runtime", "probe", "zeroclaw-tools/probe"]
+
+[[profiles]]
+id = "channels-minimal"
+package = "zeroclaw-channels"
+mode = "no-default-features"
+
+[[profiles]]
+id = "channels-default"
+package = "zeroclaw-channels"
+mode = "defaults"
+
+[[contracts]]
+id = "hardware-package-present"
+profile = "hardware-probe"
+kind = "package"
+package = "zeroclaw-hardware"
+expect = "present"
+
+[[contracts]]
+id = "hardware-probe-enabled"
+profile = "hardware-probe"
+kind = "feature"
+package = "zeroclaw-hardware"
+feature = "probe"
+expect = "enabled"
+
+[[contracts]]
+id = "tools-probe-enabled"
+profile = "hardware-probe"
+kind = "feature"
+package = "zeroclaw-tools"
+feature = "probe"
+expect = "enabled"
+
+[[contracts]]
+id = "root-default-no-hardware-probe"
+profile = "root-default"
+kind = "feature"
+package = "zeroclaw-hardware"
+feature = "probe"
+expect = "forbidden"
+
+[[contracts]]
+id = "standard-distribution-no-hardware-probe"
+profile = "standard-distribution"
+kind = "feature"
+package = "zeroclaw-hardware"
+feature = "probe"
+expect = "forbidden"

--- a/scripts/ci/fixtures/dependency-footprint/raw/agent-runtime.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/agent-runtime.tree
@@ -1,0 +1,2 @@
+zeroclaw v0.8.4	features:agent-runtime
+zeroclaw-tools v0.8.4	features:

--- a/scripts/ci/fixtures/dependency-footprint/raw/channels-default.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/channels-default.tree
@@ -1,0 +1,2 @@
+zeroclaw-channels v0.8.4	features:default-channels
+lettre v0.11.0	features:

--- a/scripts/ci/fixtures/dependency-footprint/raw/channels-minimal.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/channels-minimal.tree
@@ -1,0 +1,1 @@
+zeroclaw-channels v0.8.4	features:

--- a/scripts/ci/fixtures/dependency-footprint/raw/ci-all.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/ci-all.tree
@@ -1,0 +1,2 @@
+zeroclaw v0.8.4	features:ci-all
+zeroclaw-hardware v0.8.4	features:

--- a/scripts/ci/fixtures/dependency-footprint/raw/foundation.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/foundation.tree
@@ -1,0 +1,3 @@
+zeroclaw v0.8.4 (/fixture/checkout)	features:
+dep-crate v1.0.0	features:
+dep-crate v2.0.0	features:__rustls,feature-a (*)

--- a/scripts/ci/fixtures/dependency-footprint/raw/hardware-probe.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/hardware-probe.tree
@@ -1,0 +1,3 @@
+zeroclaw v0.8.4	features:agent-runtime,probe
+zeroclaw-hardware v0.8.4	features:probe
+zeroclaw-tools v0.8.4	features:probe

--- a/scripts/ci/fixtures/dependency-footprint/raw/root-default.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/root-default.tree
@@ -1,0 +1,2 @@
+zeroclaw v0.8.4	features:default
+zeroclaw-runtime v0.8.4	features:

--- a/scripts/ci/fixtures/dependency-footprint/raw/standard-distribution.tree
+++ b/scripts/ci/fixtures/dependency-footprint/raw/standard-distribution.tree
@@ -1,0 +1,2 @@
+zeroclaw v0.8.4	features:agent-runtime,channel-matrix
+zeroclaw-runtime v0.8.4	features:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add a deterministic local report for Cargo package/version pairs and enabled package features across eight representative ZeroClaw build profiles.
  - Keep profile definitions and feature-closure assertions in one TOML policy, including the existing standard distribution feature resolver instead of duplicating that list.
  - Add capture, offline normalization, and report comparison paths with strict schema validation, captured named-selection inputs, deterministic package and feature deltas, source and lockfile identity, toolchain and target context, symlink-safe atomic output, and adversarial fixtures.
- **Scope boundary:** This PR does not change Cargo manifests, feature defaults, runtime behavior, release packaging, GitHub workflows, or tracked dependency baselines. It does not measure binary bytes or runtime memory, and the report labels both as not measured.
- **Blast radius:** Developer tooling only. Nothing invokes the script unless a contributor runs it explicitly; existing builds and CI jobs are unchanged.
- **Linked issue(s):** Related #5574 and #9507. This PR supplies measurement evidence for that architecture direction but does not complete the microkernel transition or the dependency-direction CI gate.
- **Labels:** `type:ci`, `risk:medium`, `size:XL`, `dev`, `scripts`, `distinguished contributor`

### What this does, simply

ZeroClaw can be built with different sets of optional capabilities. Until now, contributors had no repeatable local way to list which Rust packages and package options each selected build included, so dependency cleanup was easy to discuss but hard to measure consistently.

This PR adds an opt-in developer command that asks Cargo what each selected build includes, writes the answer as stable JSON, and compares two reports. Each report records the code revision, lockfile, Rust and Cargo versions, target platform, and selected package options. The tool records the real option list for a named build once, and every profile using that name must show the same list, so offline comparison rejects internally inconsistent inputs. Malformed input fails instead of producing a plausible but misleading result.

The command does not shrink builds, change default capabilities, or add a CI rule. It gives contributors a consistent before-and-after measurement for later reduction work. The JSON is an unsigned local report, not a tamper-proof attestation.

### Scope and maintenance tradeoff

The aggregate change is 2,068 lines: 1,228 lines for the parser, wrapper, and policy, and 840 lines for the test driver and compact fixtures. Keeping the capture, normalization, validation, and comparison schema together is the smallest coherent version because splitting them would either publish reports that cannot be validated or add a comparison format without a canonical producer.

The implementation uses Python's standard library and the existing locked `xtask` feature-selection command. It adds no Rust crate or third-party dependency and does not duplicate the standard distribution feature list. Strict parsing and the larger negative-test matrix are intentional because a dependency report is only useful when truncated Cargo output, malformed feature tokens or policy types, stale contracts, selection-profile drift, incompatible targets, redirected output paths, and partial writes fail closed.

Tracked baselines and workflow enforcement remain separate decisions. That keeps this PR report-only and avoids turning the first measurement format into a release policy before maintainers have used it.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes. A local A/B run directly demonstrates deterministic capture and comparison.
- **Interface(s) exercised:** `cli` developer script; no messaging channel.
- **Setup / preconditions:** Python 3.11 or newer, the repository Rust toolchain, and the checked-in `Cargo.lock`.
- **Steps to run:**

```sh
./scripts/ci/dependency_footprint.sh --output /tmp/zeroclaw-footprint-a.json
./scripts/ci/dependency_footprint.sh --output /tmp/zeroclaw-footprint-b.json
cmp /tmp/zeroclaw-footprint-a.json /tmp/zeroclaw-footprint-b.json
./scripts/ci/dependency_footprint.sh compare /tmp/zeroclaw-footprint-a.json /tmp/zeroclaw-footprint-b.json
```

- **Expected on this branch (after):** Both captures succeed, the files are byte-identical for unchanged source and toolchain context, all five policy contracts pass, and comparison reports no package, feature, or count deltas.
- **Prior behavior on `master` (before):** `scripts/ci/dependency_footprint.sh` does not exist, so the same measurement and comparison are unavailable.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required hosted CI is green on repair head `ba49a7762a4013f72f1406a81e7d574b0fef1577`. The focused local checks below cover the new Python, shell, parser, and report behavior, including Cargo-invocation shape through fixtures; hosted CI supplies repository-integration coverage.
- **Known CI coverage gap, if any:** No workflow invokes the new report in this PR. That is intentional; the report format and local evidence land before any baseline or enforcement policy.
- **Commands run and tail output:**

```text
$ bash scripts/ci/dependency_footprint.test.sh
dependency footprint fixture tests: pass

$ bash -n scripts/ci/dependency_footprint.sh scripts/ci/dependency_footprint.test.sh
$ PYTHONPYCACHEPREFIX=/tmp/zeroclaw-dependency-footprint-pycache python3 -m py_compile scripts/ci/dependency_footprint.py
$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ ./scripts/ci/dependency_footprint.sh --output /tmp/zeroclaw-footprint-a.json
$ ./scripts/ci/dependency_footprint.sh --output /tmp/zeroclaw-footprint-b.json
$ cmp /tmp/zeroclaw-footprint-a.json /tmp/zeroclaw-footprint-b.json
```

The live capture commands above ran on prior published head `adf59ff2c8f201227f6e27c1cd7591546ff068ad`. `cmp` exited 0; both reports had SHA-256 `3f99d0eb1094f68b260212bd397d1997b022ae3963ba72a9735629394116b45f`. The current repair does not change Cargo invocation or graph selection, but it adds captured selection expansion to normalized report context. Exact-head fixture coverage exercises that serialization, exact policy selection keys, identical bogus selection-profile inputs in both reports, comparison, validation, and output publication directly.

- **Beyond CI, what did you manually verify?** The prior published head produced two byte-identical reports covering eight profiles and five passing contracts. A separate parser matched all four count fields for the foundation and standard distribution profiles. The reports contain no checkout, temporary-directory, or Cargo cache paths. On the repair head, focused fixtures cover serialized selection context, missing and extra selection keys, identical bogus selection-profile inputs, malformed nested-array edge kinds without a traceback, equal-cardinality feature replacement, version-only package movement, omitted declared roots, failed subprocesses, malformed and truncated trees, unknown policy fields, incompatible toolchain or target context, false contract records, tracked output paths, symlink leaves across all three writers, tracked files reached through symlinked parents, output-parent replacement, missing output parents, and invalid feature whitespace. The external sentinel and existing destinations remain unchanged after every rejected write. Binary size and runtime memory were not measured.
- **Visual interface changed?** N/A; no rendered or interactive surface changed.
- **If any command was intentionally skipped, why:** No local Cargo command or broad workspace build was run for this repair because it changes only Python report serialization, offline validation, policy diagnostics, and shell fixtures. The prior live captures already establish the canonical resolver and Cargo-tree shape, while fresh required hosted CI remains the repository-integration check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes.** The opt-in developer command reads repository and Cargo metadata and writes only the caller-selected report path through an atomic replacement. The immediate output parent must already exist; the tool rejects symlink leaves and tracked output paths and does not run from application or daemon code.
- New external network calls? **Yes.** The script has no custom network client, but its Cargo and `xtask` subprocesses may use Cargo's normal registry, index, or dependency-download behavior when required artifacts are not cached. Operators who require offline behavior must supply Cargo's normal offline configuration and a populated cache; the tool does not enforce offline mode.
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Fixtures use synthetic package names, versions, revisions, and toolchain strings.
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any `Yes`, describe the risk and mitigation: A caller can choose where to write a report. The tool refuses tracked destinations and symlink leaves, excludes its own untracked output from source identity, requires and pins the existing output parent, writes and replaces descriptor-relatively through a sibling temporary file, and never embeds checkout or cache paths in the report. Cargo network access uses the contributor's existing Cargo configuration and credentials; the tool adds no network client, endpoint, credential handling, or runtime invocation.

## Compatibility (required)

- Backward compatible? **Yes.**
- Config / env / CLI surface changed? **Yes.** This adds an optional developer-script CLI and policy TOML; it does not change the `zeroclaw` user CLI, runtime config, or environment-variable contract.
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade is required. Existing builds do not invoke the tool. Contributors who run it need Python 3.11 or newer plus the repository Rust toolchain.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the commits from this PR; no manifest, lockfile, baseline, workflow, or persisted runtime state needs migration.
- **Feature flags or config toggles:** None. The developer command is opt-in and has no CI or runtime integration.
- **Observable failure symptoms:** The command exits nonzero with a profile, schema, contract, subprocess, context, or output-path error and leaves existing destinations and external symlink targets unchanged. Existing application logs and metrics are unaffected because the tool is never called by runtime code.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
