### PR TITLE
fix(providers): preserve model context when anchoring Gemini requests

### DIFF
--- a/crates/zeroclaw-providers/src/gemini.rs
+++ b/crates/zeroclaw-providers/src/gemini.rs
@@ -1097,6 +1097,23 @@ impl GeminiModelProvider {
         if let Some(instructions) = tool_instructions {
             system_parts.push(instructions);
         }
+        // Gemini rejects a request whose last turn is a model turn. History
+        // trims, session restores, and steering continuations can all leave the
+        // history ending on the model's own output, so drop the trailing model
+        // turns. The last surviving turn must be a user turn, or a bare request
+        // falls back to a user placeholder.
+        while contents
+            .last()
+            .is_some_and(|c| c.role.as_deref() == Some("model"))
+        {
+            contents.pop();
+        }
+        if contents.is_empty() {
+            contents.push(Content {
+                role: Some("user".to_string()),
+                parts: vec![Part::text("[continue]")],
+            });
+        }
         let system_instruction = if system_parts.is_empty() {
             None
         } else {
@@ -2671,7 +2688,6 @@ mod tests {
         let messages = vec![
             ChatMessage::system("You are helpful"),
             ChatMessage::user("Hello [IMAGE:data:image/png;base64,AA==]"),
-            ChatMessage::assistant("I see the image"),
         ];
 
         let (contents, system_instruction) =
@@ -2683,7 +2699,7 @@ mod tests {
             matches!(&system_instruction.parts[0], Part::Text { text } if text == "You are helpful")
         );
 
-        assert_eq!(contents.len(), 2);
+        assert_eq!(contents.len(), 1);
         assert_eq!(contents[0].role.as_deref(), Some("user"));
         assert!(
             contents[0]
@@ -2691,8 +2707,32 @@ mod tests {
                 .iter()
                 .any(|p| matches!(p, Part::Inline { .. }))
         );
-        assert_eq!(contents[1].role.as_deref(), Some("model"));
-        assert!(matches!(&contents[1].parts[0], Part::Text { text } if text == "I see the image"));
+    }
+
+    #[test]
+    fn chat_contents_drop_trailing_model_turn() {
+        let messages = vec![
+            ChatMessage::system("You are helpful"),
+            ChatMessage::user("Hello"),
+            ChatMessage::assistant("I see the image"),
+        ];
+
+        let (contents, _system_instruction) =
+            GeminiModelProvider::build_chat_contents(&messages, None);
+
+        assert_eq!(contents.len(), 1, "trailing model turn must be dropped");
+        assert_eq!(contents[0].role.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn chat_contents_standalone_model_history_falls_back_to_user() {
+        let messages = vec![ChatMessage::assistant("I see the image")];
+
+        let (contents, _system_instruction) =
+            GeminiModelProvider::build_chat_contents(&messages, None);
+
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0].role.as_deref(), Some("user"));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/gemini.rs
+++ b/crates/zeroclaw-providers/src/gemini.rs
@@ -1077,7 +1077,7 @@ impl GeminiModelProvider {
     fn build_chat_contents(
         messages: &[ChatMessage],
         tool_instructions: Option<&str>,
-    ) -> (Vec<Content>, Option<Content>) {
+    ) -> anyhow::Result<(Vec<Content>, Option<Content>)> {
         let mut system_parts: Vec<&str> = Vec::new();
         let mut contents: Vec<Content> = Vec::new();
         for msg in messages {
@@ -1098,21 +1098,43 @@ impl GeminiModelProvider {
             system_parts.push(instructions);
         }
         // Gemini rejects a request whose last turn is a model turn. History
-        // trims, session restores, and steering continuations can all leave the
-        // history ending on the model's own output, so drop the trailing model
-        // turns. The last surviving turn must be a user turn, or a bare request
-        // falls back to a user placeholder.
-        while contents
-            .last()
-            .is_some_and(|c| c.role.as_deref() == Some("model"))
-        {
-            contents.pop();
-        }
-        if contents.is_empty() {
-            contents.push(Content {
-                role: Some("user".to_string()),
-                parts: vec![Part::text("[continue]")],
-            });
+        // trims, session restores, and steering continuations can all leave
+        // the history ending on the model's own output. Those model turns are
+        // the context a continuation must see, so they are kept and a final
+        // user continuation turn is appended; a request with no turns at all
+        // falls back to a lone user placeholder, and model-only history has
+        // nothing to anchor a request on and fails explicitly instead of
+        // being silently replaced with a context-free one.
+        match contents.last().map(|c| c.role.as_deref()) {
+            Some(Some("user")) => {}
+            Some(Some("model")) => {
+                if contents.iter().any(|c| c.role.as_deref() == Some("user")) {
+                    contents.push(Content {
+                        role: Some("user".to_string()),
+                        parts: vec![Part::text("[continue]")],
+                    });
+                } else {
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                            .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                            .with_attrs(::serde_json::json!({ "turns": contents.len() })),
+                        "gemini: model-only history cannot anchor a generateContent request"
+                    );
+                    return Err(anyhow::Error::msg(
+                        "gemini: history ends on model turns but contains no user turn; \
+                         refusing to drop the model context or fabricate a context-free request",
+                    ));
+                }
+            }
+            // no turns at all (empty or system-only): a request still needs
+            // one user turn to anchor on
+            _ => {
+                contents.push(Content {
+                    role: Some("user".to_string()),
+                    parts: vec![Part::text("[continue]")],
+                });
+            }
         }
         let system_instruction = if system_parts.is_empty() {
             None
@@ -1122,7 +1144,7 @@ impl GeminiModelProvider {
                 parts: vec![Part::text(system_parts.join("\n\n"))],
             })
         };
-        (contents, system_instruction)
+        Ok((contents, system_instruction))
     }
 
     async fn chat_with_history_full(
@@ -1131,7 +1153,7 @@ impl GeminiModelProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<(String, Option<TokenUsage>)> {
-        let (contents, system_instruction) = Self::build_chat_contents(messages, None);
+        let (contents, system_instruction) = Self::build_chat_contents(messages, None)?;
         self.send_generate_content(contents, system_instruction, model, temperature)
             .await
     }
@@ -1491,7 +1513,7 @@ impl ModelProvider for GeminiModelProvider {
             None
         };
         let (contents, system_instruction) =
-            Self::build_chat_contents(request.messages, tool_instructions.as_deref());
+            Self::build_chat_contents(request.messages, tool_instructions.as_deref())?;
         let (text, usage) = self
             .send_generate_content(contents, system_instruction, model, temperature)
             .await?;
@@ -2691,7 +2713,8 @@ mod tests {
         ];
 
         let (contents, system_instruction) =
-            GeminiModelProvider::build_chat_contents(&messages, None);
+            GeminiModelProvider::build_chat_contents(&messages, None)
+                .expect("user-anchored history must build");
 
         let system_instruction = system_instruction.expect("system prompt should be separated");
         assert_eq!(system_instruction.role, None);
@@ -2710,7 +2733,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_contents_drop_trailing_model_turn() {
+    fn chat_contents_preserves_trailing_model_turn_and_appends_user_continuation() {
         let messages = vec![
             ChatMessage::system("You are helpful"),
             ChatMessage::user("Hello"),
@@ -2718,21 +2741,70 @@ mod tests {
         ];
 
         let (contents, _system_instruction) =
-            GeminiModelProvider::build_chat_contents(&messages, None);
+            GeminiModelProvider::build_chat_contents(&messages, None)
+                .expect("history with a prior user turn must build");
 
-        assert_eq!(contents.len(), 1, "trailing model turn must be dropped");
+        // the model turn is the context a continuation needs, so it is kept
+        // and the request is anchored with a final user continuation turn
+        assert_eq!(contents.len(), 3, "model turn must be preserved");
         assert_eq!(contents[0].role.as_deref(), Some("user"));
+        assert_eq!(contents[1].role.as_deref(), Some("model"));
+        assert!(
+            matches!(&contents[1].parts[0], Part::Text { text } if text == "I see the image"),
+            "the assistant context must survive the request build"
+        );
+        assert_eq!(contents[2].role.as_deref(), Some("user"));
+        assert!(matches!(&contents[2].parts[0], Part::Text { text } if text == "[continue]"));
     }
 
     #[test]
-    fn chat_contents_standalone_model_history_falls_back_to_user() {
+    fn chat_contents_model_only_history_fails_explicitly() {
         let messages = vec![ChatMessage::assistant("I see the image")];
 
+        let result = GeminiModelProvider::build_chat_contents(&messages, None);
+
+        let err = result.expect_err("model-only history must fail instead of losing context");
+        assert!(
+            err.to_string()
+                .contains("history ends on model turns but contains no user turn"),
+            "error should name the anchoring problem, got: {err}"
+        );
+    }
+
+    #[test]
+    fn chat_contents_empty_history_falls_back_to_bare_continue() {
+        let messages = vec![ChatMessage::system("You are helpful")];
+
         let (contents, _system_instruction) =
-            GeminiModelProvider::build_chat_contents(&messages, None);
+            GeminiModelProvider::build_chat_contents(&messages, None)
+                .expect("system-only history must build with a bare anchor turn");
 
         assert_eq!(contents.len(), 1);
         assert_eq!(contents[0].role.as_deref(), Some("user"));
+        assert!(matches!(&contents[0].parts[0], Part::Text { text } if text == "[continue]"));
+    }
+
+    #[test]
+    fn chat_contents_ending_on_user_turn_is_untouched() {
+        let messages = vec![
+            ChatMessage::user("Hello"),
+            ChatMessage::assistant("Hi"),
+            ChatMessage::user("Now continue"),
+        ];
+
+        let (contents, _system_instruction) =
+            GeminiModelProvider::build_chat_contents(&messages, None)
+                .expect("history already ending on a user turn must build");
+
+        assert_eq!(contents.len(), 3, "no synthetic turn may be appended");
+        assert!(
+            !contents.iter().any(|c| {
+                c.parts
+                    .iter()
+                    .any(|p| matches!(p, Part::Text { text } if text == "[continue]"))
+            }),
+            "no [continue] placeholder may appear"
+        );
     }
 
     #[test]
@@ -2743,7 +2815,8 @@ mod tests {
         ];
 
         let (_contents, system_instruction) =
-            GeminiModelProvider::build_chat_contents(&messages, Some("Use tools carefully"));
+            GeminiModelProvider::build_chat_contents(&messages, Some("Use tools carefully"))
+                .expect("user-anchored history must build");
 
         let system_instruction = system_instruction.expect("system prompt should include tools");
         assert!(
@@ -2756,7 +2829,8 @@ mod tests {
         let messages = vec![ChatMessage::user("Hello")];
 
         let (_contents, system_instruction) =
-            GeminiModelProvider::build_chat_contents(&messages, Some("Use tools carefully"));
+            GeminiModelProvider::build_chat_contents(&messages, Some("Use tools carefully"))
+                .expect("user-anchored history must build");
 
         let system_instruction =
             system_instruction.expect("tool instructions should be system prompt");


### PR DESCRIPTION
> **Maintainer's note** (Audacity88): I corrected the title, current-head CI summary, and request-shape examples on behalf of @blockballr so the public description matches the post-review implementation. The contributor's code and authorship are unchanged; #10064 remains the separate Telegram PR.

## Summary

- **Base branch:** `master`
- **What changed and why:** Gemini requests must not end on a model turn, but the model turns are the context a continuation needs. `build_chat_contents` now keeps the model turns and appends a final user `[continue]` turn when the history ends on the model's output, falls back to a lone user placeholder only when there are no turns at all, and fails explicitly for model-only history instead of silently replacing it with a context-free request. History trimming, session restores, and steering continuations can all leave the tail on the model's own output.
- **Scope boundary:** This touches only request-contents assembly in the Gemini provider, not model selection, streaming, or tool calling. No approval, channel, or gateway surface is affected.
- **Blast radius:** `crates/zeroclaw-providers/src/gemini.rs` only. No other provider shares this code path.
- **Labels (live snapshot at this revision):** `bug`, `provider`, `provider:gemini`, `risk:medium`, `size:S`.
- **Linked issue(s):** Related [#10064](https://github.com/zeroclaw-labs/zeroclaw/pull/10064). Split from that Telegram approval-card PR so the two fixes can be reviewed, tested, reverted, and tracked independently.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** Gemini provider request path (`build_chat_contents`). No user-facing surface.
- **Setup / preconditions:** A Gemini API key if you want the live check below; otherwise the unit tests cover the rule at the request-builder boundary.
- **Steps to run:** `cargo test -p zeroclaw-providers --lib chat_contents`
- **Expected:** The continuation tests pass: `chat_contents_preserves_trailing_model_turn_and_appends_user_continuation` (assistant text preserved, final turn is the user continuation), `chat_contents_model_only_history_fails_explicitly` (model-only history errors instead of losing context), `chat_contents_empty_history_falls_back_to_bare_continue`, and `chat_contents_ending_on_user_turn_is_untouched`, plus the two tool-instruction tests.
- **Prior behavior on `master` (before):** A request whose `contents` end on a model turn is sent as-is and Gemini returns 400.

### How I tested

- **CI checks relied on and why they cover this change:** The workspace `cargo test` and `clippy --all-targets` jobs cover `zeroclaw-providers`, where the entire diff lives.
- **Known CI coverage gap, if any:** No live Gemini API round-trip runs in CI; the request shapes are pinned by unit tests at the request-builder boundary, and the optional curl runbook below exercises the live contract at review time.
- **Commands run and tail output:**

```text
cargo test --locked -p zeroclaw-providers --lib chat_contents
    running 6 tests
    test gemini::tests::chat_contents_create_system_prompt_from_tool_instructions ... ok
    test gemini::tests::chat_contents_append_tool_instructions_to_system_prompt ... ok
    test gemini::tests::chat_contents_preserves_trailing_model_turn_and_appends_user_continuation ... ok
    test gemini::tests::chat_contents_model_only_history_fails_explicitly ... ok
    test gemini::tests::chat_contents_empty_history_falls_back_to_bare_continue ... ok
    test gemini::tests::chat_contents_ending_on_user_turn_is_untouched ... ok
    test result: ok. 6 passed; 0 failed; 0 ignored
```

- **Beyond CI, what did you manually verify?** The three branches of `build_chat_contents` (preserve-and-anchor, explicit model-only failure, bare-anchor fallback) map one-to-one onto the new tests, and the asserted request shapes match the API contract exercised by the live check below.
- **Visual interface changed?** No.
- **Tested revision, interface, and terminal or viewport dimensions:** N/A (no viewport interface).
- **If any command was intentionally skipped, why:** The full-workspace `cargo test` is left to CI; the focused `chat_contents` tests cover the changed surface directly, as shown above. One full `zeroclaw-providers --lib` run observed 2 timing-flaky failures that did not reproduce on two consecutive reruns (1441 passed, 0 failed both times).

## Post-review fix (head `984dd7457`)

Review feedback flagged that the original version of this fix made the request syntactically valid by dropping the trailing model turns, which deletes the context a continuation needs: a history ending on the model's own output would have been sent without the assistant turns, inviting regeneration or contradiction instead of continuation, and the model-only fallback replaced the whole history with a context-free `[continue]`.

`build_chat_contents` now:
- keeps the trailing model turns and appends a final user `[continue]` turn whenever the history ends on a model turn and a prior user turn exists, so the request still ends on a user turn while the assistant context survives (asserted by `chat_contents_preserves_trailing_model_turn_and_appends_user_continuation`);
- fails explicitly for model-only history instead of fabricating context, per the review's explicit-failure option (asserted by `chat_contents_model_only_history_fails_explicitly`);
- falls back to a lone user placeholder only for histories with no turns at all (asserted by `chat_contents_empty_history_falls_back_to_bare_continue`);
- leaves histories already ending on a user turn untouched (asserted by `chat_contents_ending_on_user_turn_is_untouched`).

- **Hosted CI on this exact head:** All 34 reported checks pass on head `ac786e947a7af3fb21b0f31c498058348a7279cb`. The main [CI run 33303292690](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33303292690) is green, including `CI Required Gate`, `Test`, `Lint`, `Security`, `Test (Landlock)`, MSRV, Nix, and Windows coverage.

### Live smoke test (optional, for a reviewer who wants live confirmation)

Put your Gemini key in an environment variable named `GEMINI_API_KEY`, sourced from your existing config so it never appears on a command line, then run the two API checks below. They print only the HTTP status code; the response body is discarded. Substitute a model available to your account.

The request the fix prevents, whose last turn is a model turn:

```text
curl -s -o /dev/null -w '%{http_code}\n' \
  -H "x-goog-api-key: $GEMINI_API_KEY" -H 'Content-Type: application/json' \
  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent" \
  -d '{"contents":[{"role":"user","parts":[{"text":"hello"}]},{"role":"model","parts":[{"text":"hi there"}]}]}'
```

Expected: `400`. Gemini rejects a `generateContent` request whose last `contents` entry is a model turn.

The shape `build_chat_contents` produces after preserving the trailing model turn and appending a user continuation:

```text
curl -s -o /dev/null -w '%{http_code}\n' \
  -H "x-goog-api-key: $GEMINI_API_KEY" -H 'Content-Type: application/json' \
  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent" \
  -d '{"contents":[{"role":"user","parts":[{"text":"hello"}]},{"role":"model","parts":[{"text":"hi there"}]},{"role":"user","parts":[{"text":"[continue]"}]}]}'
```

Expected: `200`.

Model-only history does not produce an HTTP request. `build_chat_contents` returns an explicit error rather than dropping the model context or fabricating a context-free request; `chat_contents_model_only_history_fails_explicitly` covers that branch.

The first API call is the payload the old code could emit and Gemini rejects. The second is the valid continuation shape this change now produces.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`. The request destination, client, and key handling are unchanged; only the assembled `contents` payload differs.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`. The only appended string is the fixed `[continue]` placeholder.
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's commit. There are no migrations and no persisted state, so a revert fully restores prior behavior.
- **Feature flags or config toggles:** None. The contents assembly rule is unconditional.
- **Observable failure symptoms:** A regression surfaces as `generateContent` 400s complaining about a trailing model turn.

## Supersede Attribution

N/A. This PR does not use `Supersedes #`.
