### PR TITLE
fix(channels): state WhatsApp formatting syntax in its delivery instructions

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -913,6 +913,9 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
         "whatsapp" | "whatsapp-web" => Some(
             "When responding on WhatsApp Web:\n\
              - Be concise and direct\n\
+             - WhatsApp has its own formatting syntax and does not render Markdown. Use *single asterisks* for bold, _underscores_ for italic, and ~tildes~ for strikethrough.\n\
+             - Do not use **double asterisks**, # headers, or [label](url) Markdown links: WhatsApp renders none of them, so the raw characters reach the reader as literal punctuation.\n\
+             - Start each list item with a dash and a space. Leave bare URLs unwrapped; WhatsApp links them automatically.\n\
              - For media attachments use markers: [IMAGE:<path>], [DOCUMENT:<path>], [VIDEO:<path>], [AUDIO:<path>], or [VOICE:<path>]\n\
              - To send a native location pin, use marker: [LOCATION:<latitude>,<longitude>,<name>,<address>] where name and address are optional. Double-quote the name if it contains commas; the trailing address may contain commas without quoting.\n\
              - Marker paths must refer to local files inside the configured workspace directory. Absolute paths and workspace-relative paths are accepted when they stay inside that workspace.\n\
@@ -28164,6 +28167,28 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(
             block.contains("Do not use http://, https://, data:, file:"),
             "whatsapp block must say URL schemes are refused"
+        );
+        assert!(
+            block.contains("does not render Markdown"),
+            "whatsapp block must say Markdown is not rendered: the send path is a byte-for-byte passthrough, so an unstated policy ships the model's guess verbatim"
+        );
+        assert!(
+            block.contains("*single asterisks* for bold"),
+            "whatsapp block must teach WhatsApp bold, not Markdown bold"
+        );
+        assert!(
+            block.contains("_underscores_ for italic"),
+            "whatsapp block must teach WhatsApp italic"
+        );
+        assert!(
+            block.contains("~tildes~ for strikethrough"),
+            "whatsapp block must teach WhatsApp strikethrough"
+        );
+        assert!(
+            channel_delivery_instructions("telegram")
+                .expect("telegram must have a delivery-instructions block")
+                .contains("Use **bold** for key terms"),
+            "control: telegram keeps its own double-asterisk syntax, so the two arms stayed distinct"
         );
         assert_eq!(
             channel_delivery_instructions("whatsapp-web"),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Added WhatsApp Web formatting syntax to the existing channel delivery instructions so models use single asterisks for bold, underscores for italic, tildes for strikethrough, dash bullets, and bare URLs instead of unsupported Markdown forms that WhatsApp can render with stray punctuation.
- **Scope boundary:** This does not add a formatter or change the WhatsApp send protocol. It changes only the model-visible WhatsApp delivery guidance and its focused contract test.
- **Blast radius:** WhatsApp Web system prompts for the production `whatsapp` channel name and the `whatsapp-web` compatibility alias. Other channel prompt arms and outbound transports are unchanged.
- **Linked issue(s):** None.
- **Labels:** `bug`, `channel`, `channel:core`, `channel:whatsapp`, `agent:prompt`, `risk:medium`, `size:XS`

### What this does, simply

ZeroClaw already tells each chat model how its destination formats messages. WhatsApp Web lacked that guidance, so models could emit doubled Markdown asterisks that WhatsApp partially rendered as bold while leaving stray asterisks visible. This change teaches the model WhatsApp’s own text markers before it writes a reply. It does not add a second conversion layer.

## Testing

### How you can test

- **Reviewer testing requested?** N/A — the load-bearing source contract is deterministic system-prompt injection, while any single end-to-end model response is stochastic. The focused regression and exact-head CI cover the changed code boundary.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head `CI Required Gate`, format, lint, all-features and no-default-features checks, tests, security, and platform checks all passed. The focused channel test directly exercises the changed prompt arm.
- **Known CI coverage gap, if any:** CI does not prove that every model will follow the instruction on every response; that is not a deterministic guarantee of this prompt-only change.
- **Commands run and tail output:**

```text
cargo fmt --check -p zeroclaw-channels
clean

cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
clean

cargo test -p zeroclaw-channels --lib channel_delivery_instructions
5 passed; 0 failed
```

- **Beyond CI, what did you manually verify?** On a live WhatsApp Web channel, a message emitted as `**0.19 USDC**` produced one `<strong>` element whose text began with a literal asterisk, with two literal asterisks still visible. This establishes the doubled-asterisk half-parse that the new guidance prevents. The exact-head branch was not used to claim deterministic model compliance.
- **Visual interface changed?** N/A — no WhatsApp or ZeroClaw renderer changes. The code changes model-visible guidance before an ordinary text reply reaches the existing WhatsApp passthrough.
- **If any command was intentionally skipped, why:** No additional reviewer Cargo run was needed because fresh exact-head CI and the focused author regression cover the changed Rust surface.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **Yes**
- If any Yes, describe the risk and mitigation: The static trusted system guidance for WhatsApp replies changes. It is scoped to the existing `whatsapp` / `whatsapp-web` arm, contains no user-controlled interpolation, and has focused assertions for the supported syntax and alias boundary.

## Compatibility

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback

- **Fast rollback command/path:** Revert commit `ba89a592f08c92356ba3c0ad7a19a4c2fa264e7c`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** WhatsApp replies regress to doubled Markdown markers or show partially bold text with stray literal asterisks.
