### PR TITLE
fix(channels): create Edge TTS artifact with owner-only permissions

### DIFF
--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -713,6 +713,35 @@ impl EdgeTtsProvider {
     }
 }
 
+impl EdgeTtsProvider {
+    /// Pre-create the media artifact with owner-only permissions (0o600) on Unix.
+    ///
+    /// Left to the edge-tts subprocess, the media file is created with
+    /// umask-affected defaults (typically 0o644), which exposes synthesized
+    /// audio to other users on shared hosts. Creating the file first means the
+    /// child truncates and writes into an existing owner-only file.
+    /// ``create_new`` also makes a UUID collision fail loudly instead of
+    /// clobbering another artifact.
+    fn create_owner_only_artifact(path: &std::path::Path) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(path)
+                .context("Failed to create Edge TTS artifact with owner-only permissions")?;
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+        }
+        Ok(())
+    }
+}
+
 #[async_trait::async_trait]
 impl TtsProvider for EdgeTtsProvider {
     fn name(&self) -> &str {
@@ -729,6 +758,7 @@ impl TtsProvider for EdgeTtsProvider {
         let output_path = output_file
             .to_str()
             .context("Failed to build temp file path for Edge TTS")?;
+        Self::create_owner_only_artifact(&output_file)?;
 
         // Spawn explicitly and move the child into the artifact guard, which
         // owns the child through timeout handling AND cancellation: on any path
@@ -1300,6 +1330,28 @@ mod tests {
             .status()
             .await
             .is_ok_and(|status| status.success())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn edge_tts_artifact_is_created_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path =
+            std::env::temp_dir().join(format!("zeroclaw_tts_perm_{}.mp3", uuid::Uuid::new_v4()));
+
+        EdgeTtsProvider::create_owner_only_artifact(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "Edge TTS artifact must be owner-only before the subprocess writes it"
+        );
+
+        // A collision fails loudly instead of clobbering an existing artifact.
+        assert!(EdgeTtsProvider::create_owner_only_artifact(&path).is_err());
+
+        let _ = std::fs::remove_file(&path);
     }
 
     #[cfg(unix)]

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -1485,11 +1485,12 @@ mod tests {
         let missing_binary = artifact_dir
             .path()
             .join(format!("missing-edge-tts-{}", uuid::Uuid::new_v4()));
-        let provider = EdgeTtsProvider::new_with_binary(
+        let provider = EdgeTtsProvider::new_with_command(
             "test",
             missing_binary
                 .to_str()
                 .expect("missing binary path must be valid UTF-8"),
+            &[],
             std::time::Duration::from_secs(5),
         )
         .with_artifact_dir(artifact_dir.path().to_path_buf());

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -736,14 +736,36 @@ impl EdgeTtsProvider {
     fn create_owner_only_artifact(path: &std::path::Path) -> Result<()> {
         #[cfg(unix)]
         {
-            use std::os::unix::fs::OpenOptionsExt;
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-            std::fs::OpenOptions::new()
+            let artifact = std::fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)
                 .mode(0o600)
                 .open(path)
                 .context("Failed to create Edge TTS artifact with owner-only permissions")?;
+
+            // `open(2)` applies the process umask to the requested mode. Apply
+            // the final mode through the open handle so a restrictive umask
+            // cannot make the file unusable, and so a path replacement between
+            // creation and permission hardening cannot redirect the chmod.
+            let permission_result = artifact
+                .set_permissions(std::fs::Permissions::from_mode(0o600))
+                .context("Failed to apply owner-only permissions to Edge TTS artifact");
+            drop(artifact);
+
+            if let Err(error) = permission_result {
+                // The file was created by this call, so retain ownership of
+                // cleanup when permission hardening fails. Do not mask the
+                // primary permission error if the best-effort unlink also
+                // fails.
+                if let Err(cleanup_error) = std::fs::remove_file(path) {
+                    return Err(error.context(format!(
+                        "Failed to remove Edge TTS artifact after permission setup failed: {cleanup_error}"
+                    )));
+                }
+                return Err(error);
+            }
         }
         #[cfg(not(unix))]
         {
@@ -1372,6 +1394,88 @@ mod tests {
         assert!(EdgeTtsProvider::create_owner_only_artifact(&path).is_err());
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn edge_tts_artifact_is_owner_only_and_writable_under_restrictive_umask() {
+        const CHILD_ENV: &str = "ZEROCLAW_TTS_UMASK_TEST_CHILD";
+        const TEST_NAME: &str =
+            "tts::tests::edge_tts_artifact_is_owner_only_and_writable_under_restrictive_umask";
+
+        // The umask is process-global. Run the behavioral part in a dedicated
+        // test subprocess so unrelated tests in the parent harness cannot
+        // observe the temporary restrictive umask.
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let status = std::process::Command::new(
+                std::env::current_exe().expect("test executable must be available"),
+            )
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(CHILD_ENV, "1")
+            .status()
+            .expect("spawn restrictive-umask test subprocess");
+            assert!(
+                status.success(),
+                "restrictive-umask test subprocess failed with status {status}"
+            );
+            return;
+        }
+
+        struct UmaskRestore(libc::mode_t);
+
+        impl Drop for UmaskRestore {
+            fn drop(&mut self) {
+                // SAFETY: umask only changes this test subprocess's process
+                // state, and the original value was captured immediately
+                // before the test changed it.
+                unsafe {
+                    libc::umask(self.0);
+                }
+            }
+        }
+
+        // Create the directory before tightening the umask; otherwise the
+        // test fixture itself would be created with mode 000 and be unusable.
+        let artifact_dir = tempfile::tempdir().expect("create isolated artifact directory");
+
+        // SAFETY: umask accepts any mode bits and returns the prior process
+        // value; this subprocess runs only the current test.
+        let previous_umask = unsafe { libc::umask(0o777) };
+        let _umask_restore = UmaskRestore(previous_umask);
+
+        let artifact_path = artifact_dir.path().join("artifact.mp3");
+        let artifact_path = artifact_path
+            .to_str()
+            .expect("artifact path must be valid UTF-8");
+        EdgeTtsProvider::create_owner_only_artifact(std::path::Path::new(artifact_path))
+            .expect("artifact creation must survive a restrictive umask");
+
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(artifact_path)
+            .expect("inspect artifact")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "the artifact must be exactly owner-only before the child writes it"
+        );
+
+        let status = std::process::Command::new("sh")
+            .args([
+                "-c",
+                "printf audio > \"$1\"",
+                "edge-tts-umask-test",
+                artifact_path,
+            ])
+            .status()
+            .expect("spawn child writer");
+        assert!(status.success(), "child writer failed with status {status}");
+        assert_eq!(
+            std::fs::read(artifact_path).expect("read child-written artifact"),
+            b"audio"
+        );
+        std::fs::remove_file(artifact_path).expect("remove test artifact");
     }
 
     #[cfg(unix)]

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -440,6 +440,8 @@ pub struct EdgeTtsProvider {
     binary_path: String,
     #[cfg(test)]
     binary_args: Vec<String>,
+    #[cfg(test)]
+    artifact_dir: Option<PathBuf>,
     timeout: std::time::Duration,
 }
 
@@ -693,6 +695,8 @@ impl EdgeTtsProvider {
             binary_path: raw_path,
             #[cfg(test)]
             binary_args: Vec::new(),
+            #[cfg(test)]
+            artifact_dir: None,
             timeout: TTS_HTTP_TIMEOUT,
         })
     }
@@ -708,8 +712,15 @@ impl EdgeTtsProvider {
             alias: alias.to_string(),
             binary_path: binary_path.to_string(),
             binary_args: binary_args.iter().map(|arg| (*arg).to_string()).collect(),
+            artifact_dir: None,
             timeout,
         }
+    }
+
+    #[cfg(all(test, unix))]
+    fn with_artifact_dir(mut self, artifact_dir: PathBuf) -> Self {
+        self.artifact_dir = Some(artifact_dir);
+        self
     }
 }
 
@@ -753,12 +764,25 @@ impl TtsProvider for EdgeTtsProvider {
         "mp3"
     }
     async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>> {
+        #[cfg(test)]
+        let temp_dir = self.artifact_dir.clone().unwrap_or_else(std::env::temp_dir);
+        #[cfg(not(test))]
         let temp_dir = std::env::temp_dir();
         let output_file = temp_dir.join(format!("zeroclaw_tts_{}.mp3", uuid::Uuid::new_v4()));
         let output_path = output_file
             .to_str()
             .context("Failed to build temp file path for Edge TTS")?;
         Self::create_owner_only_artifact(&output_file)?;
+
+        // Take ownership of the newly-created artifact before attempting to
+        // start the subprocess. If spawning fails (for example, because the
+        // binary is missing or cannot be executed), dropping this guard removes
+        // the otherwise-empty file instead of leaving one orphan per request.
+        let mut artifact = EdgeTtsTempArtifact {
+            path: output_file.clone(),
+            child: None,
+            stderr_reader: None,
+        };
 
         // Spawn explicitly and move the child into the artifact guard, which
         // owns the child through timeout handling AND cancellation: on any path
@@ -779,11 +803,7 @@ impl TtsProvider for EdgeTtsProvider {
             .kill_on_drop(true)
             .spawn()
             .context("Failed to spawn edge-tts subprocess")?;
-        let mut artifact = EdgeTtsTempArtifact {
-            path: output_file.clone(),
-            child: Some(child),
-            stderr_reader: None,
-        };
+        artifact.child = Some(child);
 
         // Drain stderr concurrently so a verbose child cannot deadlock on a
         // full pipe while we wait for it to exit. Bytes are decoded lossily so
@@ -1352,6 +1372,43 @@ mod tests {
         assert!(EdgeTtsProvider::create_owner_only_artifact(&path).is_err());
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn edge_tts_removes_temp_output_when_spawn_fails() {
+        let artifact_dir = tempfile::tempdir().expect("create isolated artifact directory");
+        let missing_binary = artifact_dir
+            .path()
+            .join(format!("missing-edge-tts-{}", uuid::Uuid::new_v4()));
+        let provider = EdgeTtsProvider::new_with_binary(
+            "test",
+            missing_binary
+                .to_str()
+                .expect("missing binary path must be valid UTF-8"),
+            std::time::Duration::from_secs(5),
+        )
+        .with_artifact_dir(artifact_dir.path().to_path_buf());
+
+        let error = provider
+            .synthesize("hello", "en-US-AriaNeural")
+            .await
+            .expect_err("a missing edge-tts binary must fail to spawn");
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to spawn edge-tts subprocess"),
+            "expected spawn failure, got: {error:#}"
+        );
+
+        let remaining = std::fs::read_dir(artifact_dir.path())
+            .expect("inspect isolated artifact directory")
+            .collect::<std::io::Result<Vec<_>>>()
+            .expect("read isolated artifact directory entries");
+        assert!(
+            remaining.is_empty(),
+            "spawn failure must remove the newly-created artifact, found: {remaining:?}"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` at the reviewed base `dc5b968e8de052ac26e74ae05f210bd1c776770f`
- **What changed and why:**
  - The Edge TTS provider let its subprocess create the MP3 artifact with umask-affected defaults (typically `0o644`), so synthesized audio was world-readable in the shared temp directory for the whole lifetime of the file.
  - The artifact is now pre-created by the provider with `0o600` (Unix) before the child spawns; edge-tts then truncates and writes into the existing owner-only file. `create_new` also makes a UUID collision fail loudly instead of clobbering another artifact.
  - The cleanup guard now owns the newly-created artifact before `spawn()`. If the binary is missing or cannot start, the guard's no-child path removes the empty file instead of leaving an orphan behind.
  - Non-Unix platforms keep their previous behavior (the per-user temp directory provides user isolation there).
- **Audit scope:** a crate-wide check of production temp-file and direct-write sites in `zeroclaw-channels` (`transcription.rs` streams to provider APIs without touching disk; `discord_slash_state.rs`, `qq.rs`, `telegram.rs`, `wechat.rs`, `wecom_ws.rs`, `voice_call.rs`, `whatsapp_storage.rs` write into the channel's own workspace/storage directories, not the shared temp directory). `zeroclaw-infra` session snapshots and `zeroclaw-runtime` quickstart already use `tempfile::NamedTempFile`, which is 0o600 by default on Unix. The Edge TTS artifact was the one sensitive file created in a shared directory with default permissions.
- **Scope boundary:** directories that intentionally live next to the conversation store (WhatsApp snapshots, channel media dirs) are unchanged; their exposure model matches the store itself and hardening them is a separate decision.
- **Linked issue(s):** Related #10409
- **Labels:** `bug`, `channel`, `experienced contributor`, `domain:security`, `risk:high`, `size:S`

## Testing (required)

### How you can test

- **Reviewer testing requested?** N/A — the behavior is covered by deterministic Unix permission, collision, spawn-failure, and subprocess-cleanup tests.

### How I tested

- **CI checks relied on and why they cover this change:** Quality Gate run `34686364223`, attempt 2, passed `CI Required Gate` on exact head `759aacaf6f93c73f488e96b56bacf0615b3d853f`. The earlier cargo-audit download failure and unrelated Telegram parallel-test timeout cleared on retry. The Windows advisory remains non-required and failed only the unchanged gateway publish-contract test described below. The focused local Edge TTS tests and strict channels Clippy cover the changed behavior.
- **Known CI coverage gap, if any:** The current-head Windows advisory completed with 3,429 passed, 1 failed, and 11 skipped. Its only failure is the existing `publish_contract::published_crates_never_include_files_outside_their_own_directory` assertion for unchanged `crates/zeroclaw-gateway/src/static_files.rs` including `../../web/dist`, outside this PR's sole `tts.rs` diff. Separately, the proxy-free full channels suite had one unrelated Telegram media-group timing failure and its isolated retry passed; the hosted 16-thread parallel gate failed once on the Telegram test above, while the same local gate passed all three runs (1,574 passed, 0 failed, 2 ignored each). These results are reported separately; no failed hosted check is represented as green. No live service or external provider was used.
- **Commands run and tail output:**

  ```text
  cargo test -p zeroclaw-channels --lib --locked (proxy variables unset)
      1573 passed; 1 unrelated Telegram timing test failed; 2 ignored
  cargo test -p zeroclaw-channels --lib telegram::tests::media_group_stays_pending_when_a_later_unsupported_member_follows_an_ordinary_update -- --exact
      1 passed; 0 failed
  cargo test -p zeroclaw-channels --lib tts::tests
      38 passed; 0 failed
  cargo clippy -p zeroclaw-channels --all-targets --locked -- -D warnings
      passed
  cargo fmt --all -- --check
      passed
  git diff --check origin/master...HEAD
      passed
  ```

- **Beyond CI, what did I manually verify?** `edge_tts_artifact_is_created_owner_only` asserts the artifact mode is exactly `0o600` before the subprocess writes it and that a second creation attempt fails (`create_new`). `edge_tts_removes_temp_output_when_spawn_fails` uses an isolated directory and a missing executable, then asserts that no artifact remains. The TTS suite also covers successful writes, timeout, cancellation, output-read failure, stderr-pipe handling, and reap ordering.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** A fully green complete channels run was not obtained because the current proxy-free run had one unrelated flaky Telegram timing failure. The isolated retry passed; the full suite and hosted required matrix remain separately reported rather than reclassified as green.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No; the change tightens permissions on a file the channel already creates (`0o644` to `0o600` on Unix) and closes the spawn-failure orphan path.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any Yes, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? Yes. The artifact path, format, endpoint, and JSON body are unchanged; only file permissions and failure cleanup are tightened.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is No or either surface/floor question is Yes: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the squash commit created for this PR; no feature flag is needed.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A rollback restores subprocess-created temp artifacts with umask-dependent permissions (typically `0o644`) and can reintroduce orphaned `zeroclaw_tts_*.mp3` files when the child cannot start.
