### PR TITLE
docs(security): update distroless base to Debian 13

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,7 +69,7 @@ ZeroClaw Docker images follow CIS Docker Benchmark best practices:
 | Control | Implementation |
 |---------|----------------|
 | **4.1 Non-root user** | Container runs as UID 65534 (distroless nonroot) |
-| **4.2 Minimal base image** | `gcr.io/distroless/cc-debian12:nonroot` — no shell, no package manager |
+| **4.2 Minimal base image** | `gcr.io/distroless/cc-debian13:nonroot` — no shell, no package manager |
 | **4.6 HEALTHCHECK** | Not applicable (stateless CLI/gateway) |
 | **5.25 Read-only filesystem** | Supported via `docker run --read-only` with `/workspace` volume |
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Updated the CIS Docker Benchmark 4.2 documentation from `gcr.io/distroless/cc-debian12:nonroot` to the current `gcr.io/distroless/cc-debian13:nonroot` image.
  - Aligns `SECURITY.md` with the canonical base-image configuration and generated Dockerfile.
- **Scope boundary:** Documentation only; no image, Dockerfile, CI, runtime, permission, or digest changes.
- **Blast radius:** Security documentation readers; no runtime or build behavior changes.
- **Linked issue(s):** Closes #10235
- **Labels:** `docs`, `security:docker`, `domain:security`, `risk:low`, `size:XS`, `type:docs`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is a one-line documentation correction with no manual runtime path.

### How I tested

- **CI checks relied on and why they cover this change:** The documentation link gate passed, and the repository documentation quality gate was run. The changed file is root-level `SECURITY.md`, so the quality gate correctly reported that no `docs/` files were detected.
- **Known CI coverage gap, if any:** The documentation quality gate does not lint root-level `SECURITY.md` through its changed-doc detection. `git diff --check` and the link gate cover whitespace and link integrity; this change adds no links.
- **Commands run and tail output:**

```text
$ git diff --check
exit 0; no output

$ bash scripts/ci/docs_quality_gate.sh
No docs files detected; skipping docs quality gate.

$ bash scripts/ci/docs_links_gate.sh
......
----------------------------------------------------------------------
Ran 6 tests in 0.253s

OK
No docs files available for link collection.
No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** Confirmed that the documented image name matches `dev/ci/container-base-images.toml` and the generated `Dockerfile`. No Docker build was run because the patch changes documentation only.
- **Visual interface changed?** N/A — no application interface or rendered layout changed.
- **If any command was intentionally skipped, why:** Rust formatting, Clippy, Rust tests, and Docker builds were skipped because no source, build, or runtime behavior changed.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A — no migration or upgrade steps are required.
- Upgrade steps for existing users: N/A — this documentation-only correction requires no migration.

## Rollback

- **Fast rollback command/path:** `git revert f47d605df`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** None expected; this is a documentation-only correction.
