### PR TITLE
fix(channels): deduplicate Discord image URL fallback

### DIFF
--- a/crates/zeroclaw-api/src/media.rs
+++ b/crates/zeroclaw-api/src/media.rs
@@ -163,17 +163,33 @@ impl MediaAttachment {
         self.marker.as_ref().map(|m| m.target.as_str())
     }
 
+    /// Return the target of a channel-rendered image marker that points at a
+    /// remote URL while the attachment bytes remain available in memory.
+    ///
+    /// Such a marker is a fallback reference rather than an owned,
+    /// reloadable image: the default provider path does not fetch remote
+    /// images. A later media-enrichment stage can therefore remove this exact
+    /// channel marker and replace it with the typed bytes without treating a
+    /// sender-authored marker as channel metadata.
+    pub fn channel_rendered_remote_image_target(&self) -> Option<&str> {
+        self.marker.as_ref().and_then(|marker| {
+            (marker.kind == MarkerKind::Image && is_remote_reference(&marker.target))
+                .then_some(marker.target.as_str())
+        })
+    }
+
     /// Whether the receiving channel already rendered a marker whose
     /// disposition a later enrichment stage must not override.
     ///
     /// See [`MarkerKind::defers_enrichment`]. The channel saw the payload, the
     /// sender's declared type, and the transport's own notion of what was
     /// sent, so its image-or-document verdict wins over a second, payload-only
-    /// classification downstream.
+    /// classification downstream. A remote URL image fallback is excluded:
+    /// its typed bytes can replace the URL when remote fetching is disabled.
     pub fn channel_rendered_owned_disposition(&self) -> bool {
         self.marker
             .as_ref()
-            .is_some_and(|m| m.kind.defers_enrichment())
+            .is_some_and(|m| m.kind.defers_enrichment() && !is_remote_reference(&m.target))
     }
 
     /// Classify this attachment into a [`MediaKind`].
@@ -257,6 +273,10 @@ impl MediaAttachment {
     pub fn provider_loadable_image_mime(&self) -> Option<&'static str> {
         provider_loadable_image_mime_for(&self.file_name, &self.data)
     }
+}
+
+fn is_remote_reference(reference: &str) -> bool {
+    reference.starts_with("http://") || reference.starts_with("https://")
 }
 
 /// The provider-loadable image MIME for a `(file_name, bytes)` pair, or `None`

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -1256,17 +1256,15 @@ async fn process_attachments(
             } else {
                 Some(ct.to_string())
             },
