### PR TITLE
fix(gateway): generate dashboard status contract

### DIFF
--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -8,6 +8,7 @@ use axum::{
     response::{IntoResponse, Json},
 };
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use zeroclaw_config::schema::{ChannelAliasInfo, Config};
 use zeroclaw_memory::MemoryEntry;
 
@@ -231,6 +232,47 @@ pub struct SessionMessagePostBody {
 
 // ── Handlers ────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+pub struct StatusNodes {
+    pub connected: Vec<String>,
+    pub mdns_peers: Vec<crate::nodes::mdns::MdnsPeerSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+pub struct StatusResponse {
+    pub version: String,
+    /// Dotted `<type>.<alias>` of the resolved model provider, or `null` when none is configured.
+    /// The unqualified provider name is reserved; this field is always qualified.
+    pub model_provider: Option<String>,
+    pub model: String,
+    /// Resolved model temperature, or `null` when no temperature is configured.
+    pub temperature: Option<f64>,
+    pub uptime_seconds: u64,
+    /// RFC 3339 UTC wall-clock time when the daemon started.
+    pub daemon_started_at: String,
+    pub gateway_port: u16,
+    pub locale: String,
+    pub memory_backend: String,
+    pub paired: bool,
+    pub channels: BTreeMap<String, bool>,
+    pub nodes: StatusNodes,
+    pub health: zeroclaw_runtime::health::HealthSnapshot,
+    /// Configured agent alias used for per-agent resolution, or `null` for the install-wide view.
+    pub agent_alias: Option<String>,
+    /// Self-process resource snapshot; unsupported hosts report zero memory and a null CPU value.
+    pub process: zeroclaw_runtime::process_stats::ProcessStats,
+    /// Whether the gateway polls for newer releases and shows an update indicator.
+    pub check_updates: bool,
+    /// Whether browser-triggered self-upgrade is enabled.
+    pub allow_self_upgrade: bool,
+    /// How the daemon is restarted after an upgrade: supervised, self-respawn, or manual.
+    pub restart_mode: crate::version::RestartMode,
+    /// Operator-facing command or instruction for completing an upgrade restart.
+    pub restart_hint: String,
+}
+
 /// Query parameters for `GET /api/status`. Pass `?agent=<alias>` to
 /// have `model_provider`, `model`, `temperature`, and `memory_backend`
 /// reflect that specific agent's resolved config; omit it for the
@@ -256,10 +298,10 @@ pub async fn handle_api_status(
 
     // Per-alias map keyed by composite `<type>.<alias>`. Every
     // populated `[channels.<type>.<alias>]` is a separate dashboard row.
-    let mut channels = serde_json::Map::new();
+    let mut channels = BTreeMap::new();
     for info in config.channels_by_alias() {
         let composite = format!("{}.{}", info.channel_type, info.alias);
-        channels.insert(composite, serde_json::Value::Bool(true));
+        channels.insert(composite, true);
     }
 
     let locale = config
@@ -315,30 +357,30 @@ pub async fn handle_api_status(
     // the upgrade button, and which restart command to show afterwards.
     let restart = crate::version::detect_restart();
 
-    let body = serde_json::json!({
-        "version": env!("CARGO_PKG_VERSION"),
-        "model_provider": model_provider,
-        "model": model,
-        "temperature": temperature,
-        "uptime_seconds": health.uptime_seconds,
-        "daemon_started_at": zeroclaw_runtime::health::daemon_started_at(),
-        "gateway_port": config.gateway.port,
-        "locale": locale,
-        "memory_backend": memory_backend,
-        "paired": state.pairing.is_paired(),
-        "channels": channels,
-        "nodes": {
-            "connected": state.node_registry.node_ids(),
-            "mdns_peers": state.mdns_peer_registry.snapshots(),
+    let body = StatusResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        model_provider,
+        model,
+        temperature,
+        uptime_seconds: health.uptime_seconds,
+        daemon_started_at: zeroclaw_runtime::health::daemon_started_at(),
+        gateway_port: config.gateway.port,
+        locale,
+        memory_backend,
+        paired: state.pairing.is_paired(),
+        channels,
+        nodes: StatusNodes {
+            connected: state.node_registry.node_ids(),
+            mdns_peers: state.mdns_peer_registry.snapshots(),
         },
-        "health": health,
-        "agent_alias": agent_alias,
-        "process": process,
-        "check_updates": config.gateway.check_updates,
-        "allow_self_upgrade": config.gateway.allow_self_upgrade,
-        "restart_mode": restart.mode.as_str(),
-        "restart_hint": restart.hint,
-    });
+        health,
+        agent_alias: agent_alias.map(String::from),
+        process,
+        check_updates: config.gateway.check_updates,
+        allow_self_upgrade: config.gateway.allow_self_upgrade,
+        restart_mode: restart.mode,
+        restart_hint: restart.hint,
+    };
 
     Json(body).into_response()
 }
@@ -2366,7 +2408,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn api_status_includes_connected_nodes_and_mdns_peers() {
+    async fn api_status_contract_includes_connected_nodes_and_mdns_peers() {
         let state = test_state(zeroclaw_config::schema::Config::default());
         let (invoke_tx, _invoke_rx) = tokio::sync::mpsc::channel(1);
         assert!(state.node_registry.register(nodes::NodeInfo {
@@ -2412,6 +2454,39 @@ pub(crate) mod tests {
                 "base_url": "http://10.0.0.2:42617/peer",
             }])
         );
+    }
+
+    #[tokio::test]
+    async fn api_status_contract_preserves_nullable_and_nested_fields() {
+        let state = test_state(zeroclaw_config::schema::Config::default());
+        let response = handle_api_status(
+            State(state),
+            HeaderMap::new(),
+            Query(StatusQuery { agent: None }),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let json = response_json(response).await;
+        assert!(json["version"].as_str().is_some());
+        assert!(json["temperature"].is_null());
+        assert!(json["agent_alias"].is_null());
+        assert!(json["uptime_seconds"].is_u64());
+        assert!(json["daemon_started_at"].as_str().is_some());
+        assert!(json["channels"].is_object());
+        assert!(json["nodes"]["connected"].is_array());
+        assert!(json["nodes"]["mdns_peers"].is_array());
+        assert!(json["health"]["pid"].is_u64());
+        assert!(json["health"]["components"].is_object());
+        assert!(json["process"]["rss_bytes"].is_u64());
+        assert!(
+            json["process"]["cpu_percent"].is_null() || json["process"]["cpu_percent"].is_number()
+        );
+        assert!(json["check_updates"].is_boolean());
+        assert!(json["allow_self_upgrade"].is_boolean());
+        assert!(json["restart_mode"].as_str().is_some());
+        assert!(json["restart_hint"].as_str().is_some());
     }
 
     #[test]

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -2469,6 +2469,36 @@ pub(crate) mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         let json = response_json(response).await;
+        let actual_fields: std::collections::BTreeSet<_> = json
+            .as_object()
+            .expect("status response object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let expected_fields = [
+            "agent_alias",
+            "allow_self_upgrade",
+            "channels",
+            "check_updates",
+            "daemon_started_at",
+            "gateway_port",
+            "health",
+            "locale",
+            "memory_backend",
+            "model",
+            "model_provider",
+            "nodes",
+            "paired",
+            "process",
+            "restart_hint",
+            "restart_mode",
+            "temperature",
+            "uptime_seconds",
+            "version",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(actual_fields, expected_fields);
         assert!(json["version"].as_str().is_some());
         assert!(json["temperature"].is_null());
         assert!(json["agent_alias"].is_null());
@@ -2485,7 +2515,10 @@ pub(crate) mod tests {
         );
         assert!(json["check_updates"].is_boolean());
         assert!(json["allow_self_upgrade"].is_boolean());
-        assert!(json["restart_mode"].as_str().is_some());
+        assert_eq!(
+            json["restart_mode"],
+            crate::version::detect_restart().mode.as_str()
+        );
         assert!(json["restart_hint"].as_str().is_some());
     }
 

--- a/crates/zeroclaw-gateway/src/nodes/mdns.rs
+++ b/crates/zeroclaw-gateway/src/nodes/mdns.rs
@@ -121,6 +121,7 @@ impl MdnsPeer {
 
 /// Authenticated API/status snapshot of a discovered LAN peer.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct MdnsPeerSnapshot {
     pub id: String,
     pub name: String,

--- a/crates/zeroclaw-gateway/src/openapi.rs
+++ b/crates/zeroclaw-gateway/src/openapi.rs
@@ -57,6 +57,7 @@ pub async fn handle_openapi_json() -> Response {
 
 #[cfg(feature = "schema-export")]
 pub fn build_spec() -> serde_json::Value {
+    use crate::api::StatusResponse;
     use crate::api_config::{
         DriftEntry, DriftResponse, InitQuery, InitResponse, ListResponse, MigrateResponse, PatchOp,
         PatchResponse, PropPutBody, PropResponse, ReloadStatusResponse, SecretResponse,
@@ -69,6 +70,14 @@ pub fn build_spec() -> serde_json::Value {
 
     fn schema_value<T: JsonSchema>() -> serde_json::Value {
         serde_json::to_value(schema_for!(T)).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn response_schema_value<T: JsonSchema>() -> serde_json::Value {
+        let generator = schemars::generate::SchemaSettings::default()
+            .for_serialize()
+            .into_generator();
+        serde_json::to_value(generator.into_root_schema_for::<T>())
+            .unwrap_or(serde_json::Value::Null)
     }
 
     let components = serde_json::json!({
@@ -99,6 +108,7 @@ pub fn build_spec() -> serde_json::Value {
             "ApprovalDecision": schema_value::<zeroclaw_runtime::sop::ApprovalDecision>(),
             "TriggerSourceRegistry": schema_value::<zeroclaw_runtime::sop::TriggerSourceRegistry>(),
             "SlashOptionKindsResult": schema_value::<crate::api_skills::SlashOptionKindsResult>(),
+            "StatusResponse": response_schema_value::<StatusResponse>(),
         },
         "securitySchemes": {
             "bearerAuth": {
@@ -157,6 +167,14 @@ pub fn build_spec() -> serde_json::Value {
         "description": "Scope the status read to a specific upgrade run (404 on mismatch)."
     });
 
+    let status_agent_param = serde_json::json!({
+        "name": "agent",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "string" },
+        "description": "Optional configured agent alias to resolve model and memory status for.",
+    });
+
     let version_error = |description: &str| {
         serde_json::json!({
             "description": description,
@@ -201,6 +219,20 @@ pub fn build_spec() -> serde_json::Value {
     });
 
     let paths = serde_json::json!({
+        "/api/status": {
+            "get": {
+                "tags": ["status"],
+                "summary": "Read gateway status",
+                "description": "Returns the authenticated gateway status snapshot.",
+                "parameters": [status_agent_param],
+                "responses": {
+                    "200": {
+                        "description": "Current gateway status.",
+                        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StatusResponse" } } }
+                    }
+                }
+            }
+        },
         "/api/config/prop": {
             "get": {
                 "tags": ["config"],
@@ -571,6 +603,7 @@ mod tests {
         let spec = build_spec();
         let paths = spec.get("paths").unwrap();
         assert!(paths.get("/api/config/prop").is_some());
+        assert!(paths.get("/api/status").is_some());
         assert!(paths.get("/api/config/list").is_some());
         assert!(paths.get("/api/config").is_some());
         assert!(paths.get("/api/config/init").is_some());
@@ -601,6 +634,107 @@ mod tests {
         // Refs must be rewritten to point at the hoisted component, not `$defs`.
         let spec_str = serde_json::to_string(&spec).unwrap();
         assert!(!spec_str.contains("#/$defs/"));
+    }
+
+    #[cfg(feature = "schema-export")]
+    #[test]
+    fn status_contract_schema_is_nullable_and_path_is_query_scoped() {
+        let spec = build_spec();
+        let schemas = spec.pointer("/components/schemas").unwrap();
+        let status = schemas.get("StatusResponse").expect("status schema");
+        let status_required = status
+            .get("required")
+            .and_then(serde_json::Value::as_array)
+            .expect("StatusResponse required fields");
+        for field in ["model_provider", "temperature", "agent_alias"] {
+            assert!(
+                status_required
+                    .iter()
+                    .any(|value| value.as_str() == Some(field)),
+                "StatusResponse.{field} must remain present even when null"
+            );
+            let schema = status
+                .pointer(&format!("/properties/{field}"))
+                .unwrap_or_else(|| panic!("missing StatusResponse.{field}"));
+            let encoded = serde_json::to_string(schema).unwrap();
+            assert!(
+                encoded.contains("null"),
+                "StatusResponse.{field} must remain nullable: {schema}"
+            );
+        }
+
+        let process = schemas.get("ProcessStats").expect("process schema");
+        let process_required = process
+            .get("required")
+            .and_then(serde_json::Value::as_array)
+            .expect("ProcessStats required fields");
+        assert!(
+            process_required
+                .iter()
+                .any(|value| value.as_str() == Some("cpu_percent")),
+            "ProcessStats.cpu_percent must remain present even when null"
+        );
+        let cpu_percent = process
+            .pointer("/properties/cpu_percent")
+            .expect("ProcessStats.cpu_percent schema");
+        assert!(
+            serde_json::to_string(cpu_percent).unwrap().contains("null"),
+            "ProcessStats.cpu_percent must remain nullable: {cpu_percent}"
+        );
+
+        let mdns_peer = schemas.get("MdnsPeerSnapshot").expect("mDNS peer schema");
+        let mdns_required = mdns_peer
+            .get("required")
+            .and_then(serde_json::Value::as_array)
+            .expect("MdnsPeerSnapshot required fields");
+        assert!(
+            mdns_required
+                .iter()
+                .any(|value| value.as_str() == Some("path_prefix")),
+            "MdnsPeerSnapshot.path_prefix must remain present even when null"
+        );
+        let path_prefix = mdns_peer
+            .pointer("/properties/path_prefix")
+            .expect("MdnsPeerSnapshot.path_prefix schema");
+        assert!(
+            serde_json::to_string(path_prefix).unwrap().contains("null"),
+            "MdnsPeerSnapshot.path_prefix must remain nullable: {path_prefix}"
+        );
+
+        let component_health = schemas
+            .get("ComponentHealth")
+            .expect("component health schema");
+        let component_required = component_health
+            .get("required")
+            .and_then(serde_json::Value::as_array)
+            .expect("ComponentHealth required fields");
+        for field in ["last_ok", "last_error"] {
+            assert!(
+                component_required
+                    .iter()
+                    .any(|value| value.as_str() == Some(field)),
+                "ComponentHealth.{field} must remain present even when null"
+            );
+            let schema = component_health
+                .pointer(&format!("/properties/{field}"))
+                .unwrap_or_else(|| panic!("missing ComponentHealth.{field}"));
+            assert!(
+                serde_json::to_string(schema).unwrap().contains("null"),
+                "ComponentHealth.{field} must remain nullable: {schema}"
+            );
+        }
+
+        let status_get = spec.pointer("/paths/~1api~1status/get").unwrap();
+        assert_eq!(
+            status_get.pointer("/parameters/0/name"),
+            Some(&serde_json::Value::String("agent".into()))
+        );
+        assert_eq!(
+            status_get.pointer("/responses/200/content/application~1json/schema/$ref"),
+            Some(&serde_json::Value::String(
+                "#/components/schemas/StatusResponse".into()
+            ))
+        );
     }
 
     #[cfg(feature = "schema-export")]

--- a/crates/zeroclaw-gateway/src/version.rs
+++ b/crates/zeroclaw-gateway/src/version.rs
@@ -41,7 +41,9 @@ fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 // ── Restart classification (advisory) ────────────────────────────
 
 /// How a post-upgrade restart is achieved in this environment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
 pub enum RestartMode {
     /// A supervisor (systemd/launchd) relaunches us after a clean exit.
     Supervised,

--- a/crates/zeroclaw-gateway/src/version.rs
+++ b/crates/zeroclaw-gateway/src/version.rs
@@ -799,10 +799,18 @@ mod tests {
     }
 
     #[test]
-    fn restart_mode_as_str_is_stable() {
-        assert_eq!(RestartMode::Supervised.as_str(), "supervised");
-        assert_eq!(RestartMode::SelfRespawn.as_str(), "self_respawn");
-        assert_eq!(RestartMode::Manual.as_str(), "manual");
+    fn restart_mode_wire_values_are_stable() {
+        for (mode, expected) in [
+            (RestartMode::Supervised, "supervised"),
+            (RestartMode::SelfRespawn, "self_respawn"),
+            (RestartMode::Manual, "manual"),
+        ] {
+            assert_eq!(mode.as_str(), expected);
+            assert_eq!(
+                serde_json::to_value(mode).expect("serialize mode"),
+                expected
+            );
+        }
         assert!(RestartMode::Supervised.auto_restartable());
         assert!(RestartMode::SelfRespawn.auto_restartable());
         assert!(!RestartMode::Manual.auto_restartable());

--- a/crates/zeroclaw-runtime/src/health/mod.rs
+++ b/crates/zeroclaw-runtime/src/health/mod.rs
@@ -6,6 +6,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 #[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct ComponentHealth {
     pub status: String,
     pub updated_at: String,
@@ -15,6 +16,7 @@ pub struct ComponentHealth {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct HealthSnapshot {
     pub pid: u32,
     pub updated_at: String,

--- a/crates/zeroclaw-runtime/src/process_stats.rs
+++ b/crates/zeroclaw-runtime/src/process_stats.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use sysinfo::{MemoryRefreshKind, Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
 
 #[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 pub struct ProcessStats {
     /// Resident set size in bytes. `0` when unsupported.
     pub rss_bytes: u64,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,38 +1,6 @@
-export interface StatusResponse {
-  version?: string;
-  /** Dotted `<type>.<alias>` of the first configured model provider, or null
-   *  when none is configured. "provider" alone is reserved — always qualify. */
-  model_provider: string | null;
-  model: string;
-  temperature: number;
-  uptime_seconds: number;
-  /** RFC 3339 wall-clock of daemon start. Stable across the daemon's
-   *  lifetime so the Logs page can default `since_ts` to "since daemon
-   *  start" without a separate `/api/logs` round-trip. */
-  daemon_started_at?: string;
-  gateway_port: number;
-  locale: string;
-  memory_backend: string;
-  paired: boolean;
-  channels: Record<string, boolean>;
-  health: HealthSnapshot;
-  /** Self-process resource snapshot. Populated on Linux, macOS, Windows,
-   * and FreeBSD via the `sysinfo` crate; on unsupported hosts
-   * `rss_bytes = 0` and `cpu_percent = null`. */
-  process?: ProcessStats;
-  /** Whether the gateway is configured to poll for newer releases and show an
-   *  update indicator (`gateway.check_updates`, default true). */
-  check_updates?: boolean;
-  /** Whether browser-triggered self-upgrade is enabled
-   *  (`gateway.allow_self_upgrade`, default false). Gates the upgrade button. */
-  allow_self_upgrade?: boolean;
-  /** How a post-upgrade restart is achieved: `supervised` (systemd/launchd
-   *  relaunches on exit), `self_respawn` (bare unix — the daemon detached-spawns
-   *  the new binary), or `manual` (container / non-unix bare — no auto-restart). */
-  restart_mode?: "supervised" | "self_respawn" | "manual";
-  /** Command to show the operator for finishing an upgrade with a restart. */
-  restart_hint?: string;
-}
+import type { components } from "../lib/api-generated";
+
+export type StatusResponse = components["schemas"]["StatusResponse"];
 
 export interface ProcessStats {
   rss_bytes: number;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `GET /api/status` now returns a typed Rust `StatusResponse`, and the gateway OpenAPI document publishes that response plus the authenticated status path. The dashboard imports the generated top-level OpenAPI component instead of maintaining a second handwritten status-response envelope.
- **What changed and why:** Status fields that are always emitted as either a value or `null` are generated from the response serialization contract. They remain required and nullable in TypeScript, while unrelated request and component schemas keep the existing generation behavior.
- **Scope boundary:** This does not change status values, dashboard rendering, memory-count behavior from #9069, the separate RPC status wire, or any other gateway endpoint. Existing handwritten `ProcessStats` and `HealthSnapshot` interfaces remain for their current direct consumers.
- **Blast radius:** Gateway status serialization and OpenAPI output, the nested health/process/mDNS/restart-mode schemas reachable from that response, and dashboard compile-time types.
- **Linked issue(s):** Related #8858
- **Labels:** `gateway`, `health`, `runtime`, `web`, `distinguished contributor`, `risk:medium`, `size:M`, `type:refactor`

### What this does, simply

The web dashboard asks the gateway for one status snapshot covering the daemon, model, channels, nodes, health, process usage, and upgrade state. The gateway previously assembled that JSON without a named response type, while the dashboard kept a separate handwritten copy of what it expected; those two descriptions could drift even when the live response still worked.

This PR makes the gateway's Rust response the single top-level status envelope used by both sides. The OpenAPI generator turns that envelope and its reachable Rust types into the dashboard type and preserves fields that are always present but sometimes `null`. Existing handwritten `ProcessStats` and `HealthSnapshot` interfaces remain for their current direct consumers; this PR does not migrate those standalone interfaces. It does not change what operators see or how status is calculated.

### Scope and maintenance tradeoff

The change touches seven files because the status response reuses health, process, mDNS, and restart-mode types from their existing owners. Adding schema derives there keeps one owner for each nested contract instead of introducing status-only mirrors. The response-specific schema generator is deliberately limited to `StatusResponse`; broadening the separate `/api/health` types or #9069's memory-count behavior would add independent acceptance and compatibility work.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — runtime JSON and dashboard rendering are intentionally unchanged; focused handler, OpenAPI, generation, and typecheck evidence exercise the contract migration directly.

### How I tested

- **CI checks relied on and why they cover this change:** The required current-head [Quality Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/32921790280) is green and provides the shared workspace, lint, test, and cross-target evidence. The focused local checks below cover the contract details that broad CI does not assert directly.
- **Known CI coverage gap, if any:** None; required current-head CI is green, and the focused tests plus generated-client check cover the Rust-to-OpenAPI-to-TypeScript path.
- **Commands run and tail output:**

```bash
scripts/zc-cargo-narrow --wait test -p zeroclaw-gateway --features schema-export status_contract
# 3 passed; 0 failed

scripts/zc-cargo-narrow --wait test -p zeroclaw-gateway --features schema-export restart_mode_wire_values_are_stable
# 1 passed; 0 failed

scripts/zc-cargo-narrow --wait run -p xtask --bin web -- check
# OpenAPI client generated; npx tsc -b passed

cargo fmt --all -- --check
# passed

bash scripts/ci/comment_hygiene_gate.sh
# passed

git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Inspected the generated `StatusResponse`, `ProcessStats`, `MdnsPeerSnapshot`, and `ComponentHealth` types and confirmed that every always-emitted nullable field is required and typed with `| null`. I did not perform a visual dashboard smoke because this changes only its compile-time response type.
- **Visual interface changed?** N/A — no rendered text, layout, interaction, or visible state changes.
- **If any command was intentionally skipped, why:** I did not run a broad local workspace build or test suite because required current-head CI supplies that shared evidence, while the focused Rust and dashboard commands cover the generated contract directly.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes — the runtime JSON field names, values, nesting, and explicit `null` behavior are preserved.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-commit>` restores the handwritten dashboard type and anonymous gateway response together.
- **Feature flags or config toggles:** None — this is a source-of-truth migration with no runtime feature switch.
- **Observable failure symptoms:** OpenAPI generation marks always-present nullable status fields as optional or non-nullable, the generated dashboard client no longer typechecks, or `GET /api/status` omits or renames an existing field.

