### PR TITLE
fix(mcp): preserve persistent SSE event boundaries

### DIFF
--- a/crates/zeroclaw-tools/src/mcp_transport.rs
+++ b/crates/zeroclaw-tools/src/mcp_transport.rs
@@ -1497,6 +1497,9 @@ impl SseTransport {
             // each event boundary. Bounds a single event so a persistent stream
             // cannot accumulate unbounded event data before dispatch.
             let mut cur_bytes: u64 = 0;
+            // Once an event is rejected, consume the rest of its lines through
+            // the blank boundary so a valid suffix cannot be dispatched alone.
+            let mut discard_event = false;
 
             loop {
                 tokio::select! {
@@ -1524,6 +1527,7 @@ impl SseTransport {
                                 cur_event = None;
                                 cur_id = None;
                                 cur_bytes = 0;
+                                discard_event = true;
                                 continue;
                             }
                             Ok(BoundedLine::Eof) | Err(_) => break,
@@ -1536,6 +1540,14 @@ impl SseTransport {
                             line.pop();
                         }
                         if line.is_empty() {
+                            if discard_event {
+                                cur_data.clear();
+                                cur_event = None;
+                                cur_id = None;
+                                cur_bytes = 0;
+                                discard_event = false;
+                                continue;
+                            }
                             if cur_event.is_none() && cur_id.is_none() && cur_data.is_empty() {
                                 continue;
                             }
@@ -1545,6 +1557,10 @@ impl SseTransport {
                             cur_bytes = 0;
                             let id = cur_id.take();
                             handle_sse_event(&server_name, &sse_url, &shared, &pending, &notify, event.as_deref(), id.as_deref(), data).await;
+                            continue;
+                        }
+
+                        if discard_event {
                             continue;
                         }
 
@@ -1577,6 +1593,7 @@ impl SseTransport {
                                 cur_event = None;
                                 cur_id = None;
                                 cur_bytes = 0;
+                                discard_event = true;
                                 continue;
                             }
                             cur_data.push(rest.to_string());
@@ -4015,6 +4032,84 @@ data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n";
             }
             other => panic!("expected a line, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn persistent_sse_reader_discards_suffix_after_oversized_event() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = zeroclaw_spawn::spawn!(async move {
+            let (mut sse_socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let bytes_read = sse_socket.read(&mut request).await.unwrap();
+            assert!(request[..bytes_read].starts_with(b"GET /sse "));
+
+            sse_socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+Content-Type: text/event-stream\r\n\
+Connection: keep-alive\r\n\r\n\
+event: endpoint\n\
+data: /messages\n\n",
+                )
+                .await
+                .unwrap();
+            sse_socket.flush().await.unwrap();
+
+            let (mut post_socket, _) = listener.accept().await.unwrap();
+            let bytes_read = post_socket.read(&mut request).await.unwrap();
+            assert!(request[..bytes_read].starts_with(b"POST /messages "));
+            post_socket
+                .write_all(
+                    b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            post_socket.shutdown().await.unwrap();
+
+            let suffix = r#"{"jsonrpc":"2.0","id":7,"result":{"source":"oversized-suffix"}}"#;
+            let expected = r#"{"jsonrpc":"2.0","id":7,"result":{"source":"next-event"}}"#;
+            let body = format!(
+                "data: {}\ndata: {}\n\ndata: {}\n\n",
+                "x".repeat(256),
+                suffix,
+                expected
+            );
+            sse_socket.write_all(body.as_bytes()).await.unwrap();
+            sse_socket.flush().await.unwrap();
+        });
+
+        let config = McpServerConfig {
+            name: "sse-event-boundary".into(),
+            transport: McpTransport::Sse,
+            url: Some(format!("http://{addr}/sse")),
+            max_response_bytes: Some(128),
+            ..Default::default()
+        };
+        let transport = SseTransport::new(&config).expect("build transport");
+        let request = JsonRpcRequest::new(7, "tools/call", serde_json::json!({}));
+        let lifecycle = McpRequestLifecycle::uncoordinated(0);
+        let response = timeout(
+            Duration::from_secs(5),
+            SharedMcpTransportConn::send_and_recv(&transport, &request, &lifecycle),
+        )
+        .await
+        .expect("next event should be delivered without waiting for EOF")
+        .expect("next event should parse");
+
+        assert_eq!(
+            response
+                .result
+                .as_ref()
+                .and_then(|result| result.get("source"))
+                .and_then(serde_json::Value::as_str),
+            Some("next-event")
+        );
+        server.await.unwrap();
+        transport.close().await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Mark a persistent SSE event as rejected when a line or its accumulated `data:` payload exceeds `max_response_bytes`.
  - Continue consuming that rejected event through its terminating blank line before parsing again.
  - Add an end-to-end regression covering an oversized event, a valid suffix from that same event, and a valid following event.
- **Scope boundary:** This changes only the persistent SSE reader boundary after an existing size-limit rejection. Direct HTTP responses, direct HTTP/SSE response parsing, stdio framing, endpoint discovery, and configured limits are unchanged.
- **Blast radius:** MCP clients using the persistent SSE transport. A malformed or oversized event is now discarded as a whole, while later events on the same connection remain eligible for delivery.
- **Linked issue(s):** Fixes #10456
- **Labels:** `bug`, `tool`, `trusted contributor`, `tool:mcp`, `risk:medium`, `size:S`.

## Testing

### How you can test

- **Reviewer testing requested?** N/A — the regression exercises the persistent transport boundary with a local TCP server and covers the prior suffix-dispatch failure.
- **Interface(s) exercised:** N/A — transport-level MCP behavior.
- **Setup / preconditions:** N/A.
- **Steps to run:** N/A.
- **Expected on this branch (after):** N/A.
- **Prior behavior on `master` (before):** The test fails because a valid `data:` suffix after an oversized line is dispatched as a standalone event.

### How I tested

- **CI checks relied on and why they cover this change:** The repository Rust quality and test workflows cover the changed `zeroclaw-tools` transport code; the local focused suite reaches the persistent SSE reader over a real loopback TCP connection.
- **Known CI coverage gap, if any:** Full workspace validation was not required locally; the complete package library run also exposed three unrelated environment-sensitive failures listed below.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check`
  - `cargo test -p zeroclaw-tools --lib mcp_transport::tests` — 88 passed, 0 failed
  - `cargo clippy -p zeroclaw-tools --all-targets -- -D warnings` — passed
  - `cargo test -p zeroclaw-tools --lib` — 1710 passed; three unrelated existing failures in `browser::tests::is_service_environment_detects_journal_stream`, `git_operations::tests::allows_readonly_ops_in_readonly_mode`, and `git_operations::tests::non_repository_error_includes_path_context_and_recovery_hint`
  - `git diff --check` — passed
- **Beyond CI, what did you manually verify?** The regression first failed on the unmodified baseline by returning `oversized-suffix`; after the fix it returned only `next-event`. The server closes the SSE connection after writing the events, so this test checks suffix rejection and recovery but does not independently prove delivery before EOF.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Full workspace tests were not run locally because the changed behavior is isolated to `zeroclaw-tools`; package-level tests, strict Clippy, and repository CI provide the relevant coverage.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No. The production code changes parsing state only; the regression uses loopback test sockets.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any Yes, describe the risk and mitigation: N/A.

## Compatibility

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.

## Rollback

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Persistent MCP SSE responses may remain unavailable after a size-limit rejection if the reader incorrectly remains in discard mode; the reader logs the existing oversized-event rejection message and subsequent valid events fail to reach their waiting requests.
