### PR TITLE
perf: stop replaying duplicated tool-result envelopes and stale reasoning into context

### DIFF
--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -361,9 +361,19 @@ impl OpenAiModelProvider {
     }
 
     fn convert_messages(messages: &[ChatMessage]) -> Vec<NativeMessage> {
+        // Reasoning is replayed verbatim to the model on every request, and it
+        // is not free: measured against qwen3-27b on llama-server, a 3,400
+        // character `reasoning_content` added 751 prompt tokens. A long
+        // tool-calling turn accumulates one block per iteration, so the cost
+        // grows with the turn while contributing nothing the model has not
+        // already acted on. Keep it on the most recent assistant message —
+        // some providers require it there — and drop the rest.
+        let last_assistant = messages.iter().rposition(|m| m.role == "assistant");
         messages
             .iter()
-            .map(|m| {
+            .enumerate()
+            .map(|(idx, m)| {
+                let keep_reasoning = Some(idx) == last_assistant;
                 if m.role == "assistant"
                     && let Ok(value) = serde_json::from_str::<serde_json::Value>(&m.content)
                     && let Some(tool_calls_value) = value.get("tool_calls")
@@ -388,10 +398,14 @@ impl OpenAiModelProvider {
                         })
                         .collect::<Vec<_>>();
                     let content = crate::request_payload::non_empty_string_field(&value, "content");
-                    let reasoning_content = value
-                        .get("reasoning_content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(ToString::to_string);
+                    let reasoning_content = keep_reasoning
+                        .then(|| {
+                            value
+                                .get("reasoning_content")
+                                .and_then(serde_json::Value::as_str)
+                                .map(ToString::to_string)
+                        })
+                        .flatten();
                     return NativeMessage {
                         role: "assistant".to_string(),
                         content,
@@ -2146,6 +2160,33 @@ mod tests {
         assert_eq!(
             native[0].reasoning_content.as_deref(),
             Some("Let me think...")
+        );
+    }
+
+    /// Only the most recent assistant message replays its reasoning; earlier
+    /// ones are dropped, because the model has already acted on them.
+    #[test]
+    fn convert_messages_drops_reasoning_from_stale_assistant_messages() {
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let msg = |thought: &str| {
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "working",
+                    "tool_calls": [{"id": "tc_1", "name": "shell", "arguments": "{}"}],
+                    "reasoning_content": thought,
+                })
+                .to_string(),
+            )
+        };
+        let messages = vec![msg("stale thought"), msg("current thought")];
+        let native = OpenAiModelProvider::convert_messages(&messages);
+
+        assert_eq!(native.len(), 2);
+        assert!(native[0].reasoning_content.is_none());
+        assert_eq!(
+            native[1].reasoning_content.as_deref(),
+            Some("current thought")
         );
     }
 

--- a/crates/zeroclaw-tools/src/mcp_client.rs
+++ b/crates/zeroclaw-tools/src/mcp_client.rs
@@ -1160,6 +1160,30 @@ impl McpRegistry {
     }
 
     /// Execute a tool by prefixed name.
+    /// Render an MCP `tools/call` result for the model.
+    ///
+    /// A `CallToolResult` carries its payload twice: once as `content[].text`
+    /// and again as `structuredContent`. Pretty-printing the whole envelope put
+    /// both copies, plus the envelope keys and indentation, into the
+    /// conversation — measured at roughly three characters stored per character
+    /// of useful text. Send the text blocks, which is what the model reads.
+    /// Results with no text block fall back to compact JSON so nothing is lost.
+    fn render_tool_result(result: &serde_json::Value) -> String {
+        let text = result
+            .get("content")
+            .and_then(serde_json::Value::as_array)
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .filter(|b| b.get("type").and_then(serde_json::Value::as_str) == Some("text"))
+                    .filter_map(|b| b.get("text").and_then(serde_json::Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .filter(|t| !t.is_empty());
+        text.unwrap_or_else(|| result.to_string())
+    }
+
     pub async fn call_tool(
         &self,
         prefixed_name: &str,
@@ -1178,8 +1202,7 @@ impl McpRegistry {
         let result = self.servers[*server_idx]
             .call_tool(original_name, arguments)
             .await?;
-        serde_json::to_string_pretty(&result)
-            .with_context(|| format!("failed to serialize result of MCP tool `{prefixed_name}`"))
+        Ok(Self::render_tool_result(&result))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1394,6 +1417,43 @@ impl McpRegistry {
             }
         }
         out
+    }
+}
+
+#[cfg(test)]
+mod render_tool_result_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The model sees the text block, not the envelope and its duplicate.
+    #[test]
+    fn sends_text_block_only() {
+        let payload = r#"{"id": 15, "name": "Upper Strength"}"#;
+        let rendered = McpRegistry::render_tool_result(&json!({
+            "content": [{"type": "text", "text": payload}],
+            "structuredContent": {"id": 15, "name": "Upper Strength"},
+            "isError": false,
+        }));
+        assert_eq!(rendered, payload);
+        assert!(!rendered.contains("structuredContent"));
+    }
+
+    /// Multiple text blocks are joined, not dropped.
+    #[test]
+    fn joins_multiple_text_blocks() {
+        let rendered = McpRegistry::render_tool_result(&json!({
+            "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+        }));
+        assert_eq!(rendered, "a\nb");
+    }
+
+    /// Results with no text block still render something.
+    #[test]
+    fn falls_back_without_text_blocks() {
+        let rendered = McpRegistry::render_tool_result(&json!({
+            "content": [{"type": "image", "data": "iVBOR"}],
+        }));
+        assert!(rendered.contains("image"));
     }
 }
 


### PR DESCRIPTION
Closes #10394.

Two independent changes, one commit each, both measured. Happy to split into separate PRs if preferred.

## `perf(mcp): send tool result text blocks, not the whole envelope`

`McpRegistry::call_tool` pretty-printed the entire `CallToolResult` into the conversation. A spec-compliant result may carry its payload twice — `content[].text` and `structuredContent` — and FastMCP servers emit both by default. Pretty-printing added indentation on top, and the inner text is itself indented JSON that then gets escaped.

Measured over one session against the wger MCP server: 162,438 characters of tool results across 70 calls, of which about 31% was text the model needed.

Now sends the joined text blocks. Results with no text block fall back to compact JSON, so image and resource results are not lost.

## `perf(providers): drop stale reasoning_content from replayed history`

`convert_messages` passed `reasoning_content` through for every assistant message in the history, so each request re-sent every thought the model had already acted on.

Measured against qwen3-27b on llama-server, two requests differing only by one 3,400-character block: `prompt_tokens` 137 → 888.

Now kept on the most recent assistant message and dropped from older ones. The most recent one is preserved deliberately — the field exists because some providers require it in assistant tool-call history messages. The existing `convert_messages_round_trips_reasoning_content` test passes unchanged, since its single message is also the last.

## Testing

`zeroclaw-tools` 1,447 passed, `zeroclaw-providers` 1,690 passed, `zeroclaw-runtime` 3,875 passed. Zero failures. New tests cover text-block joining, multi-block joining, the no-text-block fallback, and reasoning being dropped from stale messages but kept on the newest.

## Why draft

Running on a patched 0.8.4 locally and want soak time on a real workload before marking ready. The measurements above are from that workload, not a synthetic benchmark.