### PR TITLE
fix(mcp): send tool result text blocks, not the whole CallToolResult envelope

### DIFF
--- a/crates/zeroclaw-tools/src/embedded_resource.rs
+++ b/crates/zeroclaw-tools/src/embedded_resource.rs
@@ -333,6 +333,43 @@ pub(crate) fn content_item_has_resource_blob(item: &serde_json::Value) -> bool {
             .is_some()
 }
 
+/// The joined text of a `tools/call` result whose payload is entirely text.
+///
+/// A `CallToolResult` carries the same payload twice: once as `content[].text`
+/// and again as `structuredContent`. Pretty-printing the whole envelope stores
+/// both copies, plus the envelope keys and the indentation, in the conversation
+/// — measured at roughly three characters per character of text the model reads,
+/// over 162,438 characters of tool results in one real session. The conversation
+/// is re-read on every agent-loop iteration, so a long tool-calling turn pays for
+/// all of it.
+///
+/// Returns `None` unless EVERY `content` item is a text block. A mixed result —
+/// text beside an image, audio, resource, resource-link, or an unknown content
+/// type — takes the full-result path instead, so no sibling block is lost.
+/// A top-level `_meta` also declines: unlike `structuredContent` it is not a copy
+/// of the text, so dropping it would lose data.
+fn all_text_content(result: &serde_json::Value) -> Option<String> {
+    if result.get("_meta").is_some() {
+        return None;
+    }
+    let items = result.get("content")?.as_array()?;
+    if items.is_empty() {
+        return None;
+    }
+    let mut text = String::new();
+    for item in items {
+        if item.get("type").and_then(|t| t.as_str()) != Some("text") {
+            return None;
+        }
+        let block = item.get("text").and_then(|t| t.as_str())?;
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str(block);
+    }
+    (!text.is_empty()).then_some(text)
+}
+
 /// Format an MCP `tools/call` result for the model.
 ///
 /// When `content` contains any `type: "resource"` item with `blob`, materialize
