### PR TITLE
fix(providers): add compatible tool-result image policy

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -759,6 +759,24 @@ impl WireApi {
     }
 }
 
+/// Policy for image markers embedded in native tool-result content.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, zeroclaw_macros::ConfigEnum,
+)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ToolResultImagePolicy {
+    /// Preserve tool-result image markers as structured `image_url` parts.
+    #[default]
+    ImageUrl,
+    /// Remove tool-result image payloads and leave a fixed notice for the model.
+    Omit,
+}
+
+fn is_default_tool_result_image_policy(value: &ToolResultImagePolicy) -> bool {
+    *value == ToolResultImagePolicy::default()
+}
+
 /// Authentication mode for model model_provider families that support more than one
 /// (e.g. Qwen, Minimax can use API key OR OAuth). Families that only support a
 /// single auth flow simply omit this field from their config struct.
@@ -924,6 +942,13 @@ pub struct ModelProviderConfig {
     #[tab(Advanced)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vision: Option<bool>,
+    /// How native compatible chat-completions providers handle image markers in
+    /// role=`tool` results. `image_url` preserves structured image parts;
+    /// `omit` removes their payloads and appends a fixed notice. This does not
+    /// affect direct user image content or OpenAI Responses providers.
+    #[tab(Advanced)]
+    #[serde(default, skip_serializing_if = "is_default_tool_result_image_policy")]
+    pub tool_result_image_policy: ToolResultImagePolicy,
     /// Arbitrary key/value pairs forwarded verbatim as a top-level
     /// `chat_template_kwargs` object in the request body of OpenAI-compatible
     /// providers. Consumed by chat-template-aware backends such as vLLM,
@@ -27698,6 +27723,26 @@ auto_save = true
         assert!(parsed.num_ctx.is_none());
         assert!(parsed.num_predict.is_none());
         assert!(parsed.temperature_override.is_none());
+    }
+
+    #[::core::prelude::v1::test]
+    fn tool_result_image_policy_defaults_and_round_trips() {
+        let parsed: ModelProviderConfig = toml::from_str("").unwrap();
+        assert_eq!(
+            parsed.tool_result_image_policy,
+            ToolResultImagePolicy::ImageUrl
+        );
+        let serialized = toml::to_string(&parsed).unwrap();
+        assert!(
+            !serialized.contains("tool_result_image_policy"),
+            "the default policy should remain omitted from serialized config"
+        );
+
+        let parsed: ModelProviderConfig =
+            toml::from_str("tool_result_image_policy = \"omit\"").unwrap();
+        assert_eq!(parsed.tool_result_image_policy, ToolResultImagePolicy::Omit);
+        let serialized = toml::to_string(&parsed).unwrap();
+        assert!(serialized.contains("tool_result_image_policy = \"omit\""));
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -18,9 +18,11 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, USER_AGENT},
 };
 use serde::{Deserialize, Serialize};
+use zeroclaw_config::schema::ToolResultImagePolicy;
 
 /// Maximum silence between body reads for OpenAI-compatible SSE streams.
 const STREAM_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+const TOOL_RESULT_IMAGE_OMITTED_NOTICE: &str = "[tool-result image omitted by provider policy]";
 
 /// A model_provider that speaks the OpenAI-compatible chat completions API.
 /// Used by: Venice, Vercel AI Gateway, Cloudflare AI Gateway, Moonshot,
