### PR TITLE
fix(channels): mark ElevenLabs TTS API key sensitive

### DIFF
--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -212,6 +212,40 @@ impl ElevenLabsTtsProvider {
                 .context("Failed to build HTTP client for ElevenLabs TTS")?,
         })
     }
+
+    fn sensitive_api_key_header(&self) -> Result<HeaderValue> {
+        let mut value = HeaderValue::from_str(&self.api_key).map_err(|_| {
+            anyhow::Error::msg("ElevenLabs TTS API key contains invalid header characters")
+        })?;
+        value.set_sensitive(true);
+        Ok(value)
+    }
+
+    fn build_synthesize_request(&self, text: &str, voice: &str) -> Result<reqwest::RequestBuilder> {
+        if !voice
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            bail!("ElevenLabs voice ID contains invalid characters: {voice}");
+        }
+
+        let url = format!("https://api.elevenlabs.io/v1/text-to-speech/{voice}");
+        let body = serde_json::json!({
+            "text": text,
+            "model_id": self.model_id,
+            "voice_settings": {
+                "stability": self.stability,
+                "similarity_boost": self.similarity_boost,
+            },
+        });
+        let api_key = self.sensitive_api_key_header()?;
+
+        Ok(self
+            .client
+            .post(&url)
+            .header("xi-api-key", api_key)
+            .json(&body))
+    }
 }
 
 #[async_trait::async_trait]
@@ -226,27 +260,8 @@ impl TtsProvider for ElevenLabsTtsProvider {
     }
 
     async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>> {
-        if !voice
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        {
-            bail!("ElevenLabs voice ID contains invalid characters: {voice}");
-        }
-        let url = format!("https://api.elevenlabs.io/v1/text-to-speech/{voice}");
-        let body = serde_json::json!({
-            "text": text,
-            "model_id": self.model_id,
-            "voice_settings": {
-                "stability": self.stability,
-                "similarity_boost": self.similarity_boost,
-            },
-        });
-
         let resp = self
-            .client
-            .post(&url)
-            .header("xi-api-key", &self.api_key)
-            .json(&body)
+            .build_synthesize_request(text, voice)?
             .send()
             .await
             .context("Failed to send ElevenLabs TTS request")?;
@@ -1351,6 +1366,75 @@ mod tests {
             },
         );
         cfg
