### PR TITLE
fix(ci): typecheck generated dashboard contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -807,9 +807,9 @@ jobs:
           emit nix      "\.nix$|^flake\.(nix|lock)$|^nix/|${wf}"
           emit nix_hash "(^|/)Cargo\.(toml|lock)$|^nix/hashes\.json$|^scripts/ci/list_git_dep_keys\.py$|${wf}"
           # The generated dashboard contract includes schemas owned by the
-          # config and runtime crates and is rendered by the xtask generator.
+          # config, runtime, and SOP graph crates and is rendered by the xtask generator.
           # Keep this trigger aligned with every source that can change it.
-          emit web      "^web/|^crates/zeroclaw-(config|gateway|runtime)/|^xtask/|^Cargo\.(toml|lock)$|^\.nvmrc$|${wf}"
+          emit web      "^web/|^crates/zeroclaw-(config|gateway|runtime|sop-graph)/|^xtask/|^Cargo\.(toml|lock)$|^\.nvmrc$|${wf}"
 
   nix-eval:
     name: Nix Module Eval

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,7 +806,10 @@ jobs:
           emit docs     "\.mdx?$|^docs/|^\.markdownlint-cli2\.yaml$|^scripts/ci/docs_(quality_gate|links_gate)\.sh$|${wf}"
           emit nix      "\.nix$|^flake\.(nix|lock)$|^nix/|${wf}"
           emit nix_hash "(^|/)Cargo\.(toml|lock)$|^nix/hashes\.json$|^scripts/ci/list_git_dep_keys\.py$|${wf}"
-          emit web      "^web/|^\.nvmrc$|${wf}"
+          # The generated dashboard contract includes schemas owned by the
+          # config and runtime crates and is rendered by the xtask generator.
+          # Keep this trigger aligned with every source that can change it.
+          emit web      "^web/|^crates/zeroclaw-(config|gateway|runtime)/|^xtask/|^Cargo\.(toml|lock)$|^\.nvmrc$|${wf}"
 
   nix-eval:
     name: Nix Module Eval
@@ -951,9 +954,17 @@ jobs:
     needs: [path-changes]
     if: needs.path-changes.outputs.web == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.96.1
+      - uses: ./.github/actions/rust-cache
+        with:
+          use-blacksmith: 'false'
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
@@ -962,6 +973,8 @@ jobs:
       - name: Install web dependencies
         working-directory: web
         run: npm ci
+      - name: Typecheck generated dashboard contract
+        run: cargo web check
       - name: Run permission and catalog regressions
         working-directory: web
         run: npm run test:permissions

--- a/docs/book/src/developing/web.md
+++ b/docs/book/src/developing/web.md
@@ -39,7 +39,7 @@ cargo web install       # npm install in web/
 
 ## CI and release builds
 
-The required CI gate runs `cargo web check` when the dashboard, its toolchain, the Rust crates that own the exported schemas (`zeroclaw-config`, `zeroclaw-gateway`, and `zeroclaw-runtime`), the `xtask` generator, workspace manifests, or this workflow changes. This regenerates the ignored TypeScript client and typechecks the dashboard without producing a bundle. The Rust lint/build/test jobs still use a `web/dist/.gitkeep` placeholder so the gateway crate can compile without the bundle. Producing a release artifact that includes the dashboard is a separate step:
+The required CI gate runs `cargo web check` when the dashboard, its toolchain, the Rust crates that own the exported schemas (`zeroclaw-config`, `zeroclaw-gateway`, `zeroclaw-runtime`, and `zeroclaw-sop-graph`), the `xtask` generator, workspace manifests, or this workflow changes. This regenerates the ignored TypeScript client and typechecks the dashboard without producing a bundle. The Rust lint/build/test jobs still use a `web/dist/.gitkeep` placeholder so the gateway crate can compile without the bundle. Producing a release artifact that includes the dashboard is a separate step:
 
 <div class="os-tabs-src">
 

--- a/docs/book/src/developing/web.md
+++ b/docs/book/src/developing/web.md
@@ -39,7 +39,7 @@ cargo web install       # npm install in web/
 
 ## CI and release builds
 
-CI does not run `cargo web build`: the lint/build/test jobs use a `web/dist/.gitkeep` placeholder so the gateway crate compiles without the bundle. Producing a release artifact that includes the dashboard is a separate step:
+The required CI gate runs `cargo web check` when the dashboard, its toolchain, the Rust crates that own the exported schemas (`zeroclaw-config`, `zeroclaw-gateway`, and `zeroclaw-runtime`), the `xtask` generator, workspace manifests, or this workflow changes. This regenerates the ignored TypeScript client and typechecks the dashboard without producing a bundle. The Rust lint/build/test jobs still use a `web/dist/.gitkeep` placeholder so the gateway crate can compile without the bundle. Producing a release artifact that includes the dashboard is a separate step:
 
 <div class="os-tabs-src">
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,9 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "build": "tsc -b && vite build",
+    "check:generated": "node scripts/check-generated-api.mjs",
+    "typecheck": "npm run check:generated && tsc -b",
+    "build": "npm run check:generated && tsc -b && vite build",
     "dev": "vite",
     "test": "node --experimental-strip-types --test src/pages/quickstart/runtime-selection.test.ts src/pages/acp-console/thought-stream.test.ts",
     "test:permissions": "jiti src/components/ToolPermissionGrid.logic.test.ts && jiti src/lib/toolCatalog.logic.test.ts && jiti src/components/ToolCatalogWarningPanel.test.ts && jiti src/lib/validationWarnings.test.ts && npm run test:navigation",