@@ -41,6 +43,7 @@ pub struct OpenAiCompatibleModelProvider {
     auth_profile_override: Option<String>,
     pub auth_header: AuthStyle,
     supports_vision: bool,
+    tool_result_image_policy: ToolResultImagePolicy,
     user_agent: Option<String>,
     /// When true, collect all `system` messages and prepend their content
     /// to the first `user` message, then drop the system messages.
@@ -403,6 +406,7 @@ pub struct OpenAiCompatibleBuilder {
     credential: Option<String>,
     auth_style: Option<AuthStyle>,
     supports_vision: bool,
+    tool_result_image_policy: ToolResultImagePolicy,
     user_agent: Option<String>,
     /// Set via [`OpenAiCompatibleBuilder::merge_system_into_user`] — the
     /// combined "merge + drop native tool calling" preset. Distinct from
@@ -478,6 +482,12 @@ impl OpenAiCompatibleBuilder {
     /// Enable OpenAI-style multimodal (image) inputs on this provider.
     pub fn vision(mut self, supports_vision: bool) -> Self {
         self.supports_vision = supports_vision;
+        self
+    }
+
+    /// Set the policy for image markers in native role=`tool` results.
+    pub fn tool_result_image_policy(mut self, policy: ToolResultImagePolicy) -> Self {
+        self.tool_result_image_policy = policy;
         self
     }
 
@@ -673,6 +683,7 @@ impl OpenAiCompatibleBuilder {
             auth_profile_override: self.auth_profile_override,
             auth_header: auth_style,
             supports_vision: self.supports_vision,
+            tool_result_image_policy: self.tool_result_image_policy,
             user_agent: self.user_agent,
             native_tool_calling,
             merge_system_into_user,
@@ -710,6 +721,7 @@ impl OpenAiCompatibleModelProvider {
             credential: None,
             auth_style: None,
             supports_vision: false,
+            tool_result_image_policy: ToolResultImagePolicy::default(),
             user_agent: None,
             merge_system_into_user: false,
             merge_system_into_user_preserve_native: false,
@@ -2310,9 +2322,29 @@ impl OpenAiCompatibleModelProvider {
     }
 
     async fn normalize_messages_for_upstream(
+        &self,
         messages: &[ChatMessage],
     ) -> anyhow::Result<Vec<ChatMessage>> {
         let config = zeroclaw_config::schema::MultimodalConfig::default();
+        let sanitized;
+        let messages = if self.tool_result_image_policy == ToolResultImagePolicy::Omit {
+            sanitized = messages
+                .iter()
+                .map(|message| {
+                    if message.role == "tool" {
+                        ChatMessage {
+                            role: message.role.clone(),
+                            content: Self::sanitize_tool_result_message(&message.content),
+                        }
+                    } else {
+                        message.clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+            sanitized.as_slice()
+        } else {
+            messages
+        };
         let prepared = multimodal::prepare_messages_for_provider(messages, &config).await?;
         Ok(prepared.messages)
     }
@@ -2349,6 +2381,76 @@ impl OpenAiCompatibleModelProvider {
         }
 
         MessageContent::Parts(parts)
+    }
+
+    fn sanitize_tool_result_content(content: &str) -> String {
+        let mut cleaned = String::with_capacity(content.len());
+        let mut cursor = 0;
+        let mut removed_image_marker = false;
+
+        while let Some(relative_start) = content[cursor..].find("[IMAGE:") {
+            let start = cursor + relative_start;
+            cleaned.push_str(&content[cursor..start]);
+            removed_image_marker = true;
+
+            let after_prefix = start + "[IMAGE:".len();
+            cursor = content[after_prefix..]
+                .find(']')
+                .map(|relative_end| after_prefix + relative_end + 1)
+                .unwrap_or(content.len());
+            if cursor == content.len() {
+                break;
+            }
+        }
+
+        cleaned.push_str(&content[cursor..]);
+        if !removed_image_marker {
+            return content.to_string();
+        }
+
+        if !cleaned.is_empty() {
+            cleaned.push_str("\n\n");
+        }
+        cleaned.push_str(TOOL_RESULT_IMAGE_OMITTED_NOTICE);
+        cleaned
+    }
+
+    fn sanitize_tool_result_message(content: &str) -> String {
+        if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(content)
+            && let Some(tool_content) = value.get_mut("content")
+        {
+            let raw_content = tool_content
+                .as_str()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| tool_content.to_string());
+            let sanitized_content = Self::sanitize_tool_result_content(&raw_content);
+            if sanitized_content == raw_content {
+                return content.to_string();
+            }
+            *tool_content = serde_json::Value::String(sanitized_content);
+            return value.to_string();
+        }
+
+        Self::sanitize_tool_result_content(content)
+    }
+
+    fn message_content_for_role(
+        &self,
+        role: &str,
+        content: &str,
+        allow_user_image_parts: bool,
+        allow_tool_image_parts: bool,
+    ) -> MessageContent {
+        if role == "tool" {
+            if self.tool_result_image_policy == ToolResultImagePolicy::Omit {
+                return MessageContent::Text(Self::sanitize_tool_result_content(content));
+            }
+            if allow_tool_image_parts && allow_user_image_parts {
+                return Self::content_with_image_parts(content);
+            }
+            return MessageContent::Text(content.to_string());
+        }
+        Self::to_message_content(role, content, allow_user_image_parts)
     }
 
     fn convert_messages_for_native(
@@ -2483,13 +2585,21 @@ impl OpenAiCompatibleModelProvider {
                         .get("content")
                         .and_then(serde_json::Value::as_str)
                         .map(|value| {
-                            if allow_user_image_parts {
-                                Self::content_with_image_parts(value)
-                            } else {
-                                MessageContent::Text(value.to_string())
-                            }
+                            self.message_content_for_role(
+                                "tool",
+                                value,
+                                allow_user_image_parts,
+                                true,
+                            )
                         })
-                        .or_else(|| Some(MessageContent::Text(message.content.clone())));
+                        .or_else(|| {
+                            Some(self.message_content_for_role(
+                                "tool",
+                                &message.content,
+                                allow_user_image_parts,
+                                false,
+                            ))
+                        });
 
                     // Groq native tool calling requires the tool `name` on
                     // every role-tool message; look it up from the paired
@@ -2519,10 +2629,11 @@ impl OpenAiCompatibleModelProvider {
 
                 NativeMessage {
                     role: message.role.clone(),
-                    content: Some(Self::to_message_content(
+                    content: Some(self.message_content_for_role(
                         &message.role,
                         &message.content,
                         allow_user_image_parts,
+                        false,
                     )),
                     tool_call_id: None,
                     tool_calls: None,
@@ -2917,11 +3028,11 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             role: "user".to_string(),
             content: message.to_string(),
         };
-        let normalized_user =
-            Self::normalize_messages_for_upstream(std::slice::from_ref(&user_msg))
-                .await?
-                .pop()
-                .unwrap_or(user_msg);
+        let normalized_user = self
+            .normalize_messages_for_upstream(std::slice::from_ref(&user_msg))
+            .await?
+            .pop()
+            .unwrap_or(user_msg);
         let normalized_message = normalized_user.content;
 
         let merge = self.effective_merge_system(model);
@@ -3026,7 +3137,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
     ) -> anyhow::Result<String> {
         let credential = self.resolve_credential().await?;
 
-        let normalized = Self::normalize_messages_for_upstream(messages).await?;
+        let normalized = self.normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
         let effective_messages = Self::flatten_system_messages(&normalized, merge);
         // Strip native tool constructs for non-native-tool model_providers.
@@ -3035,7 +3146,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             .iter()
             .map(|m| Message {
                 role: m.role.clone(),
-                content: Self::to_message_content(&m.role, &m.content, !merge),
+                content: self.message_content_for_role(&m.role, &m.content, !merge, false),
             })
             .collect();
 
@@ -3111,7 +3222,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
     ) -> anyhow::Result<ProviderChatResponse> {
         let credential = self.resolve_credential().await?;
 
-        let normalized = Self::normalize_messages_for_upstream(messages).await?;
+        let normalized = self.normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
         let effective_messages = Self::flatten_system_messages(&normalized, merge);
         let effective_messages = if self.native_tool_calling {
@@ -3223,7 +3334,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
     ) -> anyhow::Result<ProviderChatResponse> {
         let credential = self.resolve_credential().await?;
 
-        let normalized = Self::normalize_messages_for_upstream(request.messages).await?;
+        let normalized = self
+            .normalize_messages_for_upstream(request.messages)
+            .await?;
         let merge = self.effective_merge_system(model);
         let effective_messages = Self::flatten_system_messages(&normalized, merge);
         let effective_messages = if self.native_tool_calling {
@@ -3391,7 +3504,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
 
         let handle = ::zeroclaw_spawn::spawn!(async move {
-            let normalized = match Self::normalize_messages_for_upstream(&messages_owned).await {
+            let normalized = match provider
+                .normalize_messages_for_upstream(&messages_owned)
+                .await
+            {
                 Ok(n) => n,
                 Err(err) => {
                     let _ = tx
@@ -3427,7 +3543,12 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                     .iter()
                     .map(|message| Message {
                         role: message.role.clone(),
-                        content: Self::to_message_content(&message.role, &message.content, !merge),
+                        content: provider.message_content_for_role(
+                            &message.role,
+                            &message.content,
+                            !merge,
+                            false,
+                        ),
                     })
                     .collect();
 
@@ -3591,10 +3712,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 role: "user".to_string(),
                 content: message_owned,
             };
-            let normalized_user = match Self::normalize_messages_for_upstream(std::slice::from_ref(
-                &user_msg,
-            ))
-            .await
+            let normalized_user = match provider
+                .normalize_messages_for_upstream(std::slice::from_ref(&user_msg))
+                .await
             {
                 Ok(mut msgs) => msgs.pop().unwrap_or(user_msg),
                 Err(err) => {
@@ -3723,7 +3843,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamChunk>>(100);
 
         let handle = ::zeroclaw_spawn::spawn!(async move {
-            let normalized = match Self::normalize_messages_for_upstream(&messages_owned).await {
+            let normalized = match provider
+                .normalize_messages_for_upstream(&messages_owned)
+                .await
+            {
                 Ok(n) => n,
                 Err(err) => {
                     let _ = tx
@@ -3740,7 +3863,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 .iter()
                 .map(|m| Message {
                     role: m.role.clone(),
-                    content: Self::to_message_content(&m.role, &m.content, !merge),
+                    content: provider.message_content_for_role(&m.role, &m.content, !merge, false),
                 })
                 .collect();
 
@@ -6171,6 +6294,10 @@ mod tests {
         )];
 
         let provider = make_model_provider("test", "https://example.com", None);
+        assert_eq!(
+            provider.tool_result_image_policy,
+            ToolResultImagePolicy::ImageUrl
+        );
         let converted = provider.convert_messages_for_native(&input, true);
         assert_eq!(converted.len(), 1);
         assert_eq!(converted[0].role, "tool");
@@ -6194,6 +6321,341 @@ mod tests {
             parts[1]["image_url"]["url"],
             "data:image/jpeg;base64,/9j/4AAQ"
         );
+    }
+
+    #[test]
+    fn convert_messages_for_native_omits_tool_result_image_payloads() {
+        let input = vec![ChatMessage::tool(
+            serde_json::json!({
+                "tool_call_id": "call_img",
+                "content": "before [IMAGE:data:image/jpeg;base64,/9j/4AAQ] middle [IMAGE:https://example.com/secret.png] after"
+            })
+            .to_string(),
+        )];
+
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+        let converted = provider.convert_messages_for_native(&input, false);
+        let content = serde_json::to_value(
+            converted[0]
+                .content
+                .as_ref()
+                .expect("tool message should carry content"),
+        )
+        .unwrap();
+        let content = content.as_str().expect("omitted tool content is text");
+
+        assert_eq!(
+            content,
+            "before  middle  after\n\n[tool-result image omitted by provider policy]"
+        );
+        assert_eq!(
+            content
+                .matches("[tool-result image omitted by provider policy]")
+                .count(),
+            1
+        );
+        assert!(!content.contains("data:image"));
+        assert!(!content.contains("https://example.com/secret.png"));
+        assert!(!content.contains("/9j/4AAQ"));
+        assert_eq!(converted[0].tool_call_id.as_deref(), Some("call_img"));
+    }
+
+    #[test]
+    fn convert_messages_for_native_sanitizes_malformed_tool_result_json() {
+        let input = vec![ChatMessage::tool(
+            "malformed result [IMAGE:/tmp/secret.png]",
+        )];
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+
+        let converted = provider.convert_messages_for_native(&input, true);
+        let content = serde_json::to_value(
+            converted[0]
+                .content
+                .as_ref()
+                .expect("malformed tool message should carry content"),
+        )
+        .unwrap();
+        let content = content.as_str().expect("sanitized fallback should be text");
+
+        assert_eq!(converted[0].role, "tool");
+        assert_eq!(
+            content,
+            "malformed result \n\n[tool-result image omitted by provider policy]"
+        );
+        assert_eq!(converted[0].tool_call_id, None);
+        assert_eq!(converted[0].name, None);
+        assert!(!content.contains("[IMAGE:"));
+        assert!(!content.contains("/tmp/secret.png"));
+    }
+
+    #[test]
+    fn convert_messages_for_native_sanitizes_non_string_tool_result_content() {
+        let input = vec![ChatMessage::tool(
+            serde_json::json!({
+                "tool_call_id": "call_obj",
+                "name": "read",
+                "content": {"payload": "[IMAGE:/tmp/secret.png]"}
+            })
+            .to_string(),
+        )];
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+
+        let converted = provider.convert_messages_for_native(&input, true);
+        let content = serde_json::to_value(
+            converted[0]
+                .content
+                .as_ref()
+                .expect("non-string tool message should carry content"),
+        )
+        .unwrap();
+        let content = content.as_str().expect("sanitized fallback should be text");
+
+        assert_eq!(converted[0].tool_call_id.as_deref(), Some("call_obj"));
+        assert_eq!(converted[0].name.as_deref(), Some("read"));
+        assert!(content.contains("\"payload\":\""));
+        assert!(content.contains(TOOL_RESULT_IMAGE_OMITTED_NOTICE));
+        assert_eq!(content.matches(TOOL_RESULT_IMAGE_OMITTED_NOTICE).count(), 1);
+        assert!(!content.contains("[IMAGE:"));
+        assert!(!content.contains("/tmp/secret.png"));
+    }
+
+    #[test]
+    fn convert_messages_for_native_sanitizes_unterminated_tool_result_marker() {
+        let input = vec![ChatMessage::tool(
+            serde_json::json!({
+                "tool_call_id": "call_unterminated",
+                "content": "prefix [IMAGE:/tmp/secret.png"
+            })
+            .to_string(),
+        )];
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+
+        let converted = provider.convert_messages_for_native(&input, true);
+        let content = serde_json::to_value(
+            converted[0]
+                .content
+                .as_ref()
+                .expect("unterminated tool message should carry content"),
+        )
+        .unwrap();
+        let content = content
+            .as_str()
+            .expect("sanitized tool content should be text");
+
+        assert_eq!(
+            content,
+            "prefix \n\n[tool-result image omitted by provider policy]"
+        );
+        assert_eq!(
+            converted[0].tool_call_id.as_deref(),
+            Some("call_unterminated")
+        );
+        assert!(!content.contains("[IMAGE:"));
+        assert!(!content.contains("/tmp/secret.png"));
+    }
+
+    #[tokio::test]
+    async fn chat_with_history_no_tools_sanitizes_tool_result_request_content() {
+        let (mut provider, captured, server) = mock_non_streaming_response(serde_json::json!({
+            "choices": [{"message": {"content": "ok"}}]
+        }))
+        .await;
+        provider.tool_result_image_policy = ToolResultImagePolicy::Omit;
+
+        let messages = vec![ChatMessage::tool(
+            "history [IMAGE:data:image/png;base64,SECRET] tail",
+        )];
+        let response = provider
+            .chat_with_history(&messages, "test-model", None)
+            .await
+            .expect("chat history should succeed");
+        assert_eq!(response, "ok");
+
+        let request = captured
+            .lock()
+            .expect("capture lock poisoned")
+            .pop()
+            .expect("server should capture request");
+        let content = request["messages"][0]["content"]
+            .as_str()
+            .expect("tool content should serialize as a string");
+        assert_eq!(
+            content,
+            "history  tail\n\n[tool-result image omitted by provider policy]"
+        );
+        assert!(!content.contains("[IMAGE:"));
+        assert!(!content.contains("data:image"));
+        assert!(!content.contains("SECRET"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn chat_with_history_no_tools_sanitizes_escaped_tool_result_marker() {
+        let (mut provider, captured, server) = mock_non_streaming_response(serde_json::json!({
+            "choices": [{"message": {"content": "ok"}}]
+        }))
+        .await;
+        provider.tool_result_image_policy = ToolResultImagePolicy::Omit;
+
+        let messages = vec![ChatMessage::tool(
+            r#"{"tool_call_id":"call_escaped","name":"inspect","content":"before \u005bIMAGE:data:image/png;base64,SECRET] after"}"#,
+        )];
+        provider
+            .chat_with_history(&messages, "test-model", None)
+            .await
+            .expect("chat history should succeed");
+
+        let request = captured
+            .lock()
+            .expect("capture lock poisoned")
+            .pop()
+            .expect("server should capture request");
+        let envelope: serde_json::Value = serde_json::from_str(
+            request["messages"][0]["content"]
+                .as_str()
+                .expect("tool envelope should serialize as a string"),
+        )
+        .expect("tool envelope remains valid JSON");
+
+        assert_eq!(envelope["tool_call_id"], "call_escaped");
+        assert_eq!(envelope["name"], "inspect");
+        assert_eq!(
+            envelope["content"],
+            "before  after\n\n[tool-result image omitted by provider policy]"
+        );
+        let serialized = envelope.to_string();
+        assert!(!serialized.contains("[IMAGE:"));
+        assert!(!serialized.contains("data:image"));
+        assert!(!serialized.contains("SECRET"));
+        server.abort();
+    }
+
+    #[test]
+    fn convert_messages_for_native_omits_older_tool_results_across_rounds() {
+        let messages = vec![
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_old",
+                        "name": "first",
+                        "arguments": "{}"
+                    }]
+                })
+                .to_string(),
+            ),
+            ChatMessage::tool(
+                serde_json::json!({
+                    "tool_call_id": "call_old",
+                    "content": "old result [IMAGE:/tmp/old.png]"
+                })
+                .to_string(),
+            ),
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_new",
+                        "name": "second",
+                        "arguments": "{}"
+                    }]
+                })
+                .to_string(),
+            ),
+            ChatMessage::tool(
+                serde_json::json!({
+                    "tool_call_id": "call_new",
+                    "content": "new result [IMAGE:data:image/png;base64,NEW]"
+                })
+                .to_string(),
+            ),
+        ];
+
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+        let converted = provider.convert_messages_for_native(&messages, true);
+
+        assert_eq!(converted.len(), 4);
+        for (index, expected_id) in [(1, "call_old"), (3, "call_new")] {
+            assert_eq!(converted[index].role, "tool");
+            assert_eq!(converted[index].tool_call_id.as_deref(), Some(expected_id));
+            assert_eq!(
+                converted[index].name.as_deref(),
+                Some(if index == 1 { "first" } else { "second" })
+            );
+            let content = serde_json::to_value(
+                converted[index]
+                    .content
+                    .as_ref()
+                    .expect("historical tool result should carry content"),
+            )
+            .unwrap();
+            let content = content.as_str().expect("omitted tool content is text");
+            assert!(content.ends_with("[tool-result image omitted by provider policy]"));
+            assert!(!content.contains("[IMAGE:"));
+            assert!(!content.contains("data:image"));
+            assert!(!content.contains("/tmp/old.png"));
+            assert!(!content.contains("base64,NEW"));
+        }
+    }
+
+    #[test]
+    fn convert_messages_for_native_keeps_direct_user_images_under_omit_policy() {
+        let input = vec![ChatMessage::user(
+            "describe this [IMAGE:data:image/png;base64,USER]",
+        )];
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+
+        let converted = provider.convert_messages_for_native(&input, true);
+        let content = serde_json::to_value(
+            converted[0]
+                .content
+                .as_ref()
+                .expect("user message should carry content"),
+        )
+        .unwrap();
+        let parts = content
+            .as_array()
+            .expect("direct user image should remain structured");
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[1]["type"], "image_url");
+        assert_eq!(parts[1]["image_url"]["url"], "data:image/png;base64,USER");
     }
 
     #[test]
@@ -6840,11 +7302,12 @@ mod tests {
             content: format!("Caption please [IMAGE:{}]", path_str),
         };
 
-        let normalized = OpenAiCompatibleModelProvider::normalize_messages_for_upstream(
-            std::slice::from_ref(&msg),
-        )
-        .await
-        .expect("normalize ok");
+        let mut provider = make_model_provider("test", "https://example.com", None);
+        provider.tool_result_image_policy = ToolResultImagePolicy::Omit;
+        let normalized = provider
+            .normalize_messages_for_upstream(std::slice::from_ref(&msg))
+            .await
+            .expect("normalize ok");
 
         assert_eq!(normalized.len(), 1);
         let content = &normalized[0].content;
@@ -6856,6 +7319,36 @@ mod tests {
             !content.contains(&path_str),
             "raw local path must not leak to upstream, got: {content}"
         );
+    }
+
+    #[tokio::test]
+    async fn normalize_messages_for_upstream_omit_preserves_tool_envelope() {
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .tool_result_image_policy(ToolResultImagePolicy::Omit)
+            .build();
+        let message = ChatMessage::tool(
+            r#"{"tool_call_id":"call_image","name":"inspect","content":"before \u005bIMAGE:/tmp/secret.png] after"}"#,
+        );
+
+        let normalized = provider
+            .normalize_messages_for_upstream(std::slice::from_ref(&message))
+            .await
+            .expect("normalize ok");
+        let envelope: serde_json::Value =
+            serde_json::from_str(&normalized[0].content).expect("tool envelope remains valid JSON");
+
+        assert_eq!(envelope["tool_call_id"], "call_image");
+        assert_eq!(envelope["name"], "inspect");
+        assert_eq!(
+            envelope["content"],
+            "before  after\n\n[tool-result image omitted by provider policy]"
+        );
+        assert!(!normalized[0].content.contains("[IMAGE:"));
+        assert!(!normalized[0].content.contains("/tmp/secret.png"));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -250,6 +250,7 @@ pub fn apply_compat_options(
     if let Some(ref cert_path) = opts.tls_ca_cert_path {
         b = b.tls_ca_cert_path(cert_path);
     }
+    b = b.tool_result_image_policy(opts.tool_result_image_policy);
     if opts.replay_assistant_reasoning == Some(false) {
         b = b.without_assistant_reasoning_replay();
     }

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -652,6 +652,9 @@ pub struct ModelProviderRuntimeOptions {
     pub chat_template_kwargs: Option<serde_json::Value>,
     /// Path to a custom CA certificate file for TLS connections.
     pub tls_ca_cert_path: Option<String>,
+    /// How compatible chat-completions providers handle image markers in
+    /// native role=`tool` results.
+    pub tool_result_image_policy: zeroclaw_config::schema::ToolResultImagePolicy,
 }
 
 impl Default for ModelProviderRuntimeOptions {
@@ -677,6 +680,7 @@ impl Default for ModelProviderRuntimeOptions {
             vision: None,
             chat_template_kwargs: None,
             tls_ca_cert_path: None,
+            tool_result_image_policy: Default::default(),
         }
     }
 }
@@ -740,6 +744,9 @@ pub fn model_provider_runtime_options_from_model_provider_entry(
         vision: entry.and_then(|e| e.vision),
         chat_template_kwargs: entry.and_then(|e| e.chat_template_kwargs.clone()),
         tls_ca_cert_path,
+        tool_result_image_policy: entry
+            .map(|e| e.tool_result_image_policy)
+            .unwrap_or_default(),
     }
 }
 
@@ -803,6 +810,10 @@ pub fn options_for_provider_ref(
             // the fallback provider's capability flag. Clearing it falls back to
             // the family default (or the choke point's own resolution).
             options.vision = None;
+            // Tool-result image handling is provider-specific: a bare
+            // fallback family must use its own default rather than inherit
+            // the previous provider alias's policy.
+            options.tool_result_image_policy = Default::default();
             options
         }
     }
@@ -2709,6 +2720,20 @@ mod tests {
     }
 
     #[test]
+    fn tool_result_image_policy_config_field_maps_into_runtime_options() {
+        use zeroclaw_config::schema::{Config, ModelProviderConfig, ToolResultImagePolicy};
+        let entry = ModelProviderConfig {
+            tool_result_image_policy: ToolResultImagePolicy::Omit,
+            ..Default::default()
+        };
+        let opts = model_provider_runtime_options_from_model_provider_entry(
+            &Config::default(),
+            Some(&entry),
+        );
+        assert_eq!(opts.tool_result_image_policy, ToolResultImagePolicy::Omit);
+    }
+
+    #[test]
     fn openai_responses_alias_honors_configured_vision_capability() {
         use zeroclaw_config::schema::{
             Config, ModelProviderConfig, OpenAIModelProviderConfig, WireApi,
@@ -3065,10 +3090,11 @@ mod tests {
     }
 
     #[test]
-    fn route_provider_options_clear_primary_only_state_for_bare_routes() {
+    fn route_provider_options_clear_alias_only_state_for_bare_routes() {
         let inherited = ModelProviderRuntimeOptions {
             provider_kind: Some("openai-compatible".to_string()),
             provider_api_url: Some("http://primary.example/v1".to_string()),
+            tool_result_image_policy: zeroclaw_config::schema::ToolResultImagePolicy::Omit,
             ..Default::default()
         };
         let config = zeroclaw_config::schema::Config::default();
@@ -3077,6 +3103,10 @@ mod tests {
 
         assert_eq!(route_options.provider_kind, None);
         assert_eq!(route_options.provider_api_url, None);
+        assert_eq!(
+            route_options.tool_result_image_policy,
+            zeroclaw_config::schema::ToolResultImagePolicy::ImageUrl
+        );
     }
 
     #[test]

--- a/docs/book/src/providers/configuration.md
+++ b/docs/book/src/providers/configuration.md
@@ -21,6 +21,7 @@ Almost every family also takes the shared fields from `ModelProviderConfig`:
 - `fallback`: ordered list of other dotted provider aliases to try after this alias fails.
 - `wire_api`, `native_tools`, `provider_extra`, `think`, and `chat_template_kwargs`: advanced protocol and request-body overrides.
 - `vision`: override the provider's image-input (vision) capability. Leave unset to use the family's built-in default. Set `false` for a text-only model served by a vision-capable family (for example, a text model behind llama.cpp) so image messages route to a configured `[multimodal] vision_model_provider` instead of erroring; set `true` to force it on.
+- `tool_result_image_policy`: handling for image markers in native `role = "tool"` results sent to compatible chat-completions providers. Defaults to `"image_url"`; set to `"omit"` to remove image URI/base64 payloads and append a fixed notice. This does not change direct user images or OpenAI Responses providers.
 - `tls_ca_cert_path`: absolute path to a PEM-encoded CA certificate for TLS connections to this provider (a per-provider trust override, distinct from the gateway TLS `ca_cert_path`). Shell expansion such as `~` is not performed; leave unset to use the system trust store.
 
 Family-specific entries add their own typed fields on top of these shared fields.

--- a/docs/book/src/providers/custom.md
+++ b/docs/book/src/providers/custom.md
@@ -12,6 +12,15 @@ If the service speaks OpenAI chat-completions, this is a config-only change. The
 
 This is the same `OpenAiCompatibleModelProvider` runtime impl used by `groq`, `mistral`, `xai`, and every other vendor with its own canonical slot in the [catalog](./catalog.md). The difference is which family slot you use: `custom` is the catch-all for endpoints not represented by a vendor slot.
 
+For a gateway that cannot accept image-bearing tool results, omit those payloads while retaining the surrounding tool text:
+
+```toml
+[providers.models.custom.gateway]
+uri = "https://gateway.example.com/v1"
+model = "my-model"
+tool_result_image_policy = "omit"
+```
+
 ## First-class local-inference servers
 
 ZeroClaw ships canonical slots for popular local-inference stacks. They're all OpenAI-compatible under the hood but with default `uri` values pre-applied so you can usually omit `uri` entirely.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Added a typed per-provider `tool_result_image_policy` so OpenAI-compatible gateways that reject image blocks inside native tool results can omit those payloads safely. The compatible request boundary strips marker payloads from fresh and historical `role = "tool"` messages while retaining surrounding text and one fixed notice.
- **Scope boundary:** This does not change direct user images, persisted history, shared multimodal parsing, OpenAI Responses or native providers, or the separate reliable-provider empty-error aggregate.
- **Blast radius:** Compatible chat-completions aliases gain one optional advanced config field. Existing aliases keep the current `image_url` behavior by default.
- **Linked issue(s):** Fixes #10063
- **Labels:** `bug`, `config`, `docs`, `follow-up`, `provider`, `provider:compatible`, `risk:medium`, `size:M`

### What this does, simply

Some gateways speak the OpenAI chat-completions protocol but use an Anthropic-style model behind it. They accept images from a user, yet reject an `image_url` block when that image appears inside a tool result. Because older tool results are replayed on later turns, one image-bearing result could also break an otherwise healthy long-running session.

Operators can now set `tool_result_image_policy = "omit"` on only the affected provider alias. ZeroClaw keeps the tool's text and identity, removes the image URI or base64 payload before sending the request, and leaves one fixed note for the model. The default remains unchanged, and direct user images still use the existing image path.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. Deterministic request-body regressions cover the provider schema boundary without requiring reviewer credentials for a particular third-party gateway.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh exact-head CI passed after repaired current `master` was merged into this branch at `57e89beb0f`; 4 jobs were intentionally skipped, and none failed. Its Rust tests and lint cover the touched config and provider crates; docs and comment-hygiene jobs cover the changed public text and source comments.
- **Known CI coverage gap, if any:** No live third-party gateway smoke was run. The focused tests inspect the exact outbound compatible-provider message shape that the gateway rejects.
- **Commands run and tail output:**

```sh
cargo test --locked -p zeroclaw-config tool_result_image_policy
# 1 passed; 0 failed

cargo test --locked -p zeroclaw-providers convert_messages_for_native_
# 25 passed; 0 failed

cargo test --locked -p zeroclaw-providers chat_with_history_no_tools_sanitizes_
# 2 passed; 0 failed

cargo test --locked -p zeroclaw-providers normalize_messages_for_upstream_
# 2 passed; 0 failed

cargo fmt --all -- --check
git diff --check
bash scripts/ci/docs_quality_gate.sh
bash scripts/ci/docs_links_gate.sh
bash scripts/ci/comment_hygiene_gate.sh
# passed
```

- **Beyond CI, what did you manually verify?** Inspected the serialized native and no-tools request bodies for default and omit policies; valid, malformed, non-string, unterminated, multiple, historical, and JSON-escaped image markers; tool ID/name preservation; bare-family fallback reset; and unchanged direct user-image normalization. I did not send requests to a live third-party gateway.
- **Visual interface changed?** N/A. This changes provider config and outbound wire representation, not rendered UI.
- **If any command was intentionally skipped, why:** No workspace-wide local run was selected because required exact-head CI is the selected source of that breadth and must pass before reviewer sign-off or merge; focused tests directly exercise the changed config-to-wire contract.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? Yes. Omit mode replaces an untrusted image URI or base64 payload with one fixed ZeroClaw policy notice while preserving ordinary tool text; it does not include the removed payload in the outbound request.
- If any Yes, describe the risk and mitigation: The notice is constant ZeroClaw text and is emitted only when an operator explicitly enables `omit` for that provider alias.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: No migration is required. Existing aliases default to `image_url`; affected compatible aliases can add `tool_result_image_policy = "omit"`.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 20f52b236a283ca6753c86e1b3ff74e1725620bc`
- **Feature flags or config toggles:** Remove `tool_result_image_policy` or set it to `"image_url"` on the affected alias to restore prior behavior without reverting code.
- **Observable failure symptoms:** Affected gateways return the prior 400 schema rejection when replay receives `image_url` inside a tool result, or operators see the fixed omission notice where an image payload should have been retained.

---

**Labels** live in the GitHub label UI, not in the body. Maintainers and reviewers with label permissions set `risk:*`, `size:*`, and any missing manual labels via the sidebar. The PR path labeler only owns path/scope labels from `.github/labeler.yml`. Contributors without label permission can note obvious label mismatches in a comment. Canonical colon-scoped labels use no-space spelling; during migration, copy exact live label spelling from the GitHub UI.

**Do not add bot/AI attribution footers** such as `Co-authored-by: Claude ...` or `Created with Claude Code` to the PR body or commit-message tail. Human co-author trailers are appropriate only for incorporated contributor work under the supersede-attribution section and privacy contract.

**Privacy contract** (`docs/book/src/contributing/privacy.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
