### PR TITLE
fix(providers): attribute reliable stream errors to served model

### DIFF
--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -3258,7 +3258,7 @@ impl ModelProvider for ReliableModelProvider {
                 served_model.clone(),
                 ProviderDispatch::from_ref(model_provider).stream_chat(
                     req,
-                    &current_model,
+                    &served_model,
                     temperature,
                     options,
                 ),
@@ -3348,7 +3348,7 @@ impl ModelProvider for ReliableModelProvider {
                 ProviderDispatch::from_ref(model_provider).stream_chat_with_system(
                     system_prompt,
                     message,
-                    &current_model,
+                    &served_model,
                     temperature,
                     options,
                 ),
@@ -3429,7 +3429,7 @@ impl ModelProvider for ReliableModelProvider {
                 served_model.clone(),
                 ProviderDispatch::from_ref(model_provider).stream_chat_with_history(
                     messages,
-                    &current_model,
+                    &served_model,
                     temperature,
                     options,
                 ),

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -1544,6 +1544,11 @@ fn combine_response_usage(response: &mut ChatResponse, prior_attempts: Option<To
 enum ReliableModelProviderEntryProvider {
     Direct(Box<dyn ModelProvider>),
     Pinned(crate::model_pin::ModelPinnedProvider),
+    #[cfg(test)]
+    DispatchObservedPinned {
+        pinned_model: String,
+        provider: Box<dyn ModelProvider>,
+    },
 }
 
 impl ReliableModelProviderEntryProvider {
@@ -1551,6 +1556,8 @@ impl ReliableModelProviderEntryProvider {
         match self {
             Self::Direct(provider) => provider.as_ref(),
             Self::Pinned(provider) => provider,
+            #[cfg(test)]
+            Self::DispatchObservedPinned { provider, .. } => provider.as_ref(),
         }
     }
 
@@ -1558,6 +1565,8 @@ impl ReliableModelProviderEntryProvider {
         match self {
             Self::Direct(_) => requested_model,
             Self::Pinned(provider) => provider.pinned_model(),
+            #[cfg(test)]
+            Self::DispatchObservedPinned { pinned_model, .. } => pinned_model,
         }
     }
 }
@@ -1624,6 +1633,26 @@ impl ReliableModelProviderEntry {
                     .inner(inner)
                     .build(),
             ),
+        }
+    }
+
+    /// Build a test-only pinned entry whose provider observes Reliable's dispatch argument.
+    #[cfg(test)]
+    fn new_dispatch_observed_pinned(
+        display_name: impl Into<String>,
+        cooldown_key: impl Into<String>,
+        pinned_model: impl Into<String>,
+        provider: Box<dyn ModelProvider>,
+    ) -> Self {
+        let cooldown_key = cooldown_key.into();
+        Self {
+            display_name: display_name.into(),
+            candidate_name: cooldown_key.clone(),
+            cooldown_key,
+            provider: ReliableModelProviderEntryProvider::DispatchObservedPinned {
+                pinned_model: pinned_model.into(),
+                provider,
+            },
         }
     }
 
@@ -8791,6 +8820,7 @@ mod tests {
 
     struct StreamingRecordMock {
         stream_calls: Arc<AtomicUsize>,
+        observed_models: Option<Arc<Mutex<Vec<String>>>>,
         supports: bool,
         mode: StreamingRecordMode,
     }
@@ -8856,6 +8886,7 @@ mod tests {
         fn success(stream_calls: Arc<AtomicUsize>) -> Self {
             Self {
                 stream_calls,
+                observed_models: None,
                 supports: true,
                 mode: StreamingRecordMode::Success,
             }
@@ -8864,6 +8895,7 @@ mod tests {
         fn unsupported(stream_calls: Arc<AtomicUsize>) -> Self {
             Self {
                 stream_calls,
+                observed_models: None,
                 supports: false,
                 mode: StreamingRecordMode::Success,
             }
@@ -8872,6 +8904,7 @@ mod tests {
         fn error(stream_calls: Arc<AtomicUsize>) -> Self {
             Self {
                 stream_calls,
+                observed_models: None,
                 supports: true,
                 mode: StreamingRecordMode::Error,
             }
@@ -8880,13 +8913,37 @@ mod tests {
         fn usage_then_error(stream_calls: Arc<AtomicUsize>) -> Self {
             Self {
                 stream_calls,
+                observed_models: None,
                 supports: true,
                 mode: StreamingRecordMode::UsageThenError,
             }
         }
 
+        /// Creates a failing stream that records the model received from ProviderDispatch.
+        fn observed_error(
+            stream_calls: Arc<AtomicUsize>,
+            observed_models: Arc<Mutex<Vec<String>>>,
+        ) -> Self {
+            Self {
+                stream_calls,
+                observed_models: Some(observed_models),
+                supports: true,
+                mode: StreamingRecordMode::Error,
+            }
+        }
+
         fn stream_error() -> crate::traits::StreamError {
             crate::traits::StreamError::ModelProvider("stream failed".to_string())
+        }
+
+        /// Records the model argument before the mock emits its configured stream result.
+        fn record_model(&self, model: &str) {
+            if let Some(observed_models) = &self.observed_models {
+                observed_models
+                    .lock()
+                    .expect("observed model lock must remain available")
+                    .push(model.to_string());
+            }
         }
     }
 
@@ -8927,11 +8984,12 @@ mod tests {
         fn stream_chat(
             &self,
             _request: ChatRequest<'_>,
-            _model: &str,
+            model: &str,
             _temperature: Option<f64>,
             _options: StreamOptions,
         ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            self.record_model(model);
             match self.mode {
                 StreamingRecordMode::Success => stream::iter(vec![
                     Ok(StreamEvent::TextDelta(StreamChunk::delta("streamed"))),
@@ -8955,11 +9013,12 @@ mod tests {
             &self,
             _system_prompt: Option<&str>,
             _message: &str,
-            _model: &str,
+            model: &str,
             _temperature: Option<f64>,
             _options: StreamOptions,
         ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            self.record_model(model);
             match self.mode {
                 StreamingRecordMode::Success => stream::iter(vec![
                     Ok(StreamChunk::delta("streamed")),
@@ -8976,11 +9035,12 @@ mod tests {
         fn stream_chat_with_history(
             &self,
             _messages: &[ChatMessage],
-            _model: &str,
+            model: &str,
             _temperature: Option<f64>,
             _options: StreamOptions,
         ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            self.record_model(model);
             match self.mode {
                 StreamingRecordMode::Success => stream::iter(vec![
                     Ok(StreamChunk::delta("streamed")),
@@ -9071,6 +9131,32 @@ mod tests {
                     "fallback",
                     "fallback.key",
                     "fallback-alias",
+                    "model-served",
+                    Box::new(fallback) as Box<dyn ModelProvider>,
+                ),
+            ],
+            0,
+            1,
+        )
+    }
+
+    /// Builds a pinned fallback whose inner mock sees Reliable's dispatch model unchanged.
+    fn reliable_with_dispatch_observed_pinned_fallback(
+        primary_calls: Arc<AtomicUsize>,
+        fallback: StreamingRecordMock,
+    ) -> ReliableModelProvider {
+        ReliableModelProvider::new_with_entries(
+            "test",
+            vec![
+                ReliableModelProviderEntry::new(
+                    "primary",
+                    "primary.key",
+                    Box::new(StreamingRecordMock::unsupported(primary_calls))
+                        as Box<dyn ModelProvider>,
+                ),
+                ReliableModelProviderEntry::new_dispatch_observed_pinned(
+                    "fallback",
+                    "fallback.key",
                     "model-served",
                     Box::new(fallback) as Box<dyn ModelProvider>,
                 ),
@@ -9297,6 +9383,56 @@ mod tests {
         assert!(
             fallback.is_none(),
             "usage before a stream error must remain provisional"
+        );
+    }
+
+    /// Protects the Reliable-to-dispatch model handoff for all three stream entry points.
+    #[tokio::test]
+    async fn pinned_stream_failures_dispatch_the_served_model_for_every_entry_point() {
+        let observed_models = Arc::new(Mutex::new(Vec::new()));
+        let model_provider = reliable_with_dispatch_observed_pinned_fallback(
+            Arc::new(AtomicUsize::new(0)),
+            StreamingRecordMock::observed_error(
+                Arc::new(AtomicUsize::new(0)),
+                Arc::clone(&observed_models),
+            ),
+        );
+        let messages = vec![ChatMessage::user("hello")];
+
+        let mut structured = model_provider.stream_chat(
+            ChatRequest {
+                messages: &messages,
+                tools: None,
+                thinking: None,
+            },
+            "model-requested",
+            Some(0.0),
+            StreamOptions::new(true),
+        );
+        assert!(structured.next().await.unwrap().is_err());
+
+        let mut system = model_provider.stream_chat_with_system(
+            Some("system"),
+            "hello",
+            "model-requested",
+            Some(0.0),
+            StreamOptions::new(true),
+        );
+        assert!(system.next().await.unwrap().is_err());
+
+        let mut history = model_provider.stream_chat_with_history(
+            &messages,
+            "model-requested",
+            Some(0.0),
+            StreamOptions::new(true),
+        );
+        assert!(history.next().await.unwrap().is_err());
+
+        assert_eq!(
+            *observed_models
+                .lock()
+                .expect("observed model lock must remain available"),
+            vec!["model-served"; 3],
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Pass each Reliable entry's resolved served model into `ProviderDispatch` for structured, system-prompt, and history streams so failure attribution identifies the model actually sent upstream. The regression test now observes the Reliable-to-dispatch argument directly instead of relying on `ModelPinnedProvider`, which rewrites the argument and previously made the test pass against the broken implementation.
- **Scope boundary:** This does not change provider selection, model pinning, fallback order, stream replay, or wire payloads.
- **Blast radius:** Reliable provider streaming attribution and its unit-test seam only; the seam is compiled only under `cfg(test)`.
- **Linked issue(s):** Fixes #10326
- **Labels:** `bug`, `provider`, `provider:reliable`, `trusted contributor`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the changed boundary is covered by a causal unit regression and fresh required CI.
- **Why N/A:** No user-visible or external-provider manual flow is required to verify the model argument handed from Reliable to `ProviderDispatch`.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI passed for current head `cd83e19c3`, including the required aggregate gate, full tests, Linux build, lint, formatting, security, MSRV, benchmark compilation, feature/target checks, and applicable platform checks. The focused local tests cover all three changed stream entry points and the provider crate lint target.
- **Known CI coverage gap, if any:** No live external-provider call was made; the model handoff is deterministic and credential-free.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# completed successfully

cargo clippy -p zeroclaw-providers --all-targets --locked -- -D warnings
# Finished dev profile successfully

cargo test -p zeroclaw-providers pinned_stream_failures_dispatch_the_served_model_for_every_entry_point --lib --locked
# 1 passed; 0 failed

cargo test -p zeroclaw-providers records_pinned_fallback_on_success --lib --locked
# 3 passed; 0 failed
```

- **Beyond CI, what did you manually verify?** I temporarily restored all three production calls to the old `current_model` argument. The new regression then failed with `left: ["model-requested", "model-requested", "model-requested"]` versus the expected served model. After restoring `served_model`, it passed. A full `zeroclaw-providers` library run reached 1466 passing tests and one unrelated suite-load-only timeout in `grok_cli::tests::unix_fake_child::timeout_kills_leader_and_descendant`; that test passed when rerun in isolation.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Full workspace tests were not run locally because required CI supplies the broader regression gate. The provider crate's unrelated full-suite timeout is reported above rather than hidden.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the landed squash-merge commit for this PR.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Reliable streaming failure attribution would again identify the requested model instead of the selected entry's pinned served model.
