### PR TITLE
fix(runtime): convert missed test call sites to ScopedToolRegistry

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -30411,7 +30411,9 @@ This is an example JSON object for profile settings."#;
             channels_by_name,
             provider_impl.clone(),
             Arc::new(zeroclaw_config::schema::Config::default()),
-            Arc::new(vec![]),
+            Arc::new(
+                zeroclaw_runtime::tools::scoped::ScopedToolRegistry::from_raw_for_test(vec![]),
+            ),
         );
         let ctx = Arc::new(ChannelRuntimeContext {
             workspace_dir: Arc::new(workspace.path().to_path_buf()),
@@ -30574,7 +30576,9 @@ This is an example JSON object for profile settings."#;
                 channels_by_name,
                 provider_impl.clone(),
                 Arc::new(zeroclaw_config::schema::Config::default()),
-                Arc::new(vec![]),
+                Arc::new(
+                    zeroclaw_runtime::tools::scoped::ScopedToolRegistry::from_raw_for_test(vec![]),
+                ),
             );
             let ctx = Arc::new(ChannelRuntimeContext {
                 workspace_dir: Arc::new(workspace.path().to_path_buf()),

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -11885,7 +11885,9 @@ mod tests {
         let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
         Agent::builder()
             .model_provider(model_provider)
-            .tools(Vec::new())
+            .tools(crate::tools::scoped::ScopedToolRegistry::from_raw_for_test(
+                Vec::new(),
+            ))
             .memory(mem)
             .observer(observer)
             .tool_dispatcher(Box::new(NativeToolDispatcher))

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -4034,7 +4034,7 @@ mod sop_step_reassembly_tests {
         let engine = Arc::new(std::sync::Mutex::new(engine));
 
         let parent_provider = TextProvider;
-        let parent_tools: Vec<Box<dyn crate::tools::Tool>> = Vec::new();
+        let parent_tools = crate::tools::scoped::ScopedToolRegistry::from_raw_for_test(Vec::new());
         let mut history: Vec<ChatMessage> = Vec::new();
         let mut exec_cache = std::collections::HashMap::new();
 


### PR DESCRIPTION
## Summary

Master's Quality Gate is fully red since e40f153fad (#9319, "seal the engine tool registry as ScopedToolRegistry"). The PR was green when last checked on **Aug 21** but merged on **Aug 29**; in the intervening week three merges added test call sites using the old `Vec<Box<dyn Tool>>` API, producing a semantic merge conflict with no textual conflict:

- `c22645ca54` (#9325) — `.tools(Vec::new())` in an agent.rs test helper
- `0cc3d55341` — two `Arc::new(vec![])` registry args in orchestrator peer-prompt tests
- `92d674afd1` (#9476) — raw `Vec` `parent_tools` in a turn/mod.rs test

One E0308 in test targets fanned out to all 8 failing gates (Check, Lint, Test, Landlock, Parallel Runtime, Security, Required Gate).

This converts the four missed call sites to `ScopedToolRegistry::from_raw_for_test(...)`, the same idiom #9319 used at every other converted site. Test-code-only change; no production behavior touched.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p zeroclaw-runtime -p zeroclaw-channels --all-targets -- -D warnings` — clean
- `cyclic_deterministic_route_exhausts_the_live_turn_step_budget` — passes
- `telegram_image_document_with_enabled_pipeline_never_inlines_base64` — passes

## Note on the Security job

The `Security` failure on this head is pre-existing on master and unrelated to this change. `cargo deny check` exits 1 on a single error:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
chacha20 0.10.0
```

Per review, #10428 (chacha20 0.10.2) needs to land first to green that job. `CI Required Gate` fails only because it gates on `Security`. Every other check on this head passes.

## Process note

Enabling "require branches to be up to date before merging" on master would have forced #9319 to re-run CI against current master and caught this before merge.


## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low risk: `git revert` of the squash commit. Reverting restores the master compilation break, so only revert together with a different repair for the four call sites.

**Labels:** `agent`, `channel`, `channel:core`, `runtime`, `risk:low`, `size:XS`, `type:test`

*(Sections above appended by @JordanTheJet during review for template compliance; all answers verified against the diff.)*
