### PR TITLE
feat(maintainers): add public maintainer dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,6 +749,8 @@ jobs:
           PY
       - name: Validate project dashboard planner
         run: python3 scripts/github/project_dashboard_plan_test.py
+      - name: Validate maintainer dashboard
+        run: python3 scripts/github/maintainer_dashboard_test.py
       - name: Install cargo-audit
         run: |
           curl -LsSf https://github.com/rustsec/rustsec/releases/download/cargo-audit%2Fv0.22.2/cargo-audit-x86_64-unknown-linux-gnu-v0.22.2.tgz \

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -15,6 +15,7 @@ additional-js = [
   "theme/version-selector.js",
   "theme/lang-switcher.js",
   "theme/pc-enhance.js",
+  "theme/maintainer-dashboard.js",
   "mermaid.min.js",
   "mermaid-init.js",
 ]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -184,6 +184,7 @@
   - [Multi-agent setup](./contributing/multi-agent-setup.md)
   - [Contributor License Agreement](./contributing/cla.md)
 - [Maintainers](./maintainers/index.md)
+  - [Maintainer dashboard](./maintainers/dashboard.md)
   - [Docs & Translations](./maintainers/docs-and-translations.md)
   - [CI & Actions](./maintainers/ci-and-actions.md)
   - [Claude Code Skills](./maintainers/skills.md)

--- a/docs/book/src/maintainers/dashboard.md
+++ b/docs/book/src/maintainers/dashboard.md
@@ -1,0 +1,38 @@
+# Maintainer dashboard
+
+This report-only dashboard collects public ZeroClaw work-selection signals in one place. GitHub remains authoritative for issue, pull request, review, check, and merge state.
+
+Use the optional maintainer field to add a personal **My work** view. The value stays in the page URL so the view can be bookmarked or shared; the dashboard does not store it or authenticate as that user.
+
+<div id="maintainer-dashboard-app" class="maintainer-dashboard" data-repository="zeroclaw-labs/zeroclaw" data-zt5-url="zt5-public-status.json">
+  <form class="maintainer-dashboard-controls" data-dashboard-controls>
+    <label for="maintainer-dashboard-actor">Maintainer</label>
+    <input id="maintainer-dashboard-actor" name="actor" type="text" inputmode="text" autocomplete="off" placeholder="GitHub login">
+    <button type="submit">Apply</button>
+    <button type="button" data-dashboard-refresh>Refresh</button>
+  </form>
+  <p class="maintainer-dashboard-note" data-dashboard-status>Loading public GitHub data…</p>
+  <section aria-labelledby="dashboard-review-heading">
+    <h2 id="dashboard-review-heading">Pull request review</h2>
+    <p>These are routing candidates, not merge-readiness decisions. Use the <a href="./reviewer-playbook.html#pr-backlog-pruning">review queue CLI</a> for unanswered-request age and exact-head Core approval detail.</p>
+    <div class="maintainer-dashboard-grid" data-dashboard-review></div>
+  </section>
+  <section aria-labelledby="dashboard-project-heading">
+    <h2 id="dashboard-project-heading">Project planning</h2>
+    <p>These views derive from public issue metadata. They do not read or write GitHub ProjectV2 fields.</p>
+    <div class="maintainer-dashboard-grid" data-dashboard-project></div>
+  </section>
+  <section aria-labelledby="dashboard-zt5-heading">
+    <h2 id="dashboard-zt5-heading">Zero-to-5 capabilities</h2>
+    <p>This section contains only deliberately public facts. Detailed evidence, unpublished gaps, and security-sensitive analysis remain outside the public site.</p>
+    <div class="maintainer-dashboard-grid" data-dashboard-zt5></div>
+  </section>
+  <noscript>This dashboard needs JavaScript to read public GitHub state. The linked GitHub searches remain available in the maintainer workflow documentation.</noscript>
+</div>
+
+## Interpretation limits
+
+- A successful-check search narrows the review queue but does not establish mergeability, approval sufficiency, or current-head review validity.
+- The author-action card shows the current label-backed backlog. The CLI inspects timelines before estimating whether a request has actually gone unanswered for the selected number of days.
+- The second-Core card identifies possible high-risk or security candidates with an approval. The CLI checks the published Core roster and the approval's commit before calling out one-current-head-approval candidates.
+- Public Zero-to-5 entries are curated snapshots, not a mirror of private dossiers. A missing score means the score has not been approved for public release.

