### PR TITLE
fix(runtime): deliver terminal fallbacks live

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -877,6 +877,20 @@ pub trait Channel: Send + Sync + crate::attribution::Attributable {
         800
     }
 
+    /// Confirmed-delivery byte offset for a MultiMessage draft: how many bytes
+    /// of the cumulative visible text previously handed to `update_draft` have
+    /// already been emitted on the transport as paragraph messages (including
+    /// their trailing `\n\n` delimiters).
+    ///
+    /// The orchestrator reads this before `finalize_draft` so it can reconcile
+    /// a sanitized final response against the paragraphs that are already on
+    /// the wire without stranding or replaying content. Channels that do not
+    /// support multi-message streaming keep the default of `0` (nothing
+    /// confirmed).
+    async fn multi_message_confirmed_offset(&self, _recipient: &str, _message_id: &str) -> usize {
+        0
+    }
+
     /// Send an initial draft message. Returns a platform-specific message ID for later edits.
     async fn send_draft(&self, _message: &SendMessage) -> anyhow::Result<Option<String>> {
         Ok(None)

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -3426,6 +3426,17 @@ impl Channel for DiscordChannel {
         self.multi_message_delay_ms
     }
 
+    async fn multi_message_confirmed_offset(&self, recipient: &str, _message_id: &str) -> usize {
+        if self.stream_mode != zeroclaw_config::schema::StreamMode::MultiMessage {
+            return 0;
+        }
+        self.multi_message_sent_len
+            .lock()
+            .get(recipient)
+            .copied()
+            .unwrap_or(0)
+    }
+
     async fn send_draft(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
         use zeroclaw_config::schema::StreamMode;
         // Interaction replies have no channel to draft into — the recipient
@@ -3544,7 +3555,7 @@ impl Channel for DiscordChannel {
             StreamMode::MultiMessage => {
                 // Track accumulated text and send new paragraphs at \n\n boundaries.
                 // Extract paragraph (if any) under the lock, then drop it before async work.
-                let (paragraph, thread_ts) = {
+                let (paragraph, consumed, thread_ts) = {
                     let thread_ts = self
                         .multi_message_thread_ts
                         .lock()
@@ -3563,11 +3574,15 @@ impl Channel for DiscordChannel {
                         return Ok(());
                     }
 
-                    let new_text = &text[sent_so_far..];
+                    // Defensive: the counter was derived from earlier frames;
+                    // if the accumulated text was rewritten around it, degrade
+                    // to a floored boundary instead of panicking mid-character.
+                    let new_text = &text[text.floor_char_boundary(sent_so_far)..];
                     let mut scan_pos = 0;
                     let mut in_fence = false;
                     let bytes = new_text.as_bytes();
                     let mut found_paragraph = None;
+                    let mut consumed = 0;
 
                     while scan_pos < bytes.len() {
                         let ch = bytes[scan_pos];
@@ -3587,8 +3602,7 @@ impl Channel for DiscordChannel {
                             && bytes[scan_pos + 1] == b'\n'
                         {
                             let paragraph = new_text[..scan_pos].trim().to_string();
-                            let consumed = scan_pos + 2;
-                            *sent_map.entry(recipient.to_string()).or_insert(0) += consumed;
+                            consumed = scan_pos + 2;
                             if !paragraph.is_empty() {
                                 found_paragraph = Some(paragraph);
                             }
@@ -3598,28 +3612,38 @@ impl Channel for DiscordChannel {
                         scan_pos += 1;
                     }
                     // Lock is dropped here at end of block.
-                    (found_paragraph, thread_ts)
+                    (found_paragraph, consumed, thread_ts)
                 };
 
                 if let Some(paragraph) = paragraph {
                     let msg = SendMessage::new(&paragraph, recipient).in_thread(thread_ts.clone());
-                    if let Err(e) = self.send(&msg).await {
-                        ::zeroclaw_log::record!(
-                            DEBUG,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            )
-                            .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                            "multi-message paragraph send failed"
-                        );
-                    }
+                    self.send(&msg).await?;
+                    // Advance only after the transport confirms delivery. A
+                    // failed paragraph remains in the buffer for finalization.
+                    *self
+                        .multi_message_sent_len
+                        .lock()
+                        .entry(recipient.to_string())
+                        .or_insert(0) += consumed;
                     if self.multi_message_delay_ms > 0 {
                         tokio::time::sleep(std::time::Duration::from_millis(
                             self.multi_message_delay_ms,
                         ))
                         .await;
                     }
+                    // Recurse to handle remaining text.
+                    return self.update_draft(recipient, message_id, text).await;
+                } else if consumed > 0 {
+                    // An empty paragraph has no transport content, so there is
+                    // no send to confirm: its delimiter advances the confirmed
+                    // coordinate immediately. Without this the scanner would
+                    // rediscover the same empty paragraph on every frame and
+                    // never reach the text behind it.
+                    *self
+                        .multi_message_sent_len
+                        .lock()
+                        .entry(recipient.to_string())
+                        .or_insert(0) += consumed;
                     // Recurse to handle remaining text.
                     return self.update_draft(recipient, message_id, text).await;
                 }
@@ -3649,20 +3673,15 @@ impl Channel for DiscordChannel {
                 .remove(recipient)
                 .unwrap_or(0);
             if text.len() > sent_so_far {
-                let remaining = text[sent_so_far..].trim().to_string();
+                // Floor defensively: the reconciled final text is built to
+                // preserve the confirmed prefix byte-for-byte, but a stale
+                // offset must degrade to re-sending a suffix, not panic.
+                let remaining = text[text.floor_char_boundary(sent_so_far)..]
+                    .trim()
+                    .to_string();
                 if !remaining.is_empty() {
                     let msg = SendMessage::new(&remaining, recipient).in_thread(thread_ts);
-                    if let Err(e) = self.send(&msg).await {
-                        ::zeroclaw_log::record!(
-                            DEBUG,
-                            ::zeroclaw_log::Event::new(
-                                module_path!(),
-                                ::zeroclaw_log::Action::Note
-                            )
-                            .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                            "multi-message final flush failed"
-                        );
-                    }
+                    self.send(&msg).await?;
                 }
             }
             return Ok(());

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -108,8 +108,12 @@ pub struct DiscordChannel {
     multi_message_delay_ms: u64,
     /// Per-channel rate-limit tracking for draft edits.
     last_draft_edit: Mutex<HashMap<String, std::time::Instant>>,
-    /// Tracks how much text has been sent in MultiMessage mode.
-    multi_message_sent_len: Mutex<HashMap<String, usize>>,
+    /// Exact confirmed-delivered frame prefix per recipient in MultiMessage
+    /// mode. The confirmed byte offset is derived as `prefix.len()`; keeping
+    /// the bytes themselves (not just a count) lets `update_draft` detect and
+    /// remap the offset when a later sanitizer pass rewrites the frame before
+    /// it (see [`crate::orchestrator::remap_confirmed_offset`]).
+    multi_message_confirmed_prefix: Mutex<HashMap<String, String>>,
     /// Thread context captured from `send_draft()` for MultiMessage paragraph delivery.
     multi_message_thread_ts: Mutex<HashMap<String, Option<String>>>,
     /// Stall-watchdog timeout in seconds (0 = disabled).
@@ -182,7 +186,7 @@ impl DiscordChannel {
             draft_update_interval_ms: 1000,
             multi_message_delay_ms: 800,
             last_draft_edit: Mutex::new(HashMap::new()),
-            multi_message_sent_len: Mutex::new(HashMap::new()),
+            multi_message_confirmed_prefix: Mutex::new(HashMap::new()),
             multi_message_thread_ts: Mutex::new(HashMap::new()),
             stall_timeout_secs: 0,
             pending_approvals: Arc::new(AsyncMutex::new(HashMap::new())),
@@ -3430,11 +3434,10 @@ impl Channel for DiscordChannel {
         if self.stream_mode != zeroclaw_config::schema::StreamMode::MultiMessage {
             return 0;
         }
-        self.multi_message_sent_len
+        self.multi_message_confirmed_prefix
             .lock()
             .get(recipient)
-            .copied()
-            .unwrap_or(0)
+            .map_or(0, String::len)
     }
 
     async fn send_draft(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
@@ -3472,7 +3475,7 @@ impl Channel for DiscordChannel {
             StreamMode::MultiMessage => {
                 // No initial draft — paragraphs are sent as new messages.
                 // Store thread context for paragraph delivery.
-                self.multi_message_sent_len.lock().clear();
+                self.multi_message_confirmed_prefix.lock().clear();
                 self.multi_message_thread_ts
                     .lock()
                     .insert(message.recipient.clone(), message.thread_ts.clone());
@@ -3555,29 +3558,37 @@ impl Channel for DiscordChannel {
             StreamMode::MultiMessage => {
                 // Track accumulated text and send new paragraphs at \n\n boundaries.
                 // Extract paragraph (if any) under the lock, then drop it before async work.
-                let (paragraph, consumed, thread_ts) = {
+                let (paragraph, sent_so_far, consumed, thread_ts) = {
                     let thread_ts = self
                         .multi_message_thread_ts
                         .lock()
                         .get(recipient)
                         .cloned()
                         .flatten();
-                    let mut sent_map = self.multi_message_sent_len.lock();
-                    let sent_so_far = sent_map.get(recipient).copied().unwrap_or(0);
-
-                    // DraftEvent::Clear resets accumulated text — reset our counter.
-                    if text.len() < sent_so_far {
-                        sent_map.insert(recipient.to_string(), 0);
-                        return Ok(());
-                    }
+                    let mut sent_map = self.multi_message_confirmed_prefix.lock();
+                    let confirmed = sent_map.get(recipient).map_or("", String::as_str);
+                    let sent_so_far = if text.as_bytes().starts_with(confirmed.as_bytes()) {
+                        confirmed.len()
+                    } else {
+                        // The frame no longer starts with the confirmed bytes:
+                        // either a later sanitizer pass (e.g. a redaction span
+                        // completing on this delta) rewrote text before the
+                        // confirmed offset, or a DraftEvent::Clear restarted
+                        // the accumulation. Remap the offset onto the new
+                        // frame before slicing anything with it; a restart
+                        // remaps to 0.
+                        let remapped = crate::orchestrator::remap_confirmed_offset(confirmed, text);
+                        sent_map.insert(recipient.to_string(), text[..remapped].to_string());
+                        remapped
+                    };
                     if text.len() == sent_so_far {
                         return Ok(());
                     }
 
-                    // Defensive: the counter was derived from earlier frames;
-                    // if the accumulated text was rewritten around it, degrade
-                    // to a floored boundary instead of panicking mid-character.
-                    let new_text = &text[text.floor_char_boundary(sent_so_far)..];
+                    // `sent_so_far` is a byte-verified prefix of `text` (or a
+                    // remap result on a `\n\n` boundary), so this slice cannot
+                    // split a UTF-8 character.
+                    let new_text = &text[sent_so_far..];
                     let mut scan_pos = 0;
                     let mut in_fence = false;
                     let bytes = new_text.as_bytes();
@@ -3612,7 +3623,7 @@ impl Channel for DiscordChannel {
                         scan_pos += 1;
                     }
                     // Lock is dropped here at end of block.
-                    (found_paragraph, consumed, thread_ts)
+                    (found_paragraph, sent_so_far, consumed, thread_ts)
                 };
 
                 if let Some(paragraph) = paragraph {
@@ -3620,11 +3631,10 @@ impl Channel for DiscordChannel {
                     self.send(&msg).await?;
                     // Advance only after the transport confirms delivery. A
                     // failed paragraph remains in the buffer for finalization.
-                    *self
-                        .multi_message_sent_len
-                        .lock()
-                        .entry(recipient.to_string())
-                        .or_insert(0) += consumed;
+                    self.multi_message_confirmed_prefix.lock().insert(
+                        recipient.to_string(),
+                        text[..sent_so_far + consumed].to_string(),
+                    );
                     if self.multi_message_delay_ms > 0 {
                         tokio::time::sleep(std::time::Duration::from_millis(
                             self.multi_message_delay_ms,
@@ -3639,11 +3649,10 @@ impl Channel for DiscordChannel {
                     // coordinate immediately. Without this the scanner would
                     // rediscover the same empty paragraph on every frame and
                     // never reach the text behind it.
-                    *self
-                        .multi_message_sent_len
-                        .lock()
-                        .entry(recipient.to_string())
-                        .or_insert(0) += consumed;
+                    self.multi_message_confirmed_prefix.lock().insert(
+                        recipient.to_string(),
+                        text[..sent_so_far + consumed].to_string(),
+                    );
                     // Recurse to handle remaining text.
                     return self.update_draft(recipient, message_id, text).await;
                 }
@@ -3667,18 +3676,21 @@ impl Channel for DiscordChannel {
                 .lock()
                 .remove(recipient)
                 .flatten();
-            let sent_so_far = self
-                .multi_message_sent_len
+            let confirmed = self
+                .multi_message_confirmed_prefix
                 .lock()
                 .remove(recipient)
-                .unwrap_or(0);
+                .unwrap_or_default();
+            // The reconciled final text is built to preserve the confirmed
+            // prefix byte-for-byte; remap defensively so a divergent frame
+            // degrades to re-sending whole paragraphs, never a corrupt slice.
+            let sent_so_far = if text.as_bytes().starts_with(confirmed.as_bytes()) {
+                confirmed.len()
+            } else {
+                crate::orchestrator::remap_confirmed_offset(&confirmed, text)
+            };
             if text.len() > sent_so_far {
-                // Floor defensively: the reconciled final text is built to
-                // preserve the confirmed prefix byte-for-byte, but a stale
-                // offset must degrade to re-sending a suffix, not panic.
-                let remaining = text[text.floor_char_boundary(sent_so_far)..]
-                    .trim()
-                    .to_string();
+                let remaining = text[sent_so_far..].trim().to_string();
                 if !remaining.is_empty() {
                     let msg = SendMessage::new(&remaining, recipient).in_thread(thread_ts);
                     self.send(&msg).await?;
@@ -3825,7 +3837,7 @@ impl Channel for DiscordChannel {
 
     async fn cancel_draft(&self, recipient: &str, message_id: &str) -> anyhow::Result<()> {
         if self.stream_mode == zeroclaw_config::schema::StreamMode::MultiMessage {
-            self.multi_message_sent_len.lock().remove(recipient);
+            self.multi_message_confirmed_prefix.lock().remove(recipient);
             self.multi_message_thread_ts.lock().remove(recipient);
             return Ok(());
         }

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -583,6 +583,14 @@ mod streaming {
         }
     }
 
+    /// Read-only confirmed-delivery offset for a live MultiMessage draft.
+    pub(super) fn multi_sent_so_far(state: &State, key: &DraftKey) -> Option<usize> {
+        match state {
+            State::Multi(drafts) => drafts.get(key).map(|d| d.sent_so_far),
+            _ => None,
+        }
+    }
+
     #[cfg(test)]
     pub(super) fn multi_contains(state: &State, key: &DraftKey) -> bool {
         matches!(state, State::Multi(drafts) if drafts.contains_key(key))
@@ -4346,7 +4354,7 @@ impl MatrixChannel {
         let key = streaming_key(recipient, message_id)?;
         let delay = Duration::from_millis(self.config.multi_message_delay_ms);
         loop {
-            let (paragraph, thread_anchor) = {
+            let (paragraph, consumed, thread_anchor) = {
                 let mut state = self.streaming_state.write().await;
                 let Some(multi) = streaming::multi_for_update(&mut state, &key) else {
                     return Ok(());
@@ -4360,29 +4368,31 @@ impl MatrixChannel {
                 if text.len() == multi.sent_so_far {
                     return Ok(());
                 }
-                let unsent = &text[multi.sent_so_far..];
+                // Defensive: the counter was derived from earlier frames; if
+                // the accumulated text was rewritten around it, degrade to a
+                // floored boundary instead of panicking mid-character.
+                let unsent = &text[text.floor_char_boundary(multi.sent_so_far)..];
                 let Some(break_at) = streaming::next_paragraph_break(unsent) else {
                     return Ok(());
                 };
                 let paragraph = unsent[..break_at].trim().to_string();
-                multi.sent_so_far += break_at + 2; // +2 for the consumed "\n\n"
-                (paragraph, multi.thread_anchor.clone())
+                (paragraph, break_at + 2, multi.thread_anchor.clone())
             };
             if !paragraph.is_empty() {
                 let mut msg = SendMessage::new(paragraph, recipient);
                 msg.thread_ts = thread_anchor.as_ref().map(|e| e.to_string());
-                if let Err(e) = outbound::send(&self.outbox(client), &msg).await {
-                    ::zeroclaw_log::record!(
-                        WARN,
-                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                            .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                        "matrix: multi-message paragraph send failed"
-                    );
-                }
+                outbound::send(&self.outbox(client), &msg).await?;
                 if !delay.is_zero() {
                     tokio::time::sleep(delay).await;
                 }
+            }
+            // The byte coordinate is a confirmed-delivery coordinate, not an
+            // attempted-send coordinate. Empty paragraphs have no transport
+            // content, so their delimiter can advance immediately; a failed
+            // non-empty send returns above and remains eligible for finalization.
+            let mut state = self.streaming_state.write().await;
+            if let Some(multi) = streaming::multi_for_update(&mut state, &key) {
+                multi.sent_so_far += consumed;
             }
         }
     }
@@ -4514,6 +4524,17 @@ impl Channel for MatrixChannel {
 
     fn multi_message_delay_ms(&self) -> u64 {
         self.config.multi_message_delay_ms
+    }
+
+    async fn multi_message_confirmed_offset(&self, recipient: &str, message_id: &str) -> usize {
+        if !matches!(self.config.stream_mode, MatrixStreamMode::MultiMessage) {
+            return 0;
+        }
+        let Ok(key) = streaming_key(recipient, message_id) else {
+            return 0;
+        };
+        let state = self.streaming_state.read().await;
+        streaming::multi_sent_so_far(&state, &key).unwrap_or(0)
     }
 
     async fn send_draft(&self, message: &SendMessage) -> Result<Option<String>> {
@@ -4895,7 +4916,12 @@ impl Channel for MatrixChannel {
                     return Ok(());
                 };
                 let remainder = if text.len() > state.sent_so_far {
-                    text[state.sent_so_far..].trim().to_string()
+                    // Floor defensively: the reconciled final text is built to
+                    // preserve the confirmed prefix byte-for-byte, but a stale
+                    // offset must degrade to re-sending a suffix, not panic.
+                    text[text.floor_char_boundary(state.sent_so_far)..]
+                        .trim()
+                        .to_string()
                 } else {
                     String::new()
                 };

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -445,12 +445,15 @@ mod streaming {
     /// MultiMessage streaming state. The runtime calls `update_draft` repeatedly
     /// with the accumulated agent output; we send each `\n\n`-bounded paragraph
     /// as its own room message, threaded under `thread_anchor` when present.
-    /// `sent_so_far` is a byte counter into the accumulated text — everything
-    /// before that index has already been emitted.
+    /// `confirmed_prefix` holds the exact frame prefix already emitted — the
+    /// confirmed byte offset is `confirmed_prefix.len()`. Keeping the bytes
+    /// (not just a count) lets `multi_update` detect and remap the offset when
+    /// a later sanitizer pass rewrites the frame before it (see
+    /// [`crate::orchestrator::remap_confirmed_offset`]).
     #[derive(Debug, Clone)]
     pub(super) struct MultiDraft {
         pub thread_anchor: Option<OwnedEventId>,
-        pub sent_so_far: usize,
+        pub confirmed_prefix: String,
     }
 
     /// Live draft storage for the Matrix stream mode selected at channel
@@ -586,7 +589,7 @@ mod streaming {
     /// Read-only confirmed-delivery offset for a live MultiMessage draft.
     pub(super) fn multi_sent_so_far(state: &State, key: &DraftKey) -> Option<usize> {
         match state {
-            State::Multi(drafts) => drafts.get(key).map(|d| d.sent_so_far),
+            State::Multi(drafts) => drafts.get(key).map(|d| d.confirmed_prefix.len()),
             _ => None,
         }
     }
@@ -4354,29 +4357,42 @@ impl MatrixChannel {
         let key = streaming_key(recipient, message_id)?;
         let delay = Duration::from_millis(self.config.multi_message_delay_ms);
         loop {
-            let (paragraph, consumed, thread_anchor) = {
+            let (paragraph, new_confirmed, thread_anchor) = {
                 let mut state = self.streaming_state.write().await;
                 let Some(multi) = streaming::multi_for_update(&mut state, &key) else {
                     return Ok(());
                 };
-                // Detect a buffer reset (e.g. DraftEvent::Clear) and re-anchor
-                // to the new shorter text.
-                if text.len() < multi.sent_so_far {
-                    multi.sent_so_far = 0;
+                if !text
+                    .as_bytes()
+                    .starts_with(multi.confirmed_prefix.as_bytes())
+                {
+                    // The frame no longer starts with the confirmed bytes:
+                    // either a later sanitizer pass (e.g. a redaction span
+                    // completing on this delta) rewrote text before the
+                    // confirmed offset, or a DraftEvent::Clear restarted the
+                    // accumulation. Remap the offset onto the new frame before
+                    // slicing anything with it; a restart remaps to 0.
+                    let remapped =
+                        crate::orchestrator::remap_confirmed_offset(&multi.confirmed_prefix, text);
+                    multi.confirmed_prefix = text[..remapped].to_string();
+                }
+                let sent_so_far = multi.confirmed_prefix.len();
+                if text.len() == sent_so_far {
                     return Ok(());
                 }
-                if text.len() == multi.sent_so_far {
-                    return Ok(());
-                }
-                // Defensive: the counter was derived from earlier frames; if
-                // the accumulated text was rewritten around it, degrade to a
-                // floored boundary instead of panicking mid-character.
-                let unsent = &text[text.floor_char_boundary(multi.sent_so_far)..];
+                // `sent_so_far` is a byte-verified prefix of `text` (or a
+                // remap result on a `\n\n` boundary), so this slice cannot
+                // split a UTF-8 character.
+                let unsent = &text[sent_so_far..];
                 let Some(break_at) = streaming::next_paragraph_break(unsent) else {
                     return Ok(());
                 };
                 let paragraph = unsent[..break_at].trim().to_string();
-                (paragraph, break_at + 2, multi.thread_anchor.clone())
+                (
+                    paragraph,
+                    sent_so_far + break_at + 2,
+                    multi.thread_anchor.clone(),
+                )
             };
             if !paragraph.is_empty() {
                 let mut msg = SendMessage::new(paragraph, recipient);
@@ -4386,13 +4402,13 @@ impl MatrixChannel {
                     tokio::time::sleep(delay).await;
                 }
             }
-            // The byte coordinate is a confirmed-delivery coordinate, not an
+            // The confirmed prefix is a confirmed-delivery coordinate, not an
             // attempted-send coordinate. Empty paragraphs have no transport
             // content, so their delimiter can advance immediately; a failed
             // non-empty send returns above and remains eligible for finalization.
             let mut state = self.streaming_state.write().await;
             if let Some(multi) = streaming::multi_for_update(&mut state, &key) {
-                multi.sent_so_far += consumed;
+                multi.confirmed_prefix = text[..new_confirmed].to_string();
             }
         }
     }
@@ -4602,7 +4618,7 @@ impl Channel for MatrixChannel {
                     key,
                     streaming::MultiDraft {
                         thread_anchor,
-                        sent_so_far: 0,
+                        confirmed_prefix: String::new(),
                     },
                 )?;
                 Ok(Some(draft_id))
@@ -4915,13 +4931,19 @@ impl Channel for MatrixChannel {
                 let Some(state) = multi else {
                     return Ok(());
                 };
-                let remainder = if text.len() > state.sent_so_far {
-                    // Floor defensively: the reconciled final text is built to
-                    // preserve the confirmed prefix byte-for-byte, but a stale
-                    // offset must degrade to re-sending a suffix, not panic.
-                    text[text.floor_char_boundary(state.sent_so_far)..]
-                        .trim()
-                        .to_string()
+                // The reconciled final text is built to preserve the confirmed
+                // prefix byte-for-byte; remap defensively so a divergent frame
+                // degrades to re-sending whole paragraphs, never a corrupt slice.
+                let sent_so_far = if text
+                    .as_bytes()
+                    .starts_with(state.confirmed_prefix.as_bytes())
+                {
+                    state.confirmed_prefix.len()
+                } else {
+                    crate::orchestrator::remap_confirmed_offset(&state.confirmed_prefix, text)
+                };
+                let remainder = if text.len() > sent_so_far {
+                    text[sent_so_far..].trim().to_string()
                 } else {
                     String::new()
                 };
@@ -8331,7 +8353,7 @@ mod tests {
                 first.clone(),
                 MultiDraft {
                     thread_anchor: None,
-                    sent_so_far: 5,
+                    confirmed_prefix: "one\n\n".to_string(),
                 },
             )
             .expect("multi state accepts first draft");
@@ -8340,25 +8362,25 @@ mod tests {
                 second.clone(),
                 MultiDraft {
                     thread_anchor: None,
-                    sent_so_far: 0,
+                    confirmed_prefix: String::new(),
                 },
             )
             .expect("multi state accepts second draft");
 
             streaming::multi_for_update(&mut state, &second)
                 .expect("second multi-message draft remains addressable")
-                .sent_so_far = 12;
+                .confirmed_prefix = "second one\n\n".to_string();
 
             assert_eq!(
                 streaming::multi_for_update(&mut state, &first)
                     .expect("first multi-message draft remains isolated")
-                    .sent_so_far,
-                5
+                    .confirmed_prefix,
+                "one\n\n"
             );
 
             let finalized = streaming::take_multi(&mut state, &second)
                 .expect("finalize removes only the addressed multi-message draft");
-            assert_eq!(finalized.sent_so_far, 12);
+            assert_eq!(finalized.confirmed_prefix, "second one\n\n");
             assert!(multi_contains(&state, &first));
             assert!(!multi_contains(&state, &second));
 
@@ -8367,13 +8389,13 @@ mod tests {
                 canceled.clone(),
                 MultiDraft {
                     thread_anchor: None,
-                    sent_so_far: 3,
+                    confirmed_prefix: "c\n\n".to_string(),
                 },
             )
             .expect("multi state accepts canceled draft");
             let canceled_draft = streaming::take_multi(&mut state, &canceled)
                 .expect("cancel removes only the addressed multi-message draft");
-            assert_eq!(canceled_draft.sent_so_far, 3);
+            assert_eq!(canceled_draft.confirmed_prefix, "c\n\n");
             assert!(multi_contains(&state, &first));
             assert!(!multi_contains(&state, &canceled));
         }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3912,6 +3912,25 @@ fn truncate_at_unclosed_protocol_fence(s: &str, known_tool_names: &HashSet<Strin
     s.to_string()
 }
 
+/// Reconstruct the cumulative text expected by MultiMessage finalizers.
+///
+/// Their paragraph offsets are measured against the text supplied to
+/// `update_draft`. Terminal runtime deltas intentionally contain only the new
+/// segment, so a tool-call narration already streamed to the draft can be
+/// absent from `outbound_response`. Preserve that streamed prefix when the
+/// final response is its suffix; otherwise retain the canonical final response
+/// because the two representations no longer describe the same stream.
+fn cumulative_multi_message_final_text(
+    streamed_text: &str,
+    outbound_response: &str,
+    delivered_response: &str,
+) -> String {
+    streamed_text.strip_suffix(outbound_response).map_or_else(
+        || delivered_response.to_string(),
+        |streamed_prefix| format!("{streamed_prefix}{delivered_response}"),
+    )
+}
+
 /// Pump draft deltas to the channel transport, sanitizing every partial on the
 /// way out.
 ///
@@ -3933,6 +3952,7 @@ async fn run_draft_updater(
     reply_target: String,
     draft_id: String,
     known_tool_names: HashSet<String>,
+    streamed_text: Arc<Mutex<String>>,
     mut rx: tokio::sync::mpsc::Receiver<zeroclaw_runtime::agent::loop_::DraftEvent>,
 ) {
     use zeroclaw_runtime::agent::loop_::StreamDelta;
@@ -3998,6 +4018,10 @@ async fn run_draft_updater(
             StreamDelta::Text(text) => {
                 accumulated.push_str(&text);
                 let visible = sanitize_streaming_draft_text(&accumulated, &known_tool_names);
+                // Keep the exact visible frame used for MultiMessage offsets;
+                // retaining the raw accumulation here could reintroduce a
+                // protocol payload during finalization.
+                *streamed_text.lock().unwrap_or_else(|e| e.into_inner()) = visible.clone();
                 if let Err(e) = channel
                     .update_draft(&reply_target, &draft_id, &visible)
                     .await
@@ -6922,6 +6946,10 @@ async fn process_channel_message_body(
     };
 
     // Spawn the appropriate handler for the delta channel.
+    // Multi-message channels use the text accumulated by the draft updater to
+    // finalize the same cumulative stream they used for paragraph offsets.
+    // Other draft modes still finalize the canonical response unchanged.
+    let streamed_draft_text = Arc::new(Mutex::new(String::new()));
     let draft_updater = if use_draft_streaming {
         // Partial: accumulate text and edit a single draft message.
         if let (Some(rx), Some(draft_id_ref), Some(channel_ref)) = (
@@ -6958,8 +6986,17 @@ async fn process_channel_message_body(
                     .iter()
                     .map(|tool| tool.name().to_ascii_lowercase())
                     .collect();
+                let streamed_draft_text = Arc::clone(&streamed_draft_text);
                 Some(zeroclaw_spawn::spawn!(async move {
-                    run_draft_updater(channel, reply_target, draft_id, known_tool_names, rx).await;
+                    run_draft_updater(
+                        channel,
+                        reply_target,
+                        draft_id,
+                        known_tool_names,
+                        streamed_draft_text,
+                        rx,
+                    )
+                    .await;
                 }))
             }
         } else {
@@ -7728,11 +7765,23 @@ async fn process_channel_message_body(
                             .is_ok()
                     } else {
                         let suppress = suppress_voice_override.unwrap_or(false);
+                        let draft_final_response = if channel.supports_multi_message_streaming() {
+                            let streamed_text = streamed_draft_text
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner());
+                            cumulative_multi_message_final_text(
+                                &streamed_text,
+                                &outbound_response,
+                                &delivered_response,
+                            )
+                        } else {
+                            delivered_response.clone()
+                        };
                         match channel
                             .finalize_draft(
                                 &delivery_recipient,
                                 draft_id,
-                                &delivered_response,
+                                &draft_final_response,
                                 suppress,
                             )
                             .await
@@ -17311,6 +17360,14 @@ api_key = "anthropic-key"
                 channel_name: "matrix",
                 supports_multi_message_streaming: stream_mode
                     == zeroclaw_config::schema::MatrixStreamMode::MultiMessage,
+                ..Self::new(false, false)
+            }
+        }
+
+        fn multi_message(channel_name: &'static str) -> Self {
+            Self {
+                channel_name,
+                supports_multi_message_streaming: true,
                 ..Self::new(false, false)
             }
         }
@@ -34904,6 +34961,7 @@ Done."#;
             "chat-1".to_string(),
             "draft-1".to_string(),
             no_tools(),
+            Arc::new(Mutex::new(String::new())),
             rx,
         )
         .await;
@@ -34927,6 +34985,112 @@ Done."#;
             progress.as_slice(),
             ["Working on it.".to_string()],
             "status text must reach the transport already stripped of reasoning"
+        );
+    }
+
+    /// Regression at the channel streaming/finalization boundary: malformed
+    /// protocol exhaustion sends only a display-safe terminal fallback after a
+    /// prior tool narration. A MultiMessage finalizer's offset is cumulative,
+    /// so the fallback must remain after the already sent narration exactly
+    /// once.
+    #[tokio::test]
+    async fn multi_message_finalization_keeps_terminal_malformed_fallback_after_narration() {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message("discord"));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let narration = "Checking the requested records.\n\n";
+        let fallback = "I couldn't complete that response safely.";
+        let streamed_text = Arc::new(Mutex::new(String::new()));
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(narration.to_string()))
+            .await
+            .unwrap();
+        tx.send(StreamDelta::Text(fallback.to_string()))
+            .await
+            .unwrap();
+        drop(tx);
+
+        run_draft_updater(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed_text),
+            rx,
+        )
+        .await;
+
+        let final_text = cumulative_multi_message_final_text(
+            &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
+            fallback,
+            fallback,
+        );
+        assert_eq!(
+            &final_text[narration.len()..],
+            fallback,
+            "the cumulative offset must leave the complete fallback for finalization"
+        );
+        assert_eq!(final_text.matches(fallback).count(), 1);
+        assert_eq!(
+            channel_impl.draft_updates.lock().await.last(),
+            Some(&final_text)
+        );
+    }
+
+    /// Regression at the channel streaming/finalization boundary: the
+    /// max-iteration path sends only its new summary segment after prior tool
+    /// narration. Once MultiMessage has emitted that summary paragraph, the
+    /// stop reason must still be the unsent suffix, not be lost to its
+    /// cumulative offset.
+    #[tokio::test]
+    async fn multi_message_finalization_keeps_max_iteration_stop_reason_after_narration() {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let channel_impl = Arc::new(DraftRecordingChannel::matrix(
+            zeroclaw_config::schema::MatrixStreamMode::MultiMessage,
+        ));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let narration = "I checked the available sources.\n\n";
+        let summary = "Here is the best partial answer.";
+        let stop_reason = "Stopped after reaching the tool-call limit.";
+        let terminal_segment = format!("{summary}\n\n{stop_reason}");
+        let streamed_text = Arc::new(Mutex::new(String::new()));
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(narration.to_string()))
+            .await
+            .unwrap();
+        tx.send(StreamDelta::Text(terminal_segment.clone()))
+            .await
+            .unwrap();
+        drop(tx);
+
+        run_draft_updater(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed_text),
+            rx,
+        )
+        .await;
+
+        let final_text = cumulative_multi_message_final_text(
+            &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
+            &terminal_segment,
+            &terminal_segment,
+        );
+        let sent_so_far = narration.len() + summary.len() + "\n\n".len();
+        assert_eq!(
+            &final_text[sent_so_far..],
+            stop_reason,
+            "the finalizer must flush the stop reason after its cumulative paragraph offset"
+        );
+        assert_eq!(final_text.matches(summary).count(), 1);
+        assert_eq!(final_text.matches(stop_reason).count(), 1);
+        assert_eq!(
+            channel_impl.draft_updates.lock().await.last(),
+            Some(&final_text)
         );
     }
 
@@ -34964,6 +35128,7 @@ Done."#;
             "chat-1".to_string(),
             "draft-1".to_string(),
             no_tools(),
+            Arc::new(Mutex::new(String::new())),
             rx,
         )
         .await;
@@ -35026,6 +35191,7 @@ Done."#;
                 "chat-1".to_string(),
                 "draft-1".to_string(),
                 no_tools(),
+                Arc::new(Mutex::new(String::new())),
                 rx,
             )
             .await;
@@ -35093,6 +35259,7 @@ Done."#;
                 "chat-1".to_string(),
                 "draft-1".to_string(),
                 known.clone(),
+                Arc::new(Mutex::new(String::new())),
                 rx,
             )
             .await;
@@ -35134,6 +35301,7 @@ Done."#;
             "chat-1".to_string(),
             "draft-1".to_string(),
             known,
+            Arc::new(Mutex::new(String::new())),
             rx,
         )
         .await;

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3912,23 +3912,71 @@ fn truncate_at_unclosed_protocol_fence(s: &str, known_tool_names: &HashSet<Strin
     s.to_string()
 }
 
-/// Reconstruct the cumulative text expected by MultiMessage finalizers.
+/// Largest byte length `k` (on a UTF-8 boundary) such that `streamed_text`
+/// already ends with `delivered_response[..k]`.
 ///
-/// Their paragraph offsets are measured against the text supplied to
-/// `update_draft`. Terminal runtime deltas intentionally contain only the new
-/// segment, so a tool-call narration already streamed to the draft can be
-/// absent from `outbound_response`. Preserve that streamed prefix when the
-/// final response is its suffix; otherwise retain the canonical final response
-/// because the two representations no longer describe the same stream.
-fn cumulative_multi_message_final_text(
-    streamed_text: &str,
-    outbound_response: &str,
-    delivered_response: &str,
-) -> String {
-    streamed_text.strip_suffix(outbound_response).map_or_else(
-        || delivered_response.to_string(),
-        |streamed_prefix| format!("{streamed_prefix}{delivered_response}"),
-    )
+/// This is the span the visible stream and the canonical final response share
+/// at the seam, so it must not be re-emitted when the two representations have
+/// diverged and we append the final response as the trailing remainder.
+fn cumulative_final_trailing_overlap(streamed_text: &str, delivered_response: &str) -> usize {
+    let mut end = delivered_response.len();
+    while end > 0 {
+        if delivered_response.is_char_boundary(end)
+            && streamed_text.ends_with(&delivered_response[..end])
+        {
+            return end;
+        }
+        end -= 1;
+    }
+    0
+}
+
+/// Reconcile the canonical final response into the cumulative visible-stream
+/// byte coordinate system used by MultiMessage finalizers.
+///
+/// Discord and Matrix MultiMessage finalizers flush `final[sent_so_far..]`,
+/// where `sent_so_far` is a byte offset into the visible cumulative text that
+/// `update_draft` received (`streamed_text`). The text handed to
+/// `finalize_draft` must therefore begin with exactly those visible bytes, or
+/// the offset selects the wrong content — and when the final text is shorter
+/// than `sent_so_far`, the finalizer's `text.len() > sent_so_far` guard drops
+/// the trailing stop reason entirely.
+///
+/// So keep `streamed_text` as the coordinate base and append only content the
+/// stream has not already carried:
+///   * identical / empty stream: nothing to reconcile;
+///   * the final response extends the stream (a runtime stop reason or provider
+///     footer appended after streaming): append only that final-only tail;
+///   * final sanitization removed an already-streamed leading prefix (e.g. a
+///     tool narration line): every delivered byte is already visible, so keep
+///     the stream verbatim and let the finalizer flush the unsent tail once;
+///   * divergent (sanitization rewrote the interior, e.g. a terminal fallback
+///     replacing a malformed payload): preserve the visible coordinate and
+///     append the canonical response past any shared seam so it is delivered
+///     exactly once without duplicating the streamed tail.
+fn cumulative_multi_message_final_text(streamed_text: &str, delivered_response: &str) -> String {
+    if streamed_text.is_empty() {
+        // Nothing was streamed (draft suppressed, or finalize fires before any
+        // visible frame). The finalizer flushes from offset 0, so the canonical
+        // response is the whole message.
+        return delivered_response.to_string();
+    }
+    if delivered_response == streamed_text {
+        return streamed_text.to_string();
+    }
+    if let Some(final_only) = delivered_response.strip_prefix(streamed_text) {
+        // The final response is the visible stream plus genuinely final-only
+        // content. Keep the streamed prefix verbatim; append only the tail.
+        return format!("{streamed_text}{final_only}");
+    }
+    if streamed_text.ends_with(delivered_response) {
+        // Final sanitization dropped a leading, already-streamed prefix. The
+        // stream already contains every delivered byte, so finalize it as-is;
+        // the finalizer's cumulative offset flushes the unsent tail once.
+        return streamed_text.to_string();
+    }
+    let overlap = cumulative_final_trailing_overlap(streamed_text, delivered_response);
+    format!("{streamed_text}{}", &delivered_response[overlap..])
 }
 
 /// Pump draft deltas to the channel transport, sanitizing every partial on the
@@ -7769,11 +7817,7 @@ async fn process_channel_message_body(
                             let streamed_text = streamed_draft_text
                                 .lock()
                                 .unwrap_or_else(|e| e.into_inner());
-                            cumulative_multi_message_final_text(
-                                &streamed_text,
-                                &outbound_response,
-                                &delivered_response,
-                            )
+                            cumulative_multi_message_final_text(&streamed_text, &delivered_response)
                         } else {
                             delivered_response.clone()
                         };
@@ -17323,6 +17367,18 @@ api_key = "anthropic-key"
         /// what the transport actually received rather than on a sanitizer it
         /// called itself. Progress text lands in `progress_messages`.
         draft_updates: tokio::sync::Mutex<Vec<String>>,
+        /// When set, `update_draft`/`finalize_draft` faithfully model the real
+        /// Discord/Matrix MultiMessage cumulative byte-offset bookkeeping: each
+        /// `\n\n`-bounded paragraph is emitted as its own message and the final
+        /// flush sends `text[sent_so_far..]`. This lets a test exercise the exact
+        /// coordinate arithmetic under test rather than a simplified stand-in.
+        cumulative_offset: bool,
+        /// Byte offset into the cumulative visible stream already emitted as
+        /// paragraphs, mirroring the adapters' `multi_message_sent_len`.
+        multi_sent_len: std::sync::Mutex<usize>,
+        /// Paragraphs actually emitted to the room/channel, in order, including
+        /// the final flush — the messages a user would really receive.
+        emitted_paragraphs: tokio::sync::Mutex<Vec<String>>,
     }
 
     struct ExpiringTypingChannel {
@@ -17352,6 +17408,22 @@ api_key = "anthropic-key"
                 stall_start_typing: false,
                 stall_stop_typing: false,
                 draft_updates: tokio::sync::Mutex::new(Vec::new()),
+                cumulative_offset: false,
+                multi_sent_len: std::sync::Mutex::new(0),
+                emitted_paragraphs: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        /// A MultiMessage channel that models the real adapters' cumulative
+        /// byte-offset paragraph delivery and final flush (see
+        /// [`Self::cumulative_offset`]). `name` selects the adapter identity
+        /// (`"discord"` or `"matrix"`); both share the same offset algorithm.
+        fn multi_message_cumulative(channel_name: &'static str) -> Self {
+            Self {
+                channel_name,
+                supports_multi_message_streaming: true,
+                cumulative_offset: true,
+                ..Self::new(false, false)
             }
         }
 
@@ -17360,14 +17432,6 @@ api_key = "anthropic-key"
                 channel_name: "matrix",
                 supports_multi_message_streaming: stream_mode
                     == zeroclaw_config::schema::MatrixStreamMode::MultiMessage,
-                ..Self::new(false, false)
-            }
-        }
-
-        fn multi_message(channel_name: &'static str) -> Self {
-            Self {
-                channel_name,
-                supports_multi_message_streaming: true,
                 ..Self::new(false, false)
             }
         }
@@ -17720,6 +17784,60 @@ api_key = "anthropic-key"
             text: &str,
         ) -> anyhow::Result<()> {
             self.draft_updates.lock().await.push(text.to_string());
+            if self.cumulative_offset && self.supports_multi_message_streaming {
+                // Mirror the Discord/Matrix MultiMessage `update_draft`: emit
+                // every complete `\n\n`-bounded paragraph (fence-aware) from the
+                // cumulative visible text and advance the sent-length counter
+                // exactly as the real adapters do.
+                let mut emitted = self.emitted_paragraphs.lock().await;
+                let mut sent = self
+                    .multi_sent_len
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                if text.len() < *sent {
+                    // A Clear reset the accumulated text; reset our counter.
+                    *sent = 0;
+                    return Ok(());
+                }
+                loop {
+                    if text.len() <= *sent {
+                        break;
+                    }
+                    let new_text = &text[*sent..];
+                    let bytes = new_text.as_bytes();
+                    let mut scan_pos = 0;
+                    let mut in_fence = false;
+                    let mut found = false;
+                    while scan_pos < bytes.len() {
+                        let ch = bytes[scan_pos];
+                        if ch == b'`'
+                            && scan_pos + 2 < bytes.len()
+                            && bytes[scan_pos + 1] == b'`'
+                            && bytes[scan_pos + 2] == b'`'
+                            && (scan_pos == 0 || bytes[scan_pos - 1] == b'\n')
+                        {
+                            in_fence = !in_fence;
+                        }
+                        if !in_fence
+                            && ch == b'\n'
+                            && scan_pos + 1 < bytes.len()
+                            && bytes[scan_pos + 1] == b'\n'
+                        {
+                            let paragraph = new_text[..scan_pos].trim().to_string();
+                            *sent += scan_pos + 2;
+                            if !paragraph.is_empty() {
+                                emitted.push(paragraph);
+                            }
+                            found = true;
+                            break;
+                        }
+                        scan_pos += 1;
+                    }
+                    if !found {
+                        break;
+                    }
+                }
+            }
             Ok(())
         }
 
@@ -17762,6 +17880,20 @@ api_key = "anthropic-key"
                 .lock()
                 .await
                 .push(format!("{recipient}:{message_id}:{text}"));
+            if self.cumulative_offset && self.supports_multi_message_streaming {
+                // Mirror the Discord/Matrix MultiMessage `finalize_draft`: flush
+                // `text[sent_so_far..]` as the final message when non-empty.
+                let sent = *self
+                    .multi_sent_len
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                if text.len() > sent {
+                    let remaining = text[sent..].trim().to_string();
+                    if !remaining.is_empty() {
+                        self.emitted_paragraphs.lock().await.push(remaining);
+                    }
+                }
+            }
             Ok(())
         }
 
@@ -34989,19 +35121,34 @@ Done."#;
     }
 
     /// Regression at the channel streaming/finalization boundary: malformed
-    /// protocol exhaustion sends only a display-safe terminal fallback after a
-    /// prior tool narration. A MultiMessage finalizer's offset is cumulative,
-    /// so the fallback must remain after the already sent narration exactly
-    /// once.
+    /// protocol exhaustion. A tool narration and a display-safe terminal
+    /// fallback are streamed live as two MultiMessage paragraphs (the fallback
+    /// is what the stream shows once the malformed protocol payload has been
+    /// held back). MultiMessage commits the narration paragraph live and keeps
+    /// the trailing fallback pending behind its cumulative byte offset. Final
+    /// sanitization then drops the leading narration line from the canonical
+    /// response, leaving only the fallback body — modeled here via
+    /// `delivered_response`, exactly as the stop-reason regressions model their
+    /// final sanitizer. Because the finalizer flushes `text[sent_so_far..]`
+    /// against the cumulative visible coordinate, the reconciled final text must
+    /// keep that coordinate so the complete fallback is delivered after the
+    /// already-sent narration exactly once: never merged into the narration
+    /// paragraph, and never duplicated. Feeding the narration-stripped canonical
+    /// response in directly would slice past the fallback with the cumulative
+    /// offset and strand it.
     #[tokio::test]
     async fn multi_message_finalization_keeps_terminal_malformed_fallback_after_narration() {
         use zeroclaw_runtime::agent::loop_::StreamDelta;
 
-        let channel_impl = Arc::new(DraftRecordingChannel::multi_message("discord"));
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative("discord"));
         let channel: Arc<dyn Channel> = channel_impl.clone();
+
         let narration = "Checking the requested records.\n\n";
         let fallback = "I couldn't complete that response safely.";
-        let streamed_text = Arc::new(Mutex::new(String::new()));
+        // Final sanitization keeps only the fallback body after dropping the
+        // leading narration line that was already streamed live.
+        let delivered_response = fallback.to_string();
+
         let (tx, rx) = tokio::sync::mpsc::channel(4);
         tx.send(StreamDelta::Text(narration.to_string()))
             .await
@@ -35011,6 +35158,7 @@ Done."#;
             .unwrap();
         drop(tx);
 
+        let streamed_text = Arc::new(Mutex::new(String::new()));
         run_draft_updater(
             channel,
             "chat-1".to_string(),
@@ -35023,18 +35171,32 @@ Done."#;
 
         let final_text = cumulative_multi_message_final_text(
             &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
-            fallback,
-            fallback,
+            &delivered_response,
         );
+        // The narration was already committed live; the cumulative offset must
+        // leave the complete fallback as the unsent tail for finalization.
         assert_eq!(
             &final_text[narration.len()..],
             fallback,
             "the cumulative offset must leave the complete fallback for finalization"
         );
         assert_eq!(final_text.matches(fallback).count(), 1);
+
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
         assert_eq!(
-            channel_impl.draft_updates.lock().await.last(),
-            Some(&final_text)
+            emitted.as_slice(),
+            [narration.trim().to_string(), fallback.to_string()],
+            "the already-streamed narration stays put and the terminal fallback is flushed after it"
+        );
+        assert_eq!(
+            emitted.iter().filter(|m| m.as_str() == fallback).count(),
+            1,
+            "the complete terminal fallback must be delivered exactly once"
         );
     }
 
@@ -35078,7 +35240,6 @@ Done."#;
         let final_text = cumulative_multi_message_final_text(
             &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
             &terminal_segment,
-            &terminal_segment,
         );
         let sent_so_far = narration.len() + summary.len() + "\n\n".len();
         assert_eq!(
@@ -35091,6 +35252,176 @@ Done."#;
         assert_eq!(
             channel_impl.draft_updates.lock().await.last(),
             Some(&final_text)
+        );
+    }
+
+    /// Real-adapter regression for the exact cumulative-offset arithmetic:
+    /// a leading tool narration is streamed live as its own MultiMessage
+    /// paragraph, then final sanitization drops that narration line from the
+    /// canonical response. Because the finalizer flushes `text[sent_so_far..]`
+    /// against the cumulative visible stream, the reconciled final text must
+    /// keep the streamed coordinate so the complete stop reason is delivered
+    /// exactly once. Feeding the canonical (narration-stripped) response
+    /// directly would slice past the stop reason and drop it.
+    #[tokio::test]
+    async fn multi_message_finalization_delivers_stop_reason_when_final_sanitizer_drops_narration_discord()
+     {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative("discord"));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let narration = "Looking through the available records.\n\n";
+        let answer = "Here is the best partial answer I have.";
+        let stop_reason = "Stopped after reaching the tool-call limit.";
+        let body = format!("{answer}\n\n{stop_reason}");
+        // The final sanitizer keeps only the body after dropping the leading
+        // narration line that was already streamed live.
+        let delivered_response = body.clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(narration.to_string()))
+            .await
+            .unwrap();
+        tx.send(StreamDelta::Text(body.clone())).await.unwrap();
+        drop(tx);
+
+        let streamed_text = Arc::new(Mutex::new(String::new()));
+        run_draft_updater(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed_text),
+            rx,
+        )
+        .await;
+
+        let final_text = cumulative_multi_message_final_text(
+            &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
+            &delivered_response,
+        );
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
+        assert_eq!(
+            emitted.as_slice(),
+            [
+                narration.trim().to_string(),
+                answer.to_string(),
+                stop_reason.to_string(),
+            ],
+            "the already-streamed narration and body stay put and the stop reason is flushed last"
+        );
+        assert_eq!(
+            emitted.iter().filter(|m| m.as_str() == stop_reason).count(),
+            1,
+            "the complete stop reason must be delivered exactly once"
+        );
+    }
+
+    /// The Matrix MultiMessage finalizer shares the same `text[sent_so_far..]`
+    /// cumulative-offset flush, so it needs the same guarantee: dropping a
+    /// streamed leading narration from the canonical response must not strand
+    /// the trailing stop reason.
+    #[tokio::test]
+    async fn multi_message_finalization_delivers_stop_reason_when_final_sanitizer_drops_narration_matrix()
+     {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative("matrix"));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let narration = "Checked the linked calendars.\n\n";
+        let answer = "You have two overlapping meetings on Tuesday.";
+        let stop_reason = "Stopped early because the tool budget was exhausted.";
+        let body = format!("{answer}\n\n{stop_reason}");
+        let delivered_response = body.clone();
+
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(narration.to_string()))
+            .await
+            .unwrap();
+        tx.send(StreamDelta::Text(body.clone())).await.unwrap();
+        drop(tx);
+
+        let streamed_text = Arc::new(Mutex::new(String::new()));
+        run_draft_updater(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed_text),
+            rx,
+        )
+        .await;
+
+        let final_text = cumulative_multi_message_final_text(
+            &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
+            &delivered_response,
+        );
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
+        assert_eq!(
+            emitted.as_slice(),
+            [
+                narration.trim().to_string(),
+                answer.to_string(),
+                stop_reason.to_string(),
+            ]
+        );
+        assert_eq!(
+            emitted.iter().filter(|m| m.as_str() == stop_reason).count(),
+            1,
+            "the complete stop reason must be delivered exactly once"
+        );
+    }
+
+    /// Unit coverage for the reconciliation branches of
+    /// [`cumulative_multi_message_final_text`], including the divergent case
+    /// (a terminal fallback replacing a malformed payload) where the visible
+    /// coordinate must be preserved and the canonical text appended once.
+    #[test]
+    fn cumulative_multi_message_final_text_reconciles_against_the_visible_stream() {
+        // Empty stream: the canonical response is the whole message.
+        assert_eq!(
+            cumulative_multi_message_final_text("", "final answer"),
+            "final answer"
+        );
+        // Identical: unchanged.
+        assert_eq!(
+            cumulative_multi_message_final_text("a\n\nb", "a\n\nb"),
+            "a\n\nb"
+        );
+        // Extends: append only the final-only tail (footer / stop reason).
+        assert_eq!(
+            cumulative_multi_message_final_text("a\n\nb", "a\n\nb\n\nc"),
+            "a\n\nb\n\nc"
+        );
+        // Leading narration stripped from the canonical response: keep the
+        // visible stream verbatim so the finalizer flushes the unsent tail.
+        assert_eq!(
+            cumulative_multi_message_final_text("narration\n\nstop", "stop"),
+            "narration\n\nstop"
+        );
+        // Divergent (terminal fallback replaced the payload): the visible
+        // stream stays the coordinate base and the canonical text is appended
+        // once, past any shared seam.
+        assert_eq!(
+            cumulative_multi_message_final_text("narration\n\n", "fallback text"),
+            "narration\n\nfallback text"
+        );
+        // Divergent with a shared seam: the overlap is not duplicated.
+        assert_eq!(
+            cumulative_multi_message_final_text("live XYZ", "XYZ done"),
+            "live XYZ done"
         );
     }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3912,71 +3912,88 @@ fn truncate_at_unclosed_protocol_fence(s: &str, known_tool_names: &HashSet<Strin
     s.to_string()
 }
 
-/// Largest byte length `k` (on a UTF-8 boundary) such that `streamed_text`
-/// already ends with `delivered_response[..k]`.
+/// Reconcile the canonical final response into the cumulative visible-stream
+/// byte coordinate system used by MultiMessage finalizers.
 ///
-/// This is the span the visible stream and the canonical final response share
-/// at the seam, so it must not be re-emitted when the two representations have
-/// diverged and we append the final response as the trailing remainder.
-fn cumulative_final_trailing_overlap(streamed_text: &str, delivered_response: &str) -> usize {
-    let mut end = delivered_response.len();
+/// Discord and Matrix MultiMessage finalizers flush `final[sent_so_far..]`,
+/// where `sent_so_far` is the channel's confirmed-delivery byte offset into
+/// the cumulative visible text that `update_draft` received (`streamed_text`).
+/// The text handed to `finalize_draft` must therefore begin with exactly the
+/// confirmed bytes — otherwise the offset selects the wrong content: when the
+/// final text is shorter than `sent_so_far` the finalizer's
+/// `text.len() > sent_so_far` guard strands the tail entirely, and when it
+/// merely diverges the flush garbles it.
+///
+/// So keep the confirmed prefix `streamed_text[..sent_so_far]` as the
+/// coordinate base — those paragraphs are on the wire and cannot be unsent —
+/// and follow it with exactly the canonical content that has not been
+/// delivered yet:
+///   * nothing confirmed: the canonical response is the whole message;
+///   * the canonical response extends the confirmed paragraphs (a runtime stop
+///     reason or provider footer appended after streaming): only the unsent
+///     canonical tail follows the prefix;
+///   * final sanitization dropped an already-delivered leading paragraph (e.g.
+///     `strip_tool_narration`): the confirmed prefix stays, and the canonical
+///     response is aligned past any confirmed paragraphs it still contains so
+///     none of them is re-sent;
+///   * final sanitization rewrote the unsent tail (credential redaction, a
+///     terminal fallback replacing a malformed payload): the canonical tail is
+///     authoritative — the streamed unsent tail is never used as content, so
+///     redacted text cannot resurface on the transport;
+///   * trailing-whitespace-only divergence: every canonical byte is already
+///     confirmed, so the finalizer flushes nothing (no final-paragraph replay).
+///
+/// `sent_so_far` is clamped into `streamed_text` and floored to a UTF-8 char
+/// boundary, so a stale or misaligned offset degrades to re-sending a suffix
+/// instead of panicking mid-character.
+fn cumulative_multi_message_final_text(
+    streamed_text: &str,
+    delivered_response: &str,
+    sent_so_far: usize,
+) -> String {
+    let confirmed = streamed_text.floor_char_boundary(sent_so_far.min(streamed_text.len()));
+    let sent_prefix = &streamed_text[..confirmed];
+    if sent_prefix.is_empty() {
+        // Nothing was confirmed on the transport (draft suppressed, no
+        // paragraph boundary reached, or every send failed). The finalizer
+        // flushes from offset 0, so the canonical response is the whole
+        // message and any streamed-but-unconfirmed text is discarded in favor
+        // of the sanitized final content.
+        return delivered_response.to_string();
+    }
+    if sent_prefix.trim_end() == delivered_response.trim_end() {
+        // Trailing-whitespace-only divergence: the confirmed paragraphs
+        // already cover every canonical byte. Keep the confirmed coordinate so
+        // the finalizer flushes nothing rather than replaying the final
+        // paragraph.
+        return sent_prefix.to_string();
+    }
+    // Align the canonical response past the confirmed paragraphs it still
+    // contains. Confirmed prefixes always end at a paragraph delimiter, so
+    // this alignment can only land on canonical paragraph boundaries — a
+    // coincidental mid-word overlap cannot garble the flush.
+    let already_delivered = confirmed_canonical_prefix(sent_prefix, delivered_response);
+    format!("{sent_prefix}{}", &delivered_response[already_delivered..])
+}
+
+/// Largest byte length `k` (on a UTF-8 boundary) such that the confirmed
+/// transport prefix ends with `delivered_response[..k]` — i.e. the leading
+/// canonical bytes that have provably been delivered already and must not be
+/// flushed again. Canonical paragraphs the final sanitizer preserved still
+/// match here when it dropped earlier narration paragraphs that the stream
+/// also delivered, which is what keeps a narration-stripped final response
+/// from re-sending the paragraphs after the narration.
+fn confirmed_canonical_prefix(sent_prefix: &str, delivered_response: &str) -> usize {
+    let mut end = delivered_response.len().min(sent_prefix.len());
     while end > 0 {
         if delivered_response.is_char_boundary(end)
-            && streamed_text.ends_with(&delivered_response[..end])
+            && sent_prefix.ends_with(&delivered_response[..end])
         {
             return end;
         }
         end -= 1;
     }
     0
-}
-
-/// Reconcile the canonical final response into the cumulative visible-stream
-/// byte coordinate system used by MultiMessage finalizers.
-///
-/// Discord and Matrix MultiMessage finalizers flush `final[sent_so_far..]`,
-/// where `sent_so_far` is a byte offset into the visible cumulative text that
-/// `update_draft` received (`streamed_text`). The text handed to
-/// `finalize_draft` must therefore begin with exactly those visible bytes, or
-/// the offset selects the wrong content — and when the final text is shorter
-/// than `sent_so_far`, the finalizer's `text.len() > sent_so_far` guard drops
-/// the trailing stop reason entirely.
-///
-/// So keep `streamed_text` as the coordinate base and append only content the
-/// stream has not already carried:
-///   * identical / empty stream: nothing to reconcile;
-///   * the final response extends the stream (a runtime stop reason or provider
-///     footer appended after streaming): append only that final-only tail;
-///   * final sanitization removed an already-streamed leading prefix (e.g. a
-///     tool narration line): every delivered byte is already visible, so keep
-///     the stream verbatim and let the finalizer flush the unsent tail once;
-///   * divergent (sanitization rewrote the interior, e.g. a terminal fallback
-///     replacing a malformed payload): preserve the visible coordinate and
-///     append the canonical response past any shared seam so it is delivered
-///     exactly once without duplicating the streamed tail.
-fn cumulative_multi_message_final_text(streamed_text: &str, delivered_response: &str) -> String {
-    if streamed_text.is_empty() {
-        // Nothing was streamed (draft suppressed, or finalize fires before any
-        // visible frame). The finalizer flushes from offset 0, so the canonical
-        // response is the whole message.
-        return delivered_response.to_string();
-    }
-    if delivered_response == streamed_text {
-        return streamed_text.to_string();
-    }
-    if let Some(final_only) = delivered_response.strip_prefix(streamed_text) {
-        // The final response is the visible stream plus genuinely final-only
-        // content. Keep the streamed prefix verbatim; append only the tail.
-        return format!("{streamed_text}{final_only}");
-    }
-    if streamed_text.ends_with(delivered_response) {
-        // Final sanitization dropped a leading, already-streamed prefix. The
-        // stream already contains every delivered byte, so finalize it as-is;
-        // the finalizer's cumulative offset flushes the unsent tail once.
-        return streamed_text.to_string();
-    }
-    let overlap = cumulative_final_trailing_overlap(streamed_text, delivered_response);
-    format!("{streamed_text}{}", &delivered_response[overlap..])
 }
 
 /// Pump draft deltas to the channel transport, sanitizing every partial on the
@@ -3995,12 +4012,39 @@ fn cumulative_multi_message_final_text(streamed_text: &str, delivered_response: 
 ///
 /// `known_tool_names` comes from the same registry the final sanitizer reads,
 /// so both boundaries judge a protocol payload by the same tool inventory.
+#[cfg(test)]
 async fn run_draft_updater(
     channel: Arc<dyn Channel>,
     reply_target: String,
     draft_id: String,
     known_tool_names: HashSet<String>,
     streamed_text: Arc<Mutex<String>>,
+    rx: tokio::sync::mpsc::Receiver<zeroclaw_runtime::agent::loop_::DraftEvent>,
+) {
+    run_draft_updater_with_leak_detection(
+        channel,
+        reply_target,
+        draft_id,
+        known_tool_names,
+        streamed_text,
+        zeroclaw_config::schema::LeakDetectionConfig::default(),
+        OutboundContentFormat::Markdown,
+        rx,
+    )
+    .await;
+}
+
+/// As [`run_draft_updater`], but applies the same outbound leak detector as
+/// final delivery. The default wrapper keeps isolated draft tests lightweight;
+/// production always enters through this function with the resolved policy.
+async fn run_draft_updater_with_leak_detection(
+    channel: Arc<dyn Channel>,
+    reply_target: String,
+    draft_id: String,
+    known_tool_names: HashSet<String>,
+    streamed_text: Arc<Mutex<String>>,
+    leak_detection: zeroclaw_config::schema::LeakDetectionConfig,
+    content_format: OutboundContentFormat,
     mut rx: tokio::sync::mpsc::Receiver<zeroclaw_runtime::agent::loop_::DraftEvent>,
 ) {
     use zeroclaw_runtime::agent::loop_::StreamDelta;
@@ -4065,7 +4109,11 @@ async fn run_draft_updater(
             StreamDelta::Reasoning(_) => {}
             StreamDelta::Text(text) => {
                 accumulated.push_str(&text);
-                let visible = sanitize_streaming_draft_text(&accumulated, &known_tool_names);
+                let visible = redact_channel_outbound_leaks(
+                    &sanitize_streaming_draft_text(&accumulated, &known_tool_names),
+                    &leak_detection,
+                    content_format,
+                );
                 // Keep the exact visible frame used for MultiMessage offsets;
                 // retaining the raw accumulation here could reintroduce a
                 // protocol payload during finalization.
@@ -7035,13 +7083,17 @@ async fn process_channel_message_body(
                     .map(|tool| tool.name().to_ascii_lowercase())
                     .collect();
                 let streamed_draft_text = Arc::clone(&streamed_draft_text);
+                let leak_detection = ctx.prompt_config.security.leak_detection.clone();
+                let content_format = outbound_content_format_for_channel(&msg.channel);
                 Some(zeroclaw_spawn::spawn!(async move {
-                    run_draft_updater(
+                    run_draft_updater_with_leak_detection(
                         channel,
                         reply_target,
                         draft_id,
                         known_tool_names,
                         streamed_draft_text,
+                        leak_detection,
+                        content_format,
                         rx,
                     )
                     .await;
@@ -7814,10 +7866,20 @@ async fn process_channel_message_body(
                     } else {
                         let suppress = suppress_voice_override.unwrap_or(false);
                         let draft_final_response = if channel.supports_multi_message_streaming() {
+                            // Ask the transport how much of the visible stream
+                            // is confirmed-delivered before reconciling the
+                            // sanitized final response against it.
+                            let confirmed_offset = channel
+                                .multi_message_confirmed_offset(&delivery_recipient, draft_id)
+                                .await;
                             let streamed_text = streamed_draft_text
                                 .lock()
                                 .unwrap_or_else(|e| e.into_inner());
-                            cumulative_multi_message_final_text(&streamed_text, &delivered_response)
+                            cumulative_multi_message_final_text(
+                                &streamed_text,
+                                &delivered_response,
+                                confirmed_offset,
+                            )
                         } else {
                             delivered_response.clone()
                         };
@@ -17777,6 +17839,17 @@ api_key = "anthropic-key"
             self.supports_multi_message_streaming
         }
 
+        async fn multi_message_confirmed_offset(
+            &self,
+            _recipient: &str,
+            _message_id: &str,
+        ) -> usize {
+            *self
+                .multi_sent_len
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+        }
+
         async fn update_draft(
             &self,
             _recipient: &str,
@@ -17882,13 +17955,14 @@ api_key = "anthropic-key"
                 .push(format!("{recipient}:{message_id}:{text}"));
             if self.cumulative_offset && self.supports_multi_message_streaming {
                 // Mirror the Discord/Matrix MultiMessage `finalize_draft`: flush
-                // `text[sent_so_far..]` as the final message when non-empty.
+                // `text[sent_so_far..]` (boundary-floored) as the final message
+                // when non-empty.
                 let sent = *self
                     .multi_sent_len
                     .lock()
                     .unwrap_or_else(|e| e.into_inner());
                 if text.len() > sent {
-                    let remaining = text[sent..].trim().to_string();
+                    let remaining = text[text.floor_char_boundary(sent)..].trim().to_string();
                     if !remaining.is_empty() {
                         self.emitted_paragraphs.lock().await.push(remaining);
                     }
@@ -35120,22 +35194,124 @@ Done."#;
         );
     }
 
+    /// A final sanitizer is authoritative for everything not yet confirmed on
+    /// the transport: the streamed unsent tail must never be used as content
+    /// after final redaction, while the already-delivered prefix keeps its
+    /// coordinate so the flush cannot strand or garble the sanitized tail.
+    #[test]
+    fn multi_message_finalization_never_reintroduces_finally_sanitized_text() {
+        let leaked = "narration\n\nTemporary key: AKIAABCDEFGHIJKLMNOP"; // gitleaks:allow
+        let final_text = "Safe fallback.";
+        // The narration paragraph (11 bytes incl. its delimiter) is confirmed
+        // on the wire; the credential-bearing tail is not. The reconciled text
+        // keeps the confirmed coordinate and appends only the sanitized tail.
+        let reconciled = cumulative_multi_message_final_text(leaked, final_text, 11);
+        assert!(
+            !reconciled.contains("AKIAABCDEFGHIJKLMNOP"), // gitleaks:allow
+            "the streamed unsent tail must not resurface after final redaction: {reconciled:?}"
+        );
+        assert_eq!(
+            reconciled, "narration\n\nSafe fallback.",
+            "the confirmed prefix keeps its coordinate and the sanitized tail follows it"
+        );
+        // Nothing confirmed: the sanitized final response replaces the stream.
+        assert_eq!(
+            cumulative_multi_message_final_text(leaked, final_text, 0),
+            final_text,
+            "with nothing on the wire the streamed draft must not prefix the final response"
+        );
+        assert_eq!(
+            cumulative_multi_message_final_text("one\n\n ", "one", 5),
+            "one\n\n",
+            "trailing-whitespace-only divergence must flush nothing"
+        );
+    }
+
+    /// Unit coverage for the confirmed-delivery reconciliation branches of
+    /// [`cumulative_multi_message_final_text`]: identical, extending, dropped
+    /// leading narration, interior rewrite, unconfirmed rewrite, offset
+    /// clamping, and non-boundary offsets.
+    #[test]
+    fn cumulative_multi_message_final_text_reconciles_against_the_confirmed_prefix() {
+        // Empty stream / nothing confirmed: the canonical response is the
+        // whole message.
+        assert_eq!(
+            cumulative_multi_message_final_text("", "final answer", 0),
+            "final answer"
+        );
+        // Identical: the confirmed paragraph aligns and only the tail follows.
+        assert_eq!(
+            cumulative_multi_message_final_text("a\n\nb", "a\n\nb", 3),
+            "a\n\nb"
+        );
+        // Extends: append only the final-only tail (footer / stop reason).
+        assert_eq!(
+            cumulative_multi_message_final_text("a\n\nb", "a\n\nb\n\nc", 3),
+            "a\n\nb\n\nc"
+        );
+        // Leading narration stripped from the canonical response after being
+        // confirmed: the confirmed coordinate stays so the finalizer flushes
+        // the complete canonical tail once.
+        assert_eq!(
+            cumulative_multi_message_final_text("narration\n\nstop", "stop", 11),
+            "narration\n\nstop"
+        );
+        // Narration stripped while a later confirmed paragraph is preserved:
+        // the preserved paragraph aligns against the confirmed prefix and is
+        // not re-sent.
+        assert_eq!(
+            cumulative_multi_message_final_text(
+                "narration\n\nanswer\n\nstop",
+                "answer\n\nstop",
+                19
+            ),
+            "narration\n\nanswer\n\nstop"
+        );
+        // Divergent (terminal fallback replaced the payload) after a confirmed
+        // narration paragraph: the fallback is delivered exactly once after it.
+        assert_eq!(
+            cumulative_multi_message_final_text("narration\n\n", "fallback text", 11),
+            "narration\n\nfallback text"
+        );
+        // Divergent with nothing confirmed: the canonical response is
+        // authoritative and the streamed text is discarded entirely.
+        assert_eq!(
+            cumulative_multi_message_final_text("live XYZ", "XYZ done", 0),
+            "XYZ done"
+        );
+        // A final rewrite shorter than the confirmed offset must not strand
+        // the tail behind the finalizer's `text.len() > sent_so_far` guard.
+        assert_eq!(
+            cumulative_multi_message_final_text("one\n\ntwo\n\n", "done", 10),
+            "one\n\ntwo\n\ndone"
+        );
+        // Offsets beyond the stream clamp instead of panicking.
+        assert_eq!(
+            cumulative_multi_message_final_text("a\n\n", "a\n\nb", 100),
+            "a\n\nb"
+        );
+        // A non-boundary offset floors to the previous char boundary instead
+        // of panicking mid-character.
+        assert_eq!(
+            cumulative_multi_message_final_text("h\u{e9}llo\n\nworld", "h\u{e9}llo\n\nworld", 2),
+            "h\u{e9}llo\n\nworld"
+        );
+    }
+
     /// Regression at the channel streaming/finalization boundary: malformed
     /// protocol exhaustion. A tool narration and a display-safe terminal
     /// fallback are streamed live as two MultiMessage paragraphs (the fallback
     /// is what the stream shows once the malformed protocol payload has been
-    /// held back). MultiMessage commits the narration paragraph live and keeps
-    /// the trailing fallback pending behind its cumulative byte offset. Final
-    /// sanitization then drops the leading narration line from the canonical
-    /// response, leaving only the fallback body — modeled here via
-    /// `delivered_response`, exactly as the stop-reason regressions model their
-    /// final sanitizer. Because the finalizer flushes `text[sent_so_far..]`
-    /// against the cumulative visible coordinate, the reconciled final text must
-    /// keep that coordinate so the complete fallback is delivered after the
-    /// already-sent narration exactly once: never merged into the narration
-    /// paragraph, and never duplicated. Feeding the narration-stripped canonical
-    /// response in directly would slice past the fallback with the cumulative
-    /// offset and strand it.
+    /// held back). MultiMessage confirms the narration paragraph live and keeps
+    /// the trailing fallback pending behind its confirmed-delivery byte offset.
+    /// Final sanitization then drops the leading narration line from the
+    /// canonical response, leaving only the fallback body. Because the
+    /// finalizer flushes `text[sent_so_far..]` against the confirmed
+    /// coordinate, the reconciled final text must keep that coordinate so the
+    /// complete fallback is delivered after the already-sent narration exactly
+    /// once: never merged into the narration paragraph, and never duplicated.
+    /// Feeding the narration-stripped canonical response in directly would
+    /// slice past the fallback with the confirmed offset and strand it.
     #[tokio::test]
     async fn multi_message_finalization_keeps_terminal_malformed_fallback_after_narration() {
         use zeroclaw_runtime::agent::loop_::StreamDelta;
@@ -35169,16 +35345,25 @@ Done."#;
         )
         .await;
 
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
+        assert_eq!(
+            sent_so_far,
+            narration.len(),
+            "the narration paragraph (incl. its delimiter) must be the confirmed prefix"
+        );
         let final_text = cumulative_multi_message_final_text(
             &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
             &delivered_response,
+            sent_so_far,
         );
-        // The narration was already committed live; the cumulative offset must
+        // The narration was already confirmed live; the reconciled text must
         // leave the complete fallback as the unsent tail for finalization.
         assert_eq!(
-            &final_text[narration.len()..],
+            &final_text[sent_so_far..],
             fallback,
-            "the cumulative offset must leave the complete fallback for finalization"
+            "the confirmed offset must leave the complete fallback for finalization"
         );
         assert_eq!(final_text.matches(fallback).count(), 1);
 
@@ -35202,16 +35387,14 @@ Done."#;
 
     /// Regression at the channel streaming/finalization boundary: the
     /// max-iteration path sends only its new summary segment after prior tool
-    /// narration. Once MultiMessage has emitted that summary paragraph, the
-    /// stop reason must still be the unsent suffix, not be lost to its
-    /// cumulative offset.
+    /// narration. Once MultiMessage has confirmed that summary paragraph, the
+    /// stop reason must still be the unsent suffix, not be lost to the
+    /// confirmed-delivery offset.
     #[tokio::test]
     async fn multi_message_finalization_keeps_max_iteration_stop_reason_after_narration() {
         use zeroclaw_runtime::agent::loop_::StreamDelta;
 
-        let channel_impl = Arc::new(DraftRecordingChannel::matrix(
-            zeroclaw_config::schema::MatrixStreamMode::MultiMessage,
-        ));
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative("matrix"));
         let channel: Arc<dyn Channel> = channel_impl.clone();
         let narration = "I checked the available sources.\n\n";
         let summary = "Here is the best partial answer.";
@@ -35237,15 +35420,25 @@ Done."#;
         )
         .await;
 
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
+        assert_eq!(
+            sent_so_far,
+            narration.len() + summary.len() + "\n\n".len(),
+            "both live paragraphs (incl. delimiters) must be the confirmed prefix"
+        );
+        // The max-iteration final response carries only the terminal segment;
+        // the narration paragraph was dropped by final sanitization.
         let final_text = cumulative_multi_message_final_text(
             &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
             &terminal_segment,
+            sent_so_far,
         );
-        let sent_so_far = narration.len() + summary.len() + "\n\n".len();
         assert_eq!(
             &final_text[sent_so_far..],
             stop_reason,
-            "the finalizer must flush the stop reason after its cumulative paragraph offset"
+            "the finalizer must flush the stop reason after the confirmed paragraph offset"
         );
         assert_eq!(final_text.matches(summary).count(), 1);
         assert_eq!(final_text.matches(stop_reason).count(), 1);
@@ -35253,16 +35446,31 @@ Done."#;
             channel_impl.draft_updates.lock().await.last(),
             Some(&final_text)
         );
+
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
+        assert_eq!(
+            emitted.as_slice(),
+            [
+                narration.trim().to_string(),
+                summary.to_string(),
+                stop_reason.to_string(),
+            ],
+            "the confirmed paragraphs stay put and the stop reason is flushed last"
+        );
     }
 
-    /// Real-adapter regression for the exact cumulative-offset arithmetic:
+    /// Real-adapter regression for the exact confirmed-delivery arithmetic:
     /// a leading tool narration is streamed live as its own MultiMessage
     /// paragraph, then final sanitization drops that narration line from the
     /// canonical response. Because the finalizer flushes `text[sent_so_far..]`
-    /// against the cumulative visible stream, the reconciled final text must
-    /// keep the streamed coordinate so the complete stop reason is delivered
-    /// exactly once. Feeding the canonical (narration-stripped) response
-    /// directly would slice past the stop reason and drop it.
+    /// against the confirmed coordinate, the reconciled final text must keep
+    /// that coordinate so the complete stop reason is delivered exactly once.
+    /// Feeding the canonical (narration-stripped) response directly would
+    /// slice past the stop reason and drop it.
     #[tokio::test]
     async fn multi_message_finalization_delivers_stop_reason_when_final_sanitizer_drops_narration_discord()
      {
@@ -35297,9 +35505,13 @@ Done."#;
         )
         .await;
 
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
         let final_text = cumulative_multi_message_final_text(
             &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
             &delivered_response,
+            sent_so_far,
         );
         channel_impl
             .finalize_draft("chat-1", "draft-1", &final_text, false)
@@ -35324,7 +35536,7 @@ Done."#;
     }
 
     /// The Matrix MultiMessage finalizer shares the same `text[sent_so_far..]`
-    /// cumulative-offset flush, so it needs the same guarantee: dropping a
+    /// confirmed-offset flush, so it needs the same guarantee: dropping a
     /// streamed leading narration from the canonical response must not strand
     /// the trailing stop reason.
     #[tokio::test]
@@ -35359,9 +35571,13 @@ Done."#;
         )
         .await;
 
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
         let final_text = cumulative_multi_message_final_text(
             &streamed_text.lock().unwrap_or_else(|e| e.into_inner()),
             &delivered_response,
+            sent_so_far,
         );
         channel_impl
             .finalize_draft("chat-1", "draft-1", &final_text, false)
@@ -35375,7 +35591,8 @@ Done."#;
                 narration.trim().to_string(),
                 answer.to_string(),
                 stop_reason.to_string(),
-            ]
+            ],
+            "the already-streamed narration and body stay put and the stop reason is flushed last"
         );
         assert_eq!(
             emitted.iter().filter(|m| m.as_str() == stop_reason).count(),
@@ -35384,45 +35601,179 @@ Done."#;
         );
     }
 
-    /// Unit coverage for the reconciliation branches of
-    /// [`cumulative_multi_message_final_text`], including the divergent case
-    /// (a terminal fallback replacing a malformed payload) where the visible
-    /// coordinate must be preserved and the canonical text appended once.
-    #[test]
-    fn cumulative_multi_message_final_text_reconciles_against_the_visible_stream() {
-        // Empty stream: the canonical response is the whole message.
-        assert_eq!(
-            cumulative_multi_message_final_text("", "final answer"),
-            "final answer"
-        );
-        // Identical: unchanged.
-        assert_eq!(
-            cumulative_multi_message_final_text("a\n\nb", "a\n\nb"),
-            "a\n\nb"
-        );
-        // Extends: append only the final-only tail (footer / stop reason).
-        assert_eq!(
-            cumulative_multi_message_final_text("a\n\nb", "a\n\nb\n\nc"),
-            "a\n\nb\n\nc"
-        );
-        // Leading narration stripped from the canonical response: keep the
-        // visible stream verbatim so the finalizer flushes the unsent tail.
-        assert_eq!(
-            cumulative_multi_message_final_text("narration\n\nstop", "stop"),
-            "narration\n\nstop"
-        );
-        // Divergent (terminal fallback replaced the payload): the visible
-        // stream stays the coordinate base and the canonical text is appended
-        // once, past any shared seam.
-        assert_eq!(
-            cumulative_multi_message_final_text("narration\n\n", "fallback text"),
-            "narration\n\nfallback text"
-        );
-        // Divergent with a shared seam: the overlap is not duplicated.
-        assert_eq!(
-            cumulative_multi_message_final_text("live XYZ", "XYZ done"),
-            "live XYZ done"
-        );
+    /// End-to-end held-paragraph credential regression through the REAL final
+    /// sanitizer and the cumulative finalization harness. A credential arrives
+    /// in the paragraph MultiMessage is still holding (no trailing `\n\n`), so
+    /// it was never confirmed live. The production updater redacts every draft
+    /// frame (leak detection on the streaming boundary), the production final
+    /// sanitizer redacts the canonical response, and finalization must deliver
+    /// the redacted held paragraph exactly once — never the raw credential and
+    /// never a duplicated intro.
+    #[tokio::test]
+    async fn multi_message_finalization_delivers_redacted_held_paragraph_from_real_sanitizer() {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let leaked = "Temporary key: AKIAABCDEFGHIJKLMNOP"; // gitleaks:allow
+        let raw_response = format!("Safe intro.\n\n{leaked} Rotate it later.");
+        for channel_name in ["discord", "matrix"] {
+            let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative(
+                channel_name,
+            ));
+            let channel: Arc<dyn Channel> = channel_impl.clone();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tx.send(StreamDelta::Text(raw_response.clone()))
+                .await
+                .unwrap();
+            drop(tx);
+
+            let streamed = Arc::new(Mutex::new(String::new()));
+            run_draft_updater_with_leak_detection(
+                channel,
+                "chat-1".to_string(),
+                "draft-1".to_string(),
+                no_tools(),
+                Arc::clone(&streamed),
+                zeroclaw_config::schema::LeakDetectionConfig::default(),
+                OutboundContentFormat::Markdown,
+                rx,
+            )
+            .await;
+
+            let frames = channel_impl.draft_updates.lock().await;
+            assert!(
+                frames.iter().all(|frame| !frame.contains(leaked)),
+                "{channel_name} transport received a credential-bearing draft: {frames:?}"
+            );
+            drop(frames);
+
+            // The REAL final sanitizer produces the canonical response — no
+            // manually supplied canonical string.
+            let delivered_response = sanitize_channel_response_with_leak_detection(
+                &raw_response,
+                &[],
+                &zeroclaw_config::schema::LeakDetectionConfig::default(),
+            );
+            assert!(
+                !delivered_response.contains(leaked),
+                "{channel_name}: the final sanitizer must redact the credential"
+            );
+            let intro = "Safe intro.\n\n";
+            assert!(
+                delivered_response.starts_with(intro),
+                "{channel_name}: sanitizer unexpectedly rewrote the confirmed intro: {delivered_response:?}"
+            );
+
+            let sent_so_far = channel_impl
+                .multi_message_confirmed_offset("chat-1", "draft-1")
+                .await;
+            assert_eq!(
+                sent_so_far,
+                intro.len(),
+                "{channel_name}: only the intro paragraph is confirmed; the credential paragraph is held"
+            );
+            let final_text = cumulative_multi_message_final_text(
+                &streamed.lock().unwrap_or_else(|e| e.into_inner()),
+                &delivered_response,
+                sent_so_far,
+            );
+            assert!(
+                !final_text.contains(leaked),
+                "{channel_name}: reconciliation must not resurrect the redacted credential"
+            );
+
+            channel_impl
+                .finalize_draft("chat-1", "draft-1", &final_text, false)
+                .await
+                .unwrap();
+
+            let emitted = channel_impl.emitted_paragraphs.lock().await;
+            assert_eq!(
+                emitted.len(),
+                2,
+                "{channel_name}: intro plus redacted held paragraph, exactly once each: {emitted:?}"
+            );
+            assert_eq!(emitted[0], "Safe intro.");
+            assert_eq!(
+                emitted[1],
+                delivered_response[intro.len()..].trim(),
+                "{channel_name}: the held paragraph must be delivered in its finally-sanitized form"
+            );
+            assert!(
+                emitted[1].contains("[REDACTED"),
+                "{channel_name}: the held paragraph must carry the redaction marker: {:?}",
+                emitted[1]
+            );
+            assert!(
+                emitted.iter().all(|m| !m.contains(leaked)),
+                "{channel_name}: the raw credential must never reach the transport: {emitted:?}"
+            );
+        }
+    }
+
+    /// End-to-end trailing-newline regression through the REAL final sanitizer
+    /// and the cumulative finalization harness. The stream ends on a paragraph
+    /// delimiter, so every paragraph is confirmed live; the final sanitizer
+    /// trims that trailing whitespace from the canonical response. That
+    /// coordinate-only divergence must not replay the final paragraph at
+    /// finalization.
+    #[tokio::test]
+    async fn multi_message_finalization_does_not_replay_final_paragraph_after_trailing_newline() {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let raw_response = "First point.\n\nSecond point.\n\n";
+        for channel_name in ["discord", "matrix"] {
+            let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative(
+                channel_name,
+            ));
+            let channel: Arc<dyn Channel> = channel_impl.clone();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tx.send(StreamDelta::Text("First point.\n\n".to_string()))
+                .await
+                .unwrap();
+            tx.send(StreamDelta::Text("Second point.\n\n".to_string()))
+                .await
+                .unwrap();
+            drop(tx);
+
+            let streamed = Arc::new(Mutex::new(String::new()));
+            run_draft_updater(
+                channel,
+                "chat-1".to_string(),
+                "draft-1".to_string(),
+                no_tools(),
+                Arc::clone(&streamed),
+                rx,
+            )
+            .await;
+
+            // The REAL final sanitizer trims the trailing paragraph delimiter
+            // from the canonical response.
+            let delivered_response = sanitize_channel_response(raw_response, &[]);
+            assert_eq!(
+                delivered_response, "First point.\n\nSecond point.",
+                "precondition: final sanitization trims only trailing whitespace here"
+            );
+
+            let sent_so_far = channel_impl
+                .multi_message_confirmed_offset("chat-1", "draft-1")
+                .await;
+            let final_text = cumulative_multi_message_final_text(
+                &streamed.lock().unwrap_or_else(|e| e.into_inner()),
+                &delivered_response,
+                sent_so_far,
+            );
+            channel_impl
+                .finalize_draft("chat-1", "draft-1", &final_text, false)
+                .await
+                .unwrap();
+
+            let emitted = channel_impl.emitted_paragraphs.lock().await;
+            assert_eq!(
+                emitted.as_slice(),
+                ["First point.".to_string(), "Second point.".to_string()],
+                "{channel_name}: trailing-newline divergence must not replay the final paragraph"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3994,8 +3994,15 @@ fn cumulative_multi_message_final_text(
 /// narration. Requiring both boundaries prevents a canonical paragraph such
 /// as `base` from matching inside a confirmed `database` paragraph.
 fn confirmed_canonical_prefix(sent_prefix: &str, delivered_response: &str) -> usize {
-    for (delimiter, _) in delivered_response.rmatch_indices("\n\n") {
-        let end = delimiter + "\n\n".len();
+    let bytes = delivered_response.as_bytes();
+    for delimiter in (0..bytes.len().saturating_sub(1)).rev() {
+        if bytes[delimiter..delimiter + 2] != *b"\n\n" {
+            continue;
+        }
+        // `end` follows an ASCII newline, so it is always a UTF-8 boundary.
+        // Scanning every byte offset (rather than using non-overlapping string
+        // matches) also considers both delimiters in runs such as `\n\n\n`.
+        let end = delimiter + 2;
         if end > sent_prefix.len() || !sent_prefix.ends_with(&delivered_response[..end]) {
             continue;
         }
@@ -36116,6 +36123,81 @@ Done."#;
     #[tokio::test]
     async fn multi_message_word_suffix_is_not_confirmed_matrix() {
         assert_multi_message_word_suffix_is_not_confirmed("matrix").await;
+    }
+
+    /// Overlapping paragraph delimiters must all be reconciliation candidates.
+    /// With three newlines, the longest candidate has three trailing newlines
+    /// and does not match the confirmed prefix, while the overlapping candidate
+    /// one byte earlier is the exact already-delivered `answer\n\n` paragraph.
+    async fn assert_multi_message_overlapping_delimiter_is_confirmed(channel_name: &'static str) {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let confirmed_prefix = "narration\n\nanswer\n\n";
+        let delivered_response = "answer\n\n\nstop";
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative(
+            channel_name,
+        ));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(format!("{confirmed_prefix}held tail")))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let streamed = Arc::new(Mutex::new(String::new()));
+        run_draft_updater(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed),
+            rx,
+        )
+        .await;
+
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
+        assert_eq!(sent_so_far, confirmed_prefix.len());
+        let final_text = cumulative_multi_message_final_text(
+            &streamed.lock().unwrap_or_else(|e| e.into_inner()),
+            delivered_response,
+            sent_so_far,
+        );
+        assert_eq!(final_text, "narration\n\nanswer\n\n\nstop");
+
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
+        assert_eq!(
+            emitted.as_slice(),
+            [
+                "narration".to_string(),
+                "answer".to_string(),
+                "stop".to_string(),
+            ],
+            "{channel_name}: the confirmed answer paragraph must not be replayed"
+        );
+        assert_eq!(
+            emitted
+                .iter()
+                .filter(|message| message.as_str() == "answer")
+                .count(),
+            1,
+            "{channel_name}: the answer paragraph must be delivered exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_message_overlapping_delimiter_is_confirmed_discord() {
+        assert_multi_message_overlapping_delimiter_is_confirmed("discord").await;
+    }
+
+    #[tokio::test]
+    async fn multi_message_overlapping_delimiter_is_confirmed_matrix() {
+        assert_multi_message_overlapping_delimiter_is_confirmed("matrix").await;
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3968,30 +3968,41 @@ fn cumulative_multi_message_final_text(
         // paragraph.
         return sent_prefix.to_string();
     }
+    if delivered_response
+        .as_bytes()
+        .starts_with(sent_prefix.as_bytes())
+    {
+        // A stale offset may have been floored to a UTF-8 boundary inside the
+        // canonical leading paragraph. Preserve an exact byte-zero prefix;
+        // unlike suffix reconciliation, this cannot match inside a word.
+        return delivered_response.to_string();
+    }
     // Align the canonical response past the confirmed paragraphs it still
-    // contains. Confirmed prefixes always end at a paragraph delimiter, so
-    // this alignment can only land on canonical paragraph boundaries — a
-    // coincidental mid-word overlap cannot garble the flush.
+    // contains. `confirmed_canonical_prefix` verifies both ends of the match
+    // are paragraph boundaries so a coincidental mid-word overlap cannot
+    // garble the flush.
     let already_delivered = confirmed_canonical_prefix(sent_prefix, delivered_response);
     format!("{sent_prefix}{}", &delivered_response[already_delivered..])
 }
 
-/// Largest byte length `k` (on a UTF-8 boundary) such that the confirmed
-/// transport prefix ends with `delivered_response[..k]` — i.e. the leading
-/// canonical bytes that have provably been delivered already and must not be
-/// flushed again. Canonical paragraphs the final sanitizer preserved still
-/// match here when it dropped earlier narration paragraphs that the stream
-/// also delivered, which is what keeps a narration-stripped final response
-/// from re-sending the paragraphs after the narration.
+/// Largest byte length `k` such that `delivered_response[..k]` is one or more
+/// complete paragraphs and the confirmed transport prefix ends with those
+/// same paragraphs at a paragraph boundary. Canonical paragraphs the final
+/// sanitizer preserved still match here when it dropped earlier narration
+/// paragraphs that the stream also delivered, which is what keeps a
+/// narration-stripped final response from re-sending the paragraphs after the
+/// narration. Requiring both boundaries prevents a canonical paragraph such
+/// as `base` from matching inside a confirmed `database` paragraph.
 fn confirmed_canonical_prefix(sent_prefix: &str, delivered_response: &str) -> usize {
-    let mut end = delivered_response.len().min(sent_prefix.len());
-    while end > 0 {
-        if delivered_response.is_char_boundary(end)
-            && sent_prefix.ends_with(&delivered_response[..end])
-        {
+    for (delimiter, _) in delivered_response.rmatch_indices("\n\n") {
+        let end = delimiter + "\n\n".len();
+        if end > sent_prefix.len() || !sent_prefix.ends_with(&delivered_response[..end]) {
+            continue;
+        }
+        let start = sent_prefix.len() - end;
+        if start == 0 || sent_prefix[..start].ends_with("\n\n") {
             return end;
         }
-        end -= 1;
     }
     0
 }
@@ -4017,6 +4028,7 @@ fn confirmed_canonical_prefix(sent_prefix: &str, delivered_response: &str) -> us
 /// offset unchanged. The result always lies on a UTF-8 char boundary of
 /// `frame`: it is either `confirmed_prefix.len()` (a byte-verified prefix of
 /// `frame`) or ends immediately after an ASCII `\n\n`.
+#[cfg(any(test, feature = "channel-discord", feature = "channel-matrix"))]
 pub(crate) fn remap_confirmed_offset(confirmed_prefix: &str, frame: &str) -> usize {
     if frame.as_bytes().starts_with(confirmed_prefix.as_bytes()) {
         return confirmed_prefix.len();
@@ -36020,6 +36032,90 @@ Done."#;
     #[tokio::test]
     async fn multi_message_redaction_spanning_deltas_remaps_confirmed_offset_matrix() {
         assert_multi_message_cross_delta_redaction_remaps_confirmed_offset("matrix").await;
+    }
+
+    /// A suffix shared only inside a word is not evidence that any canonical
+    /// paragraph was delivered. Exercise the cumulative updater/finalizer
+    /// boundary used by both real adapters: `base` must remain pending even
+    /// though the confirmed `database` paragraph ends with the same bytes.
+    async fn assert_multi_message_word_suffix_is_not_confirmed(channel_name: &'static str) {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let confirmed_prefix = "I looked at database\n\n";
+        let leading_paragraph = "base";
+        let stop_reason = "Stopped after reaching the tool-call limit.";
+        let delivered_response = format!("{leading_paragraph}\n\n{stop_reason}");
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative(
+            channel_name,
+        ));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(format!("{confirmed_prefix}held tail")))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let streamed = Arc::new(Mutex::new(String::new()));
+        run_draft_updater(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed),
+            rx,
+        )
+        .await;
+
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
+        assert_eq!(sent_so_far, confirmed_prefix.len());
+        let final_text = cumulative_multi_message_final_text(
+            &streamed.lock().unwrap_or_else(|e| e.into_inner()),
+            &delivered_response,
+            sent_so_far,
+        );
+        assert_eq!(
+            &final_text[sent_so_far..],
+            delivered_response,
+            "{channel_name}: a word-internal suffix must not count as a delivered paragraph"
+        );
+
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
+        assert_eq!(
+            emitted.as_slice(),
+            [
+                confirmed_prefix.trim().to_string(),
+                delivered_response.clone(),
+            ],
+            "{channel_name}: the complete canonical response must be emitted exactly once"
+        );
+        assert_eq!(
+            emitted
+                .iter()
+                .filter(|message| message.as_str() == delivered_response)
+                .count(),
+            1,
+            "{channel_name}: the canonical response must not be dropped or replayed"
+        );
+        assert!(
+            emitted[1].starts_with(leading_paragraph),
+            "{channel_name}: the real leading canonical paragraph must remain intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_message_word_suffix_is_not_confirmed_discord() {
+        assert_multi_message_word_suffix_is_not_confirmed("discord").await;
+    }
+
+    #[tokio::test]
+    async fn multi_message_word_suffix_is_not_confirmed_matrix() {
+        assert_multi_message_word_suffix_is_not_confirmed("matrix").await;
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3996,6 +3996,43 @@ fn confirmed_canonical_prefix(sent_prefix: &str, delivered_response: &str) -> us
     0
 }
 
+/// Remap a MultiMessage confirmed-delivery offset onto a rewritten frame.
+///
+/// `confirmed_prefix` is the exact frame prefix (in the coordinates of the
+/// frame it was captured from) whose paragraphs the transport already
+/// delivered; `frame` is the newest visible frame recomputed from the raw
+/// accumulation. When a later sanitizer pass — e.g. a streaming redaction
+/// span that only completes on a later delta — rewrites bytes inside the
+/// confirmed region, the stored byte offset no longer addresses the same
+/// content in `frame`, and slicing `frame` at it would corrupt everything
+/// sent afterwards (including the terminal stop-reason text).
+///
+/// The remapped offset is the longest byte-identical common prefix of the two
+/// strings, floored to the end of a paragraph delimiter (`\n\n`). Confirmed
+/// prefixes only ever grow in whole `\n\n`-terminated paragraphs, so every
+/// paragraph fully inside the common prefix was delivered verbatim and stays
+/// confirmed, while the first rewritten paragraph is re-emitted in its
+/// sanitized form instead of being sliced mid-way. A frame that still starts
+/// with the confirmed prefix (the overwhelmingly common case) keeps its
+/// offset unchanged. The result always lies on a UTF-8 char boundary of
+/// `frame`: it is either `confirmed_prefix.len()` (a byte-verified prefix of
+/// `frame`) or ends immediately after an ASCII `\n\n`.
+pub(crate) fn remap_confirmed_offset(confirmed_prefix: &str, frame: &str) -> usize {
+    if frame.as_bytes().starts_with(confirmed_prefix.as_bytes()) {
+        return confirmed_prefix.len();
+    }
+    let common = confirmed_prefix
+        .as_bytes()
+        .iter()
+        .zip(frame.as_bytes())
+        .take_while(|(a, b)| a == b)
+        .count();
+    frame.as_bytes()[..common]
+        .windows(2)
+        .rposition(|w| w == b"\n\n")
+        .map_or(0, |i| i + 2)
+}
+
 /// Pump draft deltas to the channel transport, sanitizing every partial on the
 /// way out.
 ///

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -17467,14 +17467,16 @@ api_key = "anthropic-key"
         /// called itself. Progress text lands in `progress_messages`.
         draft_updates: tokio::sync::Mutex<Vec<String>>,
         /// When set, `update_draft`/`finalize_draft` faithfully model the real
-        /// Discord/Matrix MultiMessage cumulative byte-offset bookkeeping: each
-        /// `\n\n`-bounded paragraph is emitted as its own message and the final
-        /// flush sends `text[sent_so_far..]`. This lets a test exercise the exact
+        /// Discord/Matrix MultiMessage confirmed-prefix bookkeeping: each
+        /// `\n\n`-bounded paragraph is emitted as its own message, a frame that
+        /// no longer starts with the confirmed bytes is remapped through
+        /// [`remap_confirmed_offset`], and the final flush sends
+        /// `text[sent_so_far..]`. This lets a test exercise the exact
         /// coordinate arithmetic under test rather than a simplified stand-in.
         cumulative_offset: bool,
-        /// Byte offset into the cumulative visible stream already emitted as
-        /// paragraphs, mirroring the adapters' `multi_message_sent_len`.
-        multi_sent_len: std::sync::Mutex<usize>,
+        /// Exact confirmed frame prefix already emitted as paragraphs,
+        /// mirroring the adapters' `multi_message_confirmed_prefix`.
+        multi_confirmed_prefix: std::sync::Mutex<String>,
         /// Paragraphs actually emitted to the room/channel, in order, including
         /// the final flush — the messages a user would really receive.
         emitted_paragraphs: tokio::sync::Mutex<Vec<String>>,
@@ -17508,7 +17510,7 @@ api_key = "anthropic-key"
                 stall_stop_typing: false,
                 draft_updates: tokio::sync::Mutex::new(Vec::new()),
                 cumulative_offset: false,
-                multi_sent_len: std::sync::Mutex::new(0),
+                multi_confirmed_prefix: std::sync::Mutex::new(String::new()),
                 emitted_paragraphs: tokio::sync::Mutex::new(Vec::new()),
             }
         }
@@ -17881,10 +17883,10 @@ api_key = "anthropic-key"
             _recipient: &str,
             _message_id: &str,
         ) -> usize {
-            *self
-                .multi_sent_len
+            self.multi_confirmed_prefix
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
+                .len()
         }
 
         async fn update_draft(
@@ -17897,23 +17899,27 @@ api_key = "anthropic-key"
             if self.cumulative_offset && self.supports_multi_message_streaming {
                 // Mirror the Discord/Matrix MultiMessage `update_draft`: emit
                 // every complete `\n\n`-bounded paragraph (fence-aware) from the
-                // cumulative visible text and advance the sent-length counter
+                // cumulative visible text and advance the confirmed prefix
                 // exactly as the real adapters do.
                 let mut emitted = self.emitted_paragraphs.lock().await;
-                let mut sent = self
-                    .multi_sent_len
+                let mut confirmed = self
+                    .multi_confirmed_prefix
                     .lock()
                     .unwrap_or_else(|e| e.into_inner());
-                if text.len() < *sent {
-                    // A Clear reset the accumulated text; reset our counter.
-                    *sent = 0;
-                    return Ok(());
+                if !text.as_bytes().starts_with(confirmed.as_bytes()) {
+                    // The frame was rewritten before the confirmed offset (a
+                    // sanitizer rewrite or a Clear restart); remap onto the new
+                    // frame exactly as the real adapters do instead of slicing
+                    // at a stale coordinate.
+                    let remapped = remap_confirmed_offset(&confirmed, text);
+                    *confirmed = text[..remapped].to_string();
                 }
                 loop {
-                    if text.len() <= *sent {
+                    let sent = confirmed.len();
+                    if text.len() <= sent {
                         break;
                     }
-                    let new_text = &text[*sent..];
+                    let new_text = &text[sent..];
                     let bytes = new_text.as_bytes();
                     let mut scan_pos = 0;
                     let mut in_fence = false;
@@ -17934,7 +17940,7 @@ api_key = "anthropic-key"
                             && bytes[scan_pos + 1] == b'\n'
                         {
                             let paragraph = new_text[..scan_pos].trim().to_string();
-                            *sent += scan_pos + 2;
+                            *confirmed = text[..sent + scan_pos + 2].to_string();
                             if !paragraph.is_empty() {
                                 emitted.push(paragraph);
                             }
@@ -17991,15 +17997,21 @@ api_key = "anthropic-key"
                 .await
                 .push(format!("{recipient}:{message_id}:{text}"));
             if self.cumulative_offset && self.supports_multi_message_streaming {
-                // Mirror the Discord/Matrix MultiMessage `finalize_draft`: flush
-                // `text[sent_so_far..]` (boundary-floored) as the final message
-                // when non-empty.
-                let sent = *self
-                    .multi_sent_len
+                // Mirror the Discord/Matrix MultiMessage `finalize_draft`:
+                // flush `text[sent_so_far..]` as the final message when
+                // non-empty, remapping a divergent frame first.
+                let confirmed = self
+                    .multi_confirmed_prefix
                     .lock()
-                    .unwrap_or_else(|e| e.into_inner());
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone();
+                let sent = if text.as_bytes().starts_with(confirmed.as_bytes()) {
+                    confirmed.len()
+                } else {
+                    remap_confirmed_offset(&confirmed, text)
+                };
                 if text.len() > sent {
-                    let remaining = text[text.floor_char_boundary(sent)..].trim().to_string();
+                    let remaining = text[sent..].trim().to_string();
                     if !remaining.is_empty() {
                         self.emitted_paragraphs.lock().await.push(remaining);
                     }
@@ -35811,6 +35823,203 @@ Done."#;
                 "{channel_name}: trailing-newline divergence must not replay the final paragraph"
             );
         }
+    }
+
+    /// Coordinate contract of the confirmed-offset remap: verified prefixes
+    /// keep their offset, a rewrite floors to the last delivered paragraph
+    /// boundary, and the result always lands on a char boundary of the frame.
+    #[test]
+    fn remap_confirmed_offset_floors_rewrites_to_delivered_paragraph_boundaries() {
+        // A frame that still starts with the confirmed bytes keeps the offset.
+        assert_eq!(remap_confirmed_offset("a\n\nb\n\n", "a\n\nb\n\ncc"), 6);
+        // A rewrite inside the second confirmed paragraph floors to the end
+        // of the first: the rewritten paragraph is re-emitted, the intact one
+        // is not replayed.
+        assert_eq!(
+            remap_confirmed_offset("a\n\nSECRET\n\n", "a\n\n[REDACTED]\n\nrest"),
+            3
+        );
+        // A rewrite inside the first paragraph remaps to the frame start.
+        assert_eq!(
+            remap_confirmed_offset("SECRET\n\n", "[REDACTED]\n\nrest"),
+            0
+        );
+        // A restarted accumulation (DraftEvent::Clear) remaps to the start.
+        assert_eq!(remap_confirmed_offset("old text\n\n", "new"), 0);
+        // Multibyte text before the rewrite: the remap lands on the paragraph
+        // delimiter, which is always a char boundary.
+        let confirmed = "héllo\n\nSECRET\n\n";
+        let frame = "héllo\n\n[REDACTED]\n\n";
+        let remapped = remap_confirmed_offset(confirmed, frame);
+        assert_eq!(remapped, "héllo\n\n".len());
+        assert!(frame.is_char_boundary(remapped));
+    }
+
+    /// Cross-delta redaction regression for the confirmed-offset bookkeeping
+    /// (reviewer-blocking finding on the MultiMessage adapters): a
+    /// private-key-shaped secret spans two deltas. The first delta ends
+    /// mid-key after the adapter has already confirmed paragraphs — including
+    /// one inside the not-yet-redactable key region — so when the second
+    /// delta completes the key, the streaming redactor rewrites bytes BEFORE
+    /// the confirmed offset while the redacted frame stays LONGER than that
+    /// stale offset. A byte-count coordinate never notices (the old
+    /// `text.len() < sent_so_far` reset cannot fire) and slices the terminal
+    /// text at a dead coordinate; the confirmed-prefix bookkeeping must remap
+    /// and deliver the complete stop reason exactly once, with no replay of
+    /// confirmed paragraphs and no key material on the transport.
+    async fn assert_multi_message_cross_delta_redaction_remaps_confirmed_offset(
+        channel_name: &'static str,
+    ) {
+        use zeroclaw_runtime::agent::loop_::StreamDelta;
+
+        let intro = "Checked the requested deployment records.\n\n";
+        let key_body = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ"; // gitleaks:allow
+        let summary = "The stored credential is ready to rotate.";
+        let stop_reason = "Stopped after reaching the tool-call limit.";
+        let key_marker = "-----BEGIN PRIVATE KEY-----";
+        // Keep content after the marker paragraph so streaming sanitization
+        // does not trim its `\n\n` delimiter before the adapter sees it. That
+        // makes the incomplete-key paragraph genuinely confirmed on the first
+        // frame; the later closing marker then redacts across that coordinate.
+        let delta_one = format!("{intro}{key_marker}\n\nKey bytes continue:");
+        let delta_two =
+            format!("\n{key_body}\n-----END PRIVATE KEY-----\n\n{summary}\n\n{stop_reason}");
+        let raw_response = format!("{delta_one}{delta_two}");
+
+        let channel_impl = Arc::new(DraftRecordingChannel::multi_message_cumulative(
+            channel_name,
+        ));
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(StreamDelta::Text(delta_one.clone())).await.unwrap();
+        tx.send(StreamDelta::Text(delta_two)).await.unwrap();
+        drop(tx);
+
+        let streamed = Arc::new(Mutex::new(String::new()));
+        run_draft_updater_with_leak_detection(
+            channel,
+            "chat-1".to_string(),
+            "draft-1".to_string(),
+            no_tools(),
+            Arc::clone(&streamed),
+            zeroclaw_config::schema::LeakDetectionConfig::default(),
+            OutboundContentFormat::Markdown,
+            rx,
+        )
+        .await;
+
+        // Scenario preconditions: the first frame still carries the incomplete
+        // key marker (an incomplete key is not yet redactable), no frame ever
+        // carries key material, and the redaction on the second frame rewrote
+        // bytes before the previously confirmed offset while leaving the frame
+        // longer than that stale offset.
+        {
+            let frames = channel_impl.draft_updates.lock().await;
+            assert_eq!(
+                frames.first().map(String::as_str),
+                Some(delta_one.as_str()),
+                "{channel_name}: the first frame must pass through unredacted mid-key"
+            );
+            assert!(
+                frames.iter().all(|f| !f.contains(key_body)),
+                "{channel_name}: no draft frame may carry key material: {frames:?}"
+            );
+        }
+        let stale_offset = intro.len() + key_marker.len() + "\n\n".len();
+        let redacted_frame = streamed.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            !redacted_frame.contains(key_body) && redacted_frame.contains("[REDACTED"),
+            "{channel_name}: the completed key must be redacted on the second frame: {redacted_frame:?}"
+        );
+        assert!(
+            !redacted_frame.as_bytes().starts_with(delta_one.as_bytes()),
+            "{channel_name}: the redaction must rewrite bytes before the confirmed offset"
+        );
+        assert!(
+            redacted_frame.len() > stale_offset,
+            "{channel_name}: the redacted frame must stay longer than the stale offset — a \
+             length-based reset never fires in this scenario"
+        );
+
+        // The confirmed offset must have been remapped onto the redacted
+        // frame: the intro stays confirmed, the rewritten paragraph was
+        // re-emitted in redacted form, and only the held stop reason remains.
+        let sent_so_far = channel_impl
+            .multi_message_confirmed_offset("chat-1", "draft-1")
+            .await;
+        assert_eq!(
+            &redacted_frame[sent_so_far..],
+            stop_reason,
+            "{channel_name}: after the remap, exactly the stop reason must remain unconfirmed"
+        );
+
+        // Finalize through the REAL final sanitizer and the production
+        // reconciliation, exactly as the neighboring regressions do.
+        let delivered_response = sanitize_channel_response_with_leak_detection(
+            &raw_response,
+            &[],
+            &zeroclaw_config::schema::LeakDetectionConfig::default(),
+        );
+        assert!(
+            !delivered_response.contains(key_body),
+            "{channel_name}: the final sanitizer must redact the credential"
+        );
+        let final_text =
+            cumulative_multi_message_final_text(&redacted_frame, &delivered_response, sent_so_far);
+        assert!(
+            !final_text.contains(key_body),
+            "{channel_name}: reconciliation must not resurrect the redacted key"
+        );
+        channel_impl
+            .finalize_draft("chat-1", "draft-1", &final_text, false)
+            .await
+            .unwrap();
+
+        let redacted_paragraph = redacted_frame[intro.len()..]
+            .split("\n\n")
+            .next()
+            .expect("the redacted frame keeps a paragraph where the key started")
+            .to_string();
+        let emitted = channel_impl.emitted_paragraphs.lock().await;
+        assert_eq!(
+            emitted.as_slice(),
+            [
+                intro.trim().to_string(),
+                key_marker.to_string(),
+                redacted_paragraph,
+                summary.to_string(),
+                stop_reason.to_string(),
+            ],
+            "{channel_name}: confirmed paragraphs stay put, the rewritten paragraph is re-sent \
+             in redacted form, and the complete stop reason arrives last untruncated"
+        );
+        assert_eq!(
+            emitted.iter().filter(|m| m.as_str() == stop_reason).count(),
+            1,
+            "{channel_name}: the complete stop reason must be delivered exactly once"
+        );
+        assert_eq!(
+            emitted
+                .iter()
+                .filter(|m| m.as_str() == intro.trim())
+                .count(),
+            1,
+            "{channel_name}: the confirmed intro paragraph must not be replayed"
+        );
+        assert!(
+            emitted.iter().all(|m| !m.contains(key_body)),
+            "{channel_name}: key material must never reach the transport: {emitted:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_message_redaction_spanning_deltas_remaps_confirmed_offset_discord() {
+        assert_multi_message_cross_delta_redaction_remaps_confirmed_offset("discord").await;
+    }
+
+    #[tokio::test]
+    async fn multi_message_redaction_spanning_deltas_remaps_confirmed_offset_matrix() {
+        assert_multi_message_cross_delta_redaction_remaps_confirmed_offset("matrix").await;
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/paced_channel.rs
+++ b/crates/zeroclaw-channels/src/paced_channel.rs
@@ -377,6 +377,12 @@ impl Channel for PacedChannel {
         self.inner.multi_message_delay_ms()
     }
 
+    async fn multi_message_confirmed_offset(&self, recipient: &str, message_id: &str) -> usize {
+        self.inner
+            .multi_message_confirmed_offset(recipient, message_id)
+            .await
+    }
+
     async fn send_draft(&self, message: &SendMessage) -> Result<Option<String>> {
         // Drafts are streaming UX, not final outbound replies — pacing
         // them would freeze the live preview. Forward unchanged.
@@ -1050,6 +1056,66 @@ mod tests {
 
         assert_eq!(counting.creates.load(Ordering::SeqCst), 1);
         assert_eq!(counting.invites.load(Ordering::SeqCst), 1);
+    }
+
+    /// A multi-message-streaming channel that reports a fixed nonzero
+    /// confirmed-delivery offset, so the test can prove the paced wrapper
+    /// forwards the query instead of falling back to the trait default of 0.
+    struct ConfirmedOffsetChannel {
+        confirmed_offset: usize,
+    }
+
+    impl Attributable for ConfirmedOffsetChannel {
+        fn role(&self) -> Role {
+            Role::Channel(zeroclaw_api::attribution::ChannelKind::Matrix)
+        }
+        fn alias(&self) -> &str {
+            "confirmed-offset"
+        }
+    }
+
+    #[async_trait]
+    impl Channel for ConfirmedOffsetChannel {
+        fn name(&self) -> &str {
+            "confirmed-offset"
+        }
+        async fn send(&self, _message: &SendMessage) -> Result<()> {
+            Ok(())
+        }
+        async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+            Ok(())
+        }
+        fn supports_multi_message_streaming(&self) -> bool {
+            true
+        }
+        async fn multi_message_confirmed_offset(
+            &self,
+            _recipient: &str,
+            _message_id: &str,
+        ) -> usize {
+            self.confirmed_offset
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_message_confirmed_offset_forwards_to_inner_channel() {
+        let inner: Arc<dyn Channel> = Arc::new(ConfirmedOffsetChannel {
+            confirmed_offset: 42,
+        });
+        let cfg = PacingFixture {
+            interval_secs: 3600,
+            depth: 4,
+        };
+        let paced = PacedChannel::wrap(inner, &cfg);
+
+        assert!(paced.supports_multi_message_streaming());
+        assert_eq!(
+            paced
+                .multi_message_confirmed_offset("alice", "draft-1")
+                .await,
+            42,
+            "paced wrapper must report the inner channel's confirmed offset, not the trait default of 0",
+        );
     }
 
     /// A channel whose `send` blocks until the test releases a gate, so the

--- a/crates/zeroclaw-plugins/src/wasm_channel.rs
+++ b/crates/zeroclaw-plugins/src/wasm_channel.rs
@@ -687,8 +687,12 @@ impl Channel for WasmChannel {
     }
 
     fn supports_multi_message_streaming(&self) -> bool {
-        self.capabilities
-            .contains(ChannelCapabilities::SUPPORTS_MULTI_MESSAGE_STREAMING)
+        // WASM plugins only advertise a rendering capability; the ABI has no
+        // confirmed-delivery coordinate to reconcile against a sanitized final
+        // response. Keep the generic finalizer on the canonical-response path
+        // until that contract exists rather than treating attempted updates as
+        // confirmed paragraphs.
+        false
     }
 
     fn multi_message_delay_ms(&self) -> u64 {

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -8993,6 +8993,9 @@ mod tests {
             ChatMessage::user("run tool calls"),
         ];
         let observer = NoopObserver;
+        let (delta_tx, mut delta_rx) = tokio::sync::mpsc::channel::<DraftEvent>(8);
+        let (event_tx, mut event_rx) =
+            tokio::sync::mpsc::channel::<zeroclaw_api::agent::TurnEvent>(8);
 
         let result = run_tool_call_loop(ToolLoop {
             parent_agent_alias: None,
@@ -9028,11 +9031,11 @@ mod tests {
             channel_name: "matrix",
             channel_reply_target: None,
             cancellation_token: None,
-            on_delta: None,
+            on_delta: Some(delta_tx),
             shared_budget: None,
             channel: None,
             collected_receipts: None,
-            event_tx: None,
+            event_tx: Some(event_tx),
             steering: None,
             new_messages_out: None,
             image_cache: None,
@@ -9061,6 +9064,24 @@ mod tests {
             .filter(|msg| msg.role == "user" && msg.content.contains("[Tool call parse error]"))
             .count();
         assert_eq!(feedback_count, MAX_MALFORMED_TOOL_PROTOCOL_RETRIES);
+
+        let fallback =
+            crate::i18n::get_required_cli_string("channel-runtime-malformed-tool-output");
+        let mut event_chunks = Vec::new();
+        while let Some(event) = event_rx.recv().await {
+            if let zeroclaw_api::agent::TurnEvent::Chunk { delta } = event {
+                event_chunks.push(delta);
+            }
+        }
+        assert_eq!(event_chunks, vec![fallback.to_string()]);
+
+        let mut draft_text = Vec::new();
+        while let Some(delta) = delta_rx.recv().await {
+            if let DraftEvent::Text(text) = delta {
+                draft_text.push(text);
+            }
+        }
+        assert_eq!(draft_text, vec![fallback]);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -610,13 +610,20 @@ mod graceful_summary_metering_tests {
 
         assert!(out.contains("wrap-up summary"), "unexpected summary: {out}");
 
-        let mut chunk_delta = None;
+        let mut chunk_deltas = Vec::new();
         while let Ok(event) = rx.try_recv() {
             if let TurnEvent::Chunk { delta } = event {
-                chunk_delta = Some(delta);
+                chunk_deltas.push(delta);
             }
         }
-        let delta = chunk_delta.expect("max-iteration exit must emit a TurnEvent::Chunk");
+        assert_eq!(
+            chunk_deltas.len(),
+            1,
+            "max-iteration exit must emit exactly one TurnEvent::Chunk"
+        );
+        let delta = chunk_deltas
+            .pop()
+            .expect("max-iteration exit must emit a TurnEvent::Chunk");
         assert!(
             delta.contains("wrap-up summary"),
             "chunk must carry the summary text: {delta}"

--- a/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/max_iter.rs
@@ -2,6 +2,7 @@
 //! LLM for a tools-free final summary (with step timeout + cancel select)
 //! and return it appended to the accumulated display text, or bail.
 
+use super::StreamDelta;
 use super::knobs::{LoopKnobs, MaxIterationBehavior};
 use super::outcome::ToolLoopCancelled;
 use anyhow::{Context, Result};
@@ -27,6 +28,7 @@ pub(crate) async fn finish_after_max_iterations(
     turn_id: &str,
     knobs: &LoopKnobs,
     event_tx: Option<&Sender<TurnEvent>>,
+    on_delta: Option<&Sender<StreamDelta>>,
     mut new_messages_out: Option<&mut Vec<ChatMessage>>,
 ) -> Result<String> {
     ::zeroclaw_log::record!(
@@ -235,6 +237,9 @@ pub(crate) async fn finish_after_max_iterations(
     // narration earlier iterations already streamed, and resending it here
     // would duplicate it in the client.
     super::events::emit_posthoc_turn_chunk(event_tx, &segment).await;
+    if let Some(tx) = on_delta {
+        let _ = tx.send(StreamDelta::Text(segment.clone())).await;
+    }
     accumulated_display_text.push_str(&segment);
     Ok(accumulated_display_text)
 }
@@ -243,7 +248,7 @@ pub(crate) async fn finish_after_max_iterations(
 mod graceful_summary_metering_tests {
     use super::finish_after_max_iterations;
     use crate::agent::cost::{TOOL_LOOP_COST_TRACKING_CONTEXT, ToolLoopCostTrackingContext};
-    use crate::agent::turn::LoopKnobs;
+    use crate::agent::turn::{LoopKnobs, StreamDelta};
     use async_trait::async_trait;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -308,6 +313,7 @@ mod graceful_summary_metering_tests {
         provider: &dyn ModelProvider,
         accumulated_display_text: String,
         event_tx: Option<&Sender<TurnEvent>>,
+        on_delta: Option<&Sender<StreamDelta>>,
     ) -> anyhow::Result<String> {
         let mut history = vec![ChatMessage::user("do the work")];
         let pacing = PacingConfig::default();
@@ -325,13 +331,14 @@ mod graceful_summary_metering_tests {
             "trace-req-test",
             &knobs,
             event_tx,
+            on_delta,
             None,
         )
         .await
     }
 
     async fn run_summary(provider: &dyn ModelProvider) -> anyhow::Result<String> {
-        run_summary_with_events(provider, String::new(), None).await
+        run_summary_with_events(provider, String::new(), None, None).await
     }
 
     // The graceful summary now routes through the metered provider seam: under a
@@ -561,6 +568,7 @@ mod graceful_summary_metering_tests {
             &knobs,
             None,
             None,
+            None,
         )
         .await
         .expect("graceful summary should succeed");
@@ -590,9 +598,15 @@ mod graceful_summary_metering_tests {
         };
         let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
 
-        let out = run_summary_with_events(&provider, "earlier narration".to_string(), Some(&tx))
-            .await
-            .expect("graceful summary should succeed");
+        let (delta_tx, mut delta_rx) = tokio::sync::mpsc::channel::<StreamDelta>(8);
+        let out = run_summary_with_events(
+            &provider,
+            "earlier narration".to_string(),
+            Some(&tx),
+            Some(&delta_tx),
+        )
+        .await
+        .expect("graceful summary should succeed");
 
         assert!(out.contains("wrap-up summary"), "unexpected summary: {out}");
 
@@ -614,6 +628,14 @@ mod graceful_summary_metering_tests {
         assert!(
             !delta.contains("earlier narration"),
             "chunk must not re-send narration already streamed in earlier iterations: {delta}"
+        );
+        assert!(matches!(
+            delta_rx.recv().await,
+            Some(StreamDelta::Text(draft_delta)) if draft_delta == delta
+        ));
+        assert!(
+            delta_rx.try_recv().is_err(),
+            "summary must emit one draft delta"
         );
     }
 
@@ -665,7 +687,7 @@ mod graceful_summary_metering_tests {
             text: raw.to_string(),
         };
         let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
-        run_summary_with_events(&provider, "earlier narration".to_string(), Some(&tx))
+        run_summary_with_events(&provider, "earlier narration".to_string(), Some(&tx), None)
             .await
             .expect("graceful summary should succeed");
         let mut chunk_delta = None;

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1059,6 +1059,7 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
             let fallback =
                 crate::i18n::get_required_cli_string("channel-runtime-malformed-tool-output");
             accumulated_display_text.push_str(&fallback);
+            events::emit_posthoc_turn_chunk(event_tx.as_ref(), &fallback).await;
             if let Some(ref tx) = on_delta {
                 let _ = tx.send(StreamDelta::Text(fallback.to_string())).await;
             }
@@ -1443,6 +1444,7 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
         turn_id,
         knobs,
         event_tx.as_ref(),
+        on_delta.as_ref(),
         turn_state.canonical.as_deref_mut(),
     )
     .await


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Deliver the display-safe fallback through both live-delivery seams when malformed tool protocol exhausts its retry budget.
  - Deliver only the newly generated max-iteration summary through the draft seam, retaining the full canonical response.
  - Reconcile Discord/Matrix MultiMessage finalization using the confirmed-delivered prefix plus the sanitized final response for the pending tail.
  - Replace the byte-count confirmed offset with a confirmed-prefix string and `remap_confirmed_offset()`, so a redaction rewriting the whole accumulated frame no longer corrupts the terminal stop-reason text.
  - `confirmed_canonical_prefix` now requires matches to land on real `\n\n` paragraph boundaries (not an arbitrary word-internal suffix), and scans overlapping delimiter candidates so a 3+-newline run can't hide a valid match.
- **Scope boundary:** No changes to provider generation, protocol parsing, retry limits, or fallback wording. Channel draft updates now apply outbound leak redaction; WASM channels opt out of MultiMessage streaming (ABI doesn't expose confirmed offsets).
- **Blast radius:** Terminal fallback delivery for ACP, gateway WebSocket, runtime RPC, channel drafts. Cumulative finalization changes are scoped to MultiMessage draft mode.
- **Linked issue(s):** Related #10186 (leaving as "Related" until a maintainer confirms this head fully resolves it)

## Testing

- **Reviewer testing:** N/A — deterministic `ScriptedModelProvider` fixture, no live model/service needed.
- **Known gap:** No live Discord/Matrix smoke test.

**Current head** (`4117cc756`):

```text
$ cargo fmt --all -- --check          → exit 0
$ git diff --check                     → exit 0
$ RUSTFLAGS="-D warnings" cargo check --locked --workspace --exclude zeroclaw-desktop --no-default-features
                                        → exit 0
$ cargo test --locked -p zeroclaw-channels --lib multi_message -- --test-threads=1
                                        → 17 passed, 0 failed
$ cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
                                        → clean
```

## Security & Privacy Impact

- New permissions/network calls? No
- Secrets handling changed? Yes — draft updates apply outbound leak redaction; finalization reconstructs the unsent tail from the sanitized final response.
- PII/prompt injection introduced? No

## Compatibility

- Backward compatible — new confirmed-offset query has a default impl. WASM channels no longer advertise MultiMessage streaming.
- No config/CLI/MSRV changes.

## Rollback

- Standard GitHub revert.
- No feature flags.
- Failure symptoms: MultiMessage drafts could omit/truncate the terminal fallback, replay narration, or (pre-round-4) drop a paragraph sharing trailing characters with an earlier confirmed word.

---

### Round 3: confirmed-offset remap across sanitizer rewrites

A later delta's redaction could rewrite the entire accumulated frame (e.g. a secret spanning two deltas), corrupting the byte-offset tracking and truncating the stop-reason text. Fixed with a confirmed-prefix string + `remap_confirmed_offset()`, which finds the longest matching prefix and floors to the nearest safe paragraph boundary instead of trusting a stale coordinate. New regression covers the exact reported scenario for both Discord and Matrix.

Known residual, not a defect: once a secret resolves, a second redacted-form paragraph gets sent since the original raw text was already on the wire — can't unsend in MultiMessage mode. Deliberate security-conservative tradeoff.

### Round 4: paragraph-boundary and overlapping-delimiter fixes

1. **No-default-features build was red** — `remap_confirmed_offset` had no caller with channel features disabled. Fixed with a `#[cfg(...)]` gate matching its real callers.
2. **Word-internal suffix matching could drop content** — a confirmed prefix ending `...database\n\n` could wrongly match a canonical response starting `base\n\n...`, dropping the real `base` paragraph. Fixed: matches must land on real `\n\n` boundaries on both sides.
3. **Overlapping delimiters in a 3+-newline run could hide a valid match** — non-overlapping string matching missed a valid candidate. Fixed by scanning every byte offset, still longest-match-first.

New regressions cover both cases for Discord and Matrix.