### PR TITLE
fix(runtime): detect context overflow through error causes

### DIFF
--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -545,7 +545,6 @@ pub fn is_tool_schema_error(err: &anyhow::Error) -> bool {
 }
 
 pub fn is_context_window_exceeded(err: &anyhow::Error) -> bool {
-    let lower = err.to_string().to_lowercase();
     let hints = [
         "exceeds the context window",
         "exceeds the available context size",
@@ -559,7 +558,10 @@ pub fn is_context_window_exceeded(err: &anyhow::Error) -> bool {
         "prompt exceeds max length",
     ];
 
-    hints.iter().any(|hint| lower.contains(hint))
+    err.chain().any(|cause| {
+        let lower = cause.to_string().to_lowercase();
+        hints.iter().any(|hint| lower.contains(hint))
+    })
 }
 
 /// Check if an error is a rate-limit (429) error.
@@ -7412,6 +7414,15 @@ mod tests {
         assert!(is_context_window_exceeded(&anyhow::Error::msg(
             "request (8968 tokens) exceeds the available context size (8448 tokens), try increasing it"
         )));
+    }
+
+    #[test]
+    fn is_context_window_exceeded_detects_nested_provider_cause() {
+        let err = anyhow::Error::msg("maximum context length exceeded")
+            .context("provider request failed after retry recovery");
+
+        assert!(!err.to_string().contains("maximum context length"));
+        assert!(is_context_window_exceeded(&err));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Make `is_context_window_exceeded` inspect the full `anyhow::Error` source chain rather than only the outer display string.
  - Preserve the existing context-window hints and recovery policy; a reliable provider wrapper that adds a generic terminal message no longer hides an inner provider context-overflow cause.
  - Add a regression where the outer error contains no context hint while the nested provider cause does.
- **Scope boundary:** This does not change retry counts, provider routing, error formatting, or the set of recognized context-window hints. It only makes the existing detector see retained causes.
- **Blast radius:** Provider failures wrapped by the reliable layer. Those failures now reach the established trim-and-retry recovery path when an underlying cause already matches an existing context-window signal.
- **Linked issue(s):** Fixes #10329
- **Labels:** `bug`, `provider`, `provider:reliable`, `trusted contributor`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A; the detector and full provider-library regressions cover the provider-neutral error-chain behavior without provider credentials or network access.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head required CI passed, including the provider crate tests, Lint, platform checks, and [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33085865261). The focused test proves the source-chain boundary and the full provider library covers wrapper, retry, routing, and model-provider behaviors.
- **Known CI coverage gap, if any:** No source-chain coverage gap remains locally. No live provider request was made because the regression uses a deterministic provider-neutral error chain.
- **Commands run and tail output:**

  ```sh
  cargo fmt --all -- --check
  # passed

  cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings
  # passed

  cargo test --locked -p zeroclaw-providers is_context_window_exceeded --no-fail-fast
  # 2 passed; 0 failed

  cargo test --locked -p zeroclaw-providers --lib --no-fail-fast
  # 1447 passed; 0 failed; 4 ignored
  ```

- **Beyond CI, what did you manually verify?** The added regression constructs a generic outer reliable-wrapper error whose display text has no context-window phrase, with `maximum context length exceeded` retained as its cause. The detector now returns true; the pre-existing direct-provider control remains true. No live provider, credentials, network traffic, or retry timing was exercised.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** No changed-surface command was skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any Yes, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? Yes. The detector gains visibility into existing hints preserved in a nested cause; errors without a recognized context-window cause retain their prior classification.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is No or either surface/floor question is Yes: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After merge, revert the single squash commit for PR #10416.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A wrapped non-context provider error incorrectly triggers context recovery, visible as an unexpected trim-and-retry attempt after reliable-provider exhaustion.
