### PR TITLE
fix(deps): update chacha20 to 0.10.2

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,11 +10,11 @@ ignore = [
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained; transitive dep awaiting upstream migration to rustls-pki-types
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained; in cargo-deny's resolved graph via matrix-sdk dev-deps; tracking #8519
     "RUSTSEC-2026-0247",  # bitmaps unmaintained; matrix-sdk reaches imbl directly and via eyeball-im; tracking #9899 and matrix-org/matrix-rust-sdk#6859
-    "RUSTSEC-2026-0253",  # lru 0.16; residual Nostr cache path constrained by deny.toml; migration tracked in #9602
 
     # ── cargo-audit reads the full Cargo.lock, so it flags advisories for
     # crates that cargo-deny (graph-aware) does not pull into the resolved
     # dependency graph. These entries are needed only in audit.toml. ──
+    "RUSTSEC-2026-0253",  # lru 0.16; residual Nostr cache path is absent from cargo-deny's resolved graph; migration tracked in #9602
     "RUSTSEC-2026-0049",  # rustls-webpki CRL matching bug; 0.102.x in Cargo.lock but not in resolved graph; awaiting rumqttc upgrade
     "RUSTSEC-2026-0098",  # rustls-webpki URI name constraints; same as above
     "RUSTSEC-2026-0099",  # rustls-webpki wildcard name constraints; same as above

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -8020,7 +8020,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.2",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -21,12 +21,6 @@ ignore = [
     # matrix-org/matrix-rust-sdk#6859 asks matrix-sdk to move off the imbl stack;
     # drop this entry once a matrix-sdk release no longer pulls bitmaps.
     { id = "RUSTSEC-2026-0247", reason = "bitmaps unmaintained; transitive via matrix-sdk -> eyeball-im -> imbl; no safe upgrade; upstream matrix-org/matrix-rust-sdk#6859" },
-    # The current lock graph retains lru 0.16 through nostr-sdk 0.44. The affected Nostr
-    # caches use EventId keys and unit values, so they do not expose the
-    # panic-on-drop prerequisite described by this advisory. Remove this entry
-    # when the nostr-sdk 0.45 migration tracked in #9602 lands. The Security
-    # job enforces the exact residual lockfile path before running cargo-deny.
-    { id = "RUSTSEC-2026-0253", reason = "lru 0.16 remains transitive through nostr-sdk 0.44; affected caches use EventId keys and unit values; nostr-sdk 0.45 migration tracked in #9602" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Updates the `rand 0.10.1` dependency path from yanked `chacha20 0.10.0` to published non-yanked `chacha20 0.10.2`, removes the graph-aware `RUSTSEC-2026-0253` cargo-deny ignore that no longer matches the resolved graph, and classifies the retained cargo-audit entry as audit-only.
- **Scope boundary:** Preserves the independent `chacha20 0.9.1` package and scoped Nostr `lru` exception tracked in #9602 while moving that exception under `.cargo/audit.toml`'s audit-only heading. It does not update manifests, advisory policy, or other dependencies.
- **Blast radius:** Dependency resolution and Security CI policy only; no ZeroClaw runtime code or user-facing interface changes.
- **Linked issue(s):** Closes #10427
- **Labels:** `dependencies`, `type:dependencies`, `risk:medium`, `size:XS`

### What this does, simply

ZeroClaw records the exact versions of outside libraries it uses so builds remain repeatable. One recorded version was withdrawn by its publisher, which caused the dependency security check to fail. The check also found a written exemption for a warning that no longer occurs and reported that leftover exemption as unused.

This PR records the current published replacement and deletes the obsolete exemption. It does not change ZeroClaw source code, the older version needed elsewhere, or the separate Nostr dependency policy that is still tracked in #9602.

### Scope and maintenance tradeoff

A precise lockfile update is the smallest repair because Cargo resolved the replacement without changing any dependency manifest. Keeping the Nostr exception separate preserves its dedicated dependency boundary and #9602 migration plan instead of coupling two unrelated security-maintenance paths.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a mechanically bounded lockfile and cargo-deny policy update covered by structured checks and repository Security CI.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh Security CI is required because it runs the repository's scoped Nostr guard, `cargo deny check`, and locked dependency fetch against the published head.
- **Known CI coverage gap, if any:** None after exact-head Security CI passed.
- **Current hosted status:** All required exact-head CI passed, including `Security` and `CI Required Gate`.
- **Commands run and tail output:**

```sh
cargo update -p chacha20@0.10.0 --precise 0.10.1
# warning: selected package `chacha20@0.10.1` was yanked by the author
# Updating chacha20 v0.10.0 -> v0.10.1

cargo update -p chacha20@0.10.1 --precise 0.10.2
# Updating chacha20 v0.10.1 -> v0.10.2

python3 scripts/ci/lru_advisory_scope_test.py
# lru advisory scope: constrained to Nostr 0.44 cache packages

git diff --check
# passed with no output

bash scripts/ci/comment_hygiene_gate.sh
# Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** Parsed `Cargo.lock` to confirm that its only `chacha20` packages are preserved `0.9.1` and updated `0.10.2`, that `rand 0.10.1` now selects `0.10.2`, and that the Nostr `lru` exception remains present under the audit-only heading without changing the ignored advisory set. No compilation or runtime test was run because the change contains no source code and those checks would not add dependency-policy evidence beyond Security CI.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Local `cargo deny check` was skipped because `cargo-deny` is not installed; exact-head Security CI ran and passed it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 290f4ba97f30e1a87cb47bb7b3598810419d0227`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The Security CI advisory or locked-fetch steps fail on `chacha20` resolution, checksum, yanked-version policy, or cargo-deny policy validation.