@@ -341,8 +378,11 @@ pub(crate) fn content_item_has_resource_blob(item: &serde_json::Value) -> bool {
 /// Document/IMAGE `materialized` marker, and image/audio `data` by a concise
 /// marker — never raw base64. Every non-binary field (text, `resource_link`,
 /// unknown content types, per-item `annotations`, and top-level
-/// `structuredContent`/`_meta`/`isError`) is preserved verbatim. Results without a
-/// resource blob keep the existing pretty-printed JSON shape.
+/// `structuredContent`/`_meta`/`isError`) is preserved verbatim.
+///
+/// A result whose `content` is entirely text blocks, with no top-level `_meta`,
+/// renders as that text alone — see [`all_text_content`]. Every other result
+/// without a resource blob keeps the existing pretty-printed JSON shape.
 ///
 /// Crate-internal: the only caller is [`crate::mcp_tool::McpToolWrapper`]; the
 /// serialized `CallToolResult` from `McpRegistry::call_tool` remains the public
@@ -351,6 +391,12 @@ pub(crate) fn format_mcp_tool_result_for_model(
     mut result: serde_json::Value,
     workspace_dir: &Path,
 ) -> Result<String, EmbeddedResourceError> {
+    // An all-text result needs none of the machinery below: no content item can
+    // hold a blob, and the envelope around the text is pure duplication.
+    if let Some(text) = all_text_content(&result) {
+        return Ok(text);
+    }
+
     // Preflight over an immutable borrow: count resource blobs and estimate their
     // aggregate decoded size WITHOUT decoding. Two independent per-call bounds
     // guard the untrusted result: the item count (bounds decode/hash/write
@@ -985,15 +1031,88 @@ mod tests {
     }
 
     #[test]
-    fn mcp_intake_without_blob_keeps_pretty_json() {
+    fn mcp_intake_all_text_sends_the_text_alone() {
+        // The model reads the tool's own payload, not the envelope and its
+        // duplicate. FastMCP-based servers emit both by default.
+        let dir = tempdir().unwrap();
+        let payload = r#"{"id": 15, "name": "Upper Strength"}"#;
+        let result = json!({
+            "content": [{ "type": "text", "text": payload }],
+            "structuredContent": { "id": 15, "name": "Upper Strength" },
+            "isError": false,
+        });
+        let out = format_mcp_tool_result_for_model(result, dir.path()).unwrap();
+        assert_eq!(out, payload);
+        assert!(!out.contains("structuredContent"), "envelope kept: {out}");
+        assert!(!dir.path().join("uploads").exists());
+    }
+
+    #[test]
+    fn mcp_intake_joins_multiple_text_blocks() {
         let dir = tempdir().unwrap();
         let result = json!({
+            "content": [
+                { "type": "text", "text": "a" },
+                { "type": "text", "text": "b" },
+            ]
+        });
+        let out = format_mcp_tool_result_for_model(result, dir.path()).unwrap();
+        assert_eq!(out, "a\nb");
+    }
+
+    #[test]
+    fn mcp_intake_mixed_content_keeps_every_block() {
+        // No-silent-loss rule: a text block beside an image, audio, resource_link
+        // or unknown content type must NOT reduce the result to its text. The
+        // binary payload is still redacted, but the block itself survives.
+        let dir = tempdir().unwrap();
+        // Binary redaction of image/audio `data` fires only on results that carry a
+        // resource blob; that path is unchanged here and covered by its own tests.
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"\x89PNG");
+        for sibling in [
+            json!({ "type": "image", "data": b64, "mimeType": "image/png" }),
+            json!({ "type": "audio", "data": b64, "mimeType": "audio/wav" }),
+            json!({ "type": "resource_link", "uri": "file:///kb/report.pdf" }),
+            json!({ "type": "video", "uri": "file:///clip.mp4" }),
+        ] {
+            let typ = sibling["type"].as_str().unwrap().to_string();
+            let result = json!({
+                "content": [
+                    { "type": "text", "text": "Screenshot captured" },
+                    sibling,
+                ]
+            });
+            let out = format_mcp_tool_result_for_model(result, dir.path()).unwrap();
+            assert!(out.contains("Screenshot captured"), "text lost: {out}");
+            assert!(out.contains(&typ), "{typ} block dropped: {out}");
+        }
+    }
+
+    #[test]
+    fn mcp_intake_all_text_with_meta_keeps_pretty_json() {
+        // `_meta` is not a copy of the text, so the text-only path declines it.
+        let dir = tempdir().unwrap();
+        let result = json!({
+            "_meta": { "trace": "abc123" },
             "content": [{ "type": "text", "text": "plain" }]
         });
         let out = format_mcp_tool_result_for_model(result, dir.path()).unwrap();
-        assert!(out.contains("\"type\": \"text\"") || out.contains("\"type\":\"text\""));
+        assert!(out.contains("abc123"), "_meta dropped: {out}");
         assert!(out.contains("plain"));
-        assert!(!dir.path().join("uploads").exists());
+    }
+
+    #[test]
+    fn mcp_intake_empty_or_absent_text_keeps_pretty_json() {
+        // Nothing to send instead of the envelope: keep the full result.
+        let dir = tempdir().unwrap();
+        for result in [
+            json!({ "content": [], "structuredContent": { "rows": 3 } }),
+            json!({ "content": [{ "type": "text", "text": "" }] }),
+            json!({ "structuredContent": { "rows": 3 } }),
+        ] {
+            let out = format_mcp_tool_result_for_model(result, dir.path()).unwrap();
+            assert!(out.contains("{"), "not JSON: {out}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `format_mcp_tool_result_for_model` pretty-printed the entire `CallToolResult` for every result without a resource blob. Per the MCP spec a server may return both `content[].text` and `structuredContent`, and FastMCP-based servers return both by default, so the same payload landed in the model's context twice.
  - Pretty-printing added indentation on top, and the inner text is itself indented JSON that then gets escaped.
  - Measured over one real session against the wger MCP server: 162,438 characters of tool results across 70 calls, of which roughly 31% was text the model needed.
  - This compounds. The conversation is re-read on every agent-loop iteration, so a 60-call turn accumulates all of it. On a 32k local model it is the difference between a long tool-calling turn completing and hitting `exceed_context_size_error`.
  - A result whose `content` is entirely text blocks now renders as that text alone. Every other result keeps the existing full-result path unchanged.
- **Scope boundary:** Does NOT change the MCP protocol, transport, tool discovery, schemas, or argument handling. Does not touch how tool *errors* are surfaced — `check_result_is_error` still runs first and is unchanged. Does not change the resource-blob materialization, the aggregate budget preflight, or the binary redaction added in #9196. Does not touch any other provider or channel path.
- **Blast radius:** Changes the text of MCP tool results the model sees, for every configured MCP server, but only for results whose content is entirely text. The sole consumer of the formatter is `McpToolWrapper::execute` (`crates/zeroclaw-tools/src/mcp_tool.rs:98`), which passes the string to the model; no code parses it for envelope fields. `grep -rn "structuredContent|structured_content" --include='*.rs'` finds only two provider tests, both about the stored `{"tool_call_id":…,"content":…}` history shape rather than `CallToolResult`.
- **Linked issue(s):** Closes #10394
- **Labels:** `bug`, `tool`, `needs-author-action`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `channel` (any messaging surface driving an agent with an MCP server configured); equally visible via `surface: cli`.
- **Setup / preconditions:** any MCP server whose tools return structured output. A FastMCP-based server is the clearest case, since FastMCP emits `content[].text` and `structuredContent` together.
- **Steps to run:** configure that server, have the agent call one of its tools, and inspect the tool result stored in the session history.
- **Expected on this branch (after):** for a text-only result, the stored value is the tool's own text payload alone. For a result carrying an image, audio, resource, or resource-link block, the stored value is unchanged from `master`.
- **Prior behavior on `master` (before):** the same text-only call stores a pretty-printed `CallToolResult` — envelope keys, the text block, and a `structuredContent` copy of the same data, roughly three characters stored per character of useful text.

### How I tested

- **CI checks relied on and why they cover this change:** `Format`, `Lint`, and `Test` all cover `zeroclaw-tools`, where the entire change lives. `Test` runs `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`, which includes the five new unit tests and the existing `embedded_resource` intake tests.
- **Known CI coverage gap, if any:** none. The change is confined to one crate that the required jobs already build and test.
- **Commands run and tail output:** local paths elided.

```
$ cargo fmt --all -- --check
(no output: clean)

$ cargo clippy --locked -p zeroclaw-tools --all-targets --all-features --no-deps -- -D warnings
    Checking zeroclaw-tools v0.8.4
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s

$ cargo test --locked -p zeroclaw-tools --lib embedded_resource::
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 1689 filtered out; finished in 0.41s

$ cargo test --locked -p zeroclaw-tools --lib mcp_client::
test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 1675 filtered out; finished in 1.00s

$ cargo test --locked -p zeroclaw-tools --lib mcp_tool::
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 1708 filtered out; finished in 0.00s

$ cargo test --locked -p zeroclaw-runtime --lib mcp
test result: ok. 56 passed; 0 failed; 1 ignored; 0 measured; 4036 filtered out; finished in 0.17s

$ cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
(exit 0; the only output is a pre-existing future-incompatibility note for the
third-party crate proc-macro-error2, which is unrelated to this change)
```

- **Beyond CI, what I manually verified:** an earlier revision of this change ran on a patched 0.8.4 build against a live wger MCP server with a local qwen3-27b. The daemon restarted cleanly, both configured channels registered, and all three agents loaded. That revision placed the reduction in `McpRegistry::call_tool`; the current revision moves it behind the formatter introduced by #9196, with the same observable effect on a text-only result.
- **What I did NOT verify:** the end-to-end effect on a long multi-call turn, which needs a full workload run. It does not gate correctness. The five unit tests cover the rendering directly, and for a text-only result the change is a strict reduction of what the model receives: the server's own text blocks, with the envelope and the duplicate removed. I also did not re-run the manual live check against the rebased revision.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — test fixtures use a synthetic routine name and integer ids.
- Prompt injection or untrusted model-visible text introduced/changed? `No` new text is introduced. For a text-only result the model-visible text is a strict subset of what it already received. For every other result it is unchanged. No new untrusted source is exposed.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

- **Fast rollback command/path:** After squash merge, `git revert <squash-merge-sha>` and rebuild/redeploy.
- **Feature flags or config toggles:** None for this formatter change.
- **Observable failure symptoms:** Missing structured tool-result data or metadata, or unexpected model-facing MCP output.
