### PR TITLE
fix(zerocode): surface clipboard cleanup failures

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -138,6 +138,7 @@ zc-input-attachment-manager-hint = { $navigate } select · { $remove } remove ·
 zc-input-help-attachment-remove = Remove attachment
 zc-input-help-attachment-detach = Remove by index
 zc-input-clipboard-error = Clipboard error: { $error }
+zc-input-clipboard-cleanup-error = Clipboard cleanup warning: { $count } temporary file(s) could not be removed and remain on disk.
 
 zc-queue-empty = Nothing to send.
 zc-cancel-timed-out = Cancel timed out; turn settled locally.

--- a/apps/zerocode/src/attachment.rs
+++ b/apps/zerocode/src/attachment.rs
@@ -1,6 +1,6 @@
 //! Client-side file attachment preparation.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
@@ -26,6 +26,38 @@ pub(crate) struct PendingAttachment {
     pub filename: String,
     pub size_bytes: u64,
     pub source: AttachmentSource,
+}
+
+/// Bounded result of best-effort clipboard temporary cleanup.
+///
+/// Cleanup deliberately reports only a count: temporary paths can contain
+/// user information and should not be copied into the info bar or logs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CleanupReport {
+    failed: usize,
+}
+
+impl CleanupReport {
+    pub(crate) fn failed_count(self) -> usize {
+        self.failed
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.failed = self.failed.saturating_add(other.failed);
+    }
+
+    pub(crate) fn notice(self) -> Option<String> {
+        (self.failed_count() > 0).then(|| {
+            crate::i18n::t_args(
+                "zc-input-clipboard-cleanup-error",
+                &[("count", &self.failed_count().to_string())],
+            )
+        })
+    }
+
+    fn failed_once() -> Self {
+        Self { failed: 1 }
+    }
 }
 
 impl PendingAttachment {
@@ -112,14 +144,27 @@ pub(crate) fn build_attachments_json(
     attachments.iter().map(|a| a.to_json(transport)).collect()
 }
 
+/// Remove one clipboard-owned temporary file and report a non-retryable
+/// cleanup failure. A missing path is already clean.
+pub(crate) fn remove_clipboard_temp(path: &Path) -> CleanupReport {
+    match std::fs::remove_file(path) {
+        Ok(()) => CleanupReport::default(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => CleanupReport::default(),
+        Err(_) => CleanupReport::failed_once(),
+    }
+}
+
 /// Remove backing temp files for clipboard-sourced attachments. File-sourced
-/// attachments reference user files and are left untouched.
-pub(crate) fn cleanup_attachment_temps(attachments: &[PendingAttachment]) {
+/// attachments reference user files and are left untouched. The returned
+/// report makes residual owned files visible without retrying indefinitely.
+pub(crate) fn cleanup_attachment_temps(attachments: &[PendingAttachment]) -> CleanupReport {
+    let mut report = CleanupReport::default();
     for att in attachments {
         if att.source == AttachmentSource::Clipboard {
-            let _ = std::fs::remove_file(&att.path);
+            report.merge(remove_clipboard_temp(&att.path));
         }
     }
+    report
 }
 
 /// Detect MIME type from filename extension via `mime_guess`.
@@ -174,6 +219,38 @@ mod tests {
             source: AttachmentSource::File,
         };
         assert_eq!(att.label(), "photo.png (2.0 KB, image/png)");
+    }
+
+    #[test]
+    fn cleanup_reports_failed_clipboard_removal_without_touching_user_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let clipboard_path = dir.path().join("clipboard-temp");
+        std::fs::create_dir(&clipboard_path).expect("create forced-failure path");
+        let user_path = dir.path().join("user-file.png");
+        std::fs::write(&user_path, b"user data").expect("write user file");
+
+        let attachments = vec![
+            PendingAttachment {
+                path: clipboard_path.clone(),
+                mime_type: "image/png".into(),
+                filename: "clipboard.png".into(),
+                size_bytes: 0,
+                source: AttachmentSource::Clipboard,
+            },
+            PendingAttachment {
+                path: user_path.clone(),
+                mime_type: "image/png".into(),
+                filename: "user.png".into(),
+                size_bytes: 9,
+                source: AttachmentSource::File,
+            },
+        ];
+
+        let report = cleanup_attachment_temps(&attachments);
+
+        assert_eq!(report.failed_count(), 1);
+        assert!(clipboard_path.exists());
+        assert!(user_path.exists());
     }
 
     #[test]

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -933,26 +933,40 @@ impl Chat {
             ChatPhase::Active(ref mut state) => state.take_next_dispatchable(),
             _ => None,
         };
-        let Some(msg) = next else { return };
+        let Some(QueuedMessage {
+            text, attachments, ..
+        }) = next
+        else {
+            return;
+        };
         let sid = match self.phase {
             ChatPhase::Active(ref state) => state.session_id.clone(),
-            _ => return,
+            _ => {
+                let _ = cleanup_attachment_temps(&attachments);
+                return;
+            }
         };
 
         let transport = self.rpc.transport();
-        let attachments_json = if msg.attachments.is_empty() {
+        let attachments_json = if attachments.is_empty() {
             Vec::new()
         } else {
-            match build_attachments_json(&msg.attachments, transport) {
+            match build_attachments_json(&attachments, transport) {
                 Ok(json) => json,
                 Err(e) => {
                     if let ChatPhase::Active(ref mut state) = self.phase {
+                        let cleanup_report = cleanup_attachment_temps(&attachments);
+                        state.surface_cleanup_report(cleanup_report);
                         state
                             .entries
                             .push(ChatEntry::SystemMessage(Arc::<str>::from(
                                 crate::i18n::t_args(
                                     "zc-queue-dispatch-failed",
-                                    &[("error", &e.to_string())],
+                                    // The anyhow context includes the local
+                                    // attachment path. Keep it out of the
+                                    // transcript; the cleanup notice already
+                                    // reports the bounded, actionable count.
+                                    &[("error", &e.root_cause().to_string())],
                                 ),
                             )));
                         state.mark_dirty_append();
@@ -963,16 +977,19 @@ impl Chat {
         };
 
         if let ChatPhase::Active(ref mut state) = self.phase {
-            let att_names: Vec<String> =
-                msg.attachments.iter().map(|a| a.filename.clone()).collect();
-            let text = if msg.text.is_empty() {
+            let att_names: Vec<String> = attachments.iter().map(|a| a.filename.clone()).collect();
+            let prompt = if text.is_empty() {
                 None
             } else {
-                Some(msg.text.clone())
+                Some(text.clone())
             };
-            state.push_user_message(text, att_names);
+            state.own_active_turn_attachments(attachments);
+            state.push_user_message(prompt, att_names);
+        } else {
+            let _ = cleanup_attachment_temps(&attachments);
+            return;
         }
-        self.spawn_prompt(sid, msg.text, attachments_json);
+        self.spawn_prompt(sid, text, attachments_json);
     }
 
     fn spawn_prompt(&self, sid: String, prompt: String, attachments_json: Vec<serde_json::Value>) {
@@ -5663,6 +5680,10 @@ pub struct ChatState {
     /// used to throttle re-fetches.
     pub git_branch_last_fetch: Option<Instant>,
     pub input_bar: InputBarState,
+    /// Attachments owned by the currently dispatched turn. Once an input-bar
+    /// submission leaves the composer, this is the sole owner until the turn
+    /// reaches a terminal outcome.
+    active_turn_attachments: Vec<PendingAttachment>,
     entries: Vec<ChatEntry>,
     streaming_text: String,
     streaming_thought: String,
@@ -5814,6 +5835,7 @@ impl ChatState {
             git_hash: None,
             git_branch_last_fetch: None,
             input_bar: InputBarState::with_shared_commands(commands),
+            active_turn_attachments: Vec::new(),
             entries: Vec::new(),
             streaming_text: String::new(),
             streaming_thought: String::new(),
@@ -6995,8 +7017,8 @@ impl ChatState {
         self.turn_in_flight = false;
         self.turn_status = TurnStatus::Idle;
         self.cancel_started_at = None;
-        self.input_bar.cleanup_temps();
-        let cleanup_report = self.input_bar.take_cleanup_report();
+        let mut cleanup_report = self.cleanup_active_turn_attachments();
+        cleanup_report.merge(self.input_bar.take_cleanup_report());
         self.surface_cleanup_report(cleanup_report);
         if !clean && !self.resume_override && !self.message_queue.is_empty() {
             self.queue_paused = true;
@@ -7037,6 +7059,15 @@ impl ChatState {
         self.turn_started_at = Instant::now();
     }
 
+    fn own_active_turn_attachments(&mut self, attachments: Vec<PendingAttachment>) {
+        debug_assert!(self.active_turn_attachments.is_empty());
+        self.active_turn_attachments = attachments;
+    }
+
+    fn cleanup_active_turn_attachments(&mut self) -> CleanupReport {
+        cleanup_attachment_temps(&std::mem::take(&mut self.active_turn_attachments))
+    }
+
     const QUEUE_CAP: usize = 32;
     const QUEUE_SIDEBAR_COLS_MIN: u16 = 24;
     const QUEUE_SIDEBAR_COLS_MAX: u16 = 80;
@@ -7055,10 +7086,14 @@ impl ChatState {
         attachments: Vec<PendingAttachment>,
     ) -> Result<(), String> {
         if text.trim().is_empty() && attachments.is_empty() {
+            let cleanup_report = cleanup_attachment_temps(&attachments);
+            self.surface_cleanup_report(cleanup_report);
             return Err(crate::i18n::t("zc-queue-empty"));
         }
         let pending = self.message_queue.len();
         if pending >= Self::QUEUE_CAP {
+            let cleanup_report = cleanup_attachment_temps(&attachments);
+            self.surface_cleanup_report(cleanup_report);
             return Err(crate::i18n::t_args(
                 "zc-queue-full",
                 &[("cap", &Self::QUEUE_CAP.to_string())],
@@ -7080,9 +7115,13 @@ impl ChatState {
         attachments: Vec<PendingAttachment>,
     ) -> Result<(), String> {
         if text.trim().is_empty() && attachments.is_empty() {
+            let cleanup_report = cleanup_attachment_temps(&attachments);
+            self.surface_cleanup_report(cleanup_report);
             return Err(crate::i18n::t("zc-queue-empty"));
         }
         if self.message_queue.len() >= Self::QUEUE_CAP {
+            let cleanup_report = cleanup_attachment_temps(&attachments);
+            self.surface_cleanup_report(cleanup_report);
             return Err(crate::i18n::t_args(
                 "zc-queue-full",
                 &[("cap", &Self::QUEUE_CAP.to_string())],
@@ -7539,6 +7578,7 @@ impl ChatState {
         // Rebuilding from freshly resolved settings also applies any Config-pane
         // edit made since this pane's `ChatState` was constructed.
         self.todo_tracker.reset_for_session(todo_settings);
+        cleanup_report.merge(self.cleanup_active_turn_attachments());
         cleanup_report.merge(self.clear_queue());
         self.surface_cleanup_report(cleanup_report);
     }
@@ -12046,6 +12086,144 @@ mod tests {
         }
     }
 
+    fn clipboard_att(path: &std::path::Path, filename: &str) -> PendingAttachment {
+        PendingAttachment {
+            path: path.to_path_buf(),
+            mime_type: "image/png".to_string(),
+            filename: filename.to_string(),
+            size_bytes: 1,
+            source: crate::attachment::AttachmentSource::Clipboard,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatched_attachments_are_cleaned_on_completion_without_touching_user_files() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let clipboard_path = dir.path().join("clipboard.png");
+        std::fs::write(&clipboard_path, b"clipboard").expect("write clipboard temp");
+        let user_path = dir.path().join("user.png");
+        std::fs::write(&user_path, b"user").expect("write user file");
+
+        let (tx, _rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc_transport(
+            rpc,
+            crate::client::Transport::Wss,
+        ));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut active = state();
+        active
+            .enqueue_message(
+                "send attachments".to_string(),
+                vec![
+                    clipboard_att(&clipboard_path, "clipboard.png"),
+                    PendingAttachment {
+                        path: user_path.clone(),
+                        mime_type: "image/png".to_string(),
+                        filename: "user.png".to_string(),
+                        size_bytes: 4,
+                        source: crate::attachment::AttachmentSource::File,
+                    },
+                ],
+            )
+            .unwrap();
+        chat.phase = ChatPhase::Active(Box::new(active));
+
+        chat.pump_queue();
+
+        let ChatPhase::Active(state) = &mut chat.phase else {
+            panic!("expected active chat");
+        };
+        assert!(state.turn_in_flight);
+        assert_eq!(state.active_turn_attachments.len(), 2);
+        assert!(clipboard_path.exists());
+        state.commit_turn(String::new(), true);
+
+        assert!(
+            !clipboard_path.exists(),
+            "active clipboard temp must be removed"
+        );
+        assert!(user_path.exists(), "user-selected file must be preserved");
+        assert!(state.active_turn_attachments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn serialization_failure_cleans_dispatched_clipboard_temp_and_reports_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let clipboard_path = dir.path().join("clipboard-temp");
+        std::fs::create_dir(&clipboard_path).expect("create forced-failure path");
+        let user_path = dir.path().join("user.png");
+        std::fs::write(&user_path, b"user").expect("write user file");
+
+        let (tx, _rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc_transport(
+            rpc,
+            crate::client::Transport::Wss,
+        ));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut active = state();
+        active
+            .enqueue_message(
+                "cannot serialize".to_string(),
+                vec![
+                    clipboard_att(&clipboard_path, "clipboard.png"),
+                    PendingAttachment {
+                        path: user_path.clone(),
+                        mime_type: "image/png".to_string(),
+                        filename: "user.png".to_string(),
+                        size_bytes: 4,
+                        source: crate::attachment::AttachmentSource::File,
+                    },
+                ],
+            )
+            .unwrap();
+        chat.phase = ChatPhase::Active(Box::new(active));
+
+        chat.pump_queue();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("expected active chat");
+        };
+        assert!(!state.turn_in_flight);
+        assert!(state.active_turn_attachments.is_empty());
+        assert!(
+            clipboard_path.exists(),
+            "failed cleanup must leave the path"
+        );
+        assert!(user_path.exists(), "user-selected file must be preserved");
+        assert!(
+            state
+                .info_message
+                .as_ref()
+                .is_some_and(|message| message.text.contains("1 temporary file"))
+        );
+        let clipboard_path = clipboard_path.to_string_lossy();
+        assert!(state.entries.iter().all(|entry| match entry {
+            ChatEntry::SystemMessage(text) => !text.contains(clipboard_path.as_ref()),
+            _ => true,
+        }));
+    }
+
+    #[test]
+    fn completion_does_not_delete_an_unsent_composer_attachment() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let clipboard_path = dir.path().join("composer.png");
+        std::fs::write(&clipboard_path, b"clipboard").expect("write clipboard temp");
+
+        let mut active = state();
+        active.input_bar.load_for_edit(
+            String::new(),
+            vec![clipboard_att(&clipboard_path, "composer.png")],
+        );
+        active.turn_in_flight = true;
+
+        active.commit_turn(String::new(), false);
+
+        assert!(clipboard_path.exists());
+        assert_eq!(active.input_bar.pending_attachments().len(), 1);
+    }
+
     #[test]
     fn enqueue_dispatches_immediately_when_idle() {
         let mut s = state();
@@ -13101,9 +13279,15 @@ mod tests {
     }
 
     fn test_chat() -> (Chat, mpsc::Receiver<String>) {
+        test_chat_with_transport(crate::client::Transport::Local)
+    }
+
+    fn test_chat_with_transport(
+        transport: crate::client::Transport,
+    ) -> (Chat, mpsc::Receiver<String>) {
         let (tx, rx) = mpsc::channel::<String>(16);
         let rpc = Arc::new(RpcOutbound::new(tx));
-        let client = Arc::new(RpcClient::with_rpc(rpc));
+        let client = Arc::new(RpcClient::with_rpc_transport(rpc, transport));
         (Chat::new(client, PaneKind::Chat), rx)
     }
 

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -16,7 +16,9 @@ use ratatui::{
 };
 use tokio::sync::{broadcast, mpsc};
 
-use crate::attachment::{PendingAttachment, build_attachments_json, cleanup_attachment_temps};
+use crate::attachment::{
+    CleanupReport, PendingAttachment, build_attachments_json, cleanup_attachment_temps,
+};
 use crate::client::{
     ApprovalDecision, RpcClient, RpcNotification, SessionEntry, SessionUpdate, TurnEndOutcome,
     method, parse_session_update,
@@ -37,6 +39,16 @@ const APPROVAL_OVERLAY_HEIGHT: u16 = 7;
 const GIT_BRANCH_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const CANCEL_WATCHDOG: Duration = Duration::from_secs(30);
 const COPY_FEEDBACK_TTL: Duration = Duration::from_secs(1);
+
+fn append_cleanup_notice(mut message: String, cleanup: Option<String>) -> String {
+    if let Some(cleanup) = cleanup {
+        if !message.is_empty() {
+            message.push_str("; ");
+        }
+        message.push_str(&cleanup);
+    }
+    message
+}
 
 // ── Chat pane (tab mode) ─────────────────────────────────────────
 
@@ -1548,7 +1560,8 @@ impl Chat {
                     return false;
                 }
                 InputBarAction::StatusMessage(msg) => {
-                    state.set_info_notice(msg);
+                    let cleanup_notice = state.input_bar.take_cleanup_report().notice();
+                    state.set_info_notice(append_cleanup_notice(msg, cleanup_notice));
                     return false;
                 }
                 InputBarAction::ToggleThinking => {
@@ -1574,7 +1587,10 @@ impl Chat {
                     return false;
                 }
                 InputBarAction::ClearQueue(idx) => {
-                    let notice = state.clear_queue_cmd(idx);
+                    let notice = append_cleanup_notice(
+                        state.clear_queue_cmd(idx),
+                        state.input_bar.take_cleanup_report().notice(),
+                    );
                     state.set_info_notice(notice);
                     return false;
                 }
@@ -1632,7 +1648,12 @@ impl Chat {
                     Self::open_provider_picker(&rpc, state).await;
                     return false;
                 }
-                InputBarAction::Consumed => return false,
+                InputBarAction::Consumed => {
+                    if let Some(message) = state.input_bar.take_cleanup_report().notice() {
+                        state.set_info_notice(message);
+                    }
+                    return false;
+                }
                 InputBarAction::NotHandled => { /* fall through to chat-specific keys */ }
             }
         }
@@ -2337,9 +2358,14 @@ impl Chat {
 
         if let ChatPhase::Active(ref mut state) = self.phase {
             // The file explorer renders above every parent overlay.
-            if state.input_bar.has_file_explorer() && state.input_bar.handle_mouse(mouse) {
-                state.clear_mouse_highlight();
-                return;
+            if state.input_bar.has_file_explorer() {
+                let consumed = state.input_bar.handle_mouse(mouse);
+                let cleanup_report = state.input_bar.take_cleanup_report();
+                state.surface_cleanup_report(cleanup_report);
+                if consumed {
+                    state.clear_mouse_highlight();
+                    return;
+                }
             }
 
             if state.model_picker.is_open() {
@@ -2426,7 +2452,10 @@ impl Chat {
                 }
             }
 
-            if state.input_bar.handle_mouse(mouse) {
+            let input_bar_consumed = state.input_bar.handle_mouse(mouse);
+            let cleanup_report = state.input_bar.take_cleanup_report();
+            state.surface_cleanup_report(cleanup_report);
+            if input_bar_consumed {
                 state.clear_mouse_highlight();
                 return;
             }
@@ -2691,7 +2720,10 @@ impl Chat {
         }
         let action = state.input_bar.handle_paste(text);
         if let InputBarAction::StatusMessage(msg) = action {
-            state.set_info_notice(msg);
+            let cleanup_notice = state.input_bar.take_cleanup_report().notice();
+            state.set_info_notice(append_cleanup_notice(msg, cleanup_notice));
+        } else if let Some(message) = state.input_bar.take_cleanup_report().notice() {
+            state.set_info_notice(message);
         }
     }
 
@@ -2752,6 +2784,8 @@ impl Chat {
     pub(crate) fn clear_input(&mut self) {
         if let ChatPhase::Active(s) = &mut self.phase {
             s.input_bar.reset();
+            let cleanup_report = s.input_bar.take_cleanup_report();
+            s.surface_cleanup_report(cleanup_report);
             s.mark_dirty_full();
         }
     }
@@ -5869,9 +5903,12 @@ impl ChatState {
 
         self.clear_mouse_highlight();
         let action = self.input_bar.handle_key(key);
+        let cleanup_notice = self.input_bar.take_cleanup_report().notice();
         // Explorer confirmation can reject an attachment (for example a file
         // over the size limit). Preserve that feedback instead of swallowing it.
         if let InputBarAction::StatusMessage(message) = action {
+            self.set_info_notice(append_cleanup_notice(message, cleanup_notice));
+        } else if let Some(message) = cleanup_notice {
             self.set_info_notice(message);
         }
         self.mark_dirty_full();
@@ -6959,6 +6996,8 @@ impl ChatState {
         self.turn_status = TurnStatus::Idle;
         self.cancel_started_at = None;
         self.input_bar.cleanup_temps();
+        let cleanup_report = self.input_bar.take_cleanup_report();
+        self.surface_cleanup_report(cleanup_report);
         if !clean && !self.resume_override && !self.message_queue.is_empty() {
             self.queue_paused = true;
         }
@@ -7131,6 +7170,12 @@ impl ChatState {
     /// and consistent rendering with model-switch notes.
     pub fn set_info_notice(&mut self, msg: String) {
         self.info_message = Some(crate::widgets::InfoMessage::note(msg));
+    }
+
+    fn surface_cleanup_report(&mut self, report: CleanupReport) {
+        if let Some(message) = report.notice() {
+            self.set_info_notice(message);
+        }
     }
 
     fn set_overlay_copy_feedback(&mut self, anchor: Rect) {
@@ -7316,7 +7361,8 @@ impl ChatState {
             return false;
         };
         if let Some(message) = self.message_queue.remove(position) {
-            cleanup_attachment_temps(&message.attachments);
+            let cleanup_report = cleanup_attachment_temps(&message.attachments);
+            self.surface_cleanup_report(cleanup_report);
         }
         let ids = self.editable_ids();
         self.queue_sel = ids.get(position.min(ids.len().saturating_sub(1))).copied();
@@ -7358,9 +7404,12 @@ impl ChatState {
                 if count == 0 {
                     return crate::i18n::t("zc-queue-clear-empty");
                 }
-                self.clear_queue();
+                let cleanup_report = self.clear_queue();
                 self.mark_dirty_full();
-                crate::i18n::t_args("zc-queue-cleared-all", &[("count", &count.to_string())])
+                append_cleanup_notice(
+                    crate::i18n::t_args("zc-queue-cleared-all", &[("count", &count.to_string())]),
+                    cleanup_report.notice(),
+                )
             }
             Some(n) => {
                 if count == 0 {
@@ -7373,27 +7422,33 @@ impl ChatState {
                     );
                 }
                 let pos = n - 1;
+                let mut cleanup_report = CleanupReport::default();
                 if let Some(msg) = self.message_queue.remove(pos) {
-                    cleanup_attachment_temps(&msg.attachments);
+                    cleanup_report = cleanup_attachment_temps(&msg.attachments);
                     if self.queue_sel == Some(msg.id) {
                         let ids = self.editable_ids();
                         self.queue_sel = ids.get(pos.min(ids.len().saturating_sub(1))).copied();
                     }
                 }
                 self.mark_dirty_full();
-                crate::i18n::t_args("zc-queue-cleared-one", &[("index", &n.to_string())])
+                append_cleanup_notice(
+                    crate::i18n::t_args("zc-queue-cleared-one", &[("index", &n.to_string())]),
+                    cleanup_report.notice(),
+                )
             }
         }
     }
 
-    fn clear_queue(&mut self) {
+    fn clear_queue(&mut self) -> CleanupReport {
+        let mut cleanup_report = CleanupReport::default();
         for msg in self.message_queue.drain(..) {
-            cleanup_attachment_temps(&msg.attachments);
+            cleanup_report.merge(cleanup_attachment_temps(&msg.attachments));
         }
         self.next_queue_id = 0;
         self.queue_paused = false;
         self.resume_override = false;
         self.queue_sel = None;
+        cleanup_report
     }
 
     fn load_history(
@@ -7443,6 +7498,7 @@ impl ChatState {
         self.model_provider_ref = None;
         self.model = None;
         self.input_bar.reset();
+        let mut cleanup_report = self.input_bar.take_cleanup_report();
         self.entries.clear();
         self.streaming_text.clear();
         self.streaming_thought.clear();
@@ -7483,7 +7539,8 @@ impl ChatState {
         // Rebuilding from freshly resolved settings also applies any Config-pane
         // edit made since this pane's `ChatState` was constructed.
         self.todo_tracker.reset_for_session(todo_settings);
-        self.clear_queue();
+        cleanup_report.merge(self.clear_queue());
+        self.surface_cleanup_report(cleanup_report);
     }
 }
 

--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -1790,6 +1790,13 @@ impl RpcClient {
     /// Test-only constructor that skips the Unix socket connect + initialize handshake.
     #[cfg(test)]
     pub fn with_rpc(outbound: Arc<RpcOutbound>) -> Self {
+        Self::with_rpc_transport(outbound, Transport::Local)
+    }
+
+    /// Test-only constructor that also controls the transport-specific payload
+    /// encoding used by callers such as attachment dispatch.
+    #[cfg(test)]
+    pub fn with_rpc_transport(outbound: Arc<RpcOutbound>, transport: Transport) -> Self {
         let (notif_tx, _) = tokio::sync::broadcast::channel(1);
         let (inbound_tx, _) = tokio::sync::broadcast::channel(1);
         Self {
@@ -1803,7 +1810,7 @@ impl RpcClient {
             connection_state: Arc::new(Mutex::new(ConnectionState::Connected)),
             tui_id: None,
             tui_sig: None,
-            transport: Transport::Local,
+            transport,
             commands: Vec::new(),
         }
     }

--- a/apps/zerocode/src/input_bar.rs
+++ b/apps/zerocode/src/input_bar.rs
@@ -15,7 +15,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
 };
 
-use crate::attachment::PendingAttachment;
+use crate::attachment::{CleanupReport, PendingAttachment, remove_clipboard_temp};
 use crate::clipboard;
 use crate::file_explorer::{ExplorerAction, FileExplorerState};
 use crate::mouse;
@@ -676,6 +676,7 @@ pub(crate) struct InputBarState {
     last_attachment_manager_area: Option<Rect>,
     file_explorer: Option<FileExplorerState>,
     clipboard_temps: Vec<PathBuf>,
+    cleanup_report: CleanupReport,
 
     // Phase 1: Soft-wrap / dynamic height
     /// Vertical scroll offset within the input bar (0-based row index of first visible line).
@@ -746,6 +747,7 @@ impl InputBarState {
             last_attachment_manager_area: None,
             file_explorer: None,
             clipboard_temps: Vec::new(),
+            cleanup_report: CleanupReport::default(),
             scroll_offset: 0,
             last_input_area: Rect::default(),
             last_inner_width: 0,
@@ -1137,7 +1139,8 @@ impl InputBarState {
         let removed = self.pending_attachments.remove(index);
         if removed.source == crate::attachment::AttachmentSource::Clipboard {
             self.clipboard_temps.retain(|path| path != &removed.path);
-            let _ = std::fs::remove_file(removed.path);
+            self.cleanup_report
+                .merge(remove_clipboard_temp(&removed.path));
         }
 
         if self.pending_attachments.is_empty() {
@@ -1200,8 +1203,14 @@ impl InputBarState {
     /// Remove clipboard temp files (called after turn completes).
     pub fn cleanup_temps(&mut self) {
         for path in self.clipboard_temps.drain(..) {
-            let _ = std::fs::remove_file(path);
+            self.cleanup_report.merge(remove_clipboard_temp(&path));
         }
+    }
+
+    /// Take cleanup failures accumulated by attachment removal or lifecycle
+    /// cleanup. The caller surfaces the bounded report through the info bar.
+    pub(crate) fn take_cleanup_report(&mut self) -> CleanupReport {
+        std::mem::take(&mut self.cleanup_report)
     }
 
     // ── Key handling ─────────────────────────────────────────
@@ -1682,7 +1691,7 @@ impl InputBarState {
                         ))
                     }
                     Err(e) => {
-                        let _ = std::fs::remove_file(&tmp_path);
+                        self.cleanup_report.merge(remove_clipboard_temp(&tmp_path));
                         InputBarAction::StatusMessage(crate::i18n::t_args(
                             "zc-input-clipboard-error",
                             &[("error", &e.to_string())],
@@ -2585,6 +2594,30 @@ mod tests {
         assert!(bar.pending_attachments().is_empty());
         assert!(bar.clipboard_temps().is_empty());
         assert!(!tmp.exists());
+    }
+
+    #[test]
+    fn removing_clipboard_attachment_surfaces_failed_cleanup() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut bar = input_bar_with_shared_commands();
+        bar.clipboard_temps.push(dir.path().to_path_buf());
+        bar.add_attachment(PendingAttachment {
+            path: dir.path().to_path_buf(),
+            mime_type: "image/png".into(),
+            filename: "clip.png".into(),
+            size_bytes: 0,
+            source: crate::attachment::AttachmentSource::Clipboard,
+        });
+
+        bar.remove_attachment(0);
+
+        assert!(bar.pending_attachments().is_empty());
+        assert!(bar.clipboard_temps().is_empty());
+        assert_eq!(bar.take_cleanup_report().failed_count(), 1);
+        assert!(
+            dir.path().exists(),
+            "failed cleanup must leave the path visible"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Keep clipboard temporary attachments owned by the active turn after they leave the composer, through dispatch and terminal completion or failure.
  - Clean ZeroCode-owned temporary files on successful completion, cancellation/failure, queue rejection/removal, serialization failure, and session reset.
  - Surface cleanup failures as a bounded count while leaving user-selected file attachments untouched.
- **Scope boundary:** This does not delete user-selected files, retry failed deletions indefinitely, expose temporary paths, or change attachment wire formats.
- **Blast radius:** ZeroCode Chat/ACP attachment ownership, queue dispatch, and session cleanup feedback.
- **Linked issue(s):** Fixes #9681
- **Labels:** `bug`, `trusted contributor`, `risk:medium`, `zerocode`, `size:M`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** (`Yes`)
- **Interface(s) exercised:** `zerocode` Chat TUI
- **Setup / preconditions:** Build this revision and start a local daemon with one configured agent. Have a clipboard image available and a separate user-selected file available for the preservation check.
- **Steps to run:** Attach the clipboard image and user file, send them, and let the turn finish. Repeat with a forced cleanup failure (for example, make the owned path a directory before the terminal cleanup attempt).
- **Expected on this branch (after):** The clipboard temporary is removed on completion; a cleanup failure shows a bounded count in the info bar, with no temporary path in the transcript; the user-selected file remains.
- **Prior behavior on master (before):** Normal queued dispatch could drop the clipboard ownership record before completion, leaving the temporary file behind and giving no visible cleanup result.

### How I tested

- **CI checks relied on and why:** The owning `zerocode` package tests cover the input-to-queue-to-dispatch-to-completion path, serialization failure, unsent composer ownership, cleanup reporting, and user-file exclusion. The latest `origin/master` base was used for validation.
- **Known CI coverage gap, if any:** No known candidate-specific Rust coverage gap. The interactive smoke used the production TUI with a local IPC fixture and covered the visible cleanup-failure surface; successful cleanup and user-file preservation remain covered by deterministic tests.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
status: passed

$ cargo clippy --locked -p zerocode --all-targets -- -D warnings
Finished `dev` profile with -D warnings

$ cargo test --locked -p zerocode --quiet
test result: ok. 191 passed; 0 failed
test result: ok. 829 passed; 0 failed; 2 ignored
```

### Visual interface evidence

- **Tested revision:** `1b961fc81bc5a3d1778544691c390356f564e548`
- **Path:** Production `zerocode` Chat TUI at 80×24; Ctrl+V attached a clipboard image, then the owned temporary directory was made non-removable before detaching the attachment.
- **Observed:** Detaching removed the attachment from the composer and the info bar surfaced the bounded clipboard cleanup warning. The warning is truncated to fit the 80-column interface, and no local path is shown.

![ZeroCode clipboard cleanup warning at 80x24](https://github.com/user-attachments/assets/38785036-b81e-4afb-8d55-02a0ac4d998a)

- **Beyond CI, what did I manually verify?** The production TUI cleanup-failure path was exercised at the tested revision with a local IPC fixture for unrelated session/log traffic. The screenshot above is the resulting 80×24 TUI frame; successful cleanup and user-file preservation remain covered by deterministic tests.
- **If any command was intentionally skipped, why:** No candidate-specific package command was skipped. A local IPC fixture was used only to avoid the unrelated external agent service while reaching the attachment flow.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: exact upgrade steps for existing users: N/A

## Rollback

- **Fast rollback command/path:** `git revert --no-edit <squash-merge-commit>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Clipboard-owned temporary files remain after a terminal outcome, cleanup warnings are missing, or user-selected files are removed; inspect the ZeroCode info bar and attachment lifecycle tests.