-            // Only claim a channel-owned disposition when the rendered target
-            // is a local path the provider can reload. A URL fallback (no
-            // workspace, or a failed save) is not fetched under the default
-            // no-remote-image path, so owning it would make the shared
-            // pipeline defer bytes nothing downstream can recover; leaving the
-            // marker unset instead lets enrichment keep a loadable image in
-            // play. The saved name carries a uniqueness prefix, so `file_name`
-            // alone cannot identify the marker just rendered above — record the
-            // target and disposition so a later stage reads the verdict rather
-            // than re-deciding it from the payload.
-            marker: saved_locally.then(|| RenderedMarker {
+            // Record the exact rendered target for image URL fallbacks too.
+            // They are deliberately not treated as channel-owned by the
+            // shared pipeline: the raw bytes are available and can replace
+            // the URL without relying on remote fetching. The saved name
+            // carries a uniqueness prefix, so `file_name` alone cannot
+            // identify the marker just rendered above — record the target and
+            // disposition so a later stage reads the verdict rather than
+            // re-deciding it from the payload.
+            marker: (saved_locally || marker_kind == MarkerKind::Image).then(|| RenderedMarker {
                 target: marker_target.clone(),
                 kind: marker_kind,
             }),
@@ -4420,10 +4418,9 @@ mod tests {
 
     /// With no workspace configured (or a failed save) the rendered target is
     /// the attachment URL, which the default no-remote-image path will not
-    /// fetch. Owning that marker would make the pipeline defer bytes nothing
-    /// downstream can recover, so a loadable image must instead fall through to
-    /// enrichment and reach the provider as inline data. Before the fix, the
-    /// URL marker was owned and the supported image was silently dropped.
+    /// fetch. The typed envelope records that fallback as non-owned, so the
+    /// pipeline replaces the URL with inline data and provider preparation
+    /// sees one effective image reference without a false partial-load note.
     #[tokio::test]
     async fn image_with_no_workspace_is_enriched_rather_than_dropped() {
         use crate::orchestrator::media_pipeline::MediaPipeline;
@@ -4449,12 +4446,17 @@ mod tests {
 
         assert_eq!(media.len(), 1, "one attachment in, one envelope out");
         assert!(
-            media[0].marker.is_none(),
-            "a URL fallback is not reloadable, so it must not be owned as a marker"
+            media[0].marker_target().is_some(),
+            "a URL fallback must retain its exact channel marker target"
+        );
+        assert_eq!(
+            media[0].channel_rendered_remote_image_target(),
+            attachments[0]["url"].as_str(),
+            "the URL fallback must be exposed for exact replacement"
         );
         assert!(
             !media[0].channel_rendered_owned_disposition(),
-            "an unowned attachment must not be deferred by the shared pipeline"
+            "a remote URL fallback must not be deferred by the shared pipeline"
         );
 
         let config = zeroclaw_config::schema::MediaPipelineConfig {
@@ -4470,6 +4472,80 @@ mod tests {
             enriched.contains("IMAGE:data:"),
             "the loadable image's bytes must reach the provider as inline data, not be dropped: {enriched}"
         );
+
+        let prepared = zeroclaw_providers::multimodal::prepare_messages_for_provider(
+            &[zeroclaw_api::model_provider::ChatMessage::user(enriched)],
+            &zeroclaw_config::schema::MultimodalConfig::default(),
+        )
+        .await
+        .expect("provider preparation should accept the inline fallback image");
+        assert!(prepared.contains_images);
+        let provider_content = &prepared.messages[0].content;
+        assert_eq!(
+            provider_content.matches("data:image/jpeg;base64,").count(),
+            1,
+            "provider preparation must receive one effective image: {provider_content}"
+        );
+        assert!(
+            !provider_content.contains("could not be loaded"),
+            "a successful inline fallback must not produce a partial-load note: {provider_content}"
+        );
+        assert!(
+            !provider_content.contains(attachments[0]["url"].as_str().unwrap()),
+            "the unfetchable URL must not survive beside the inline image: {provider_content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn image_with_failed_workspace_save_is_enriched_rather_than_dropped() {
+        use crate::orchestrator::media_pipeline::MediaPipeline;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/attachments/1/photo.jpg"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![0xFFu8, 0xD8, 0xFF, 0xE0]))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/attachments/1/photo.jpg", server.uri());
+        let attachments = vec![serde_json::json!({
+            "filename": "photo.jpg",
+            "content_type": "image/jpeg",
+            "url": url,
+        })];
+        // A regular file cannot contain the `discord_files` save directory,
+        // so this exercises the same URL fallback after download succeeds.
+        let blocked_workspace = tempfile::NamedTempFile::new().unwrap();
+
+        let (text, media) = process_attachments(
+            &attachments,
+            &reqwest::Client::new(),
+            Some(blocked_workspace.path()),
+            None,
+        )
+        .await;
+
+        assert_eq!(media.len(), 1, "one attachment in, one envelope out");
+        assert_eq!(media[0].marker_target(), Some(url.as_str()));
+        assert_eq!(
+            media[0].channel_rendered_remote_image_target(),
+            Some(url.as_str())
+        );
+        assert!(!media[0].channel_rendered_owned_disposition());
+
+        let config = zeroclaw_config::schema::MediaPipelineConfig {
+            enabled: true,
+            describe_images: true,
+            ..Default::default()
+        };
+        let enriched = MediaPipeline::new(&config, None, true)
+            .process(&text, &media)
+            .await;
+
+        assert!(enriched.contains("[IMAGE:data:image/jpeg;base64,"));
+        assert!(!enriched.contains(&url));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/media_pipeline.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/media_pipeline.rs
@@ -42,9 +42,23 @@ impl<'a> MediaPipeline<'a> {
             return original_text.to_string();
         }
 
+        let mut text = original_text.to_string();
         let mut annotations = Vec::new();
 
         for attachment in attachments {
+            // Discord can render an image URL when saving the downloaded
+            // bytes fails. The typed envelope still owns those bytes, so
+            // replace exactly one channel-rendered URL marker with the inline
+            // representation this pipeline is about to add. Removing from
+            // the end preserves a sender-authored marker with the same URL in
+            // the message caption.
+            if self.vision_available
+                && self.config.describe_images
+                && let Some(target) = attachment.channel_rendered_remote_image_target()
+            {
+                text = remove_last_channel_image_marker(&text, target);
+            }
+
             // A channel that saved these bytes and rendered a marker for them
             // has already classified this attachment, with more to go on than
             // the pipeline has: the payload, the sender's declared type, and
@@ -104,9 +118,9 @@ impl<'a> MediaPipeline<'a> {
             enriched.push('\n');
         }
 
-        if !original_text.is_empty() {
+        if !text.is_empty() {
             enriched.push('\n');
-            enriched.push_str(original_text);
+            enriched.push_str(&text);
         }
 
         enriched.trim().to_string()
@@ -156,6 +170,18 @@ impl<'a> MediaPipeline<'a> {
     fn process_video(&self, attachment: &MediaAttachment) -> String {
         format!("[Video: {} attached]", attachment.file_name)
     }
+}
+
+fn remove_last_channel_image_marker(text: &str, target: &str) -> String {
+    let marker = format!("[IMAGE:{target}]");
+    let Some(start) = text.rfind(&marker) else {
+        return text.to_string();
+    };
+    let end = start + marker.len();
+    let mut cleaned = String::with_capacity(text.len() - marker.len());
+    cleaned.push_str(&text[..start]);
+    cleaned.push_str(&text[end..]);
+    cleaned
 }
 
 fn image_payload_for_vision(attachment: &MediaAttachment) -> (String, Cow<'_, [u8]>) {
@@ -453,6 +479,46 @@ mod tests {
             !result.contains("IMAGE:data:"),
             "uuid-prefixed save names must still join to their marker: {result}"
         );
+    }
+
+    #[tokio::test]
+    async fn discord_remote_image_fallback_replaces_its_channel_marker() {
+        let config = default_pipeline_config(true);
+        let pipeline = MediaPipeline::new(&config, None, true);
+        let url = "https://cdn.discordapp.com/attachments/1/photo.jpg";
+        let attachment = MediaAttachment {
+            file_name: "photo.jpg".to_string(),
+            data: vec![0xFF, 0xD8, 0xFF, 0xE0],
+            mime_type: Some("image/jpeg".to_string()),
+            marker: Some(RenderedMarker {
+                target: url.to_string(),
+                kind: MarkerKind::Image,
+            }),
+        };
+        let original = format!("caption\n\n[IMAGE:{url}]");
+
+        let result = pipeline.process(&original, &[attachment]).await;
+
+        assert!(
+            !result.contains(url),
+            "the fallback URL must be replaced: {result}"
+        );
+        assert_eq!(
+            result.matches("[IMAGE:data:").count(),
+            1,
+            "the typed bytes must produce one inline image marker: {result}"
+        );
+        assert!(result.contains("caption"));
+    }
+
+    #[test]
+    fn discord_remote_image_fallback_removes_only_the_last_matching_marker() {
+        let url = "https://cdn.discordapp.com/attachments/1/photo.jpg";
+        let original = format!("[IMAGE:{url}] is part of the caption\n\n[IMAGE:{url}]");
+
+        let result = remove_last_channel_image_marker(&original, url);
+
+        assert_eq!(result, format!("[IMAGE:{url}] is part of the caption\n\n"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Preserve the exact Discord image URL fallback in the typed media envelope when the downloaded bytes cannot be saved locally.
  - Treat that fallback as a non-owned reload reference so the shared media pipeline can replace it with the already-held inline bytes.
  - Remove only the matching channel-rendered marker before provider preparation, preventing duplicate image references and the misleading partial-load warning when remote fetching is disabled.
- **Scope boundary:** Supported Discord image URL fallbacks only; no change to remote image-fetch policy or audio, video, document, and successful local-save handling.
- **Blast radius:** Discord inbound attachment text and the shared media pipeline/provider-preparation input; successful local saves and sender-authored markers retain their existing behavior.
- **Linked issue(s):** Fixes #10327
- **Labels:** `bug`, `channel`, `channel:core`, `channel:discord`, `risk:medium`, `size:S`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — deterministic wiremock tests cover both no-workspace and failed-save fallbacks without Discord credentials.

### How I tested

- **CI checks relied on and why:** No remote CI checks exist before publication. The profile-selected ZeroClaw preflight covered the changed Rust/API/channel surface and its runtime interactions: formatting, workspace Clippy, locked workspace tests, and the repeated parallel runtime regression gate all passed.
- **Known CI coverage gap, if any:** No live Discord account smoke test was run. The attempted package-wide `zeroclaw-channels --no-default-features` lane reached 626 passing tests but had 5 failures in existing `link_enricher` redirect-policy wiremock tests, outside the changed files; the final profile-selected preflight passed with local wiremock/public-test hosts excluded from the proxy.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
status: passed

$ cargo test -p zeroclaw-api --lib
test result: ok. 191 passed; 0 failed

$ cargo test -p zeroclaw-channels --lib orchestrator::media_pipeline -- --nocapture
test result: ok. 21 passed; 0 failed

$ cargo test -p zeroclaw-channels --lib image_with_no_workspace_is_enriched_rather_than_dropped -- --nocapture
test result: ok. 1 passed; 0 failed

$ cargo test -p zeroclaw-channels --lib image_with_failed_workspace_save_is_enriched_rather_than_dropped -- --nocapture
test result: ok. 1 passed; 0 failed

$ cargo test -p zeroclaw-channels --lib --no-default-features
test result: FAILED. 626 passed; 5 failed
failures: link_enricher::tests::redirect_policy_follows_public_hop,
redirect_policy_preserves_five_redirect_limit,
redirect_policy_rejects_absolute_localhost_hop,
redirect_policy_rejects_public_to_private_hop,
redirect_policy_rejects_sixth_redirect

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
status: passed

$ cargo test --locked
status: passed

$ NO_PROXY=127.0.0.1,localhost,::1,public.test,public.test. bash scripts/ci/parallel_runtime_test_gate.sh
status: passed
parallel gate tails: zeroclaw-runtime 3 x (3880 passed, 3 ignored);
zeroclaw-channels 3 x (1492 passed, 2 ignored)

$ git diff --check
status: passed
```

- **Beyond CI, what did I manually verify?** Reviewed the provider-facing fallback path and confirmed that remote fetching remains disabled, the typed bytes are reused, and only the channel-rendered URL is removed. No live Discord credentials or external service smoke test were used.
- **Visual interface changed?** `N/A` — no UI, layout, or terminal presentation changed; this only deduplicates internal provider-facing attachment text.
- **If any command was intentionally skipped, why:** No required profile-selected validation command was skipped. Live Discord smoke testing was not run because it requires external account credentials; the deterministic wiremock tests cover the fallback behavior.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No — the change does not enable remote image fetching; downloading the Discord attachment already existed.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? Yes — provider-facing text now replaces a channel-rendered Discord URL fallback with the corresponding typed image bytes. The replacement requires typed attachment provenance, exact marker matching, and the existing vision/config gates; sender-authored markers do not establish provenance.
- If any `Yes`, describe the risk and mitigation: The model-visible representation changes only for a downloaded image whose exact channel marker is recorded in the typed envelope. No new remote content is fetched, and the existing bytes/configuration controls remain in force.

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: `N/A`

## Rollback

- **Fast rollback command/path:** Revert the squashed merge commit for this PR with `git revert <squashed-merge-commit-sha>`.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Repeated Discord image fallbacks would again appear as both a remote URL marker and inline bytes, or provider preparation would report a false `1 of 2 attached image(s) could not be loaded` warning when remote fetching is disabled.