--- a/docs/book/src/maintainers/zt5-public-status.json
+++ b/docs/book/src/maintainers/zt5-public-status.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "as_of": "2026-08-30",
+  "disclosure": "Curated public snapshot. Detailed evidence, unpublished gaps, and security-sensitive analysis are intentionally excluded.",
+  "capabilities": [
+    {
+      "name": "Persistent memory",
+      "status": "Public implementation slices landed",
+      "score": null,
+      "target": 5,
+      "summary": "Public work includes the durable store seam, unified memory-context injection, and content scanning.",
+      "links": [
+        {"label": "Store seam", "url": "https://github.com/zeroclaw-labs/zeroclaw/pull/8570"},
+        {"label": "Context injection", "url": "https://github.com/zeroclaw-labs/zeroclaw/pull/8619"},
+        {"label": "Memory safety scan", "url": "https://github.com/zeroclaw-labs/zeroclaw/pull/8984"}
+      ]
+    },
+    {
+      "name": "Authentication",
+      "status": "Public foundation landed",
+      "score": null,
+      "target": 5,
+      "summary": "The public foundation introduces principal identity and the authentication-provider seam without publishing private gap analysis.",
+      "links": [
+        {"label": "Principal and AuthProvider seam", "url": "https://github.com/zeroclaw-labs/zeroclaw/pull/8063"}
+      ]
+    },
+    {
+      "name": "Agent-to-agent interoperability",
+      "status": "Public discovery slice landed",
+      "score": null,
+      "target": 5,
+      "summary": "The public surface includes A2A agent discovery. Further maturity claims remain unpublished until they are reviewed for disclosure.",
+      "links": [
+        {"label": "A2A discovery", "url": "https://github.com/zeroclaw-labs/zeroclaw/pull/7763"}
+      ]
+    }
+  ]
+}

--- a/docs/book/theme/custom.css
+++ b/docs/book/theme/custom.css
@@ -1260,3 +1260,99 @@ html.js #mdbook-content main {
 .provider-entry > .cfg-fields table {
   margin-top: 0;
 }
