### PR TITLE
fix(channels): cap the setMyCommands body by size, not only by command count

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -40,6 +40,15 @@ enum IncomingAttachmentKind {
 const TELEGRAM_BIND_COMMAND: &str = "/bind";
 /// Telegram Bot API allows at most 100 commands via setMyCommands.
 const TELEGRAM_MAX_BOT_COMMANDS: usize = 100;
+/// setMyCommands also refuses on total BODY SIZE, and reports that refusal with the
+/// same `BOT_COMMANDS_TOO_MUCH` string it uses for too many commands. The size limit
+/// is undocumented, so it is measured: against the live API, a body of 100 commands
+/// serializing to 9,714 bytes is accepted and the same shape at 9,814 bytes is
+/// refused. 100 commands each carrying a description at
+/// `TELEGRAM_COMMAND_DESCRIPTION_MAX_LEN` serializes to roughly 14,800 bytes, so the
+/// two per-item caps can both be satisfied and the request still be rejected. Budget
+/// well under the measured edge.
+const TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES: usize = 8192;
 /// Telegram command names: 1-32 lowercase a-z, 0-9, and underscore.
 const TELEGRAM_COMMAND_NAME_MAX_LEN: usize = 32;
 /// Telegram command descriptions nominally allow up to 256 characters per the API docs,
@@ -90,6 +99,30 @@ fn truncate_telegram_command_description(raw: &str) -> String {
         .collect();
     truncated.push('…');
     truncated
+}
+
+/// Serialized length of the `setMyCommands` request body for `commands`.
+///
+/// A serialization failure cannot make the real body smaller, so it reports 0 and
+/// lets the request itself surface the problem rather than dropping every command.
+fn telegram_bot_commands_body_len(commands: &[serde_json::Value]) -> usize {
+    serde_json::to_string(&serde_json::json!({ "commands": commands })).map_or(0, |s| s.len())
+}
+
+/// Drop trailing commands until the `setMyCommands` body fits
+/// `TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES`, and report how many were dropped.
+///
+/// This is a second cap, applied after the count cap: the two are independent, and
+/// a command set inside the count limit can still exceed the size limit.
+fn fit_telegram_bot_commands_to_body_budget(commands: &mut Vec<serde_json::Value>) -> usize {
+    let mut dropped = 0;
+    while !commands.is_empty()
+        && telegram_bot_commands_body_len(commands) > TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES
+    {
+        commands.pop();
+        dropped += 1;
+    }
+    dropped
 }
 
 /// Split a message into chunks that respect Telegram's 4096 character limit.
@@ -1285,6 +1318,29 @@ impl TelegramChannel {
                 // measurements (limit, configured, registered) ride solely in
                 // `attributes` above, never in the message.
                 "Telegram command registration truncated to the platform limit"
+            );
+        }
+
+        // Second, independent cap: setMyCommands also refuses on total body size,
+        // reporting it as BOT_COMMANDS_TOO_MUCH. A set inside the count limit can
+        // still exceed it, which is why this runs after the truncation above.
+        let before_body_cap = commands.len();
+        let dropped_for_body = fit_telegram_bot_commands_to_body_budget(&mut commands);
+        if dropped_for_body > 0 {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({
+                        "TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES":
+                            TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES,
+                        "before_body_cap": before_body_cap,
+                        "registered": commands.len(),
+                        "dropped": dropped_for_body,
+                    })),
+                // Stable literal per the logging contract: per-event measurements
+                // ride solely in `attributes` above, never in the message.
+                "Telegram command registration trimmed to the platform body-size limit"
             );
         }
 
