### PR TITLE
chore(channels): gate axum by channel features

### DIFF
--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -37,7 +37,7 @@ axum = { version = "0.8", default-features = false, features = [
   "query",
   "tokio",
   "ws",
-] }
+], optional = true }
 async-imap = { version = "0.11", features = [
   "runtime-tokio",
 ], default-features = false, optional = true }
@@ -216,14 +216,14 @@ channel-email = [
 ]
 image-normalization = ["dep:image"]
 channel-telegram = ["image-normalization"]
-channel-lark = ["dep:prost"]
+channel-lark = ["dep:axum", "dep:prost"]
 channel-git = ["provider-github", "provider-gitea"]
 # Forge providers for the git channel. `provider-github` (GitHub Apps) and
 # `provider-gitea` (Gitea/Forgejo PAT) are default-on under `channel-git`;
 # future forges (e.g. `provider-gitlab`) add their own sub-feature and deps here.
 provider-github = ["dep:jsonwebtoken", "dep:thiserror"]
 provider-gitea = []
-channel-line = []
+channel-line = ["dep:axum"]
 channel-nostr = ["dep:nostr-sdk"]
 whatsapp-web = [
   "dep:bytes",
@@ -268,9 +268,9 @@ channel-wechat = [
 channel-wecom = []
 channel-wecom-ws = ["dep:aes", "dep:cbc"]
 channel-clawdtalk = []
-channel-webhook = []
+channel-webhook = ["dep:axum"]
 channel-whatsapp-cloud = []
-channel-voice-call = []
+channel-voice-call = ["dep:axum"]
 channel-acp-server = []
 channel-matrix = ["dep:matrix-sdk", "dep:mime_guess"]
 voice-wake = ["dep:cpal"]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Made the channels crate's production `axum` dependency optional, then enabled it from the webhook, Lark, LINE, and voice-call features that compile the current axum consumers.
- **Scope boundary:** Does not change channel behavior, root feature forwarding, ACP, the test-only Discord dependency, or the other dependency slices tracked by #6864.
- **Blast radius:** Cargo feature resolution for selective `zeroclaw-channels` builds; default and full channel builds continue to include the same channel implementations.
- **Linked issue(s):** Related #6864
- **Labels:** `dependencies`, `distinguished contributor`, `risk:low`, `size:XS`, `type:dependencies`

### What this does, simply

ZeroClaw can be built with only selected messaging channels. Before this change, every such build pulled in the web-server library even when none of the selected channels used it.

This PR connects that library only to webhook, Lark, LINE, and voice-call, the four channels that actually need it. It does not change how those channels behave or remove the library from builds that include them.

### Scope and maintenance tradeoff

All four current production users move together because changing fewer would break at least one selective channel build. The PR reuses the existing per-channel features instead of adding another shared `http-server` switch that could drift from them.

ACP is deliberately not included because the current channels source does not use axum there. SQLite and the TLS/WebSocket dependency family remain separate #6864 slices with different consumers and validation needs.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this changes Cargo dependency activation without changing a user-facing runtime path.

### How I tested

- **CI checks relied on and why they cover this change:** Required current-head CI is green on `812a7c1`, including the repository lint and test gates, all-features and no-default-features checks, platform checks, MSRV, and the aggregate `CI Required Gate`.
- **Known CI coverage gap, if any:** None. The local matrix below covers the selective feature contract directly.
- **Commands run and tail output:**

```text
$ cargo tree -p zeroclaw-channels --locked --no-default-features --edges normal --invert axum
warning: nothing to print.

$ cargo check -p zeroclaw-channels --locked --no-default-features --features channel-lark
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 19s

$ cargo check -p zeroclaw-channels --locked --no-default-features --features channel-webhook
Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.06s

$ cargo check -p zeroclaw-channels --locked --no-default-features --features channel-line
Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.22s

$ cargo check -p zeroclaw-channels --locked --no-default-features --features channel-voice-call
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 56s

$ cargo check -p zeroclaw-channels --locked --tests --no-default-features --features channel-discord
Finished `dev` profile [unoptimized + debuginfo] target(s) in 10m 16s

$ cargo fmt --all -- --check
pass
```

- **Beyond CI, what did you manually verify?** Inspected every direct channels-crate axum use and its module feature gate. Verified that webhook, Lark, LINE, and voice-call are the production consumers, Discord's use is test-only, ACP has no direct axum use, and `Cargo.lock` is unchanged. The Discord compilation emitted Cargo's existing future-incompatibility notice for `proc-macro-error2 v2.0.1`, which is already present on `master` and is not changed here. No runtime smoke was needed because runtime behavior is unchanged.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** No broad local workspace build was run; fresh required CI supplies that aggregate coverage, while the focused local matrix independently checks each changed feature boundary.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

`git revert 812a7c1fcb9a6d8a3a7e1d1cd1ecc61ceb504e0a`
