### PR TITLE
fix(providers): drop stale reasoning_content from replayed assistant history

### DIFF
--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -361,9 +361,19 @@ impl OpenAiModelProvider {
     }
 
     fn convert_messages(messages: &[ChatMessage]) -> Vec<NativeMessage> {
+        // Reasoning is replayed verbatim to the model on every request, and it
+        // is not free: measured against qwen3-27b on llama-server, a 3,400
+        // character `reasoning_content` added 751 prompt tokens. A long
+        // tool-calling turn accumulates one block per iteration, so the cost
+        // grows with the turn while contributing nothing the model has not
+        // already acted on. Keep it on the most recent assistant message —
+        // some providers require it there — and drop the rest.
+        let last_assistant = messages.iter().rposition(|m| m.role == "assistant");
         messages
             .iter()
-            .map(|m| {
+            .enumerate()
+            .map(|(idx, m)| {
+                let keep_reasoning = Some(idx) == last_assistant;
                 if m.role == "assistant"
                     && let Ok(value) = serde_json::from_str::<serde_json::Value>(&m.content)
                     && let Some(tool_calls_value) = value.get("tool_calls")
@@ -388,10 +398,14 @@ impl OpenAiModelProvider {
                         })
                         .collect::<Vec<_>>();
                     let content = crate::request_payload::non_empty_string_field(&value, "content");
-                    let reasoning_content = value
-                        .get("reasoning_content")
-                        .and_then(serde_json::Value::as_str)
-                        .map(ToString::to_string);
+                    let reasoning_content = keep_reasoning
+                        .then(|| {
+                            value
+                                .get("reasoning_content")
+                                .and_then(serde_json::Value::as_str)
+                                .map(ToString::to_string)
+                        })
+                        .flatten();
                     return NativeMessage {
                         role: "assistant".to_string(),
                         content,
@@ -2146,6 +2160,33 @@ mod tests {
         assert_eq!(
             native[0].reasoning_content.as_deref(),
             Some("Let me think...")
+        );
+    }
+
+    /// Only the most recent assistant message replays its reasoning; earlier
+    /// ones are dropped, because the model has already acted on them.
+    #[test]
+    fn convert_messages_drops_reasoning_from_stale_assistant_messages() {
+        use zeroclaw_api::model_provider::ChatMessage;
+
+        let msg = |thought: &str| {
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "working",
+                    "tool_calls": [{"id": "tc_1", "name": "shell", "arguments": "{}"}],
+                    "reasoning_content": thought,
+                })
+                .to_string(),
+            )
+        };
+        let messages = vec![msg("stale thought"), msg("current thought")];
+        let native = OpenAiModelProvider::convert_messages(&messages);
+
+        assert_eq!(native.len(), 2);
+        assert!(native[0].reasoning_content.is_none());
+        assert_eq!(
+            native[1].reasoning_content.as_deref(),
+            Some("current thought")
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `OpenAiModelProvider::convert_messages` extracted `reasoning_content` from stored assistant history and passed it through on *every* message, so each request re-sent every thought the model had already acted on.
  - Measured directly against `llama-server` with qwen3-27b: two requests, `max_tokens: 1`, identical except one assistant history message carried 3,400 characters of `reasoning_content`. `prompt_tokens` went from **137 to 888** — 751 tokens for a single block.
  - A long tool-calling turn accumulates one block per iteration, so the cost grows with the turn while contributing nothing new. One session here holds 20,930 characters of stored reasoning across 35 assistant messages, roughly 4,600 tokens of a 32k window.
  - Now kept on the most recent assistant message and dropped from older ones. Qwen3's own guidance is not to include previous turns' thinking in history.
- **Scope boundary:** The most recent assistant message is preserved deliberately and NOT dropped — the field exists because some providers require it in assistant tool-call history messages, per the comment on `NativeMessage`. Does not change how `reasoning_content` is *parsed* from responses, nor the Anthropic or Bedrock paths.
- **Blast radius:** Affects every model provider routed through `OpenAiModelProvider::convert_messages`, in any deployment where stored assistant history carries `reasoning_content` — i.e. reasoning models. A provider that requires the full reasoning chain across *all* history messages, rather than just the latest, would see a behaviour change. I could not find one that documents such a requirement, but I cannot rule it out, and that is the main thing worth a maintainer's judgement here.
- **Linked issue(s):** Closes #10396
- **Labels:** none applied yet at time of writing.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `channel` or `cli`, with any reasoning model whose responses populate `reasoning_content`.
- **Setup / preconditions:** a provider on the OpenAI-compatible path returning `reasoning_content` (verified here with qwen3-27b via llama-server). Needs a conversation with at least two assistant tool-call turns so there is a stale block to drop.
- **Steps to run:** drive a multi-step tool-calling turn, then compare `usage.prompt_tokens` reported for the later requests.
- **Expected on this branch (after):** only the newest assistant message carries reasoning; prompt tokens no longer grow with accumulated thinking.
- **Prior behavior on `master` (before):** the same conversation re-sends every prior `reasoning_content` block on every request. The isolated A/B is two `/v1/chat/completions` calls, `max_tokens: 1`, differing only by one 3,400-character block: 137 vs 888 prompt tokens.

### How I tested

- **CI checks relied on and why they cover this change:** the standard Rust job. `cargo test -p zeroclaw-providers` covers `convert_messages` directly, including the pre-existing `convert_messages_round_trips_reasoning_content` test, which still passes unchanged because its single message is also the most recent one.
- **Known CI coverage gap, if any:** no test exercised *multiple* assistant messages carrying reasoning, which is exactly the case that regressed. Added one.
- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(no output: clean)

$ cargo clippy --all-targets -- -D warnings
    Checking zeroclaw-channels v0.8.4 (/home/billy/src/zc-pr-reasoning/crates/zeroclaw-channels)
    Checking zeroclaw-eval v0.8.4 (/home/billy/src/zc-pr-reasoning/crates/zeroclaw-eval)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 12s

$ cargo test -p zeroclaw-providers -p zeroclaw-runtime
test result: ok. 1447 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 3.11s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3877 filtered out; finished in 0.00s
test result: ok. 3875 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 22.13s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
```

- **Beyond CI, what I manually verified:** the token measurement above, run against a live llama-server rather than a mock. Also confirmed on the deployed tree that the pass-through is unconditional today — the extraction has no positional guard, so every stored assistant message contributes.
- **What I did NOT verify:** behaviour against a hosted reasoning provider such as OpenAI's o-series. All measurement here is local. I also have not measured the end-to-end effect on a long turn yet, which is why this is a draft.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** none skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — the new test uses synthetic strings.
- Prompt injection or untrusted model-visible text introduced/changed? `No` new text is introduced; strictly less model-visible content is sent than before.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low risk: `git revert <sha>` is the plan. If a provider turns out to need the full reasoning chain, the revert restores the previous unconditional pass-through exactly.