+    }
+
+    fn elevenlabs_tts_provider(api_key: &str) -> ElevenLabsTtsProvider {
+        ElevenLabsTtsProvider::new(
+            "test",
+            &TtsProviderConfig {
+                api_key: Some(api_key.to_string()),
+                ..TtsProviderConfig::default()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn elevenlabs_synthesize_request_preserves_endpoint_body_and_sensitive_header() {
+        let credential = "synthetic-elevenlabs-key";
+        let provider = elevenlabs_tts_provider(credential);
+        let request = provider
+            .build_synthesize_request("hello world", "voice_123")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.url().as_str(),
+            "https://api.elevenlabs.io/v1/text-to-speech/voice_123"
+        );
+
+        let header = request
+            .headers()
+            .get("xi-api-key")
+            .expect("ElevenLabs TTS API key header");
+        assert_eq!(header.to_str().unwrap(), credential);
+        assert!(header.is_sensitive());
+
+        let payload = request
+            .body()
+            .and_then(|body| body.as_bytes())
+            .expect("ElevenLabs TTS request body should be bytes");
+        let body: serde_json::Value = serde_json::from_slice(payload).unwrap();
+
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "text": "hello world",
+                "model_id": "eleven_monolingual_v1",
+                "voice_settings": {
+                    "stability": 0.5,
+                    "similarity_boost": 0.5,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn elevenlabs_tts_rejects_control_characters_without_echoing_credential() {
+        let credential = "synthetic-elevenlabs-key\r\ninjected: value";
+        let provider = elevenlabs_tts_provider(credential);
+
+        let error = match provider.build_synthesize_request("hello", "voice_123") {
+            Ok(_) => panic!("control characters must be rejected before dispatch"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "ElevenLabs TTS API key contains invalid header characters"
+        );
+        assert!(!error.to_string().contains(credential));
     }
 
     fn google_tts_provider(api_key: &str) -> GoogleTtsProvider {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Mark the existing ElevenLabs TTS `xi-api-key` header value as sensitive before attaching it to the request so credential values are protected by reqwest's sensitive-header handling.
  - Construct the API-key header through fallible `HeaderValue` conversion and return fixed credential-free error text when the configured value contains invalid header characters.
  - Add request-level regression coverage for the endpoint, JSON payload, header value, sensitivity flag, and malformed-key rejection before dispatch.
- **Scope boundary:** This PR does not change credential storage, provider selection, ElevenLabs endpoint or payload semantics, voice validation, response handling, configuration, CLI behavior, or other TTS providers.
- **Blast radius:** Limited to construction of ElevenLabs TTS requests in `zeroclaw-channels`. Existing valid ElevenLabs API keys continue to be sent under the same `xi-api-key` header. Invalid header values now fail before dispatch rather than reaching reqwest request construction.
- **Linked issue(s):** Closes #10432
- **Labels:** `bug`, `channel`, `domain:security`, `follow-up`, `risk:high`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — deterministic request-construction tests and exact-head CI exercise the changed credential boundary; a live ElevenLabs request would require a real credential without adding useful evidence.

### How I tested

Fresh required CI for head `eb8637e88976e520d1f7b3d88322da0667dc0b48` is green. The required gate covers formatting, linting, Linux build, feature/default-target checks, tests, and the parallel-runtime test surface for the changed crate.

- **CI checks relied on and why they cover this change:** `CI Required Gate`, `Format`, `Lint`, Linux build, feature/no-default/default-target checks, `Test`, and `Parallel Runtime Test`. The change is confined to `zeroclaw-channels`, is not feature-gated, and the request-construction path is exercised directly by focused package tests.
- **Known CI coverage gap, if any:** No live ElevenLabs vendor request was made. That would require a real API key and would not add evidence beyond the deterministic request-boundary tests for this change.
- **Commands run and tail output:**

  `cargo fmt --all -- --check`
  - Passed.

  `cargo test --locked -p zeroclaw-channels --lib elevenlabs_`
  - `2 passed, 0 failed, 1497 filtered out`

  `cargo test --locked -p zeroclaw-channels --lib google_tts`
  - `1 passed, 0 failed, 1498 filtered out`

  `cargo test --locked -p zeroclaw-channels --lib -- --test-threads=16`
  - `1497 passed, 0 failed, 2 ignored`

  `cargo clippy --locked -p zeroclaw-channels --all-targets -- -D warnings`
  - Passed.

  `cargo build --profile ci --locked -p zeroclaw-channels`
  - Passed.

  `git diff --check origin/master...HEAD`
  - Passed.

- **Beyond CI, what did you manually verify?** The request-level tests exercise the production ElevenLabs request builder and verify the exact endpoint, serialized JSON payload, `xi-api-key` value, `is_sensitive()` flag, and rejection of a control-character credential before dispatch without including the credential in the returned error. I did not perform a live ElevenLabs request because it would require a real credential and would not add useful evidence for this request-construction boundary.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** `cargo clippy --locked -p zeroclaw-channels --all-targets --all-features -- -D warnings` was attempted locally but could not run because the environment lacks the system `alsa.pc` file required by `alsa-sys`. The failure occurred during system-library discovery rather than in this diff. Exact-head CI `Lint` passed, and this change is not feature-gated.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **Yes**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- **If any Yes, describe the risk and mitigation:** The ElevenLabs API key already crosses this request boundary. This PR reduces exposure risk by constructing it through fallible `HeaderValue` conversion, marking the value sensitive before attaching it to `xi-api-key`, and returning fixed error text for malformed values without echoing the credential.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merged PR commit to restore the previous ElevenLabs request-construction path.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Unexpected ElevenLabs TTS request-construction failures, especially errors indicating that the configured ElevenLabs API key cannot be converted to a valid HTTP header value. For valid API keys, request endpoint, payload, header name/value, and response handling are unchanged.
