### PR TITLE
fix(channels): forward transcription language hints

### DIFF
--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -231,6 +231,7 @@ impl TranscriptionProvider for GroqProvider {
 /// OpenAI Whisper API transcription_provider.
 pub struct OpenAiWhisperProvider {
     alias: String,
+    api_url: String,
     api_key: String,
     model: String,
     language: Option<String>,
@@ -251,6 +252,7 @@ impl OpenAiWhisperProvider {
 
         Ok(Self {
             alias: alias.to_string(),
+            api_url: "https://api.openai.com/v1/audio/transcriptions".to_string(),
             api_key,
             model: config.model.clone(),
             language: None,
@@ -276,6 +278,7 @@ impl OpenAiWhisperProvider {
             })?;
         Ok(Self {
             alias: alias.to_string(),
+            api_url: "https://api.openai.com/v1/audio/transcriptions".to_string(),
             api_key,
             model: cfg
                 .model
@@ -311,7 +314,7 @@ impl TranscriptionProvider for OpenAiWhisperProvider {
         }
 
         let resp = client
-            .post("https://api.openai.com/v1/audio/transcriptions")
+            .post(&self.api_url)
             .bearer_auth(&self.api_key)
             .multipart(form)
             .timeout(std::time::Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS))
@@ -328,6 +331,7 @@ impl TranscriptionProvider for OpenAiWhisperProvider {
 /// Deepgram STT API transcription_provider.
 pub struct DeepgramProvider {
     alias: String,
+    api_url: String,
     api_key: String,
     model: String,
     language: Option<String>,
@@ -348,6 +352,7 @@ impl DeepgramProvider {
 
         Ok(Self {
             alias: alias.to_string(),
+            api_url: "https://api.deepgram.com/v1/listen".to_string(),
             api_key,
             model: config.model.clone(),
             language: None,
@@ -373,6 +378,7 @@ impl DeepgramProvider {
             })?;
         Ok(Self {
             alias: alias.to_string(),
+            api_url: "https://api.deepgram.com/v1/listen".to_string(),
             api_key,
             model: cfg
                 .model
@@ -402,7 +408,7 @@ impl TranscriptionProvider for DeepgramProvider {
         let client = zeroclaw_config::schema::build_runtime_proxy_client("transcription.deepgram");
 
         let url = reqwest::Url::parse_with_params(
-            "https://api.deepgram.com/v1/listen",
+            &self.api_url,
             [
                 ("model", self.model.as_str()),
                 ("punctuate", "true"),
@@ -1700,11 +1706,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn typed_registration_defaults_and_language_hints() {
+    #[tokio::test]
+    async fn typed_registration_defaults_and_language_hints() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
         let base = zeroclaw_config::schema::TranscriptionProviderConfig {
             api_key: Some("test-key".to_string()),
-            language: Some("it-IT".to_string()),
+            language: Some("it".to_string()),
             ..zeroclaw_config::schema::TranscriptionProviderConfig::default()
         };
 
@@ -1718,7 +1727,7 @@ mod tests {
         .unwrap();
         assert_eq!(groq.model, "whisper-large-v3-turbo");
 
-        let openai = OpenAiWhisperProvider::from_typed_config(
+        let mut openai = OpenAiWhisperProvider::from_typed_config(
             "default",
             &zeroclaw_config::schema::OpenAiTranscriptionProviderConfig {
                 base: base.clone(),
@@ -1727,7 +1736,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(openai.model, "whisper-1");
-        assert_eq!(openai.language.as_deref(), Some("it-IT"));
+        assert_eq!(openai.language.as_deref(), Some("it"));
 
         let mut deepgram = DeepgramProvider::from_typed_config(
             "default",
@@ -1738,9 +1747,40 @@ mod tests {
         )
         .unwrap();
         assert_eq!(deepgram.model, "nova-2");
-        assert_eq!(deepgram.language_query(), ("language", "it-IT"));
+        assert_eq!(deepgram.language_query(), ("language", "it"));
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "text": "ciao",
+                "results": {"channels": [{"alternatives": [{"transcript": "ciao"}]}]}
+            })))
+            .mount(&server)
+            .await;
+        openai.api_url = format!("{}/openai", server.uri());
+        deepgram.api_url = format!("{}/deepgram", server.uri());
+        openai.transcribe(b"audio", "voice.wav").await.unwrap();
+        deepgram.transcribe(b"audio", "voice.wav").await.unwrap();
         deepgram.language = None;
+        deepgram.transcribe(b"audio", "voice.wav").await.unwrap();
         assert_eq!(deepgram.language_query(), ("detect_language", "true"));
+
+        let requests = server.received_requests().await.unwrap();
+        let multipart = String::from_utf8_lossy(&requests[0].body);
+        assert!(multipart.contains("name=\"language\""));
+        assert!(multipart.contains("\r\n\r\nit\r\n"));
+        assert!(
+            requests[1]
+                .url
+                .query_pairs()
+                .any(|(key, value)| key == "language" && value == "it")
+        );
+        assert!(
+            requests[2]
+                .url
+                .query_pairs()
+                .any(|(key, value)| key == "detect_language" && value == "true")
+        );
 
         let google = GoogleSttProvider::from_typed_config(
             "default",

--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -233,6 +233,7 @@ pub struct OpenAiWhisperProvider {
     alias: String,
     api_key: String,
     model: String,
+    language: Option<String>,
 }
 
 impl OpenAiWhisperProvider {
@@ -252,6 +253,7 @@ impl OpenAiWhisperProvider {
             alias: alias.to_string(),
             api_key,
             model: config.model.clone(),
+            language: None,
         })
     }
 
@@ -280,6 +282,7 @@ impl OpenAiWhisperProvider {
                 .clone()
                 .filter(|model| !model.trim().is_empty())
                 .unwrap_or_else(|| "whisper-1".to_string()),
+            language: cfg.base.language.clone(),
         })
     }
 }
@@ -299,10 +302,13 @@ impl TranscriptionProvider for OpenAiWhisperProvider {
             .file_name(normalized_name)
             .mime_str(mime)?;
 
-        let form = Form::new()
+        let mut form = Form::new()
             .part("file", file_part)
             .text("model", self.model.clone())
             .text("response_format", "json");
+        if let Some(language) = &self.language {
+            form = form.text("language", language.clone());
+        }
 
         let resp = client
             .post("https://api.openai.com/v1/audio/transcriptions")
@@ -324,6 +330,7 @@ pub struct DeepgramProvider {
     alias: String,
     api_key: String,
     model: String,
+    language: Option<String>,
 }
 
 impl DeepgramProvider {
@@ -343,6 +350,7 @@ impl DeepgramProvider {
             alias: alias.to_string(),
             api_key,
             model: config.model.clone(),
+            language: None,
         })
     }
 
@@ -371,7 +379,14 @@ impl DeepgramProvider {
                 .clone()
                 .filter(|model| !model.trim().is_empty())
                 .unwrap_or_else(|| "nova-2".to_string()),
+            language: cfg.base.language.clone(),
         })
+    }
+
+    fn language_query(&self) -> (&str, &str) {
+        self.language
+            .as_deref()
+            .map_or(("detect_language", "true"), |value| ("language", value))
     }
 }
 
@@ -386,13 +401,18 @@ impl TranscriptionProvider for DeepgramProvider {
 
         let client = zeroclaw_config::schema::build_runtime_proxy_client("transcription.deepgram");
 
-        let url = format!(
-            "https://api.deepgram.com/v1/listen?model={}&punctuate=true",
-            self.model
-        );
+        let url = reqwest::Url::parse_with_params(
+            "https://api.deepgram.com/v1/listen",
+            [
+                ("model", self.model.as_str()),
+                ("punctuate", "true"),
+                self.language_query(),
+            ],
+        )
+        .context("Invalid Deepgram transcription endpoint")?;
 
         let resp = client
-            .post(&url)
+            .post(url)
             .header("Authorization", format!("Token {}", self.api_key))
             .header("Content-Type", mime)
             .body(audio_data.to_vec())
@@ -1681,9 +1701,10 @@ mod tests {
     }
 
     #[test]
-    fn typed_registration_defaults_blank_optional_values() {
+    fn typed_registration_defaults_and_language_hints() {
         let base = zeroclaw_config::schema::TranscriptionProviderConfig {
             api_key: Some("test-key".to_string()),
+            language: Some("it-IT".to_string()),
             ..zeroclaw_config::schema::TranscriptionProviderConfig::default()
         };
 
@@ -1706,8 +1727,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(openai.model, "whisper-1");
+        assert_eq!(openai.language.as_deref(), Some("it-IT"));
 
-        let deepgram = DeepgramProvider::from_typed_config(
+        let mut deepgram = DeepgramProvider::from_typed_config(
             "default",
             &zeroclaw_config::schema::DeepgramTranscriptionProviderConfig {
                 base: base.clone(),
@@ -1716,6 +1738,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(deepgram.model, "nova-2");
+        assert_eq!(deepgram.language_query(), ("language", "it-IT"));
+        deepgram.language = None;
+        assert_eq!(deepgram.language_query(), ("detect_language", "true"));
 
         let google = GoogleSttProvider::from_typed_config(
             "default",


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Carry the existing typed transcription `language` setting into OpenAI's multipart request.
  - Carry the same setting into Deepgram's query parameters and explicitly request language detection when no hint is configured.
  - Add deterministic request-capture coverage for OpenAI's multipart language field and both Deepgram query modes.
- **Scope boundary:** This does not add configuration fields, change the legacy provider schema, or alter Groq/Google transcription behavior.
- **Blast radius:** OpenAI Whisper and Deepgram transcription requests created from typed provider configuration.
- **Linked issue(s):** Fixes #10429
- **Labels:** `bug`, `channel`, `provider`, `risk:medium`, `size:XS`.

### What this does, simply

ZeroClaw already lets typed OpenAI and Deepgram transcription providers carry an optional language hint. Before this change, their outbound requests dropped that setting; Deepgram also defaulted to English when no hint existed. This patch forwards configured hints and asks Deepgram to detect the language when none is set, including on the reachable legacy Deepgram path whose schema has no language field. It stops non-English Telegram voice notes from being silently skipped without changing other transcription providers or adding configuration fields.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** No; deterministic local request capture now covers the requested contract.
- **Interface(s) exercised:** `channel:telegram` voice transcription with the OpenAI or Deepgram provider.
- **Setup / preconditions:** Configure a typed transcription provider with provider-valid ISO-639-1 `language = "it"` and valid provider credentials.
- **Steps to run:** Send a short Italian voice note through the configured Telegram channel and inspect the resulting transcript.
- **Expected on this branch (after):** The provider receives the language hint and the transcript reaches the agent.
- **Prior behavior on `master` (before):** OpenAI and Deepgram omit the configured hint, which can produce an empty transcript that the channel skips.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh upstream CI will provide the full repository matrix; exact-head request-capture tests and Clippy cover the changed transcription module.
- **Known CI coverage gap, if any:** No credential-backed live request was sent to either external provider.
- **Commands run and tail output:**

```sh
cargo fmt --check -- crates/zeroclaw-channels/src/transcription.rs
# passed

cargo test -p zeroclaw-channels typed_registration_defaults_and_language_hints --lib
# test result: ok. 1 passed; 0 failed

cargo clippy -p zeroclaw-channels --lib --tests -- -D warnings
# finished successfully with no Clippy warnings

git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Captured the actual local mock-server requests and verified OpenAI's multipart `language=it` field, Deepgram's `language=it` query, and Deepgram's `detect_language=true` fallback; I did not call the live provider APIs.
- **Visual interface changed?** N/A — request construction only.
- **Tested revision, interface, and terminal or viewport dimensions:** `d64d254`; Rust unit-test/Clippy commands; terminal dimensions N/A.
- **Screenshot evidence:** N/A
- **Action or changed state and observed result:** Three local requests were captured with the expected provider-specific language parameters.
- **If any command was intentionally skipped, why:** Full-workspace tests were not run because the focused crate suite and all-target Clippy exercise the changed module; upstream CI supplies the full matrix.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No; this honors an existing field.
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge commit SHA>` after merge.
- **Feature flags or config toggles:** Unsetting the existing language field restores provider-default detection behavior.
- **Observable failure symptoms:** OpenAI/Deepgram transcription request errors or empty transcripts in channel logs.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors: N/A
- Scope materially carried forward: N/A
- `Co-authored-by` trailers added in commit messages for incorporated contributors? N/A
- If `No`, why: N/A