--- a/web/scripts/check-generated-api.mjs
+++ b/web/scripts/check-generated-api.mjs
@@ -1,0 +1,19 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const generatedFiles = [
+  "src/lib/api-generated.ts",
+  "src/lib/api-descriptions.ts",
+  "src/lib/api-enums.ts",
+];
+const missingFiles = generatedFiles.filter((file) => !existsSync(resolve(file)));
+
+if (missingFiles.length > 0) {
+  console.error(
+    "Generated dashboard API files are missing. Run `cargo web check` from the repository root.",
+  );
+  for (const file of missingFiles) {
+    console.error(`Missing: ${file}`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add `cargo web check` to the required `web-permission-tests` job after dependency installation, so the generated OpenAPI client is produced before the dashboard TypeScript project is checked.
  - Extend the `web` path filter to include `crates/zeroclaw-config/`, `crates/zeroclaw-gateway/`, `crates/zeroclaw-runtime/`, `crates/zeroclaw-sop-graph/`, and `xtask/`, so every generated OpenAPI contract owner schedules the dashboard gate.
  - Add a generated-file preflight to the supported `npm run typecheck` and `npm run build` entry points, replacing the cascading missing-module output with a direct `cargo web check` instruction.
  - Pin the Rust toolchain used by this job, use the repository Rust cache action with Blacksmith disabled for the fixed `ubuntu-latest` runner, and allow the first Rust build up to 20 minutes.
- **Scope boundary:** This PR does not commit generated TypeScript or OpenAPI files, change dashboard or gateway runtime behavior, alter the manual release workflows, or replace the raw TypeScript compiler executable. The contributor-facing guard is applied to the supported npm scripts; a direct `tsc -b` invocation remains TypeScript's native behavior.
- **Blast radius:** The existing web job now also runs a Rust-backed API generation and TypeScript check when dashboard, generated-contract source, toolchain, or workflow paths change. The dashboard build and typecheck scripts fail early when generated API files are absent.
- **Linked issue(s):** Related #10306
- **Labels (live at this revision):** `ci`, `docs`, `web`, `risk:high`, `size:XS`, `type:ci`, `needs-maintainer-review`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A; the change is a CI and developer-tooling guard with deterministic local commands.

### How I tested

- **CI checks relied on and why they cover this change:** The changed required workflow path selects the existing dashboard job for `web/`, generated-contract source changes, and the web toolchain/generator paths, then runs the same `cargo web check` flow used to generate the client and typecheck the dashboard. The workflow YAML parser, repository comment-hygiene gate, and docs gates also cover the changed configuration and documentation.
- **Known CI coverage gap, if any:** The first `cargo web check` on an uncached runner may take substantially longer than the previous Node-only job; the timeout is increased to 20 minutes and the repository Rust cache is enabled. The raw `tsc -b` executable is not wrapped by the npm preflight.
- **Commands run and tail output:**

  ```text
  npm ci --ignore-scripts
  added 216 packages
  found 0 vulnerabilities

  npm run build
  Generated dashboard API files are missing. Run `cargo web check` from the repository root.

  cargo web check
  generated api files written; TypeScript project check exited 0

  npm run typecheck
  exited 0

  npm run build
  ✓ built in 280ms

  npm run test:permissions
  all permission, catalog, warning, validation, and navigation groups passed

  npm run test:contexts
  18 passed, 0 failed

  node --check scripts/check-generated-api.mjs
  passed

  workflow YAML parse
  workflow YAML parsed

  git diff --check
  passed
  Comment hygiene gate passed.
  Markdownlint Summary: 0 error(s)
  ```

- **Beyond CI, what did you manually verify?** On an unmodified clean checkout, a bare web build reproduced the four missing generated-module diagnostics and the resulting cascade. On this branch, the supported npm preflight reported the actionable `cargo web check` instruction before generation; after generation, the TypeScript check, Vite build, permission regressions, and context tests passed. The ignored generated files and `target/openapi.json` were not included in the commit.
- **Visual interface changed?** N/A; no rendered dashboard behavior or assets changed.
- **If any command was intentionally skipped, why:** Raw `tsc -b` was not claimed as wrapped because it bypasses package scripts and TypeScript has no pre-command hook in `tsconfig`. Full workspace tests and release builds were not rerun because this change is limited to the web CI job, its npm entry points, and documentation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No beyond the existing CI dependency/toolchain setup; the change adds no runtime network call.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No. The CI job uses the repository's pinned `1.96.1` toolchain explicitly; this does not change the project floor.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After merge, revert the single squash commit for PR #10399; this removes the CI gate, npm preflight, and full generated-contract path filter together.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A failing dashboard typecheck, missing generated API preflight message, or a web job timing out during Rust API generation. Reverting removes the new gate and restores the prior CI behavior.