@@ -10440,6 +10496,75 @@ mod tests {
         assert_eq!(
             truncate_telegram_command_description("Short desc"),
             "Short desc"
+        );
+    }
+
+    /// Build `n` commands whose descriptions sit at the per-command cap. This is the
+    /// shape a real install reaches once enough tools and skills expose commands.
+    fn telegram_commands_fixture(n: usize, description_len: usize) -> Vec<serde_json::Value> {
+        (0..n)
+            .map(|i| {
+                serde_json::json!({
+                    "command": format!("toolcmd{i:03}"),
+                    "description": "d".repeat(description_len),
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn telegram_bot_commands_within_count_limit_can_still_exceed_the_body_budget() {
+        // The exact shape the live API refuses: the count cap and the per-command
+        // description cap are both satisfied, and the body is still too large.
+        let commands = telegram_commands_fixture(
+            TELEGRAM_MAX_BOT_COMMANDS,
+            TELEGRAM_COMMAND_DESCRIPTION_MAX_LEN,
+        );
+        assert_eq!(commands.len(), TELEGRAM_MAX_BOT_COMMANDS);
+        assert!(
+            telegram_bot_commands_body_len(&commands) > TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES,
+            "a full command set at the description cap must exceed the body budget, \
+             otherwise this test is not exercising the case the API rejects"
+        );
+    }
+
+    #[test]
+    fn fit_telegram_bot_commands_trims_an_oversized_body_to_the_budget() {
+        let mut commands = telegram_commands_fixture(
+            TELEGRAM_MAX_BOT_COMMANDS,
+            TELEGRAM_COMMAND_DESCRIPTION_MAX_LEN,
+        );
+        let before = commands.len();
+        let dropped = fit_telegram_bot_commands_to_body_budget(&mut commands);
+
+        assert!(dropped > 0, "an oversized body must lose commands");
+        assert_eq!(
+            commands.len() + dropped,
+            before,
+            "every dropped command must be accounted for"
+        );
+        assert!(
+            telegram_bot_commands_body_len(&commands) <= TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES,
+            "the trimmed body must fit the budget"
+        );
+        assert!(
+            !commands.is_empty(),
+            "trimming must not empty the menu outright"
+        );
+    }
+
+    #[test]
+    fn fit_telegram_bot_commands_leaves_a_small_set_untouched() {
+        // Over-correction control: a set that already fits must not be trimmed, so a
+        // green result above cannot come from a function that always drops commands.
+        let mut commands = telegram_commands_fixture(6, 40);
+        let before = commands.clone();
+        let dropped = fit_telegram_bot_commands_to_body_budget(&mut commands);
+
+        assert_eq!(dropped, 0, "a body inside the budget must lose nothing");
+        assert_eq!(
+            commands, before,
+            "a fitting set must be left byte-identical"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Telegram accepts at most 100 bot commands, but it can also reject a `setMyCommands` request whose serialized body is too large even when the count and per-description limits are individually satisfied. After the existing count cap, this change drops trailing commands until the exact `{"commands": ...}` JSON shape sent to Telegram fits a conservative 8,192-byte budget. Built-ins and earlier skill/tool commands retain their existing priority.
- **Scope boundary:** Telegram command registration only. This does not change command construction, ordering, deduplication, command-name or description limits, configuration, inbound handling, or any other channel.
- **Blast radius:** Telegram startup command-menu registration. Oversized menus register a deterministic prefix instead of leaving Telegram's last successful menu silently stale; menus already within the budget are byte-identical.
- **Linked issue(s):** Related #8950. Related #8963. Those addressed the independent command-count cap and its warning; this PR covers the distinct serialized-body limit.
- **Labels:** `bug`, `channel`, `channel:telegram`, `risk:medium`, `size:S`

## Measurement and implementation

The Telegram Bot API reports a body-size rejection with the same `BOT_COMMANDS_TOO_MUCH` description used for too many commands. In an author-run live API probe on 2026-08-26, command count was held at 100 while description length changed:

| Commands | Description characters | Body bytes | Result |
| ---: | ---: | ---: | :--- |
| 100 | 10 | 5,814 | Accepted |
| 100 | 43 | 9,014 | Accepted |
| 100 | 50 | 9,714 | Accepted |
| 100 | 51 | 9,814 | `BOT_COMMANDS_TOO_MUCH` |
| 100 | 100 | 14,814 | `BOT_COMMANDS_TOO_MUCH` |
| 70 | 256 | 21,294 | `BOT_COMMANDS_TOO_MUCH` |

The 100-command, 10-character row is the count control. The exact threshold is undocumented, so `TELEGRAM_MAX_BOT_COMMANDS_BODY_BYTES` is deliberately conservative at 8,192 bytes. A future maintainer can repeat the privacy-safe method with a disposable bot token supplied from the environment: hold the generated command names and count constant, vary only description length, serialize the `{"commands": [...]}` body, record its byte length locally, and compare the `setMyCommands` response without recording the token.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the deterministic tests exercise the exact serialized request shape; a live Telegram repetition requires a bot credential and is not needed for this bounded review.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head required CI is green. `Test` runs the changed Telegram unit tests; `Lint`, `Format`, the build/check matrix, MSRV, and `CI Required Gate` cover the changed Rust surface.
- **Known CI coverage gap, if any:** No live Telegram Bot API smoke at the reviewed head. The byte budget is based on the author-run empirical probe above, while unit tests prove the local serialization and trimming invariant.
- **Commands run and tail output:** The first block is author-reported validation from the current PR body. The final registration-path command was run by the exact-head repository reviewer and is preserved separately so it is not attributed to the author.

```text
cargo fmt --check -p zeroclaw-channels
(no output; clean)

cargo clippy -p zeroclaw-channels --all-targets -- -D warnings
Finished successfully with no warnings

cargo test -p zeroclaw-channels --lib telegram_bot_commands
test result: ok. 3 passed; 0 failed

cargo test -p zeroclaw-channels --lib fit_telegram_bot_commands
test result: ok. 2 passed; 0 failed

scripts/ci/comment_hygiene_gate.sh
passed
```

Exact-head repository-review evidence:

```text
cargo test --locked -p zeroclaw-channels --lib register_bot_commands
test result: ok. 7 passed; 0 failed; 1 ignored
```

- **Beyond CI, what did you manually verify?** The author probed the live Telegram API using the controlled body-size method above. The mutation control raises the budget until no trimming occurs: the oversized trim test fails while the already-fitting control remains green.
- **Visual interface changed?** N/A — this changes Telegram's remote command-menu registration payload, not a ZeroClaw-rendered interface.
- **If any command was intentionally skipped, why:** No reviewer live Telegram smoke was run because no review credential was available; the direct serialization boundary is deterministic.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**; it changes the existing `setMyCommands` payload only.
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any **Yes**, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge-sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Telegram logs `BOT_COMMANDS_TOO_MUCH` during startup command registration and the visible command menu remains at its last successfully registered state instead of reflecting the current tools and skills.
