### PR TITLE
fix(zerocode): decode split SGR mouse events

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -125,14 +125,27 @@ impl SgrMouseEventDecoder {
     }
 
     fn read_ready(&mut self) -> Result<Option<Event>> {
+        self.read_ready_with(|| {
+            if event::poll(Duration::ZERO)? {
+                Ok(Some(event::read()?))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+
+    fn read_ready_with<F>(&mut self, mut read_event: F) -> Result<Option<Event>>
+    where
+        F: FnMut() -> Result<Option<Event>>,
+    {
         loop {
             if let Some(event) = self.next() {
                 return Ok(Some(event));
             }
-            if !event::poll(Duration::ZERO)? {
+            let Some(event) = read_event()? else {
                 return Ok(None);
-            }
-            self.feed(event::read()?);
+            };
+            self.feed(event);
         }
     }
 
@@ -210,11 +223,15 @@ fn key_event_char(event: &Event) -> Option<char> {
 fn parse_sgr_mouse(chars: &[char]) -> Option<MouseEvent> {
     let final_char = *chars.last()?;
     let payload: String = chars[2..chars.len().checked_sub(1)?].iter().collect();
-    let mut fields = payload.split(';');
-    let cb = fields.next()?.parse::<u8>().ok()?;
-    let column = fields.next()?.parse::<u16>().ok()?;
-    let row = fields.next()?.parse::<u16>().ok()?;
-    if fields.next().is_some_and(|field| !field.is_empty()) || column == 0 || row == 0 {
+    let payload = payload.strip_suffix(';').unwrap_or(payload.as_str());
+    let fields: Vec<_> = payload.split(';').collect();
+    if fields.len() != 3 || fields.iter().any(|field| field.is_empty()) {
+        return None;
+    }
+    let cb = fields[0].parse::<u8>().ok()?;
+    let column = fields[1].parse::<u16>().ok()?;
+    let row = fields[2].parse::<u16>().ok()?;
+    if column == 0 || row == 0 {
         return None;
     }
 
@@ -2054,12 +2071,41 @@ mod tests {
     use std::collections::VecDeque;
 
     fn mouse_event(kind: MouseEventKind, column: u16, row: u16) -> Event {
+        mouse_event_with_modifiers(kind, column, row, KeyModifiers::NONE)
+    }
+
+    fn mouse_event_with_modifiers(
+        kind: MouseEventKind,
+        column: u16,
+        row: u16,
+        modifiers: KeyModifiers,
+    ) -> Event {
         Event::Mouse(crossterm::event::MouseEvent {
             kind,
             column,
             row,
-            modifiers: KeyModifiers::NONE,
+            modifiers,
         })
+    }
+
+    fn key_event(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn decode_sgr_sequence(sequence: &str) -> Vec<Event> {
+        let mut decoder = SgrMouseEventDecoder::default();
+        decoder.feed(key_event(KeyCode::Esc));
+        for character in sequence.chars() {
+            decoder.feed(key_event(KeyCode::Char(character)));
+        }
+        std::iter::from_fn(|| decoder.next()).collect()
+    }
+
+    fn split_sgr_events(sequence: &str) -> VecDeque<Event> {
+        sequence
+            .chars()
+            .map(|character| key_event(KeyCode::Char(character)))
+            .collect()
     }
 
     #[test]
@@ -2201,19 +2247,117 @@ mod tests {
     }
 
     #[test]
-    fn split_sgr_mouse_sequence_becomes_one_mouse_event() {
-        let mut decoder = SgrMouseEventDecoder::default();
-        decoder.feed(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
-        for character in "[<64;32;17M".chars() {
-            decoder.feed(Event::Key(KeyEvent::new(
-                KeyCode::Char(character),
-                KeyModifiers::NONE,
-            )));
+    fn split_sgr_mouse_decoder_decodes_vertical_wheel_events() {
+        for (sequence, kind) in [
+            ("[<64;32;17M", MouseEventKind::ScrollUp),
+            ("[<65;32;17M", MouseEventKind::ScrollDown),
+        ] {
+            assert_eq!(
+                decode_sgr_sequence(sequence),
+                vec![mouse_event(kind, 31, 16)]
+            );
         }
+    }
 
-        let decoded: Vec<Event> = std::iter::from_fn(|| decoder.next()).collect();
+    #[test]
+    fn split_sgr_mouse_decoder_decodes_click_and_release_events() {
+        for (sequence, kind) in [
+            ("[<0;3;4M", MouseEventKind::Down(MouseButton::Left)),
+            ("[<1;3;4M", MouseEventKind::Down(MouseButton::Middle)),
+            ("[<2;3;4M", MouseEventKind::Down(MouseButton::Right)),
+            ("[<3;3;4M", MouseEventKind::Up(MouseButton::Left)),
+            ("[<0;3;4m", MouseEventKind::Up(MouseButton::Left)),
+        ] {
+            assert_eq!(decode_sgr_sequence(sequence), vec![mouse_event(kind, 2, 3)]);
+        }
+    }
 
-        assert_eq!(decoded, vec![mouse_event(MouseEventKind::ScrollUp, 31, 16)]);
+    #[test]
+    fn split_sgr_mouse_decoder_decodes_drag_and_movement_events() {
+        for (sequence, kind) in [
+            ("[<32;5;6M", MouseEventKind::Drag(MouseButton::Left)),
+            ("[<33;5;6M", MouseEventKind::Drag(MouseButton::Middle)),
+            ("[<34;5;6M", MouseEventKind::Drag(MouseButton::Right)),
+            ("[<35;5;6M", MouseEventKind::Moved),
+        ] {
+            assert_eq!(decode_sgr_sequence(sequence), vec![mouse_event(kind, 4, 5)]);
+        }
+    }
+
+    #[test]
+    fn split_sgr_mouse_decoder_decodes_horizontal_wheel_events() {
+        for (sequence, kind) in [
+            ("[<66;10;11M", MouseEventKind::ScrollLeft),
+            ("[<67;10;11M", MouseEventKind::ScrollRight),
+        ] {
+            assert_eq!(
+                decode_sgr_sequence(sequence),
+                vec![mouse_event(kind, 9, 10)]
+            );
+        }
+    }
+
+    #[test]
+    fn split_sgr_mouse_decoder_preserves_modifiers_and_coordinates() {
+        assert_eq!(
+            decode_sgr_sequence("[<93;1;2M"),
+            vec![mouse_event_with_modifiers(
+                MouseEventKind::ScrollDown,
+                0,
+                1,
+                KeyModifiers::SHIFT | KeyModifiers::ALT | KeyModifiers::CONTROL,
+            )]
+        );
+    }
+
+    #[test]
+    fn split_sgr_mouse_decoder_accepts_optional_delimiter_and_lowercase_release() {
+        assert_eq!(
+            decode_sgr_sequence("[<64;32;17;M"),
+            vec![mouse_event(MouseEventKind::ScrollUp, 31, 16)]
+        );
+        assert_eq!(
+            decode_sgr_sequence("[<0;32;17;m"),
+            vec![mouse_event(MouseEventKind::Up(MouseButton::Left), 31, 16)]
+        );
+    }
+
+    #[test]
+    fn split_sgr_mouse_decoder_rejects_multiple_empty_trailing_fields() {
+        let sequence = "[<64;32;17;;M";
+        let expected: Vec<Event> = std::iter::once(key_event(KeyCode::Esc))
+            .chain(
+                sequence
+                    .chars()
+                    .map(|character| key_event(KeyCode::Char(character))),
+            )
+            .collect();
+
+        assert_eq!(decode_sgr_sequence(sequence), expected);
+    }
+
+    #[test]
+    fn drag_read_ahead_reassembles_split_sgr_drag_without_leaking_escape() {
+        let first_drag = mouse_event(MouseEventKind::Drag(MouseButton::Left), 4, 5);
+        let latest_drag = mouse_event(MouseEventKind::Drag(MouseButton::Left), 7, 8);
+        let following_key = key_event(KeyCode::Char('x'));
+        let mut queued = VecDeque::from([key_event(KeyCode::Esc)]);
+        queued.extend(split_sgr_events("[<32;8;9M"));
+        queued.push_back(following_key.clone());
+        let mut decoder = SgrMouseEventDecoder::default();
+
+        let (current, pending) = coalesce_mouse_drag(first_drag, || {
+            decoder.read_ready_with(|| Ok(queued.pop_front()))
+        })
+        .expect("reassemble SGR drag during read-ahead");
+
+        assert_eq!(current, latest_drag);
+        assert_eq!(pending, Some(following_key.clone()));
+        assert!(decoder.candidate.is_empty());
+        assert!(queued.is_empty());
+
+        decoder.push_front(pending.expect("preserve following input"));
+        assert_eq!(decoder.next(), Some(following_key));
     }
 
     #[test]

--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -1,10 +1,12 @@
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::event::{
-    self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEventKind,
+    self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
 };
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -59,6 +61,209 @@ enum QuickstartChatDrain {
 const TICK: Duration = Duration::from_millis(200);
 const CHROME_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const MAX_COALESCED_MOUSE_DRAGS: usize = 64;
+const SGR_MOUSE_SEQUENCE_TIMEOUT: Duration = Duration::from_millis(50);
+const MAX_SGR_MOUSE_SEQUENCE_EVENTS: usize = 32;
+
+/// Reassembles SGR mouse sequences that crossterm exposed as individual key
+/// events after an input read split the sequence at the escape byte.
+///
+/// A complete sequence is converted back into the same `MouseEvent` that
+/// crossterm would have produced. Invalid or incomplete sequences are replayed
+/// in order, so ordinary Escape-prefixed keyboard input is not discarded.
+#[derive(Debug, Default)]
+struct SgrMouseEventDecoder {
+    pending: VecDeque<Event>,
+    candidate: Vec<Event>,
+    candidate_started_at: Option<Instant>,
+}
+
+impl SgrMouseEventDecoder {
+    fn feed(&mut self, event: Event) {
+        let output = if self.candidate.is_empty() {
+            if is_sgr_mouse_start(&event) {
+                self.candidate.push(event);
+                self.candidate_started_at = Some(Instant::now());
+                Vec::new()
+            } else {
+                vec![event]
+            }
+        } else {
+            self.candidate.push(event);
+            self.decode_candidate()
+        };
+        self.pending.extend(output);
+    }
+
+    fn next(&mut self) -> Option<Event> {
+        self.pending.pop_front()
+    }
+
+    fn push_front(&mut self, event: Event) {
+        self.pending.push_front(event);
+    }
+
+    fn poll_timeout(&self) -> Duration {
+        self.candidate_started_at
+            .map(|started| SGR_MOUSE_SEQUENCE_TIMEOUT.saturating_sub(started.elapsed()))
+            .unwrap_or(TICK)
+    }
+
+    fn flush_candidate(&mut self) -> bool {
+        if self.candidate.is_empty() {
+            return false;
+        }
+        self.pending.extend(self.candidate.drain(..));
+        self.candidate_started_at = None;
+        true
+    }
+
+    fn flush_timed_out_candidate(&mut self) -> bool {
+        let timed_out = self
+            .candidate_started_at
+            .is_some_and(|started| started.elapsed() >= SGR_MOUSE_SEQUENCE_TIMEOUT);
+        timed_out && self.flush_candidate()
+    }
+
+    fn read_ready(&mut self) -> Result<Option<Event>> {
+        loop {
+            if let Some(event) = self.next() {
+                return Ok(Some(event));
+            }
+            if !event::poll(Duration::ZERO)? {
+                return Ok(None);
+            }
+            self.feed(event::read()?);
+        }
+    }
+
+    fn decode_candidate(&mut self) -> Vec<Event> {
+        if self.candidate.len() > MAX_SGR_MOUSE_SEQUENCE_EVENTS {
+            return self.replay_candidate();
+        }
+
+        let Some(chars) = self.candidate[1..]
+            .iter()
+            .map(key_event_char)
+            .collect::<Option<Vec<_>>>()
+        else {
+            return self.replay_candidate();
+        };
+
+        let prefix = ['[', '<'];
+        for (index, expected) in prefix.iter().enumerate() {
+            let Some(actual) = chars.get(index) else {
+                return Vec::new();
+            };
+            if actual != expected {
+                return self.replay_candidate();
+            }
+        }
+
+        let Some(final_char) = chars.last().copied() else {
+            return Vec::new();
+        };
+        if !matches!(final_char, 'M' | 'm') {
+            if chars[2..]
+                .iter()
+                .all(|character| character.is_ascii_digit() || *character == ';')
+            {
+                return Vec::new();
+            }
+            return self.replay_candidate();
+        }
+
+        let Some(mouse) = parse_sgr_mouse(&chars) else {
+            return self.replay_candidate();
+        };
+        self.candidate.clear();
+        self.candidate_started_at = None;
+        vec![Event::Mouse(mouse)]
+    }
+
+    fn replay_candidate(&mut self) -> Vec<Event> {
+        self.candidate_started_at = None;
+        self.candidate.drain(..).collect()
+    }
+}
+
+fn is_sgr_mouse_start(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Key(key)
+            if key.code == KeyCode::Esc // keyguard: recognize terminal protocol escape, not an app chord
+                && key.kind == KeyEventKind::Press
+                && key.modifiers == KeyModifiers::NONE
+    )
+}
+
+fn key_event_char(event: &Event) -> Option<char> {
+    match event {
+        Event::Key(KeyEvent {
+            code: KeyCode::Char(character), // keyguard: extract terminal protocol byte
+            kind: KeyEventKind::Press,
+            ..
+        }) => Some(*character),
+        _ => None,
+    }
+}
+
+fn parse_sgr_mouse(chars: &[char]) -> Option<MouseEvent> {
+    let final_char = *chars.last()?;
+    let payload: String = chars[2..chars.len().checked_sub(1)?].iter().collect();
+    let mut fields = payload.split(';');
+    let cb = fields.next()?.parse::<u8>().ok()?;
+    let column = fields.next()?.parse::<u16>().ok()?;
+    let row = fields.next()?.parse::<u16>().ok()?;
+    if fields.next().is_some_and(|field| !field.is_empty()) || column == 0 || row == 0 {
+        return None;
+    }
+
+    let (mut kind, modifiers) = parse_sgr_mouse_button(cb)?;
+    if final_char == 'm'
+        && let MouseEventKind::Down(button) = kind
+    {
+        kind = MouseEventKind::Up(button);
+    }
+
+    Some(MouseEvent {
+        kind,
+        column: column - 1,
+        row: row - 1,
+        modifiers,
+    })
+}
+
+fn parse_sgr_mouse_button(cb: u8) -> Option<(MouseEventKind, KeyModifiers)> {
+    let button_number = (cb & 0b0000_0011) | ((cb & 0b1100_0000) >> 4);
+    let dragging = cb & 0b0010_0000 == 0b0010_0000;
+    let kind = match (button_number, dragging) {
+        (0, false) => MouseEventKind::Down(MouseButton::Left),
+        (1, false) => MouseEventKind::Down(MouseButton::Middle),
+        (2, false) => MouseEventKind::Down(MouseButton::Right),
+        (0, true) => MouseEventKind::Drag(MouseButton::Left),
+        (1, true) => MouseEventKind::Drag(MouseButton::Middle),
+        (2, true) => MouseEventKind::Drag(MouseButton::Right),
+        (3, false) => MouseEventKind::Up(MouseButton::Left),
+        (3, true) | (4, true) | (5, true) => MouseEventKind::Moved,
+        (4, false) => MouseEventKind::ScrollUp,
+        (5, false) => MouseEventKind::ScrollDown,
+        (6, false) => MouseEventKind::ScrollLeft,
+        (7, false) => MouseEventKind::ScrollRight,
+        _ => return None,
+    };
+
+    let mut modifiers = KeyModifiers::NONE;
+    if cb & 0b0000_0100 != 0 {
+        modifiers |= KeyModifiers::SHIFT;
+    }
+    if cb & 0b0000_1000 != 0 {
+        modifiers |= KeyModifiers::ALT;
+    }
+    if cb & 0b0001_0000 != 0 {
+        modifiers |= KeyModifiers::CONTROL;
+    }
+    Some((kind, modifiers))
+}
 
 /// Returns whether an application-level confirmation modal owns an input event.
 ///
@@ -474,9 +679,9 @@ pub async fn run(
     )?;
     let mut chrome_status = ChromeStatus::default();
     chrome_status.tick(&rpc);
-    let mut pending_event = None;
+    let mut input_decoder = SgrMouseEventDecoder::default();
 
-    loop {
+    'event_loop: loop {
         // Draw
         let conn_state = rpc.connection_state();
         if matches!(conn_state, ConnectionState::Disconnected { .. }) {
@@ -693,13 +898,20 @@ pub async fn run(
             }
         }
 
-        let input_event = if let Some(pending) = pending_event.take() {
-            pending
-        } else {
+        let input_event = loop {
+            if let Some(event) = input_decoder.next() {
+                break event;
+            }
+
             // Poll for input with a timeout so live panes refresh periodically.
-            if !event::poll(TICK)? {
-                if matches!(conn_state, ConnectionState::Disconnected { .. }) {
+            // A shorter deadline while an Escape-prefixed sequence is being
+            // assembled keeps an ordinary Escape key responsive.
+            if !event::poll(input_decoder.poll_timeout())? {
+                if input_decoder.flush_timed_out_candidate() {
                     continue;
+                }
+                if matches!(conn_state, ConnectionState::Disconnected { .. }) {
+                    continue 'event_loop;
                 }
                 if mode == Mode::Dashboard {
                     dashboard_pane.tick().await;
@@ -720,18 +932,15 @@ pub async fn run(
                     &mut chat_pane,
                 )
                 .await;
-                continue;
+                continue 'event_loop;
             }
-            event::read()?
+            input_decoder.feed(event::read()?);
         };
-        let (input_event, next_pending) = coalesce_mouse_drag(input_event, || {
-            if event::poll(Duration::ZERO)? {
-                Ok(Some(event::read()?))
-            } else {
-                Ok(None)
-            }
-        })?;
-        pending_event = next_pending;
+        let (input_event, next_pending) =
+            coalesce_mouse_drag(input_event, || input_decoder.read_ready())?;
+        if let Some(next_pending) = next_pending {
+            input_decoder.push_front(next_pending);
+        }
 
         if confirmation_modal_owns_event(&input_event, reload_confirm, quit_confirm) {
             // The visible confirmation modal is the authoritative input
@@ -1989,6 +2198,62 @@ mod tests {
         assert_eq!(current, first);
         assert_eq!(pending, None);
         assert!(!read_ahead);
+    }
+
+    #[test]
+    fn split_sgr_mouse_sequence_becomes_one_mouse_event() {
+        let mut decoder = SgrMouseEventDecoder::default();
+        decoder.feed(Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+        for character in "[<64;32;17M".chars() {
+            decoder.feed(Event::Key(KeyEvent::new(
+                KeyCode::Char(character),
+                KeyModifiers::NONE,
+            )));
+        }
+
+        let decoded: Vec<Event> = std::iter::from_fn(|| decoder.next()).collect();
+
+        assert_eq!(decoded, vec![mouse_event(MouseEventKind::ScrollUp, 31, 16)]);
+    }
+
+    #[test]
+    fn invalid_escape_prefix_is_replayed_in_order() {
+        let original = vec![
+            Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            Event::Key(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)),
+            Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+        ];
+        let mut decoder = SgrMouseEventDecoder::default();
+        for event in original.iter().cloned() {
+            decoder.feed(event);
+        }
+
+        let decoded: Vec<Event> = std::iter::from_fn(|| decoder.next()).collect();
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn incomplete_escape_flush_preserves_the_escape_key() {
+        let escape = Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let mut decoder = SgrMouseEventDecoder::default();
+        decoder.feed(escape.clone());
+
+        assert_eq!(decoder.next(), None);
+        assert!(decoder.flush_candidate());
+        assert_eq!(decoder.next(), Some(escape));
+    }
+
+    #[test]
+    fn delayed_input_flushes_an_expired_escape_before_the_next_tick() {
+        let escape = Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let mut decoder = SgrMouseEventDecoder::default();
+        decoder.feed(escape.clone());
+        decoder.candidate_started_at = Some(Instant::now() - SGR_MOUSE_SEQUENCE_TIMEOUT);
+
+        assert_eq!(decoder.poll_timeout(), Duration::ZERO);
+        assert!(decoder.flush_timed_out_candidate());
+        assert_eq!(decoder.next(), Some(escape));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Reassemble split Escape-prefixed SGR mouse reports before pane and key handling sees them.
  - Decode wheel, click/release, drag/movement, modifier, coordinate, optional-delimiter, and lowercase-release forms into crossterm mouse events.
  - Require exactly three non-empty SGR fields and bound incomplete-sequence buffering with ordered replay for invalid or ordinary Escape input.
- **Scope boundary:** This handles in-process terminal input only; it does not change terminal shutdown restoration, mouse capture configuration, or the separate shell leakage issue tracked by #9800.
- **Blast radius:** ZeroCode top-level event acquisition and all TUI surfaces consuming `MouseEvent`; normal keyboard and paste routing remain unchanged.
- **Linked issue(s):** Fixes #10437
- **Labels:** `bug`, `risk:medium`, `size:M`, `zerocode`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `tui` — Chat or Code transcript
- **Setup / preconditions:** Build this revision in a terminal with mouse reporting enabled and open a transcript long enough to scroll.
- **Steps to run:** Repeat vertical and horizontal scrolling while the transcript is busy or input is delayed; exercise click/release and drag selection while keeping the composer visible. Compare the same sequence on `master` and this branch.
- **Expected on this branch (after):** Scrolling and selection remain mouse events, no raw `[<...M` report appears in the composer, and split drag input does not reorder a queued Escape.
- **Prior behavior on master (before):** A split Escape-prefixed report could be exposed as ordinary composer text during delayed input processing, so scrolling or selection became unreliable.

### How I tested

- **CI checks relied on and why they cover this change:** The owning `zerocode` package tests cover every decoded mouse family, malformed field shapes, invalid prefixes, timeout flushing, split drag read-ahead, and preservation of queued Escape input. The branch is rebased onto the latest `origin/master` base.
- **Known CI coverage gap, if any:** No known candidate-specific Rust coverage gap. Automated tests do not replace the requested real-terminal A/B smoke test; no screenshot is claimed here.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
status: passed

$ cargo clippy --locked -p zerocode --all-targets -- -D warnings
status: passed

$ cargo test --locked -p zerocode --quiet
test result: ok. 191 passed; 0 failed
test result: ok. 835 passed; 0 failed; 2 ignored
```

- **Beyond CI, what did you manually verify?** The decoder's unit-level event stream covers vertical/horizontal wheel, click/release, drag/movement, modifiers, optional delimiter, lowercase release, malformed fields, bounded buffering, timeout flushing, and ordered replay. A real terminal session was not completed, so the reviewer smoke test remains explicitly requested.
- **Visual interface changed?** N/A — this changes input interpretation, not rendered presentation.
- **If any command was intentionally skipped, why:** No candidate-specific package command was skipped. Workspace-wide validation is recorded separately in the local preflight receipt; the real-terminal A/B check remains for reviewer confirmation.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After merge, fetch `master`, resolve the landed squash commit with `gh pr view 10444 --repo zeroclaw-labs/zeroclaw --json mergeCommit --jq .mergeCommit.oid`, then run `git revert <landed-squash-sha>`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Split mouse input stops scrolling, raw terminal bytes enter the composer, or ordinary Escape-prefixed input is delayed or reordered; inspect top-level TUI input handling and decoder regressions.
