### PR TITLE
refactor(channels): gate rusqlite by channel features

### DIFF
--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -88,7 +88,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-webpki-roots-no-provider",
   "stream",
 ] }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.37", optional = true, features = ["bundled"] }
 rustls = { version = "0.23", default-features = false, features = [
   "logging",
   "ring",
@@ -228,6 +228,7 @@ whatsapp-web = [
   "dep:bytes",
   "dep:prost",
   "dep:qrcode",
+  "dep:rusqlite",
   "dep:serde-big-array",
   "dep:wacore",
   "dep:wacore-binary",
@@ -244,7 +245,7 @@ channel-signal = []
 channel-mattermost = []
 channel-irc = []
 channel-twitch = ["channel-irc"]
-channel-imessage = []
+channel-imessage = ["dep:rusqlite"]
 channel-dingtalk = []
 channel-qq = []
 channel-bluesky = []
@@ -300,6 +301,7 @@ matrix-sdk = { version = "0.18", default-features = false, features = [
 ] }
 matrix-sdk-base = { version = "0.18", default-features = false, features = ["e2e-encryption"] }
 matrix-sdk-test = "0.18"
+rusqlite = { version = "0.37", features = ["bundled"] }
 tempfile = "3.26"
 toml = "1.0"
 wiremock = "0.6"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Make `rusqlite` optional in `zeroclaw-channels` instead of compiling it as a direct dependency for every channel build.
  - Let the iMessage and WhatsApp Web feature flags each enable the dependency they use, while retaining it as a development dependency for ACP tests.
- **Scope boundary:** This does not change SQLite behavior, channel storage formats, root feature forwarding, distribution profiles, or runtime code.
- **Blast radius:** Cargo feature resolution for `zeroclaw-channels`, specifically no-default builds plus the iMessage, WhatsApp Web, and ACP test paths.
- **Linked issue(s):** Related #6864
- **Labels:** `dependencies`, `risk:medium`, `size:XS`, `type:dependencies`

### What this does, simply

ZeroClaw can be built with only the messaging services a deployment uses. Previously, its channel package always included the SQLite database library, even when neither iMessage nor WhatsApp Web was enabled. This change includes it only when needed, without changing messaging behavior or stored data.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the feature is compiled through two independent owners, and a combined build could hide a missing feature edge.
- **Interface(s) exercised:** `channel` (iMessage and WhatsApp Web build surfaces) and the ACP channel test harness.
- **Setup / preconditions:** A Rust development environment with the repository dependencies available. No account, credentials, or external service is required.
- **Steps to run:** Run the no-default direct dependency-tree check, compile `channel-imessage` and `whatsapp-web` separately, then run the filtered ACP reservation-error tests.
- **Expected on this branch (after):** `rusqlite` is absent from the crate's direct no-default normal dependencies, both owner features compile independently, and both ACP regressions pass.
- **Prior behavior on `master` (before):** `rusqlite` remains an unconditional direct normal dependency of `zeroclaw-channels` even with no features enabled.

### How I tested

- **CI checks relied on and why they cover this change:** Required exact-head CI passed on commit `31c83eb94e9f07cad087b637e5c9ef7a6b68bd4f`, including the no-default, all-features, MSRV, Linux, 32-bit, Windows, macOS, test, lint, security, and aggregate required-gate jobs.
- **Known CI coverage gap, if any:** Required CI does not directly assert the no-default dependency ownership edge, so the local depth-one tree check supplies that proof.
- **Commands run and tail output:**

  ```text
  $ cargo tree --locked -p zeroclaw-channels --no-default-features --edges normal --depth 1 --prefix none
  verified: rusqlite absent from direct no-default normal dependencies

  $ cargo check --locked -p zeroclaw-channels --no-default-features --features channel-imessage
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 34s

  $ cargo check --locked -p zeroclaw-channels --no-default-features --features whatsapp-web
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 35s

  $ cargo test --locked -p zeroclaw-channels --no-default-features --features channel-acp-server --lib releases_reservation_on_store_error
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 761 filtered out
  ```

- **Beyond CI, what did you manually verify?** Confirmed every production `rusqlite` use remains under either `channel-imessage` or `whatsapp-web`, while the two ACP-only calls remain test-only. No live channel smoke was run because the change affects Cargo dependency selection rather than runtime behavior.
- **Visual interface changed?** N/A; this changes no rendered interface.
- **If any command was intentionally skipped, why:** No broad local workspace suite was run because separate owner-feature compilation, the direct dependency-tree check, the focused ACP tests, and required hosted CI cover the changed contract without duplicative local breadth.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the PR commit to restore the unconditional channels dependency.
- **Feature flags or config toggles:** The affected production paths already use `channel-imessage` and `whatsapp-web`.
- **Observable failure symptoms:** Either owner feature fails to compile because `rusqlite` is unavailable, or the ACP channel test harness fails to resolve its test-only SQLite calls.