+
+/* ── Public maintainer dashboard ────────────────────────────────────────── */
+.maintainer-dashboard {
+  --dashboard-card-min: 15rem;
+}
+
+.maintainer-dashboard-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 1rem 0;
+  padding: 0.8rem;
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  background: var(--pc-bg-surface);
+}
+
+.maintainer-dashboard-controls label {
+  font-weight: 600;
+}
+
+.maintainer-dashboard-controls input {
+  min-width: 13rem;
+  flex: 1 1 13rem;
+  padding: 0.55rem 0.7rem;
+  color: var(--pc-text-primary);
+  background: var(--pc-bg-input);
+  border: 1px solid var(--pc-border-strong);
+  border-radius: 0.5rem;
+}
+
+.maintainer-dashboard-controls button {
+  padding: 0.55rem 0.8rem;
+  color: var(--pc-text-primary);
+  background: var(--pc-bg-elevated);
+  border: 1px solid var(--pc-border-strong);
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.maintainer-dashboard-controls button:hover,
+.maintainer-dashboard-controls button:focus-visible {
+  border-color: var(--pc-accent);
+}
+
+.maintainer-dashboard-note,
+.maintainer-dashboard-detail,
+.maintainer-dashboard-status {
+  color: var(--pc-text-secondary);
+}
+
+.maintainer-dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--dashboard-card-min)), 1fr));
+  gap: 0.8rem;
+  margin: 1rem 0 1.5rem;
+}
+
+.maintainer-dashboard-card {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  background: var(--pc-bg-surface);
+}
+
+.maintainer-dashboard-card h3 {
+  margin-top: 0;
+}
+
+.maintainer-dashboard-count {
+  margin: 0.35rem 0;
+  color: var(--pc-accent-light);
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.maintainer-dashboard-count-error {
+  color: var(--pc-status-warning);
+  font-size: 1rem;
+}
+
+.maintainer-dashboard-items {
+  margin: 0.75rem 0;
+  padding-left: 1.2rem;
+}
+
+.maintainer-dashboard-items li {
+  margin: 0.35rem 0;
+  overflow-wrap: anywhere;
+}
+
+.maintainer-dashboard-links {
+  margin-bottom: 0;
+}

--- a/docs/book/theme/maintainer-dashboard.js
+++ b/docs/book/theme/maintainer-dashboard.js
@@ -1,0 +1,282 @@
+(function () {
+    "use strict";
+
+    var root = document.getElementById("maintainer-dashboard-app");
+    if (!root) {
+        return;
+    }
+
+    var repository = root.dataset.repository;
+    var statusNode = root.querySelector("[data-dashboard-status]");
+    var reviewNode = root.querySelector("[data-dashboard-review]");
+    var projectNode = root.querySelector("[data-dashboard-project]");
+    var zt5Node = root.querySelector("[data-dashboard-zt5]");
+    var controls = root.querySelector("[data-dashboard-controls]");
+    var actorInput = controls.querySelector("[name=actor]");
+    var refreshButton = controls.querySelector("[data-dashboard-refresh]");
+    var params = new URLSearchParams(window.location.search);
+    var renderGeneration = 0;
+    var searchCache = new Map();
+    var searchCacheTtlMs = 60 * 1000;
+    var searchTimeoutMs = 10 * 1000;
+
+    actorInput.value = validLogin(params.get("actor")) ? params.get("actor") : "";
+
+    function validLogin(value) {
+        return typeof value === "string" && /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(value);
+    }
+
+    function githubSearchUrl(query, kind) {
+        var path = kind === "pr" ? "pulls" : "issues";
+        return "https://github.com/" + repository + "/" + path + "?q=" + encodeURIComponent(query);
+    }
+
+    function element(tag, className, text) {
+        var node = document.createElement(tag);
+        if (className) {
+            node.className = className;
+        }
+        if (text !== undefined) {
+            node.textContent = text;
+        }
+        return node;
+    }
+
+    function addLink(parent, label, url) {
+        var link = element("a", "", label);
+        link.href = url;
+        link.rel = "noreferrer";
+        parent.appendChild(link);
+    }
+
+    function renderPending(container, definitions) {
+        container.replaceChildren();
+        definitions.forEach(function (definition) {
+            var card = element("article", "maintainer-dashboard-card");
+            card.dataset.dashboardKey = definition.key;
+            card.appendChild(element("h3", "", definition.title));
+            card.appendChild(element("p", "maintainer-dashboard-count", "…"));
+            card.appendChild(element("p", "maintainer-dashboard-detail", definition.detail));
+            addLink(card, "Open GitHub search", githubSearchUrl(definition.query, definition.kind));
+            container.appendChild(card);
+        });
+    }
+
+    function renderResult(container, definition, result) {
+        var card = container.querySelector('[data-dashboard-key="' + definition.key + '"]');
+        var count = card.querySelector(".maintainer-dashboard-count");
+        count.textContent = result.ok ? String(result.total) : "Unavailable";
+        count.classList.toggle("maintainer-dashboard-count-error", !result.ok);
+
+        var oldList = card.querySelector("ul");
+        if (oldList) {
+            oldList.remove();
+        }
+        if (!result.ok || result.items.length === 0) {
+            return;
+        }
+        var list = element("ul", "maintainer-dashboard-items");
+        result.items.forEach(function (item) {
+            var row = element("li");
+            var label = "#" + item.number + " " + item.title;
+            addLink(row, label, item.html_url);
+            list.appendChild(row);
+        });
+        card.insertBefore(list, card.lastElementChild);
+    }
+
+    function publicQueries(actor) {
+        var base = "repo:" + repository;
+        var routed = ' is:pr is:open draft:false label:"needs-maintainer-review" -label:"needs-author-action" -label:"status:blocked" -label:"do-not-merge" -label:stacked';
+        var review = [
+            {key: "near-ready", title: "Near-ready", kind: "pr", query: base + routed + " status:success", detail: "Successful-check candidates routed for maintainer review."},
+            {key: "maintainer", title: "Maintainer review", kind: "pr", query: base + routed, detail: "Open PRs routed to maintainers."},
+            {key: "second-core", title: "Potential second Core", kind: "pr", query: base + routed + ' label:"risk:high","domain:security" review:approved', detail: "Possible high-risk or security PRs needing exact-head Core review inspection."},
+            {key: "author-action", title: "Author action", kind: "pr", query: base + ' is:pr is:open draft:false label:"needs-author-action" -label:"status:blocked" -label:"do-not-merge"', detail: "Label-backed backlog; use the CLI for unanswered-request age."},
+            {key: "stacked", title: "Stacked", kind: "pr", query: base + " is:pr is:open draft:false label:stacked", detail: "Open non-draft dependent PRs."}
+        ];
+        var project = [
+            {key: "roadmap", title: "Roadmap", kind: "issue", query: base + " is:issue is:open -no:milestone", detail: "Open issues carrying a milestone."},
+            {key: "board", title: "Active board", kind: "issue", query: base + ' is:issue is:open label:"status:in-progress","status:blocked"', detail: "In-progress or explicitly blocked issue work."},
+            {key: "backlog", title: "Accepted backlog", kind: "issue", query: base + ' is:issue is:open label:"status:accepted" -label:"status:in-progress"', detail: "Accepted issues without the active-PR signal."}
+        ];
+        if (actor) {
+            project.push({key: "my-work", title: "My work", kind: "issue", query: base + " is:issue is:open assignee:" + actor, detail: "Open issues assigned to @" + actor + "."});
+            review.push({key: "my-prs", title: "My PRs", kind: "pr", query: base + routed + " author:" + actor, detail: "Maintainer-review candidates authored by @" + actor + "."});
+        }
+        return {review: review, project: project};
+    }
+
+    function search(definition) {
+        var cached = searchCache.get(definition.query);
+        if (cached && cached.expiresAt > Date.now()) {
+            return cached.promise;
+        }
+
+        var endpoint = "https://api.github.com/search/issues?q=" + encodeURIComponent(definition.query) + "&per_page=5";
+        var controller = new AbortController();
+        var timeout = window.setTimeout(function () {
+            controller.abort();
+        }, searchTimeoutMs);
+        var promise = (async function () {
+            try {
+                var response = await fetch(endpoint, {
+                    headers: {Accept: "application/vnd.github+json"},
+                    signal: controller.signal
+                });
+                if (!response.ok) {
+                    throw new Error("GitHub returned " + response.status);
+                }
+                var payload = await response.json();
+                if (!Number.isInteger(payload.total_count) || !Array.isArray(payload.items)) {
+                    throw new Error("GitHub returned an unexpected response");
+                }
+                return {ok: true, total: payload.total_count, items: payload.items.slice(0, 5)};
+            } catch (error) {
+                return {ok: false, total: null, items: [], error: String(error)};
+            } finally {
+                window.clearTimeout(timeout);
+            }
+        }());
+        searchCache.set(definition.query, {expiresAt: Date.now() + searchCacheTtlMs, promise: promise});
+        return promise;
+    }
+
+    async function renderQueries() {
+        var generation = ++renderGeneration;
+        var actor = validLogin(actorInput.value.trim()) ? actorInput.value.trim() : "";
+        var definitions = publicQueries(actor);
+        renderPending(reviewNode, definitions.review);
+        renderPending(projectNode, definitions.project);
+        statusNode.textContent = "Refreshing public GitHub data…";
+        var all = definitions.review.concat(definitions.project);
+        var results = await Promise.all(all.map(search));
+        if (generation !== renderGeneration) {
+            return;
+        }
+        var failures = 0;
+        all.forEach(function (definition, index) {
+            var container = definition.kind === "pr" ? reviewNode : projectNode;
+            renderResult(container, definition, results[index]);
+            failures += results[index].ok ? 0 : 1;
+        });
+        statusNode.textContent = failures === 0
+            ? "Public GitHub snapshot. Responses are cached for up to one minute; refresh before making a review or merge decision."
+            : failures + " view" + (failures === 1 ? " is" : "s are") + " unavailable. Use the GitHub search links instead.";
+    }
+
+    function publicZt5Url(value) {
+        try {
+            var url = new URL(value, window.location.href);
+            return url.origin === window.location.origin ? url.href : null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function hasExactKeys(value, keys) {
+        return value && typeof value === "object" && !Array.isArray(value)
+            && Object.keys(value).sort().join("|") === keys.slice().sort().join("|");
+    }
+
+    function validPublicZt5Link(link) {
+        if (!hasExactKeys(link, ["label", "url"]) || typeof link.label !== "string" || typeof link.url !== "string") {
+            return false;
+        }
+        try {
+            var url = new URL(link.url);
+            return url.protocol === "https:" && url.hostname === "github.com"
+                && /^\/zeroclaw-labs\/zeroclaw\/pull\/\d+$/.test(url.pathname);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function validPublicZt5Capability(capability) {
+        return hasExactKeys(capability, ["name", "status", "score", "target", "summary", "links"])
+            && typeof capability.name === "string"
+            && typeof capability.status === "string"
+            && capability.score === null
+            && capability.target === 5
+            && typeof capability.summary === "string"
+            && Array.isArray(capability.links)
+            && capability.links.length > 0
+            && capability.links.every(validPublicZt5Link);
+    }
+
+    function validPublicZt5(payload) {
+        return hasExactKeys(payload, ["schema_version", "as_of", "disclosure", "capabilities"])
+            && payload.schema_version === 1
+            && /^\d{4}-\d{2}-\d{2}$/.test(payload.as_of)
+            && typeof payload.disclosure === "string"
+            && Array.isArray(payload.capabilities)
+            && payload.capabilities.length > 0
+            && payload.capabilities.every(validPublicZt5Capability);
+    }
+
+    function renderZt5(payload) {
+        zt5Node.replaceChildren();
+        payload.capabilities.forEach(function (capability) {
+            var card = element("article", "maintainer-dashboard-card maintainer-dashboard-zt5-card");
+            card.appendChild(element("h3", "", capability.name));
+            var score = capability.score === null ? "Not publicly scored" : capability.score + " / " + capability.target;
+            card.appendChild(element("p", "maintainer-dashboard-count", score));
+            card.appendChild(element("p", "maintainer-dashboard-status", capability.status));
+            card.appendChild(element("p", "maintainer-dashboard-detail", capability.summary));
+            var links = element("p", "maintainer-dashboard-links");
+            capability.links.forEach(function (link, index) {
+                if (index > 0) {
+                    links.appendChild(document.createTextNode(" · "));
+                }
+                addLink(links, link.label, link.url);
+            });
+            card.appendChild(links);
+            zt5Node.appendChild(card);
+        });
+        var freshness = element("p", "maintainer-dashboard-note", "Public ZT5 snapshot as of " + payload.as_of + ". " + payload.disclosure);
+        zt5Node.parentNode.insertBefore(freshness, zt5Node);
+    }
+
+    async function loadZt5() {
+        var url = publicZt5Url(root.dataset.zt5Url);
+        if (!url) {
+            zt5Node.textContent = "Public Zero-to-5 snapshot unavailable.";
+            return;
+        }
+        try {
+            var response = await fetch(url);
+            if (!response.ok) {
+                throw new Error("snapshot returned " + response.status);
+            }
+            var payload = await response.json();
+            if (!validPublicZt5(payload)) {
+                throw new Error("snapshot has an unexpected schema");
+            }
+            renderZt5(payload);
+        } catch (error) {
+            zt5Node.textContent = "Public Zero-to-5 snapshot unavailable.";
+        }
+    }
+
+    controls.addEventListener("submit", function (event) {
+        event.preventDefault();
+        var actor = actorInput.value.trim();
+        if (actor && !validLogin(actor)) {
+            statusNode.textContent = "Enter a valid GitHub login.";
+            actorInput.focus();
+            return;
+        }
+        var next = new URL(window.location.href);
+        if (actor) {
+            next.searchParams.set("actor", actor);
+        } else {
+            next.searchParams.delete("actor");
+        }
+        window.history.replaceState({}, "", next);
+        renderQueries();
+    });
+    refreshButton.addEventListener("click", renderQueries);
+
+    renderQueries();
+    loadZt5();
+}());

--- a/scripts/github/maintainer_dashboard_test.py
+++ b/scripts/github/maintainer_dashboard_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Static contract tests for the public maintainer dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import unittest
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BOOK = ROOT / "docs/book"
+PAGE = BOOK / "src/maintainers/dashboard.md"
+ZT5 = BOOK / "src/maintainers/zt5-public-status.json"
+SCRIPT = BOOK / "theme/maintainer-dashboard.js"
+
+
+class MaintainerDashboardTest(unittest.TestCase):
+    def test_page_is_registered_and_script_is_loaded(self) -> None:
+        summary = (BOOK / "src/SUMMARY.md").read_text()
+        config = (BOOK / "book.toml").read_text()
+        page = PAGE.read_text()
+
+        self.assertIn("./maintainers/dashboard.md", summary)
+        self.assertIn('"theme/maintainer-dashboard.js"', config)
+        self.assertIn('id="maintainer-dashboard-app"', page)
+        self.assertIn('data-zt5-url="zt5-public-status.json"', page)
+
+    def test_script_is_page_scoped_and_has_failure_fallbacks(self) -> None:
+        script = SCRIPT.read_text()
+
+        self.assertIn('document.getElementById("maintainer-dashboard-app")', script)
+        self.assertIn("https://api.github.com/search/issues", script)
+        self.assertIn("Open GitHub search", script)
+        self.assertIn("Unavailable", script)
+        self.assertNotIn("Authorization", script)
+        self.assertNotIn("api.github.com/graphql", script)
+
+    def test_refreshes_are_bounded_and_stale_results_are_ignored(self) -> None:
+        script = SCRIPT.read_text()
+
+        self.assertIn("var searchCache = new Map()", script)
+        self.assertIn("var controller = new AbortController()", script)
+        self.assertIn("signal: controller.signal", script)
+        self.assertIn("if (generation !== renderGeneration)", script)
+        self.assertIn("Responses are cached for up to one minute", script)
+        self.assertNotIn("searchCache.delete(definition.query)", script)
+
+    def test_dashboard_queries_remain_report_only(self) -> None:
+        script = SCRIPT.read_text()
+
+        self.assertIn('label:\"needs-maintainer-review\"', script)
+        self.assertIn('label:\"needs-author-action\"', script)
+        self.assertIn('label:\"risk:high\",\"domain:security\" review:approved', script)
+        self.assertIn("is:issue is:open assignee:", script)
+        self.assertNotRegex(script, re.compile(r'fetch\([^)]*method\s*:\s*["\'](?:POST|PUT|PATCH|DELETE)', re.I | re.S))
+
+    def test_public_zt5_snapshot_uses_only_allowlisted_fields(self) -> None:
+        payload = json.loads(ZT5.read_text())
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertRegex(payload["as_of"], r"^\d{4}-\d{2}-\d{2}$")
+        self.assertGreater(len(payload["capabilities"]), 0)
+        self.assertEqual(set(payload), {"schema_version", "as_of", "disclosure", "capabilities"})
+
+        allowed_capability = {"name", "status", "score", "target", "summary", "links"}
+        allowed_link = {"label", "url"}
+        for capability in payload["capabilities"]:
+            self.assertEqual(set(capability), allowed_capability)
+            self.assertIsNone(capability["score"])
+            self.assertEqual(capability["target"], 5)
+            self.assertGreater(len(capability["links"]), 0)
+            for link in capability["links"]:
+                self.assertEqual(set(link), allowed_link)
+                parsed = urlparse(link["url"])
+                self.assertEqual(parsed.scheme, "https")
+                self.assertEqual(parsed.netloc, "github.com")
+                self.assertTrue(parsed.path.startswith("/zeroclaw-labs/zeroclaw/pull/"))
+
+    def test_browser_rejects_non_public_zt5_shapes(self) -> None:
+        script = SCRIPT.read_text()
+
+        self.assertIn('capability.score === null', script)
+        self.assertIn('capability.target === 5', script)
+        self.assertIn('hasExactKeys(payload, ["schema_version", "as_of", "disclosure", "capabilities"])', script)
+        self.assertIn('hasExactKeys(capability, ["name", "status", "score", "target", "summary", "links"])', script)
+        self.assertIn('url.hostname === "github.com"', script)
+
+    def test_public_snapshot_contains_no_machine_local_paths(self) -> None:
+        text = ZT5.read_text()
+        for marker in ("/Users/", "/Volumes/", "file://", "localhost", "127.0.0.1"):
+            self.assertNotIn(marker, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a public, report-only maintainer dashboard to the mdBook with repository-wide pull request review candidates, issue-planning views, and an optional maintainer filter.
- **What changed and why:** Reuses public GitHub searches for current counts and links while keeping the exact author-action age and current-head Core approval checks in the existing review queue CLI.
- **What changed and why:** Adds a deliberately curated public Zero-to-5 snapshot. Human curation keeps private analysis out of the public site, while the browser-side schema rejects scores, non-GitHub links, and unexpected fields.
- **What changed and why:** Bounds GitHub requests with a ten-second timeout, caches each in-flight or completed query for up to one minute, ignores stale refresh generations, and preserves direct search links when the API is unavailable.
- **Scope boundary:** This PR does not determine merge readiness, authenticate as a maintainer, mutate GitHub, write ProjectV2 fields, expose private Zero-to-5 dossiers, or create a second durable queue.
- **Blast radius:** The new JavaScript is loaded by the documentation theme but exits immediately outside the dashboard page. The dashboard page makes unauthenticated read-only requests to GitHub's public Search API; existing runtime, CLI, configuration, and GitHub permissions are unchanged. CI gains one standard-library Python contract-test invocation.
- **Linked issue(s):** Related #6808. This is an independent follow-up to merged PRs #10439 and #8914 and does not close the remaining rollout scope.
- **Labels:** `enhancement`, `risk:medium`, `size:L`, `docs`, `scripts`, `ci`

### What this does, simply

Maintainers currently have useful command-line reports for choosing pull requests, but no single page that combines those review signals with the repository's issue-planning views. This PR adds that page to the public ZeroClaw documentation. It shows live public candidates, lets a maintainer bookmark a view filtered to their GitHub login, and links every card back to GitHub.

The page is a work-selection aid, not a merge button or a new source of truth. GitHub still owns issue, pull request, check, review, and merge state, while the existing CLI remains the precise tool for questions that public search cannot answer safely.

### Scope and maintenance tradeoff

The dashboard is a static mdBook page rather than a new application or backend. It reuses the public GitHub Search API, the review semantics from #10439, and the issue-planning vocabulary from #8914. That keeps deployment inside the existing docs site and avoids credentials, ProjectV2 permissions, scheduled jobs, server state, or a second queue database.

The browser cannot prove exact-head approval validity or how long an author request has gone unanswered, so those cards are explicitly labeled as candidates and link readers to the existing CLI for detailed checks. The Zero-to-5 section accepts only a small checked-in public schema with public pull request links and no scores. Private evidence and security-sensitive gap analysis remain outside this repository.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes. The rendered page should be checked at desktop and mobile widths because this PR adds a responsive public interface.
- **Interface(s) exercised:** `web`
- **Setup / preconditions:** Build or serve the documentation with the repository's `cargo mdbook` command. Public GitHub API access is required for live counts; no GitHub token is used by the page.
- **Steps to run:** Run `cargo mdbook serve`, open `/maintainers/dashboard.html`, apply a valid GitHub login, refresh the page, and repeat at a narrow mobile viewport.
- **Expected on this branch (after):** Repository-wide review, planning, and public Zero-to-5 cards render without horizontal overflow. Applying a login adds personal pull request and issue cards, refresh preserves the current view, and failed GitHub reads remain visibly unavailable with direct search links.
- **Prior behavior on `master` (before):** The maintainer dashboard page and its combined repository and personal views do not exist.

### How I tested

- **CI checks relied on and why they cover this change:** Required current-head CI is green. The added CI step runs the focused dashboard contract tests, while the existing workflow YAML and documentation checks cover the integration points.
- **Known CI coverage gap, if any:** None. The focused suite is intentionally static; the real-interface smoke below covers rendering, responsive layout, live public API responses, and refresh behavior.
- **Commands run and tail output:**

```text
$ python3 scripts/github/maintainer_dashboard_test.py
.......
----------------------------------------------------------------------
Ran 7 tests

OK

$ python3 scripts/github/project_dashboard_plan_test.py
............
----------------------------------------------------------------------
Ran 12 tests

OK

$ node --check docs/book/theme/maintainer-dashboard.js
# no output

$ ruby -e '<load .github/workflows/ci.yml with YAML>'
.github/workflows/ci.yml: valid

$ scripts/ci/docs_quality_gate.sh
Summary: 0 error(s)

$ scripts/ci/docs_links_gate.sh --added
No broken added links.

$ cargo mdbook build
All locale builds completed; internal link check passed.

$ git diff --check
# no output
```

- **Beyond CI, what did you manually verify?** At head `b8522b8877e976be72db4940cb0a015ba0c2064f`, based on `d0658727` from merged #10439, I exercised the generated mdBook page with live GitHub data. The default view rendered five pull request cards, three project cards, and three public Zero-to-5 cards. The `?actor=Audacity88` view rendered six pull request cards, four project cards, and three public Zero-to-5 cards. Refresh preserved the cards, and neither view produced duplicate IDs, console errors, or horizontal overflow. A fresh mobile entry began with the navigation sidebar closed.
- **Visual interface changed?** Yes.
- **Tested revision, interface, and terminal or viewport dimensions:** Head `b8522b8877e976be72db4940cb0a015ba0c2064f`; generated mdBook `web` interface at 1429 x 893 desktop and 379 x 820 captured from a fresh 390 x 844 mobile viewport.
- **Screenshot evidence:**

<img width="1429" height="893" alt="image" src="https://github.com/user-attachments/assets/13264349-2e56-47dc-81f7-0aa047eb2003" />
<img width="379" height="820" alt="image" src="https://github.com/user-attachments/assets/f097ca73-62ad-441d-a43a-e62002d1a974" />

- **Action or changed state and observed result:** Applied the `Audacity88` actor filter, refreshed the page, and entered at a mobile viewport. Personal cards appeared, refresh retained the view, and the mobile layout remained readable without horizontal overflow.
- **If any command was intentionally skipped, why:** No additional Rust runtime test was run because the Rust change is limited to exercising the existing mdBook build command; the feature itself is documentation JavaScript, CSS, Markdown, JSON, and a Python contract test.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: The dashboard makes unauthenticated read-only requests to GitHub's public Search API. It sends only public repository search queries, requests no new permission, stores no token, renders issue and pull request titles with `textContent`, times out stalled requests, and falls back to direct public GitHub search links.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade steps are required.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-sha>` removes the dashboard page, theme assets, and focused CI invocation together.
- **Feature flags or config toggles:** None. The page-scoped script exits immediately when the dashboard root is absent.
- **Observable failure symptoms:** Dashboard cards remain unavailable, counts appear stale after an explicit refresh, the public snapshot is rejected, the layout overflows at supported widths, or the focused dashboard test or documentation build fails. The page has no mutation path, so these failures cannot change GitHub state.

## Supersede Attribution (required only when `Supersedes #` is used)

Not applicable.
