### PR TITLE
test(channels): keep Telegram photo upload test offline

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -5927,21 +5927,47 @@ mod tests {
 
     #[tokio::test]
     async fn telegram_send_photo_bytes_builds_correct_form() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Keep this unit test hermetic: a fake token against the official API
+        // can wait indefinitely when CI networking degrades.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/bot[^/]+/sendPhoto$"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
         let mention_only = false;
         let ch = TelegramChannel::new(
             "fake-token".into(),
             "telegram_test_alias",
             Arc::new(|| vec!["*".into()]),
             mention_only,
-        );
+        )
+        .with_api_base(mock_server.uri());
         // Minimal valid PNG header bytes
         let file_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
 
-        let result = ch
-            .send_photo_bytes("123456", None, file_bytes, "test.png", None)
-            .await;
+        ch.send_photo_bytes("123456", None, file_bytes.clone(), "test.png", None)
+            .await
+            .expect("mock Telegram API should accept photo upload");
 
-        assert!(result.is_err());
+        let requests = mock_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let body = &requests[0].body;
+        let form = String::from_utf8_lossy(body);
+        assert!(form.contains("name=\"chat_id\""));
+        assert!(form.contains("123456"));
+        assert!(form.contains("name=\"photo\""));
+        assert!(form.contains("filename=\"test.png\""));
+        assert!(
+            body.windows(file_bytes.len())
+                .any(|window| window == file_bytes),
+            "multipart body must contain the original photo bytes"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replaced the real `api.telegram.org` request in `telegram_send_photo_bytes_builds_correct_form` with a local Wiremock endpoint. The test now verifies the multipart chat ID, photo field, filename, and original bytes instead of treating an external network error as success.
- **Scope boundary:** Test-only; no Telegram runtime behavior, HTTP client configuration, or production timeout changes.
- **Blast radius:** One `zeroclaw-channels` Telegram unit test.
- **Linked issue(s):** Related #10278 (the parallel runtime job exposed this test hanging during its second 16-thread pass).
- **Labels:** `channel`, `channel:telegram`, `risk:low`, `size:XS`, `type:test`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a hermetic test-only correction covered by the focused test and the repository's parallel runtime gate.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head required CI passed, including `Test`, `Parallel Runtime Test`, `Lint`, the feature checks, and [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33081427064).
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```sh
cargo test --locked -p zeroclaw-channels --lib telegram_send_photo_bytes_builds_correct_form -- --nocapture
# test telegram::tests::telegram_send_photo_bytes_builds_correct_form ... ok
# test result: ok. 1 passed; 0 failed; 1494 filtered out

ZEROCLAW_PARALLEL_TEST_SCOPE=channels ZEROCLAW_PARALLEL_TEST_RUNS=3 ZEROCLAW_PARALLEL_TEST_THREADS=16 ./scripts/ci/parallel_runtime_test_gate.sh
# run 1: 1493 passed; 0 failed; 2 ignored
# run 2: 1493 passed; 0 failed; 2 ignored
# run 3: 1493 passed; 0 failed; 2 ignored

cargo fmt --all -- --check
# passed

cargo clippy --locked -p zeroclaw-channels --all-targets -- -D warnings
# Finished dev profile; exit 0
```

- **Beyond CI, what did you manually verify?** Inspected the captured multipart request and verified it contains the chat ID, photo field, filename, and exact PNG bytes. No live Telegram request was made.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Full workspace tests were not run locally because the repeated full `zeroclaw-channels` binary is the relevant interference boundary for this test-only change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**; the test removes one.
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk test-only change: after merge, revert the landed squash commit for PR #10413.
