### PR TITLE
ci(codeql): route Rust analysis to Blacksmith

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,9 @@ jobs:
     name: Analyze (${{ matrix.language }})
     # Results upload to this repo's Security tab; skip on forks.
     if: github.repository == 'zeroclaw-labs/zeroclaw'
-    runs-on: ubuntu-latest
+    # Keep the fast interpreted-language scan on GitHub; give only Rust the
+    # existing closed Blacksmith toggle used by compile-heavy CI jobs.
+    runs-on: ${{ matrix.language == 'rust' && vars.CI_USE_BLACKSMITH == 'true' && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Route only the Rust CodeQL matrix job to `blacksmith-8vcpu-ubuntu-2404` when the existing `CI_USE_BLACKSMITH` repository variable is exactly `true`. Five recent upstream runs completed JavaScript/TypeScript in about two minutes while Rust reached the unchanged 60-minute limit. The repository variable is currently `true`, so merging this PR would activate the Rust route immediately.
- **Scope boundary:** JavaScript/TypeScript remains on `ubuntu-latest`. This PR does not change the matrix, triggers, permissions, timeout, action versions, build step, query configuration, upload categories, or concurrency behavior.
- **Blast radius:** GitHub Actions runner selection for the pushed, scheduled, and manually dispatched Rust CodeQL job. With the live toggle on, the existing source checkout, job-scoped `GITHUB_TOKEN`, and `security-events: write` capability execute on Blacksmith. A missing, false, or differently spelled toggle value falls back to `ubuntu-latest`.
- **Linked issue(s):** None. This is a self-contained CI maintenance change.
- **Labels:** `ci`, `risk:high`, `size:XS`, `type:ci`

### What this does, simply

CodeQL scans ZeroClaw's JavaScript/TypeScript and Rust code for security problems. Five recent upstream runs finished the JavaScript/TypeScript scan in about two minutes, but the Rust scan reached its 60-minute limit. This PR moves only the Rust scan to the repository's existing Blacksmith runner and preserves GitHub's runner as the immediate fallback. The toggle is already enabled, so the route takes effect when this PR merges; the current organization-admin confirmation that interactive runner access remains disabled landed on #10041 on 2026-09-01.

### Scope and maintenance tradeoff

This reuses the repository's existing closed Blacksmith toggle and an already allowed runner label instead of adding another setting or moving the entire matrix. The CodeQL job can select only the two source-controlled runner labels. The accepted rollout record in [#10041](https://github.com/zeroclaw-labs/zeroclaw/issues/10041) requires organization SSH access to remain disabled for attesting Blacksmith CI and records that Blacksmith prints the SSH endpoint independently of whether member keys are installed. The fresh organization-admin readback of that setting landed on #10041 on 2026-09-01. The first eligible upstream CodeQL run after this workflow lands will provide operational confirmation of runner allocation and runtime because the workflow deliberately skips fork runs.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The CodeQL job deliberately skips personal forks, so local or fork dispatches cannot provide meaningful live runner evidence for this exact revision.

### How I tested

- **CI checks relied on and why they cover this change:** All exact-head PR checks completed green; 6 conditional checks were skipped. They do not exercise CodeQL because this workflow deliberately has no pull-request trigger.
- **Known CI coverage gap, if any:** Live Blacksmith allocation and end-to-end Rust analysis duration require the first eligible upstream scheduled or manual CodeQL run after this workflow lands. The organization-admin readback that Blacksmith SSH Access remains disabled landed on #10041 on 2026-09-01; the printed SSH endpoint is not a valid proxy because Blacksmith states that it appears regardless of key installation.
- **Historical timeout evidence:** Runs [33239152734](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33239152734), [33200180599](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33200180599), [33182820749](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33182820749), [33155516489](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33155516489), and [33146910904](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33146910904) each completed JavaScript/TypeScript in about two minutes while Rust was cancelled at about 60 minutes.
- **Commands run and tail output:**

```text
$ actionlint .github/workflows/codeql.yml
pass (no output)

$ ruby YAML parse and runner-structure assertions
yaml: ok
structure: ok

$ git diff --check
pass (no output)
```

- **Beyond CI, what did you manually verify?** Confirmed the matrix still contains only JavaScript/TypeScript and Rust; only Rust can select Blacksmith; every non-`true` toggle value falls back to `ubuntu-latest`; and the existing timeout, actions, build, query, category, trigger, permission, and concurrency settings remain unchanged. I did not claim a live Blacksmith run for this fork-only revision.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Cargo checks were not run because this PR changes only GitHub Actions YAML and no Rust source or build configuration.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes**
- New external network calls? **Yes, when enabled**
- Secrets / tokens / credentials handling changed? **Yes, when enabled**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: The workflow does not grant a new GitHub permission, but enabling this route moves the Rust CodeQL job's source checkout, job-scoped `GITHUB_TOKEN`, logs, CodeQL processing, and existing `security-events: write` capability onto Blacksmith infrastructure. The runner choice is closed to two source-controlled labels, every non-`true` value fails safe to `ubuntu-latest`, and the accepted rollout contract requires organization SSH access to remain disabled for attesting jobs. The current public record says the SSH service and endpoint banner remain visible even when no organization-member keys are installed, so the dated admin settings readback on #10041, not disappearance of the banner, is the relevant merge evidence.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes for repository CI configuration only.** The existing `CI_USE_BLACKSMITH` variable now also selects the Rust CodeQL runner; product configuration, environment variables, CLI behavior, and required check names are unchanged.
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: Any value other than exact lowercase `true`, including unset, preserves the GitHub-hosted `ubuntu-latest` path.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Set repository variable `CI_USE_BLACKSMITH` to any value other than exact lowercase `true` to restore `ubuntu-latest` immediately. After merge, revert the squash-merge commit created for #10441 to remove the CodeQL selector; that landed SHA does not exist before merge.
- **Feature flags or config toggles:** Repository Actions variable `CI_USE_BLACKSMITH`; only exact lowercase `true` selects Blacksmith.
- **Observable failure symptoms:** The Rust `Analyze (rust)` job cannot acquire the named runner, fails during runner setup or CodeQL upload, exposes an unexpected permission or key-installation boundary, or continues to reach the 60-minute timeout.

