### PR TITLE
fix(channels): preserve WhatsApp storage integrity

### DIFF
--- a/crates/zeroclaw-channels/src/whatsapp_storage.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_storage.rs
@@ -1519,14 +1519,19 @@ impl DeviceStoreTrait for RusqliteStore {
         extra_content: Option<&[u8]>,
     ) -> wacore::store::error::Result<()> {
         let snapshot_path = format!("{}.snapshot.{}", self.db_path, name);
+        let content_path = format!("{}.extra", snapshot_path);
 
         // Serialize replacement and sidecar creation with the database copy so
         // concurrent requests cannot pair artifacts from different snapshots.
         let conn = self.conn.lock();
-        match std::fs::remove_file(&snapshot_path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(wacore::store::error::StoreError::Database(Box::new(error))),
+        for path in [&snapshot_path, &content_path] {
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(wacore::store::error::StoreError::Database(Box::new(error)));
+                }
+            }
         }
         // VACUUM INTO reads through SQLite, so committed pages still in the
         // WAL are included in the standalone snapshot.
@@ -1534,7 +1539,6 @@ impl DeviceStoreTrait for RusqliteStore {
 
         // If extra_content is provided, save it alongside.
         if let Some(content) = extra_content {
-            let content_path = format!("{}.extra", snapshot_path);
             to_store_err!(std::fs::write(&content_path, content))?;
         }
 
@@ -1671,14 +1675,24 @@ mod tests {
             .unwrap();
 
         let snapshot_path = format!("{}.snapshot.wal", path.to_string_lossy());
-        let snapshot = Connection::open(&snapshot_path).unwrap();
-        let value: String = snapshot
-            .query_row("SELECT value FROM snapshot_probe", [], |row| row.get(0))
-            .unwrap();
-        assert_eq!(value, "wal-only");
+        {
+            let snapshot = Connection::open(&snapshot_path).unwrap();
+            let value: String = snapshot
+                .query_row("SELECT value FROM snapshot_probe", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(value, "wal-only");
+        }
         assert_eq!(
             std::fs::read(format!("{snapshot_path}.extra")).unwrap(),
             b"extra"
+        );
+
+        DeviceStoreTrait::snapshot_db(&store, "wal", None)
+            .await
+            .unwrap();
+        assert!(
+            !Path::new(&format!("{snapshot_path}.extra")).exists(),
+            "snapshot without extra content must remove a stale sidecar"
         );
     }
 

--- a/crates/zeroclaw-channels/src/whatsapp_storage.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_storage.rs
@@ -1388,19 +1388,34 @@ impl DeviceStoreTrait for RusqliteStore {
                     rusqlite::Error::ToSqlConversionFailure(Box::new(e))
                 }
 
-                // Deserialize KeyPairs from bytes (64 bytes each)
-                let noise_key_bytes: Vec<u8> = row.get("noise_key")?;
-                let identity_key_bytes: Vec<u8> = row.get("identity_key")?;
-                let signed_pre_key_bytes: Vec<u8> = row.get("signed_pre_key")?;
+                fn fixed_blob<const N: usize>(
+                    name: &str,
+                    bytes: Vec<u8>,
+                ) -> Result<[u8; N], rusqlite::Error> {
+                    if bytes.len() != N {
+                        return Err(rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Blob,
+                            Box::new(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                format!("{name} must be {N} bytes, got {}", bytes.len()),
+                            )),
+                        ));
+                    }
 
-                if noise_key_bytes.len() != 64
-                    || identity_key_bytes.len() != 64
-                    || signed_pre_key_bytes.len() != 64
-                {
-                    return Err(rusqlite::Error::InvalidParameterName("key_pair".into()));
+                    let mut value = [0u8; N];
+                    value.copy_from_slice(&bytes);
+                    Ok(value)
                 }
 
                 use wacore::libsignal::protocol::{KeyPair, PrivateKey, PublicKey};
+
+                // Deserialize KeyPairs from fixed-size blobs.
+                let noise_key_bytes: [u8; 64] = fixed_blob("noise_key", row.get("noise_key")?)?;
+                let identity_key_bytes: [u8; 64] =
+                    fixed_blob("identity_key", row.get("identity_key")?)?;
+                let signed_pre_key_bytes: [u8; 64] =
+                    fixed_blob("signed_pre_key", row.get("signed_pre_key")?)?;
 
                 let noise_key = KeyPair::new(
                     PublicKey::from_djb_public_key_bytes(&noise_key_bytes[32..64])
@@ -1423,14 +1438,12 @@ impl DeviceStoreTrait for RusqliteStore {
 
                 let lid_str: Option<String> = row.get("lid")?;
                 let pn_str: Option<String> = row.get("pn")?;
-                let signature_bytes: Vec<u8> = row.get("signed_pre_key_signature")?;
-                let adv_secret_bytes: Vec<u8> = row.get("adv_secret_key")?;
+                let signature = fixed_blob::<64>(
+                    "signed_pre_key_signature",
+                    row.get("signed_pre_key_signature")?,
+                )?;
+                let adv_secret = fixed_blob::<32>("adv_secret_key", row.get("adv_secret_key")?)?;
                 let account_bytes: Option<Vec<u8>> = row.get("account")?;
-
-                let mut signature = [0u8; 64];
-                let mut adv_secret = [0u8; 32];
-                signature.copy_from_slice(&signature_bytes);
-                adv_secret.copy_from_slice(&adv_secret_bytes);
 
                 let account = if let Some(bytes) = account_bytes {
                     Some(
@@ -1505,12 +1518,21 @@ impl DeviceStoreTrait for RusqliteStore {
         name: &str,
         extra_content: Option<&[u8]>,
     ) -> wacore::store::error::Result<()> {
-        // Create a snapshot by copying the database file
         let snapshot_path = format!("{}.snapshot.{}", self.db_path, name);
 
-        to_store_err!(std::fs::copy(&self.db_path, &snapshot_path))?;
+        // Serialize replacement and sidecar creation with the database copy so
+        // concurrent requests cannot pair artifacts from different snapshots.
+        let conn = self.conn.lock();
+        match std::fs::remove_file(&snapshot_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(wacore::store::error::StoreError::Database(Box::new(error))),
+        }
+        // VACUUM INTO reads through SQLite, so committed pages still in the
+        // WAL are included in the standalone snapshot.
+        to_store_err!(execute: conn.execute("VACUUM INTO ?1", params![snapshot_path.as_str()]))?;
 
-        // If extra_content is provided, save it alongside
+        // If extra_content is provided, save it alongside.
         if let Some(content) = extra_content {
             let content_path = format!("{}.extra", snapshot_path);
             to_store_err!(std::fs::write(&content_path, content))?;
@@ -1575,6 +1597,89 @@ mod tests {
         device.pn = Some(wacore_binary::jid::Jid::pn("15551234567"));
         DeviceStoreTrait::save(&store, &device).await.unwrap();
         assert!(persisted_device_exists(&path));
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn device_load_rejects_malformed_fixed_blobs_without_unwinding() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let store = RusqliteStore::new(tmp.path()).unwrap();
+        let device = CoreDevice::new();
+
+        DeviceStoreTrait::save(&store, &device).await.unwrap();
+
+        for (column, expected_len) in [
+            ("noise_key", 64),
+            ("identity_key", 64),
+            ("signed_pre_key", 64),
+            ("signed_pre_key_signature", 64),
+            ("adv_secret_key", 32),
+        ] {
+            DeviceStoreTrait::save(&store, &device).await.unwrap();
+            {
+                let conn = store.conn.lock();
+                conn.execute(
+                    &format!("UPDATE device SET {column} = ?1 WHERE id = ?2"),
+                    params![vec![0u8; expected_len - 1], store.device_id],
+                )
+                .unwrap();
+            }
+
+            let result = DeviceStoreTrait::load(&store).await;
+            assert!(
+                matches!(result, Err(wacore::store::error::StoreError::Database(_))),
+                "malformed {column} should return a database error"
+            );
+        }
+    }
+
+    #[cfg(feature = "whatsapp-web")]
+    #[tokio::test]
+    async fn snapshot_db_includes_committed_wal_pages() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.db");
+        let store = RusqliteStore::new(&path).unwrap();
+
+        {
+            let conn = store.conn.lock();
+            conn.execute_batch(
+                "PRAGMA wal_autocheckpoint = 0;
+                 CREATE TABLE snapshot_probe (value TEXT NOT NULL);",
+            )
+            .unwrap();
+            conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+                .unwrap();
+            conn.execute(
+                "INSERT INTO snapshot_probe (value) VALUES (?1)",
+                params!["wal-only"],
+            )
+            .unwrap();
+        }
+
+        // Copying the main file directly omits the committed row still held
+        // in the live WAL, which is the failure mode this snapshot fixes.
+        let main_only_path = tmp.path().join("main-only.db");
+        std::fs::copy(&path, &main_only_path).unwrap();
+        let main_only = Connection::open(&main_only_path).unwrap();
+        let main_count: i64 = main_only
+            .query_row("SELECT COUNT(*) FROM snapshot_probe", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(main_count, 0);
+
+        DeviceStoreTrait::snapshot_db(&store, "wal", Some(b"extra"))
+            .await
+            .unwrap();
+
+        let snapshot_path = format!("{}.snapshot.wal", path.to_string_lossy());
+        let snapshot = Connection::open(&snapshot_path).unwrap();
+        let value: String = snapshot
+            .query_row("SELECT value FROM snapshot_probe", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "wal-only");
+        assert_eq!(
+            std::fs::read(format!("{snapshot_path}.extra")).unwrap(),
+            b"extra"
+        );
     }
 
     #[cfg(feature = "whatsapp-web")]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Validate every fixed-size WhatsApp device key blob before converting it into an in-memory array, so a malformed SQLite row returns a storage error instead of panicking.
  - Create diagnostic snapshots through SQLite's `VACUUM INTO` operation, so committed pages still resident in the write-ahead log are included in the standalone database.
  - Serialize destination replacement, database materialization, and optional sidecar writing under the store's existing connection lock.
  - Remove a previous optional sidecar when re-creating the same named snapshot without extra content, so stale diagnostics cannot be paired with a fresh database.
  - Add real-SQLite regressions for all five malformed fixed-size columns and for a committed WAL-only row.
- **Scope boundary:** This does not change the WhatsApp schema, session format, configuration, protocol, snapshot filenames, or optional sidecar format. It does not include the larger passkey and dependency-port changes proposed in #10084 and #10153.
- **Blast radius:** The `whatsapp-web` SQLite backend only. Device loading now fails cleanly on malformed fixed-size cryptographic state, and debug snapshot creation uses SQLite rather than a raw file copy.
- **Linked issue(s):** None. This is a self-contained maintenance fix identified from the existing storage implementation.
- **Labels:** `bug`, `channel`, `channel:whatsapp`, `risk:medium`, `size:S`

This implementation is authored from a maintainer account and requires independent maintainer approval before merge.

### What this does, simply

WhatsApp Web keeps the linked device's cryptographic state in a local SQLite database. Two recovery paths were unsafe: a damaged fixed-size value could crash while being loaded, and a diagnostic copy could omit recently committed data that still lived in SQLite's write-ahead log.

This PR makes damaged rows return the backend's normal database error and lets SQLite produce the snapshot itself, including committed WAL data. A repeated snapshot without new extra content also clears the old sidecar instead of leaving mismatched diagnostics. It does not change valid sessions or the on-disk schema.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; the focused storage suite reproduces both failure modes with real SQLite databases and requires no WhatsApp account.
- **Interface(s) exercised:** `channel` (WhatsApp Web persistence backend)
- **Setup / preconditions:** A Rust development environment with the repository dependencies available. No account, credentials, or external service is required.
- **Steps to run:** `cargo test --locked -p zeroclaw-channels --features whatsapp-web --lib 'whatsapp_storage::tests::'`
- **Expected on this branch (after):** The malformed-row case returns `StoreError::Database` for all five fixed-size columns, and the snapshot case opens a standalone database containing a committed WAL-only row. All 10 focused tests pass.
- **Prior behavior on `master` (before):** Wrong-length signature or advertisement-secret blobs panic during device loading, while copying only the main database file omits the committed WAL-only row.

### How I tested

- **CI checks relied on and why they cover this change:** All required CI passed on exact head `9d0a33dadc`, including the workspace test job, Linux build, cross-platform checks, lint, format, security, MSRV, parallel runtime tests, and focused boundary checks.
- **Known CI coverage gap, if any:** None expected after the focused real-SQLite suite and required CI. A live WhatsApp account is not needed because the changed boundary is local database decoding and snapshot creation.
- **Commands run and tail output:**

```text
$ cargo test --locked -p zeroclaw-channels --features whatsapp-web --lib 'whatsapp_storage::tests::'
running 10 tests
test whatsapp_storage::tests::device_load_rejects_malformed_fixed_blobs_without_unwinding ... ok
test whatsapp_storage::tests::snapshot_db_includes_committed_wal_pages ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 1716 filtered out

$ cargo fmt -p zeroclaw-channels -- --check
# passed

$ scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** Confirmed the malformed-row regression mutates each of the five fixed-size columns and receives the public database-error variant. Confirmed the snapshot regression first demonstrates that a raw main-file copy misses a committed WAL-only row, then opens the SQLite-generated snapshot independently, reads that row plus the optional sidecar, and verifies that a later no-sidecar snapshot removes the stale sidecar.
- **Visual interface changed?** N/A; this changes no rendered interface.
- **If any command was intentionally skipped, why:** No live account smoke was run because it would not exercise the changed local SQLite boundary more directly than the real-database regressions.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No. Snapshots use the same destination path and sidecar format as before; when no replacement sidecar is requested, the previous sidecar for that snapshot name is removed.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? Yes. Persisted WhatsApp device cryptographic blobs are now length-validated before use, and SQLite creates a consistent diagnostic copy. The change does not log, expose, migrate, or broaden access to those values.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any `Yes`, describe the risk and mitigation: Malformed persisted cryptographic state now fails through the existing database-error boundary instead of panicking. Snapshot consistency is delegated to SQLite while the existing store lock prevents same-store snapshot artifacts from interleaving.

## Compatibility (required)

- Backward compatible? Yes. Valid existing databases and snapshot filenames are unchanged. The sidecar format is unchanged, but re-running a named snapshot without extra content now clears that snapshot's previous sidecar.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the landed commit to restore raw snapshot copying and the prior device-row decoder.
- **Feature flags or config toggles:** The affected backend is compiled only with `whatsapp-web`; there is no narrower runtime toggle.
- **Observable failure symptoms:** WhatsApp Web fails to resume a malformed session with a database storage error, or diagnostic snapshot creation reports a SQLite or destination-file error.
