### PR TITLE
ci(policy): enforce calibrated PR risk approvals

### DIFF
--- a/.github/risk-labeler.yml
+++ b/.github/risk-labeler.yml
@@ -1,0 +1,26 @@
+{
+  "risk:high": [
+    {
+      "changed-files": {
+        "any-glob-to-any-file": [
+          "crates/zeroclaw-runtime/src/security/**",
+          "crates/zeroclaw-runtime/src/approval/**",
+          "crates/zeroclaw-runtime/src/trust/**",
+          "crates/zeroclaw-providers/src/auth/**",
+          "wit/**",
+          ".github/CODEOWNERS",
+          ".github/risk-labeler.yml",
+          ".github/workflows/pr-risk-labeler.yml",
+          ".github/workflows/pr-risk-policy.yml",
+          ".github/workflows/pr-risk-policy-review-signal.yml",
+          ".github/workflows/*release*.yml",
+          ".github/workflows/*publish*.yml",
+          ".github/workflows/pub-*.yml",
+          "docs/book/src/contributing/communication.md",
+          "scripts/github/pr_risk_policy.py",
+          "scripts/release/**"
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,12 +741,16 @@ jobs:
 
           for path in (
               ".github/workflows/ci.yml",
+              ".github/workflows/pr-risk-policy.yml",
+              ".github/workflows/pr-risk-policy-review-signal.yml",
               ".github/workflows/project-dashboard-plan.yml",
               ".github/workflows/release-stable-manual.yml",
           ):
               yaml.safe_load(open(path))
               print(f"{path}: valid")
           PY
+      - name: Validate PR risk policy
+        run: python3 scripts/github/pr_risk_policy_test.py
       - name: Validate project dashboard planner
         run: python3 scripts/github/project_dashboard_plan_test.py
       - name: Install cargo-audit

--- a/.github/workflows/pr-risk-policy-review-signal.yml
+++ b/.github/workflows/pr-risk-policy-review-signal.yml
@@ -1,0 +1,19 @@
+name: PR Risk Event Signal
+run-name: PR Risk Event Signal pr=${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, converted_to_draft, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions: {}
+
+jobs:
+  signal:
+    name: Signal PR policy input change
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Complete signal
+        run: ":"

--- a/.github/workflows/pr-risk-policy.yml
+++ b/.github/workflows/pr-risk-policy.yml
@@ -1,0 +1,217 @@
+name: PR Risk Policy
+
+on:
+  workflow_run:
+    workflows: [PR Risk Event Signal]
+    types: [completed]
+  push:
+    branches: [master]
+    paths:
+      - .github/risk-labeler.yml
+      - .github/workflows/pr-risk-policy.yml
+      - .github/workflows/pr-risk-policy-review-signal.yml
+      - docs/book/src/contributing/communication.md
+      - scripts/github/pr_risk_policy.py
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to evaluate"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  resolve:
+    name: Resolve PR risk policy target
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Resolve pull request
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          signal_head=""
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              pr_number="$DISPATCH_PR_NUMBER"
+              head_sha=""
+              ;;
+            workflow_run)
+              case "$WORKFLOW_RUN_EVENT" in
+                pull_request_target)
+                  if [[ ! "$WORKFLOW_RUN_TITLE" =~ ^PR\ Risk\ Event\ Signal\ pr=([1-9][0-9]*)\ head=([0-9a-fA-F]{40})$ ]]; then
+                    echo "malformed PR risk event signal identity" >&2
+                    exit 1
+                  fi
+                  pr_number="${BASH_REMATCH[1]}"
+                  signal_head="${BASH_REMATCH[2]}"
+                  if [[ -n "$WORKFLOW_RUN_PR_NUMBER" && "$WORKFLOW_RUN_PR_NUMBER" != "$pr_number" ]]; then
+                    echo "PR risk event signal association mismatch" >&2
+                    exit 1
+                  fi
+                  ;;
+                pull_request_review)
+                  if [[ ! "$WORKFLOW_RUN_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+                    echo "review signal has no native pull request association" >&2
+                    exit 1
+                  fi
+                  pr_number="$WORKFLOW_RUN_PR_NUMBER"
+                  ;;
+                *)
+                  echo "unsupported PR risk event signal source: $WORKFLOW_RUN_EVENT" >&2
+                  exit 1
+                  ;;
+              esac
+              head_sha=""
+              ;;
+            *)
+              echo "unsupported event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+          if [[ -z "$head_sha" ]]; then
+            if ! head_sha="$(gh api "repos/$REPOSITORY/pulls/$pr_number" --jq '.head.sha')"; then
+              if [[ -n "$signal_head" ]]; then
+                gh api --method POST "repos/$REPOSITORY/statuses/$signal_head" \
+                  -f state=error \
+                  -f context='zeroclaw/pr-risk-policy' \
+                  -f description='Risk policy could not resolve live PR state' || true
+              fi
+              exit 1
+            fi
+          fi
+          [[ "$head_sha" =~ ^[0-9a-fA-F]{40}$ ]]
+          printf 'pr_number=%s\n' "$pr_number" >> "$GITHUB_OUTPUT"
+          printf 'head_sha=%s\n' "$head_sha" >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    name: Evaluate PR risk policy
+    if: github.event_name != 'push'
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: pr-risk-policy-${{ needs.resolve.outputs.pr_number }}
+      cancel-in-progress: true
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Fetch trusted policy inputs
+        shell: bash
+        env:
+          PR_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+        run: |
+          set -uo pipefail
+          failed=0
+          fetch_trusted() {
+            local path="$1"
+            local output="$2"
+            if ! gh api "repos/$REPOSITORY/contents/$path?ref=$DEFAULT_BRANCH" --jq '.content' | base64 --decode > "$output"; then
+              failed=1
+            fi
+          }
+          fetch_trusted "scripts/github/pr_risk_policy.py" "$RUNNER_TEMP/pr_risk_policy.py"
+          fetch_trusted ".github/risk-labeler.yml" "$RUNNER_TEMP/risk-labeler.yml"
+          fetch_trusted "docs/book/src/contributing/communication.md" "$RUNNER_TEMP/communication.md"
+          if (( failed )); then
+            gh api --method POST "repos/$REPOSITORY/statuses/$PR_HEAD_SHA" \
+              -f state=error \
+              -f context='zeroclaw/pr-risk-policy' \
+              -f description='Risk policy helper unavailable' || true
+            exit 1
+          fi
+
+      - name: Evaluate and publish exact-head status
+        shell: bash
+        env:
+          PR_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          python3 "$RUNNER_TEMP/pr_risk_policy.py" \
+            --repository "$REPOSITORY" \
+            --pr-number "$PR_NUMBER" \
+            --policy "$RUNNER_TEMP/risk-labeler.yml" \
+            --roster "$RUNNER_TEMP/communication.md" \
+            --status-context 'zeroclaw/pr-risk-policy' \
+            --summary "$GITHUB_STEP_SUMMARY"
+
+  reconcile-open:
+    name: Reconcile open PR risk policy
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      group: pr-risk-policy-reconcile-open
+      cancel-in-progress: true
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Fetch trusted policy inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          fetch_trusted() {
+            local path="$1"
+            local output="$2"
+            gh api "repos/$REPOSITORY/contents/$path?ref=$DEFAULT_BRANCH" --jq '.content' \
+              | base64 --decode > "$output"
+          }
+          fetch_trusted "scripts/github/pr_risk_policy.py" "$RUNNER_TEMP/pr_risk_policy.py"
+          fetch_trusted ".github/risk-labeler.yml" "$RUNNER_TEMP/risk-labeler.yml"
+          fetch_trusted "docs/book/src/contributing/communication.md" "$RUNNER_TEMP/communication.md"
+
+      - name: Reconcile every open pull request
+        shell: bash
+        run: |
+          set -uo pipefail
+          failed=0
+          gh api --paginate "repos/$REPOSITORY/pulls?state=open&per_page=100" --jq '.[].number' \
+            > "$RUNNER_TEMP/open-prs"
+          while IFS= read -r pr_number; do
+            [[ "$pr_number" =~ ^[1-9][0-9]*$ ]] || {
+              failed=1
+              continue
+            }
+            head_sha="$(gh api "repos/$REPOSITORY/pulls/$pr_number" --jq '.head.sha')" || {
+              failed=1
+              continue
+            }
+            [[ "$head_sha" =~ ^[0-9a-fA-F]{40}$ ]] || {
+              failed=1
+              continue
+            }
+            if ! PR_HEAD_SHA="$head_sha" python3 "$RUNNER_TEMP/pr_risk_policy.py" \
+              --repository "$REPOSITORY" \
+              --pr-number "$pr_number" \
+              --policy "$RUNNER_TEMP/risk-labeler.yml" \
+              --roster "$RUNNER_TEMP/communication.md" \
+              --status-context 'zeroclaw/pr-risk-policy' \
+              --allow-policy-failure; then
+              failed=1
+            fi
+          done < "$RUNNER_TEMP/open-prs"
+          exit "$failed"

--- a/docs/book/src/contributing/communication.md
+++ b/docs/book/src/contributing/communication.md
@@ -72,7 +72,7 @@ The Focus column describes where each person works, not how much authority they 
 | [@Stalesamy](https://github.com/Stalesamy) | Core Team | Marketing and community, plus occasional PRs |
 | [@perlowja](https://github.com/perlowja) | Core Team | Marketing and community, plus occasional PRs |
 
-Repository automation uses this table as the operational projection of current Core Team membership when it evaluates the conditional two-Core-approval merge policy. The parser accepts only unique GitHub handles whose Role includes `Core Team` and fails closed if the table is empty or malformed. Update this summary promptly after a public membership decision so the automated projection remains accurate; editing the table records that decision downstream but does not create or end membership.
+Repository automation uses this table as the operational projection of current Core Team membership when it evaluates the conditional two-Core-approval merge policy. The parser accepts only unique GitHub handles whose Role begins with `Core Team` and fails closed if the table is empty or malformed. Update this summary promptly after a public membership decision so the automated projection remains accurate; editing the table records that decision downstream but does not create or end membership.
 
 Not everyone listed reviews code. Route code review by the Focus column and by CODEOWNERS, not by tier.
 

--- a/docs/book/src/contributing/communication.md
+++ b/docs/book/src/contributing/communication.md
@@ -72,6 +72,8 @@ The Focus column describes where each person works, not how much authority they 
 | [@Stalesamy](https://github.com/Stalesamy) | Core Team | Marketing and community, plus occasional PRs |
 | [@perlowja](https://github.com/perlowja) | Core Team | Marketing and community, plus occasional PRs |
 
+Repository automation uses this table as the operational projection of current Core Team membership when it evaluates the conditional two-Core-approval merge policy. The parser accepts only unique GitHub handles whose Role includes `Core Team` and fails closed if the table is empty or malformed. Update this summary promptly after a public membership decision so the automated projection remains accurate; editing the table records that decision downstream but does not create or end membership.
+
 Not everyone listed reviews code. Route code review by the Focus column and by CODEOWNERS, not by tier.
 
 Focus areas track [`.github/CODEOWNERS`](https://github.com/zeroclaw-labs/zeroclaw/blob/master/.github/CODEOWNERS), which is the authoritative routing record. This table is the human-readable summary; if the two disagree, CODEOWNERS wins.

--- a/docs/book/src/foundations/fnd-003-governance.md
+++ b/docs/book/src/foundations/fnd-003-governance.md
@@ -385,7 +385,7 @@ Membership itself is established by decision, not by any file or GitHub setting.
 
 **`.github/CODEOWNERS`** at the repository root: **review routing**, not membership. It records who is requested on which paths. Being listed does not confer membership and being a member does not imply being listed. Changes to it require an explicit Core Team vote, per §5.2.
 
-**The maintainer table in [Communication](../contributing/communication.md#maintainer-contacts)**: the human-readable summary of current members and what each works on. It is the closest thing to a published roster, and it is maintained by hand, so treat it as a summary of admission decisions rather than as an authority. For focus areas it is a convenience view over CODEOWNERS, and where those two disagree, CODEOWNERS wins.
+**The maintainer table in [Communication](../contributing/communication.md#maintainer-contacts)**: the human-readable summary of current members and what each works on. It is the closest thing to a published roster, and it is maintained by hand, so treat it as a summary of admission decisions rather than as the authority that creates or ends membership. Repository automation uses the checked table as its operational enforcement projection, so update it promptly after a public membership decision and review changes to it as high risk. For focus areas it is a convenience view over CODEOWNERS, and where those two disagree, CODEOWNERS wins.
 
 Removals work the same way as admissions: they are decisions, recorded where they are made. Revoking access or removing someone from CODEOWNERS implements a departure; it does not by itself constitute one.
 
@@ -454,7 +454,7 @@ Configure the following branch protection rules for `master`:
 
 **Why admins cannot bypass:** One of the most common mistakes in small team projects is treating branch protection as "for other people." When an admin can bypass, they will, under time pressure, in an emergency, "just this once." Then it becomes the norm. The rule must apply to everyone for it to mean anything. If there is a genuine emergency, the right response is to follow the process faster, not to skip it.
 
-GitHub's native approval count is configured per protected branch or ruleset target, not conditionally by PR label. Until a separately approved technical enforcement design has a machine-readable authority for Core Team approval, maintainers must apply the `risk:high OR domain:security` requirement through the documented merge checklist and retain an auditable review record. `risk:manual` freezes future automatic risk replacement only; it cannot lower this requirement.
+GitHub's native approval count is configured per protected branch or ruleset target, not conditionally by PR label. The `zeroclaw/pr-risk-policy` status evaluates the conditional rule against exact-head formal approvals from the operational Core Team projection in the Communication maintainer table. It becomes merge enforcement only when a separately approved repository ruleset requires that status on `master`; until then, maintainers must also apply the requirement through the documented merge checklist. `risk:manual` freezes future automatic risk replacement only; it cannot lower this requirement.
 
 ### 6.3 Required Status Checks
 
@@ -466,6 +466,8 @@ test                    ← cargo test
 fmt                     ← cargo fmt --all -- --check
 clippy                  ← cargo clippy --all-targets -- -D warnings
 ```
+
+After its workflow has landed and the separately approved repository ruleset is active, `zeroclaw/pr-risk-policy` is also required. It applies the conditional two-Core-approval rule without replacing the ordinary CI gate.
 
 As the workspace decomposes into crates (per the architecture RFC), add per-crate checks. A change to `crates/zeroclaw-api` should run that crate's test suite independently.
 

--- a/docs/book/src/maintainers/ci-and-actions.md
+++ b/docs/book/src/maintainers/ci-and-actions.md
@@ -84,6 +84,18 @@ This workflow does not currently apply `risk:*`, `size:*`, `type:*`, contributor
 
 Dependabot has separate label configuration in `.github/dependabot.yml` for its own PRs. Cargo update PRs start with `dependencies`; GitHub Actions and Docker update PRs start with `ci` and `dependencies`.
 
+### PR Risk Policy (`pr-risk-policy.yml`)
+
+Pull request updates and label changes trigger `pull_request_target` only in the no-permission `pr-risk-policy-review-signal.yml`, so the fixed signal definition comes from the trusted default branch; formal review submissions or dismissals trigger the same inert signal through `pull_request_review`. The signal has empty token permissions, performs no checkout, and emits no artifact. For the trusted target event, its fixed run title carries only GitHub's pull request number and exact 40-hex head SHA. For review events, the privileged consumer ignores the merge-commit workflow title and requires GitHub's native run-to-PR association. Completion triggers the privileged default-branch policy workflow through `workflow_run`, which rejects unsupported event sources and strictly validates the identity appropriate to the source event. The privileged workflow never downloads signal artifacts, checks out contributor code, or executes contributor-controlled content. It resolves the live pull request through the GitHub API, loads the policy helper, `.github/risk-labeler.yml`, and the published Core Team summary from the default branch, evaluates current API state, and writes the stable `zeroclaw/pr-risk-policy` status on the exact live head. The encoded target-event head is used only for a bounded error status when live pull request resolution itself fails; a review signal without native association or live resolution fails without writing a status, and manual dispatch is the recovery path.
+
+Pull requests without `risk:high` or `domain:security` pass the conditional approval gate. Pull requests carrying either label pass only with two distinct Core Team approvals on the exact head. Automated reviews do not count. `risk:manual` prevents future automatic replacement of a maintainer's risk choice, but it does not suppress this approval requirement.
+
+The same run emits a report-only risk recommendation and evidence. It does not add, remove, or replace labels. `.github/risk-labeler.yml` uses the `actions/labeler` path dialect for deterministic high-risk path evidence, and the helper applies the narrow #9530 production-inert test-only exception only when the complete changed-line context proves every high-risk Rust change stays inside an existing `#[cfg(test)]` item or module. Missing or ambiguous evidence remains high risk.
+
+When the trusted policy, helper, event-signal workflow, or Core Team summary changes on `master`, the workflow reevaluates every open pull request so an old green status cannot outlive its authority inputs. Manual dispatch reevaluates one named pull request and is the fail-closed recovery path if event-run association is unavailable.
+
+The workflow status is advisory until a separately approved repository ruleset requires `zeroclaw/pr-risk-policy` on `master`. Source changes must not describe the policy as merge-enforcing before that repository setting is active.
+
 ### Project Dashboard Planner (`project-dashboard-plan.yml`)
 
 Runs manually for a single issue number. It reads issue state and labels, then writes a report-only step summary proposing the existing Project Status value that best matches the issue.

--- a/docs/book/src/maintainers/pr-workflow.md
+++ b/docs/book/src/maintainers/pr-workflow.md
@@ -114,6 +114,7 @@ Branch protection on `master`:
 
 - Require status checks before merge.
 - Require check `CI Required Gate`.
+- Require check `zeroclaw/pr-risk-policy` after the workflow has landed and a separate repository-ruleset change has been approved. The check passes ordinary PRs and conditionally requires two exact-head Core Team approvals for PRs carrying `risk:high` or `domain:security`.
 - Require pull request reviews before merge.
 - Require CODEOWNERS review for protected paths. `.github/**` (including `.github/workflows/**`) is owned by the maintainers listed in `.github/CODEOWNERS`, so workflow changes need an owning maintainer's review.
 - Keep branch / ruleset bypass limited to org owners.
@@ -137,6 +138,7 @@ Before requesting review, the PR has all of these:
 Before merge:
 
 - `CI Required Gate` is green.
+- `zeroclaw/pr-risk-policy` is green once it is configured as a required status check.
 - Required reviewers approved (including any CODEOWNERS paths); a PR carrying `risk:high` or `domain:security` has two independent Core Team approvals.
 - Risk labels match the actual diff and consequence rather than broad component location. See [Labels](./labels.md).
 - Migration / compatibility impact is documented.
@@ -148,6 +150,7 @@ Every merge:
 
 - Scope is focused and understandable.
 - CI gate is green.
+- `zeroclaw/pr-risk-policy` is green once it is configured as a required status check.
 - Docs-quality checks are green when docs changed.
 - Security and privacy fields are complete; evidence is redacted / anonymized.
 - A PR carrying `risk:high` or `domain:security` has two independent Core Team approvals; automated review does not count.

--- a/scripts/github/pr_risk_policy.py
+++ b/scripts/github/pr_risk_policy.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Evaluate the report-only pull-request risk and approval policy."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+from datetime import datetime, timezone
+from functools import lru_cache
+import html
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode, urljoin
+from urllib.request import Request, urlopen
+
+
+DEFAULT_REPOSITORY = "zeroclaw-labs/zeroclaw"
+DEFAULT_STATUS_CONTEXT = "zeroclaw/pr-risk-policy"
+PAGE_SIZE = 100
+MAX_PAGES = 1000
+MAX_PR_FILES = 3000
+HIGH_LABEL = "risk:high"
+MANUAL_LABEL = "risk:manual"
+SECURITY_LABEL = "domain:security"
+RISK_LABELS = {"risk:low", "risk:medium", HIGH_LABEL, MANUAL_LABEL}
+DECISIVE_STATES = {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
+NONDECISIVE_STATES = {"COMMENTED", "PENDING"}
+LOW_PATH_GLOBS = (
+    "docs/**",
+    "**/*.md",
+    "**/*.mdx",
+    "LICENSE",
+    ".markdownlint-cli2.yaml",
+    "locales/**",
+    "**/locales/**",
+    "**/fixtures/**",
+    "fixtures/**",
+    "**/__fixtures__/**",
+    ".editorconfig",
+    ".gitattributes",
+    ".gitignore",
+)
+RUST_SUFFIX = ".rs"
+CFG_TEST_RE = re.compile(r"^\s*#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
+CFG_BOUNDARY_RE = re.compile(r"(?:#\s*\[\s*cfg\b|\bcfg\s*(?:!|_attr\s*\())")
+HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+HANDLE_RE = re.compile(r"^\[@([A-Za-z0-9][A-Za-z0-9-]*)\]\([^)]*\)$")
+RAW_STRING_START_RE = re.compile(r'(?:br|cr|r)(?P<hashes>#{0,255})"')
+CHAR_LITERAL_RE = re.compile(r"'(?:\\(?:[nrt0\\'\"]|x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f_]{1,6}\})|[^\\'\n])'")
+
+
+class PolicyError(RuntimeError):
+    """An API, policy, roster, patch, or source input was not trustworthy."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PolicyError(message)
+
+
+def normalize_path(value: str) -> str:
+    require(isinstance(value, str), "invalid file path")
+    path = value.replace("\\", "/")
+    require(path and not path.startswith("/") and "\x00" not in path, "invalid file path")
+    require(all(part not in {"", ".", ".."} for part in path.split("/")), "invalid file path")
+    return path
+
+
+def parse_json_file(path: Path, description: str) -> Any:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            return json.load(stream)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PolicyError(f"invalid {description}") from exc
+
+
+def load_policy(path: Path) -> tuple[str, ...]:
+    payload = parse_json_file(path, "risk policy")
+    require(isinstance(payload, dict) and set(payload) == {HIGH_LABEL}, "risk policy shape is invalid")
+    rules = payload[HIGH_LABEL]
+    require(isinstance(rules, list) and rules, "risk policy has no high-risk rules")
+    globs: list[str] = []
+    for rule in rules:
+        require(isinstance(rule, dict) and set(rule) == {"changed-files"}, "risk policy rule is invalid")
+        changed_files = rule["changed-files"]
+        require(
+            isinstance(changed_files, dict) and set(changed_files) == {"any-glob-to-any-file"},
+            "risk policy changed-files rule is invalid",
+        )
+        values = changed_files["any-glob-to-any-file"]
+        require(isinstance(values, list) and values, "risk policy glob list is empty")
+        for value in values:
+            require(isinstance(value, str) and value and "\x00" not in value, "risk policy glob is invalid")
+            globs.append(value)
+    require(len(globs) == len(set(globs)), "risk policy contains duplicate globs")
+    return tuple(globs)
+
+
+def parse_table_cells(line: str) -> list[str] | None:
+    if not line.strip().startswith("|"):
+        return None
+    cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+    return cells if cells else None
+
+
+def load_core_roster(path: Path) -> set[str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise PolicyError("Core roster cannot be read") from exc
+
+    table_starts: list[int] = []
+    for index, line in enumerate(lines[:-1]):
+        cells = parse_table_cells(line)
+        next_cells = parse_table_cells(lines[index + 1])
+        if not cells or len(cells) < 2 or not next_cells or len(next_cells) < 2:
+            continue
+        if cells[0].casefold() == "handle" and cells[1].casefold() == "role":
+            if all(re.fullmatch(r":?-{3,}:?", cell) for cell in next_cells[: len(cells)]):
+                table_starts.append(index + 2)
+    require(len(table_starts) == 1, "Core roster table is missing or ambiguous")
+
+    roster: set[str] = set()
+    saw_core = False
+    for line in lines[table_starts[0] :]:
+        cells = parse_table_cells(line)
+        if cells is None:
+            break
+        require(len(cells) >= 2, "Core roster row is malformed")
+        role = cells[1]
+        if not re.fullmatch(r"Core Team(?:,.*)?", role):
+            continue
+        saw_core = True
+        match = HANDLE_RE.fullmatch(cells[0])
+        require(match is not None, "Core roster handle is malformed")
+        handle = match.group(1).casefold()
+        require(handle not in roster, "Core roster contains a duplicate")
+        roster.add(handle)
+    require(saw_core and roster, "Core roster is empty")
+    return roster
+
+
+def labels_from_pr(pr: dict[str, Any]) -> set[str]:
+    values = pr.get("labels")
+    require(isinstance(values, list), "PR labels are malformed")
+    names: set[str] = set()
+    for value in values:
+        require(isinstance(value, dict) and isinstance(value.get("name"), str) and value["name"], "PR label is malformed")
+        names.add(value["name"])
+    return names
+
+
+def parse_sha(value: Any, description: str) -> str:
+    require(isinstance(value, str) and re.fullmatch(r"[0-9a-fA-F]{40}", value) is not None, f"{description} is missing")
+    return value
+
+
+def parse_pr_metadata(pr: Any) -> tuple[str, str, set[str], int]:
+    require(isinstance(pr, dict), "PR metadata is malformed")
+    head = pr.get("head")
+    base = pr.get("base")
+    require(isinstance(head, dict) and isinstance(base, dict), "PR refs are malformed")
+    changed_files = pr.get("changed_files")
+    require(isinstance(changed_files, int) and changed_files >= 0, "PR changed-files count is malformed")
+    return parse_sha(head.get("sha"), "PR head SHA"), parse_sha(base.get("sha"), "PR base SHA"), labels_from_pr(pr), changed_files
+
+
+def parse_timestamp(value: Any) -> datetime:
+    require(isinstance(value, str), "review timestamp is missing")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise PolicyError("review timestamp is malformed") from exc
+    require(parsed.tzinfo is not None, "review timestamp has no timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def review_login(review: dict[str, Any]) -> str:
+    user = review.get("user")
+    require(isinstance(user, dict) and isinstance(user.get("login"), str) and user["login"], "review author is malformed")
+    return user["login"]
+
+
+def validate_reviews(reviews: Iterable[Any]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for review in reviews:
+        require(isinstance(review, dict), "review record is malformed")
+        require(isinstance(review.get("id"), int) and review["id"] >= 0, "review ID is malformed")
+        state = review.get("state")
+        require(isinstance(state, str) and state.upper() in DECISIVE_STATES | NONDECISIVE_STATES, "review state is malformed")
+        review_login(review)
+        if state.upper() in DECISIVE_STATES:
+            parse_timestamp(review.get("submitted_at"))
+            parse_sha(review.get("commit_id"), "review commit SHA")
+        result.append(review)
+    return result
+
+
+def review_snapshot(reviews: Iterable[dict[str, Any]]) -> tuple[tuple[Any, ...], ...]:
+    return tuple(
+        sorted(
+            (
+                int(review["id"]),
+                review_login(review).casefold(),
+                str(review["state"]).upper(),
+                review.get("commit_id"),
+                review.get("submitted_at"),
+            )
+            for review in reviews
+        )
+    )
+
+
+def latest_decisive_reviews(reviews: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, tuple[tuple[datetime, int], dict[str, Any]]] = {}
+    for review in reviews:
+        state = str(review["state"]).upper()
+        if state not in DECISIVE_STATES:
+            continue
+        reviewer = review_login(review).casefold()
+        key = (parse_timestamp(review["submitted_at"]), int(review.get("id") or 0))
+        if reviewer not in latest or key >= latest[reviewer][0]:
+            latest[reviewer] = (key, review)
+    return {reviewer: review for reviewer, (_, review) in latest.items()}
+
+
+def is_high_path(path: str, high_globs: Iterable[str]) -> list[str]:
+    return [pattern for pattern in high_globs if glob_matches(path, pattern)]
+
+
+@lru_cache(maxsize=None)
+def glob_regex(pattern: str) -> re.Pattern[str]:
+    parts: list[str] = []
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            parts.append("(?:.*/)?")
+            index += 3
+        elif pattern.startswith("**", index):
+            parts.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            parts.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            parts.append("[^/]")
+            index += 1
+        elif pattern[index] == "[":
+            end = pattern.find("]", index + 1)
+            if end == -1:
+                parts.append(r"\[")
+                index += 1
+            else:
+                parts.append(pattern[index : end + 1])
+                index = end + 1
+        else:
+            parts.append(re.escape(pattern[index]))
+            index += 1
+    return re.compile("^" + "".join(parts) + "$")
+
+
+def glob_matches(path: str, pattern: str) -> bool:
+    return glob_regex(pattern).match(path) is not None
+
+
+def is_low_path(path: str) -> bool:
+    return any(glob_matches(path, pattern) for pattern in LOW_PATH_GLOBS)
+
+
+def item_paths(item: dict[str, Any]) -> tuple[str, ...]:
+    current = normalize_path(item["filename"])
+    if item.get("status") != "renamed":
+        return (current,)
+    previous = normalize_path(item.get("previous_filename"))
+    return (current, previous)
+
+
+def validate_files(files: Any, expected_count: int) -> list[dict[str, Any]]:
+    require(0 < expected_count <= MAX_PR_FILES, "PR file count exceeds the complete API boundary")
+    require(isinstance(files, list) and len(files) == expected_count, "PR file list is incomplete")
+    result: list[dict[str, Any]] = []
+    for item in files:
+        require(isinstance(item, dict), "PR file record is malformed")
+        filename = item.get("filename")
+        status = item.get("status")
+        require(isinstance(filename, str) and filename, "PR filename is missing")
+        require(isinstance(status, str) and status in {"added", "modified", "removed", "renamed", "copied"}, "PR file status is malformed")
+        normalize_path(filename)
+        if status == "renamed":
+            normalize_path(item.get("previous_filename"))
+        for key in ("additions", "deletions", "changes"):
+            require(isinstance(item.get(key), int) and item[key] >= 0, "PR file counts are malformed")
+        if "patch" in item:
+            require(item["patch"] is None or isinstance(item["patch"], str), "PR patch is malformed")
+        result.append(item)
+    return result
+
+
+def changed_lines(patch: str) -> tuple[list[int], list[int], bool]:
+    old_changed, new_changed, saw_hunk = changed_line_content(patch)
+    return [line for line, _ in old_changed], [line for line, _ in new_changed], saw_hunk
+
+
+def changed_line_content(patch: str) -> tuple[list[tuple[int, str]], list[tuple[int, str]], bool]:
+    old_line = new_line = 0
+    old_changed: list[tuple[int, str]] = []
+    new_changed: list[tuple[int, str]] = []
+    saw_hunk = False
+    for line in patch.splitlines():
+        match = HUNK_RE.match(line)
+        if match:
+            old_line = int(match.group(1))
+            new_line = int(match.group(3))
+            saw_hunk = True
+            continue
+        if not saw_hunk or line.startswith("\\"):
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            new_changed.append((new_line, line[1:]))
+            new_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            old_changed.append((old_line, line[1:]))
+            old_line += 1
+        else:
+            old_line += 1
+            new_line += 1
+    return old_changed, new_changed, saw_hunk
+
+
+def source_text(payload: Any) -> str:
+    require(isinstance(payload, dict), "source response is malformed")
+    encoding = payload.get("encoding")
+    content = payload.get("content")
+    require(encoding == "base64" and isinstance(content, str), "source response is incomplete")
+    try:
+        return base64.b64decode("".join(content.split()), validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise PolicyError("source response is not valid UTF-8") from exc
+
+
+def rust_structural_text(source: str) -> str:
+    """Blank Rust comments and literals while preserving code positions."""
+
+    output = list(source)
+
+    def blank(start: int, end: int) -> None:
+        for position in range(start, end):
+            if output[position] not in {"\n", "\r"}:
+                output[position] = " "
+
+    index = 0
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end == -1 else end
+            blank(index, end)
+            index = end
+            continue
+
+        if source.startswith("/*", index):
+            depth = 1
+            end = index + 2
+            while end < len(source) and depth:
+                if source.startswith("/*", end):
+                    depth += 1
+                    end += 2
+                elif source.startswith("*/", end):
+                    depth -= 1
+                    end += 2
+                else:
+                    end += 1
+            require(depth == 0, "Rust source has an unterminated block comment")
+            blank(index, end)
+            index = end
+            continue
+
+        raw = RAW_STRING_START_RE.match(source, index)
+        if raw and (index == 0 or not (source[index - 1].isalnum() or source[index - 1] == "_")):
+            terminator = '"' + raw.group("hashes")
+            end = source.find(terminator, raw.end())
+            require(end != -1, "Rust source has an unterminated raw string")
+            end += len(terminator)
+            blank(index, end)
+            index = end
+            continue
+
+        if source[index] == '"':
+            end = index + 1
+            escaped = False
+            while end < len(source):
+                character = source[end]
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == '"':
+                    end += 1
+                    break
+                end += 1
+            require(end <= len(source) and source[end - 1] == '"', "Rust source has an unterminated string")
+            blank(index, end)
+            index = end
+            continue
+
+        if source[index] == "'":
+            character = CHAR_LITERAL_RE.match(source, index)
+            if character:
+                blank(index, character.end())
+                index = character.end()
+                continue
+
+        index += 1
+    return "".join(output)
+
+
+def cfg_test_ranges(source: str) -> list[tuple[int, int]]:
+    lines = source.splitlines()
+    structural_lines = rust_structural_text(source).splitlines()
+    ranges: list[tuple[int, int]] = []
+    for index, line in enumerate(lines):
+        if not CFG_TEST_RE.match(line):
+            continue
+        next_index = index + 1
+        while next_index < len(lines) and not lines[next_index].strip():
+            next_index += 1
+        require(next_index < len(lines), "cfg(test) item is incomplete")
+        if "{" not in structural_lines[next_index]:
+            end = next_index
+            while end < len(lines) and ";" not in structural_lines[end]:
+                end += 1
+            require(end < len(lines), "cfg(test) item has no end")
+            ranges.append((index + 1, end + 1))
+            continue
+
+        depth = 0
+        opened = False
+        end = next_index
+        for line_index in range(next_index, len(lines)):
+            for character in structural_lines[line_index]:
+                if character == "{":
+                    depth += 1
+                    opened = True
+                elif character == "}" and opened:
+                    depth -= 1
+            if opened and depth == 0:
+                end = line_index
+                break
+        require(opened and depth == 0, "cfg(test) item has unbalanced braces")
+        ranges.append((index + 1, end + 1))
+    return ranges
+
+
+def line_in_ranges(line_number: int, ranges: Iterable[tuple[int, int]]) -> bool:
+    return any(start <= line_number <= end for start, end in ranges)
+
+
+def strict_test_only_proof(files: list[dict[str, Any]], high_globs: tuple[str, ...], api: Any, base_sha: str, head_sha: str) -> tuple[bool, str]:
+    rust_files = [item for item in files if normalize_path(item["filename"]).endswith(RUST_SUFFIX) and is_high_path(normalize_path(item["filename"]), high_globs)]
+    if not rust_files:
+        return False, "no canonical high-risk Rust file"
+    if any(item["status"] != "modified" for item in rust_files):
+        return False, "Rust test-only proof requires an unchanged file path"
+    for item in files:
+        paths = item_paths(item)
+        if paths[0] in {normalize_path(rust["filename"]) for rust in rust_files}:
+            continue
+        if not all(is_low_path(path) for path in paths):
+            return False, "non-test or non-low file is present"
+
+    for item in rust_files:
+        patch = item.get("patch")
+        if not isinstance(patch, str) or patch.endswith("..."):
+            return False, "complete Rust patch is unavailable"
+        old_changed, new_changed, saw_hunk = changed_lines(patch)
+        if not saw_hunk:
+            return False, "Rust patch has no complete hunks"
+        additions = sum(1 for line in patch.splitlines() if line.startswith("+") and not line.startswith("+++"))
+        deletions = sum(1 for line in patch.splitlines() if line.startswith("-") and not line.startswith("---"))
+        if not old_changed and not new_changed:
+            return False, "Rust patch has no changed lines"
+        if additions != item["additions"] or deletions != item["deletions"] or item["changes"] != additions + deletions:
+            return False, "Rust patch is truncated"
+        changed_text = [line[1:] for line in patch.splitlines() if (line.startswith("+") and not line.startswith("+++")) or (line.startswith("-") and not line.startswith("---"))]
+        if any(CFG_BOUNDARY_RE.search(line) for line in changed_text):
+            return False, "conditional-compilation boundary changed"
+
+        current_path = normalize_path(item["filename"])
+        previous_path = current_path
+        base_source = source_text(api.get_source(previous_path, base_sha))
+        head_source = source_text(api.get_source(current_path, head_sha))
+        old_content, new_content, _ = changed_line_content(patch)
+        base_lines = base_source.splitlines()
+        head_lines = head_source.splitlines()
+        for line_number, content in old_content:
+            require(1 <= line_number <= len(base_lines) and base_lines[line_number - 1] == content, "Rust patch does not match base source")
+        for line_number, content in new_content:
+            require(1 <= line_number <= len(head_lines) and head_lines[line_number - 1] == content, "Rust patch does not match head source")
+        if not all(line_in_ranges(line, cfg_test_ranges(base_source)) for line in old_changed):
+            return False, "deleted Rust line is outside an existing cfg(test) item"
+        if not all(line_in_ranges(line, cfg_test_ranges(head_source)) for line in new_changed):
+            return False, "added Rust line is outside an existing cfg(test) item"
+    return True, "complete diff is confined to existing cfg(test) items"
+
+
+def classify(files: list[dict[str, Any]], high_globs: tuple[str, ...], api: Any, base_sha: str, head_sha: str) -> dict[str, Any]:
+    evidence: list[dict[str, Any]] = []
+    high_matches = []
+    for item in files:
+        for filename in item_paths(item):
+            patterns = is_high_path(filename, high_globs)
+            if patterns:
+                high_matches.append(filename)
+                evidence.append({"path": filename, "high_globs": patterns})
+    if high_matches:
+        exception, detail = strict_test_only_proof(files, high_globs, api, base_sha, head_sha)
+        return {
+            "proposed_risk": "risk:medium" if exception else HIGH_LABEL,
+            "matching_evidence": evidence,
+            "exception_9530": {"applied": exception, "detail": detail},
+        }
+    if all(all(is_low_path(path) for path in item_paths(item)) for item in files):
+        return {"proposed_risk": "risk:low", "matching_evidence": [], "exception_9530": {"applied": False, "detail": "not applicable"}}
+    return {"proposed_risk": "risk:medium", "matching_evidence": [], "exception_9530": {"applied": False, "detail": "not applicable"}}
+
+
+def approval_state(reviews: list[dict[str, Any]], roster: set[str], head_sha: str) -> dict[str, Any]:
+    latest = latest_decisive_reviews(reviews)
+    current: list[str] = []
+    latest_states: dict[str, str] = {}
+    for reviewer, review in sorted(latest.items()):
+        state = str(review["state"]).upper()
+        latest_states[reviewer] = state
+        if reviewer in roster and state == "APPROVED" and review.get("commit_id") == head_sha:
+            current.append(reviewer)
+    return {
+        "required": 2,
+        "current_head_core_approvals": sorted(current),
+        "count": len(current),
+        "latest_decisive_states": latest_states,
+        "passed": len(current) >= 2,
+    }
+
+
+def build_report(
+    pr: dict[str, Any],
+    reviews: list[dict[str, Any]],
+    roster: set[str],
+    classification: dict[str, Any],
+) -> dict[str, Any]:
+    head_sha, _, live_labels, _ = parse_pr_metadata(pr)
+    approvals = approval_state(reviews, roster, head_sha)
+    manual = MANUAL_LABEL in live_labels
+    security = SECURITY_LABEL in live_labels
+    triggered = HIGH_LABEL in live_labels or security
+    current_risk = sorted(live_labels & {"risk:low", "risk:medium", HIGH_LABEL})
+    mismatches: list[str] = []
+    if len(current_risk) > 1:
+        mismatches.append("multiple current risk labels")
+    if current_risk and classification["proposed_risk"] not in current_risk and not manual:
+        mismatches.append("proposed risk differs from current risk label")
+    if manual and current_risk and classification["proposed_risk"] not in current_risk:
+        mismatches.append("risk:manual freezes the proposed replacement")
+    return {
+        "head_sha": head_sha,
+        "proposed_risk": classification["proposed_risk"],
+        "matching_evidence": classification["matching_evidence"],
+        "current_risk": current_risk,
+        "risk_manual": manual,
+        "mutation_freeze": manual,
+        "domain_security": security,
+        "approval_gate": {"triggered": triggered, **approvals},
+        "mismatches": mismatches,
+        "exception_9530": classification["exception_9530"],
+    }
+
+
+class GitHubAPI:
+    """Small read/write GitHub REST client used by the trusted workflow."""
+
+    def __init__(self, repository: str, token: str, api_url: str | None = None) -> None:
+        require(repository and token, "GitHub API credentials are missing")
+        self.repository = repository
+        self.base_url = (api_url or os.environ.get("GITHUB_API_URL", "https://api.github.com")).rstrip("/")
+        self.token = token
+
+    def request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+        url = urljoin(self.base_url + "/", path.lstrip("/"))
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        request = Request(
+            url,
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": "zeroclaw-pr-risk-policy",
+                **({"Content-Type": "application/json"} if body is not None else {}),
+            },
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                raw = response.read()
+        except (HTTPError, URLError, TimeoutError) as exc:
+            raise PolicyError("GitHub API request failed") from exc
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PolicyError("GitHub API returned invalid JSON") from exc
+
+    def get_pull(self, number: int) -> Any:
+        return self.request("GET", f"/repos/{self.repository}/pulls/{number}")
+
+    def paginate(self, path: str) -> list[Any]:
+        values: list[Any] = []
+        for page in range(1, MAX_PAGES + 1):
+            separator = "&" if "?" in path else "?"
+            payload = self.request("GET", f"{path}{separator}{urlencode({'per_page': PAGE_SIZE, 'page': page})}")
+            require(isinstance(payload, list), "GitHub paginated response is malformed")
+            values.extend(payload)
+            if len(payload) < PAGE_SIZE:
+                return values
+        raise PolicyError("GitHub pagination did not terminate")
+
+    def get_source(self, path: str, revision: str) -> Any:
+        encoded = "/".join(quote(part, safe="") for part in path.split("/"))
+        return self.request("GET", f"/repos/{self.repository}/contents/{encoded}?{urlencode({'ref': revision})}")
+
+    def create_status(self, sha: str, state: str, description: str, context: str) -> Any:
+        require(state in {"success", "failure", "error", "pending"}, "status state is invalid")
+        return self.request(
+            "POST",
+            f"/repos/{self.repository}/statuses/{sha}",
+            {"state": state, "context": context, "description": description[:140]},
+        )
+
+
+def evaluate(api: Any, pr_number: int, policy_path: Path, roster_path: Path) -> dict[str, Any]:
+    high_globs = load_policy(policy_path)
+    roster = load_core_roster(roster_path)
+    pr = api.get_pull(pr_number)
+    head_sha, base_sha, live_labels, changed_file_count = parse_pr_metadata(pr)
+    files = validate_files(api.paginate(f"/repos/{api.repository}/pulls/{pr_number}/files"), changed_file_count)
+    classification = classify(files, high_globs, api, base_sha, head_sha)
+    reviews = validate_reviews(api.paginate(f"/repos/{api.repository}/pulls/{pr_number}/reviews"))
+    latest_pr = api.get_pull(pr_number)
+    latest_head, latest_base, latest_labels, latest_file_count = parse_pr_metadata(latest_pr)
+    require(
+        (latest_head, latest_base, latest_labels, latest_file_count) == (head_sha, base_sha, live_labels, changed_file_count),
+        "PR metadata changed during evaluation",
+    )
+    latest_reviews = validate_reviews(api.paginate(f"/repos/{api.repository}/pulls/{pr_number}/reviews"))
+    require(review_snapshot(latest_reviews) == review_snapshot(reviews), "PR reviews changed during evaluation")
+    report = build_report(latest_pr, latest_reviews, roster, classification)
+    report["status"] = "success" if not report["approval_gate"]["triggered"] or report["approval_gate"]["passed"] else "failure"
+    report["status_description"] = (
+        "Risk policy passed" if report["status"] == "success" else f"Two distinct exact-head Core approvals required ({report['approval_gate']['count']}/2)"
+    )
+    require(report["head_sha"] == head_sha, "PR head changed during evaluation")
+    return report
+
+
+def write_summary(path: Path, report: dict[str, Any]) -> None:
+    serialized = html.escape(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True))
+    path.write_text(f"## PR risk policy report\n\n<pre>{serialized}</pre>\n", encoding="utf-8")
+
+
+def known_event_head() -> str | None:
+    value = os.environ.get("PR_HEAD_SHA")
+    return value if value and re.fullmatch(r"[0-9a-fA-F]{40}", value) else None
+
+
+def main(argv: list[str] | None = None, api: Any | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--roster", type=Path, required=True)
+    parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
+    parser.add_argument("--status-context", default=DEFAULT_STATUS_CONTEXT)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("--allow-policy-failure", action="store_true")
+    args = parser.parse_args(argv)
+    require(args.pr_number > 0, "PR number is invalid")
+    client = api or GitHubAPI(args.repository, os.environ.get("GH_TOKEN", ""))
+    known_head = known_event_head()
+    try:
+        if known_head:
+            client.create_status(known_head, "pending", "Risk policy evaluating", args.status_context)
+        report = evaluate(client, args.pr_number, args.policy, args.roster)
+        if args.summary:
+            write_summary(args.summary, report)
+        client.create_status(report["head_sha"], report["status"], report["status_description"], args.status_context)
+        print(json.dumps(report, sort_keys=True, ensure_ascii=True))
+        return 0 if report["status"] == "success" or args.allow_policy_failure else 1
+    except Exception:  # Convert every evaluation failure to a bounded error status.
+        head = known_head
+        if head is None:
+            try:
+                metadata = client.get_pull(args.pr_number)
+                candidate = metadata.get("head", {}).get("sha") if isinstance(metadata, dict) else None
+                head = candidate if isinstance(candidate, str) and re.fullmatch(r"[0-9a-fA-F]{40}", candidate) else None
+            except Exception:
+                head = None
+        report = {"status": "error", "status_description": "Risk policy evaluation failed", "error": "evaluation failed"}
+        if head:
+            try:
+                client.create_status(head, "error", report["status_description"], args.status_context)
+            except Exception:
+                pass
+        if args.summary:
+            try:
+                write_summary(args.summary, report)
+            except OSError:
+                pass
+        print(json.dumps(report, sort_keys=True, ensure_ascii=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github/pr_risk_policy_test.py
+++ b/scripts/github/pr_risk_policy_test.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Focused tests for the report-only pull-request risk policy."""
+
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+import re
+import tempfile
+import unittest
+from unittest import mock
+
+try:
+    from scripts.github import pr_risk_policy as policy
+except ModuleNotFoundError:
+    import pr_risk_policy as policy
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / ".github/risk-labeler.yml"
+POLICY_WORKFLOW_PATH = ROOT / ".github/workflows/pr-risk-policy.yml"
+SIGNAL_WORKFLOW_PATH = ROOT / ".github/workflows/pr-risk-policy-review-signal.yml"
+HEAD = "a" * 40
+BASE = "b" * 40
+SIGNAL_TITLE_RE = re.compile(r"^PR Risk Event Signal pr=([1-9][0-9]*) head=([0-9a-fA-F]{40})$")
+
+
+def resolve_signal_identity(source_event: str, title: str, native_pr_number: str = "") -> tuple[int, str | None]:
+    if source_event == "pull_request_target":
+        match = SIGNAL_TITLE_RE.fullmatch(title)
+        if match is None:
+            raise ValueError("malformed signal identity")
+        pr_number = int(match.group(1))
+        if native_pr_number and native_pr_number != str(pr_number):
+            raise ValueError("signal association mismatch")
+        return pr_number, match.group(2)
+    if source_event == "pull_request_review":
+        if re.fullmatch(r"[1-9][0-9]*", native_pr_number) is None:
+            raise ValueError("review signal has no native association")
+        return int(native_pr_number), None
+    raise ValueError("unsupported signal source")
+
+
+def pull(labels: list[str] | None = None, **extra: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "head": {"sha": HEAD},
+        "base": {"sha": BASE},
+        "labels": [{"name": label} for label in labels or []],
+        "changed_files": 1,
+    }
+    value.update(extra)
+    return value
+
+
+def changed_file(path: str, additions: int = 1, deletions: int = 0, patch: str | None = None, **extra: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "filename": path,
+        "status": "modified",
+        "additions": additions,
+        "deletions": deletions,
+        "changes": additions + deletions,
+        "patch": patch,
+    }
+    value.update(extra)
+    return value
+
+
+def review(login: str, state: str = "APPROVED", commit: str = HEAD, review_id: int = 1, submitted_at: str | None = None) -> dict[str, object]:
+    return {
+        "id": review_id,
+        "user": {"login": login},
+        "state": state,
+        "commit_id": commit,
+        "submitted_at": submitted_at or f"2026-08-2{review_id}T00:00:00Z",
+    }
+
+
+class FakeAPI:
+    repository = "zeroclaw-labs/zeroclaw"
+
+    def __init__(self, pr: dict[str, object], files: list[dict[str, object]], reviews: list[dict[str, object]] | None = None) -> None:
+        self.pr = pr
+        self.files = files
+        self.pr["changed_files"] = len(files)
+        self.reviews = reviews or []
+        self.sources: dict[tuple[str, str], dict[str, str]] = {}
+        self.statuses: list[tuple[str, str, str, str]] = []
+
+    def get_pull(self, number: int) -> dict[str, object]:
+        return self.pr
+
+    def paginate(self, path: str) -> list[dict[str, object]]:
+        if path.endswith("/files"):
+            return self.files
+        if path.endswith("/reviews"):
+            return self.reviews
+        raise AssertionError(path)
+
+    def get_source(self, path: str, revision: str) -> dict[str, str]:
+        return self.sources[(path, revision)]
+
+    def add_source(self, path: str, revision: str, content: str) -> None:
+        self.sources[(path, revision)] = {"encoding": "base64", "content": base64.b64encode(content.encode()).decode()}
+
+    def create_status(self, sha: str, state: str, description: str, context: str) -> None:
+        self.statuses.append((sha, state, description, context))
+
+
+def roster_file(directory: Path, text: str | None = None) -> Path:
+    path = directory / "communication.md"
+    path.write_text(
+        text
+        or "| Handle | Role | Focus |\n|---|---|---|\n| [@core-one](https://example.invalid/one) | Core Team | Runtime |\n| [@core-two](https://example.invalid/two) | Core Team | Docs |\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def evaluate(api: FakeAPI) -> dict[str, object]:
+    with tempfile.TemporaryDirectory() as directory:
+        return policy.evaluate(api, 1, POLICY_PATH, roster_file(Path(directory)))
+
+
+TEST_SOURCE = """fn production() {\n    println!(\"production\");\n}\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn existing() {\n        assert_eq!(1, 1);\n    }\n}\n"""
+TEST_PATCH = """@@ -9,1 +9,1 @@\n-        assert_eq!(1, 1);\n+        assert_eq!(1, 2);\n"""
+
+
+class RiskPolicyTest(unittest.TestCase):
+    def test_policy_uses_accepted_labeler_shape_and_high_globs(self) -> None:
+        globs = policy.load_policy(POLICY_PATH)
+        self.assertIn("wit/**", globs)
+        self.assertIn(".github/workflows/*release*.yml", globs)
+        self.assertIn(".github/workflows/pr-risk-policy.yml", globs)
+        self.assertIn(".github/workflows/pr-risk-policy-review-signal.yml", globs)
+        self.assertIn("docs/book/src/contributing/communication.md", globs)
+        self.assertIn("scripts/github/pr_risk_policy.py", globs)
+        self.assertIn("crates/zeroclaw-runtime/src/security/**", globs)
+        self.assertTrue(policy.glob_matches(".github/workflows/release-stable.yml", ".github/workflows/*release*.yml"))
+        self.assertFalse(policy.glob_matches(".github/workflows/nested/release-stable.yml", ".github/workflows/*release*.yml"))
+
+    def test_high_glob_classifies_high_and_reports_evidence(self) -> None:
+        api = FakeAPI(pull(), [changed_file("wit/plugin.wit")])
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:high")
+        self.assertEqual(report["matching_evidence"][0]["path"], "wit/plugin.wit")
+
+    def test_docs_and_fixtures_are_low(self) -> None:
+        api = FakeAPI(pull(), [changed_file("docs/book/src/guide.md"), changed_file("tests/fixtures/input.json")])
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:low")
+
+    def test_ordinary_behavior_is_medium(self) -> None:
+        api = FakeAPI(pull(), [changed_file("crates/zeroclaw-providers/src/openai.rs")])
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:medium")
+
+    def test_renaming_out_of_high_boundary_stays_high(self) -> None:
+        file = changed_file("crates/zeroclaw-runtime/src/policy.rs", previous_filename="crates/zeroclaw-runtime/src/security/policy.rs", status="renamed")
+        api = FakeAPI(pull(), [file])
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:high")
+
+    def test_manual_freeze_is_reported_without_suppressing_gate(self) -> None:
+        api = FakeAPI(pull(["risk:high", "risk:manual"]), [changed_file("wit/plugin.wit")])
+        report = evaluate(api)
+        self.assertTrue(report["risk_manual"])
+        self.assertTrue(report["approval_gate"]["triggered"])
+
+    def test_security_only_label_triggers_two_approval_gate(self) -> None:
+        api = FakeAPI(pull(["domain:security"]), [changed_file("src/providers/openai.rs")], [review("core-one")])
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:medium")
+        self.assertTrue(report["approval_gate"]["triggered"])
+        self.assertFalse(report["approval_gate"]["passed"])
+
+    def test_latest_decisive_exact_head_core_reviews_only(self) -> None:
+        reviews = [
+            review("core-one", review_id=1),
+            review("core-one", state="CHANGES_REQUESTED", review_id=2),
+            review("core-two", commit="c" * 40, review_id=3),
+            review("automation-bot", review_id=4),
+            review("core-three", review_id=5),
+            review("core-two", state="PENDING", review_id=6),
+        ]
+        state = policy.approval_state(policy.validate_reviews(reviews), {"core-one", "core-two"}, HEAD)
+        self.assertEqual(state["count"], 0)
+        self.assertEqual(state["latest_decisive_states"]["core-one"], "CHANGES_REQUESTED")
+        self.assertNotIn("automation-bot", state["current_head_core_approvals"])
+
+        reviews[1] = review("core-one", state="COMMENTED", review_id=2)
+        state = policy.approval_state(policy.validate_reviews(reviews), {"core-one", "core-two"}, HEAD)
+        self.assertEqual(state["count"], 1)
+
+    def test_two_distinct_exact_head_approvals_pass(self) -> None:
+        api = FakeAPI(pull(["risk:high"]), [changed_file("wit/plugin.wit")], [review("core-one"), review("core-two", review_id=2)])
+        report = evaluate(api)
+        self.assertEqual(report["status"], "success")
+
+    def test_review_change_during_evaluation_fails_closed(self) -> None:
+        class ChangingReviewsAPI(FakeAPI):
+            review_reads = 0
+
+            def paginate(self, path: str) -> list[dict[str, object]]:
+                if not path.endswith("/reviews"):
+                    return super().paginate(path)
+                self.review_reads += 1
+                if self.review_reads == 1:
+                    return [review("core-one"), review("core-two", review_id=2)]
+                return [review("core-one"), review("core-two", state="DISMISSED", review_id=3)]
+
+        api = ChangingReviewsAPI(pull(["risk:high"]), [changed_file("wit/plugin.wit")])
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(policy.PolicyError, "reviews changed"):
+                policy.evaluate(api, 1, POLICY_PATH, roster_file(Path(directory)))
+
+    def test_malformed_api_and_roster_fail_closed(self) -> None:
+        with self.assertRaises(policy.PolicyError):
+            policy.parse_pr_metadata({"head": {"sha": HEAD}, "base": {"sha": BASE}, "labels": [{"bad": "label"}], "changed_files": 1})
+        with self.assertRaises(policy.PolicyError):
+            policy.parse_pr_metadata({"head": {"sha": "not-a-sha"}, "base": {"sha": BASE}, "labels": [], "changed_files": 1})
+        with self.assertRaises(policy.PolicyError):
+            policy.validate_files([{"filename": "src/lib.rs", "status": "modified"}], 1)
+        with tempfile.TemporaryDirectory() as directory:
+            path = roster_file(Path(directory), "| Handle | Role |\n|---|---|\n| not-a-link | Core Team |\n")
+            with self.assertRaises(policy.PolicyError):
+                policy.load_core_roster(path)
+
+            path = roster_file(Path(directory), "| Handle | Role |\n|---|---|\n| [@core-one](https://example.invalid/one) | Core Teamish |\n")
+            with self.assertRaises(policy.PolicyError):
+                policy.load_core_roster(path)
+
+            path = roster_file(
+                Path(directory),
+                "| Handle | Role |\n|---|---|\n| [@core-one](https://example.invalid/one) | Core Team |\n| [@CORE-ONE](https://example.invalid/two) | Core Team |\n",
+            )
+            with self.assertRaises(policy.PolicyError):
+                policy.load_core_roster(path)
+
+            path = roster_file(Path(directory), "| Handle | Role |\n|---|---|\n| [@community](https://example.invalid/c) | Community |\n")
+            with self.assertRaises(policy.PolicyError):
+                policy.load_core_roster(path)
+
+        class IncompleteAPI(FakeAPI):
+            def paginate(self, path: str) -> list[dict[str, object]]:
+                raise policy.PolicyError("pagination incomplete")
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(policy.PolicyError):
+                policy.evaluate(IncompleteAPI(pull(), [changed_file("docs/book/src/guide.md")]), 1, POLICY_PATH, roster_file(Path(directory)))
+
+        too_many = pull(changed_files=policy.MAX_PR_FILES + 1)
+        api = FakeAPI(too_many, [changed_file("docs/book/src/guide.md")])
+        api.pr["changed_files"] = policy.MAX_PR_FILES + 1
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(policy.PolicyError):
+                policy.evaluate(api, 1, POLICY_PATH, roster_file(Path(directory)))
+
+    def test_missing_or_truncated_patch_stays_high(self) -> None:
+        for patch, additions, changes in [(None, 1, 1), (TEST_PATCH, 2, 3)]:
+            file = changed_file("crates/zeroclaw-runtime/src/security/policy.rs", additions, 1, patch)
+            file["changes"] = changes
+            api = FakeAPI(pull(), [file])
+            report = evaluate(api)
+            self.assertEqual(report["proposed_risk"], "risk:high")
+            self.assertFalse(report["exception_9530"]["applied"])
+
+    def test_9530_positive_case_requires_complete_inert_sources(self) -> None:
+        file = changed_file("crates/zeroclaw-runtime/src/security/policy.rs", 1, 1, TEST_PATCH)
+        api = FakeAPI(pull(), [file])
+        api.add_source("crates/zeroclaw-runtime/src/security/policy.rs", BASE, TEST_SOURCE)
+        api.add_source("crates/zeroclaw-runtime/src/security/policy.rs", HEAD, TEST_SOURCE.replace("assert_eq!(1, 1)", "assert_eq!(1, 2)"))
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:medium")
+        self.assertTrue(report["exception_9530"]["applied"])
+
+    def test_9530_negative_cases_remain_high(self) -> None:
+        cases = [
+            ("@@ -1,1 +1,1 @@\n-fn production() {}\n+fn production() { println!(\"changed\"); }\n", """fn production() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn existing() {
+        assert_eq!(1, 1);
+    }
+}
+""", """fn production() { println!(\"changed\"); }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn existing() {
+        assert_eq!(1, 1);
+    }
+}
+"""),
+            ("@@ -9,1 +9,1 @@\n-        assert_eq!(1, 1);\n+        #[cfg(test)]\n", TEST_SOURCE, TEST_SOURCE),
+        ]
+        for patch, base_source, head_source in cases:
+            file = changed_file("crates/zeroclaw-runtime/src/security/policy.rs", 1, 1, patch)
+            api = FakeAPI(pull(), [file])
+            api.add_source("crates/zeroclaw-runtime/src/security/policy.rs", BASE, base_source)
+            api.add_source("crates/zeroclaw-runtime/src/security/policy.rs", HEAD, head_source)
+            report = evaluate(api)
+            self.assertEqual(report["proposed_risk"], "risk:high")
+            self.assertFalse(report["exception_9530"]["applied"])
+
+    def test_9530_lexer_does_not_extend_test_scope_across_literals_or_comments(self) -> None:
+        base_source = '''mod outer {
+    #[cfg(test)]
+    mod tests {
+        const OPEN: &str = "{";
+        const RAW: &str = r#"}"#;
+        const BRACE: char = '{';
+        /* } nested /* { */ comment */
+    }
+
+    fn production() {
+        run_old();
+        let _ = "}";
+    }
+}
+'''
+        head_source = base_source.replace("run_old();", "run_new();")
+        patch = "@@ -11,1 +11,1 @@\n-        run_old();\n+        run_new();\n"
+        file = changed_file("crates/zeroclaw-runtime/src/security/policy.rs", 1, 1, patch)
+        api = FakeAPI(pull(), [file])
+        api.add_source("crates/zeroclaw-runtime/src/security/policy.rs", BASE, base_source)
+        api.add_source("crates/zeroclaw-runtime/src/security/policy.rs", HEAD, head_source)
+        report = evaluate(api)
+        self.assertEqual(report["proposed_risk"], "risk:high")
+        self.assertFalse(report["exception_9530"]["applied"])
+
+    def test_main_publishes_one_stable_status(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            roster = roster_file(Path(directory))
+            api = FakeAPI(pull(), [changed_file("docs/book/src/guide.md")])
+            result = policy.main(
+                ["--pr-number", "1", "--policy", str(POLICY_PATH), "--roster", str(roster)],
+                api,
+            )
+        self.assertEqual(result, 0)
+        self.assertEqual(api.statuses, [(HEAD, "success", "Risk policy passed", policy.DEFAULT_STATUS_CONTEXT)])
+
+    def test_main_fails_status_for_trigger_without_two_approvals(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            roster = roster_file(Path(directory))
+            api = FakeAPI(pull(["risk:high"]), [changed_file("wit/plugin.wit")], [review("core-one")])
+            with mock.patch.dict(os.environ, {"PR_HEAD_SHA": HEAD}, clear=False):
+                result = policy.main(
+                    ["--pr-number", "1", "--policy", str(POLICY_PATH), "--roster", str(roster)],
+                    api,
+                )
+        self.assertEqual(result, 1)
+        self.assertEqual(api.statuses[0], (HEAD, "pending", "Risk policy evaluating", policy.DEFAULT_STATUS_CONTEXT))
+        self.assertEqual(api.statuses[1][0], HEAD)
+        self.assertEqual(api.statuses[1][1], "failure")
+        self.assertEqual(api.statuses[1][3], policy.DEFAULT_STATUS_CONTEXT)
+
+    def test_known_event_head_gets_pending_before_success(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            roster = roster_file(Path(directory))
+            api = FakeAPI(pull(), [changed_file("docs/book/src/guide.md")])
+            with mock.patch.dict(os.environ, {"PR_HEAD_SHA": HEAD}, clear=False):
+                result = policy.main(
+                    ["--pr-number", "1", "--policy", str(POLICY_PATH), "--roster", str(roster)],
+                    api,
+                )
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            api.statuses,
+            [
+                (HEAD, "pending", "Risk policy evaluating", policy.DEFAULT_STATUS_CONTEXT),
+                (HEAD, "success", "Risk policy passed", policy.DEFAULT_STATUS_CONTEXT),
+            ],
+        )
+
+    def test_policy_failure_can_be_reported_without_failing_reconciliation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            roster = roster_file(Path(directory))
+            api = FakeAPI(pull(["risk:high"]), [changed_file("wit/plugin.wit")], [review("core-one")])
+            result = policy.main(
+                [
+                    "--pr-number",
+                    "1",
+                    "--policy",
+                    str(POLICY_PATH),
+                    "--roster",
+                    str(roster),
+                    "--allow-policy-failure",
+                ],
+                api,
+            )
+        self.assertEqual(result, 0)
+        self.assertEqual(api.statuses[-1][1], "failure")
+
+    def test_error_status_prefers_validated_event_head(self) -> None:
+        class BrokenAPI(FakeAPI):
+            def get_pull(self, number: int) -> dict[str, object]:
+                raise policy.PolicyError("unavailable")
+
+        with tempfile.TemporaryDirectory() as directory:
+            roster = roster_file(Path(directory))
+            api = BrokenAPI(pull(), [changed_file("docs/book/src/guide.md")])
+            with mock.patch.dict(os.environ, {"PR_HEAD_SHA": HEAD}, clear=False):
+                result = policy.main(
+                    ["--pr-number", "1", "--policy", str(POLICY_PATH), "--roster", str(roster)],
+                    api,
+                )
+        self.assertEqual(result, 1)
+        self.assertEqual(
+            api.statuses,
+            [
+                (HEAD, "pending", "Risk policy evaluating", policy.DEFAULT_STATUS_CONTEXT),
+                (HEAD, "error", "Risk policy evaluation failed", policy.DEFAULT_STATUS_CONTEXT),
+            ],
+        )
+
+
+class WorkflowContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy_workflow = POLICY_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.signal_workflow = SIGNAL_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_privileged_workflow_consumes_only_trusted_events(self) -> None:
+        self.assertNotIn("pull_request_target:", self.policy_workflow)
+        self.assertNotIn("pull_request_review:", self.policy_workflow)
+        self.assertIn("workflow_run:\n    workflows: [PR Risk Event Signal]\n    types: [completed]", self.policy_workflow)
+        self.assertIn("push:\n    branches: [master]", self.policy_workflow)
+        self.assertIn("workflow_dispatch:", self.policy_workflow)
+        self.assertIn(
+            "group: pr-risk-policy-${{ needs.resolve.outputs.pr_number }}",
+            self.policy_workflow,
+        )
+        self.assertIn("cancel-in-progress: true", self.policy_workflow)
+
+    def test_signal_covers_pr_updates_and_review_changes_without_permissions(self) -> None:
+        self.assertIn("name: PR Risk Event Signal", self.signal_workflow)
+        self.assertIn(
+            "run-name: PR Risk Event Signal pr=${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}",
+            self.signal_workflow,
+        )
+        self.assertIn(
+            "pull_request_target:\n    types: [opened, synchronize, reopened, edited, converted_to_draft, ready_for_review, labeled, unlabeled]",
+            self.signal_workflow,
+        )
+        self.assertIn("pull_request_review:\n    types: [submitted, dismissed]", self.signal_workflow)
+        self.assertIn("\npermissions: {}\n", self.signal_workflow)
+        self.assertNotIn("\n  pull_request:\n", self.signal_workflow)
+
+    def test_workflows_do_not_transfer_or_execute_contributor_content(self) -> None:
+        combined = self.policy_workflow + self.signal_workflow
+        self.assertNotIn("actions/checkout", combined)
+        self.assertNotIn("download-artifact", combined)
+        self.assertNotIn("upload-artifact", combined)
+        self.assertNotIn("github.event.pull_request.head", self.policy_workflow)
+        self.assertNotIn("actions/runs/", self.policy_workflow)
+
+    def test_workflow_run_uses_its_validated_pr_association(self) -> None:
+        self.assertIn(
+            "WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}",
+            self.policy_workflow,
+        )
+        self.assertIn(
+            "WORKFLOW_RUN_TITLE: ${{ github.event.workflow_run.display_title }}",
+            self.policy_workflow,
+        )
+        self.assertIn(
+            "WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}",
+            self.policy_workflow,
+        )
+        self.assertIn(
+            r'[[ ! "$WORKFLOW_RUN_TITLE" =~ ^PR\ Risk\ Event\ Signal\ pr=([1-9][0-9]*)\ head=([0-9a-fA-F]{40})$ ]]',
+            self.policy_workflow,
+        )
+        self.assertIn('pr_number="${BASH_REMATCH[1]}"', self.policy_workflow)
+        self.assertIn('signal_head="${BASH_REMATCH[2]}"', self.policy_workflow)
+        self.assertIn('pull_request_review)', self.policy_workflow)
+        self.assertIn('pr_number="$WORKFLOW_RUN_PR_NUMBER"', self.policy_workflow)
+        self.assertIn('[[ "$pr_number" =~ ^[1-9][0-9]*$ ]]', self.policy_workflow)
+
+    def test_target_signal_fixtures_allow_trusted_title_fallback(self) -> None:
+        title = f"PR Risk Event Signal pr=42 head={HEAD}"
+        fixtures = (
+            ("normal", "42"),
+            ("fork", "42"),
+            ("dependabot", "42"),
+            ("empty-association", ""),
+        )
+        for name, native_association in fixtures:
+            with self.subTest(name=name):
+                self.assertEqual(resolve_signal_identity("pull_request_target", title, native_association), (42, HEAD))
+
+    def test_review_signal_fixtures_require_native_association_and_ignore_title(self) -> None:
+        for name in ("normal", "fork", "dependabot"):
+            with self.subTest(name=name):
+                self.assertEqual(resolve_signal_identity("pull_request_review", "attacker-controlled", "42"), (42, None))
+        with self.assertRaisesRegex(ValueError, "no native association"):
+            resolve_signal_identity("pull_request_review", f"PR Risk Event Signal pr=42 head={HEAD}", "")
+
+    def test_signal_identity_rejects_malformed_or_mismatched_values(self) -> None:
+        malformed = (
+            f"PR Risk Event Signal pr=0 head={HEAD}",
+            f"PR Risk Event Signal pr=42 head={HEAD} extra=x",
+            "PR Risk Event Signal pr=42 head=not-a-sha",
+        )
+        for title in malformed:
+            with self.subTest(title=title):
+                with self.assertRaises(ValueError):
+                    resolve_signal_identity("pull_request_target", title)
+        with self.assertRaisesRegex(ValueError, "association mismatch"):
+            resolve_signal_identity("pull_request_target", f"PR Risk Event Signal pr=42 head={HEAD}", "43")
+        with self.assertRaisesRegex(ValueError, "unsupported signal source"):
+            resolve_signal_identity("pull_request", f"PR Risk Event Signal pr=42 head={HEAD}", "42")
+
+    def test_live_resolution_failure_uses_only_encoded_head_for_error_status(self) -> None:
+        self.assertIn('statuses/$signal_head', self.policy_workflow)
+        self.assertIn("Risk policy could not resolve live PR state", self.policy_workflow)
+        self.assertIn('head_sha="$(gh api "repos/$REPOSITORY/pulls/$pr_number"', self.policy_workflow)
+        review_branch = self.policy_workflow.split("pull_request_review)", 1)[1].split(";;", 1)[0]
+        self.assertNotIn("signal_head=", review_branch)
+
+    def test_privileged_permissions_and_status_context_are_fixed(self) -> None:
+        self.assertIn(
+            "permissions:\n  contents: read\n  pull-requests: read\n  statuses: write\n",
+            self.policy_workflow,
+        )
+        self.assertIn("--status-context 'zeroclaw/pr-risk-policy'", self.policy_workflow)
+        self.assertIn("-f context='zeroclaw/pr-risk-policy'", self.policy_workflow)
+        self.assertNotIn("actions: read", self.policy_workflow)
+        self.assertNotIn("pull_request_target:", self.policy_workflow)
+
+    def test_policy_inputs_come_from_the_default_branch(self) -> None:
+        for path in (
+            "scripts/github/pr_risk_policy.py",
+            ".github/risk-labeler.yml",
+            "docs/book/src/contributing/communication.md",
+        ):
+            self.assertIn(f'fetch_trusted "{path}"', self.policy_workflow)
+        self.assertIn('contents/$path?ref=$DEFAULT_BRANCH', self.policy_workflow)
+
+    def test_open_pr_reconciliation_validates_each_live_head(self) -> None:
+        self.assertIn('[[ "$head_sha" =~ ^[0-9a-fA-F]{40}$ ]]', self.policy_workflow)
+        self.assertIn('--allow-policy-failure', self.policy_workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/github/pr_risk_policy_test.py
+++ b/scripts/github/pr_risk_policy_test.py
@@ -214,6 +214,21 @@ class RiskPolicyTest(unittest.TestCase):
             with self.assertRaisesRegex(policy.PolicyError, "reviews changed"):
                 policy.evaluate(api, 1, POLICY_PATH, roster_file(Path(directory)))
 
+    def test_head_change_during_evaluation_fails_closed(self) -> None:
+        class ChangingHeadAPI(FakeAPI):
+            pull_reads = 0
+
+            def get_pull(self, number: int) -> dict[str, object]:
+                self.pull_reads += 1
+                if self.pull_reads == 1:
+                    return super().get_pull(number)
+                return pull(["risk:high"], head={"sha": "c" * 40})
+
+        api = ChangingHeadAPI(pull(["risk:high"]), [changed_file("wit/plugin.wit")])
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(policy.PolicyError, "metadata changed"):
+                policy.evaluate(api, 1, POLICY_PATH, roster_file(Path(directory)))
+
     def test_malformed_api_and_roster_fail_closed(self) -> None:
         with self.assertRaises(policy.PolicyError):
             policy.parse_pr_metadata({"head": {"sha": HEAD}, "base": {"sha": BASE}, "labels": [{"bad": "label"}], "changed_files": 1})


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Adds a report-only risk classifier and a stable exact-head status that requires two current Core Team approvals when a PR carries `risk:high` or `domain:security`. Adds deterministic fixtures for high-risk paths, manual risk freezes, the #9530 test-only exception, malformed or incomplete API data, review changes during evaluation, and the workflow trust boundary. Documents the operational roster projection, failure behavior, rollout boundary, and later ruleset activation.
- **Scope boundary:** Does not add or replace risk labels, enable automatic risk-label mutation, change Core Team membership, alter repository rulesets, or make the new status required.
- **Blast radius:** Adds two GitHub Actions workflows, a standard-library Python policy helper, a JSON-compatible path policy, CI fixtures, and maintainer/governance documentation, and wires the fixtures and workflow YAML validation into the existing CI security job. The privileged workflow can read repository and PR metadata and write only commit statuses.
- **Linked issue(s):** Related #10185
- **Labels:** `type:ci`, `risk:high`, `size:XL`, `ci`, `docs`, `scripts`

### What this does, simply

ZeroClaw already labels pull requests by risk, and the accepted policy says high-risk or security-sensitive changes need two Core Team approvals. What was missing was a check that GitHub could evaluate consistently. This check deliberately counts only approvals on the current head so an approval cannot survive a code change.

This PR adds that check without letting contributor code run with elevated access. An inert signal notices PR or review changes with no token permissions. A separate trusted workflow reads current PR data through GitHub's API, reports the proposed risk and evidence, and updates one stable status context on the live head, publishing a pending state followed by the final result. Ordinary PRs pass the conditional approval rule; PRs labeled `risk:high` or `domain:security` pass only after two distinct current-head Core approvals.

It does not change labels automatically or activate merge enforcement by itself. The status remains advisory until maintainers separately approve a repository ruleset, after the live rollout checks are completed and recorded in #10185.

### Scope and maintenance tradeoff

The diff is `size:XL` because the fail-closed policy helper is 724 lines and its focused fixture suite is 565 lines; the workflows and docs are comparatively small. The helper uses only the Python standard library and treats incomplete file lists, malformed roster or review data, PR changes during evaluation, and ambiguous Rust test-only evidence as errors or high risk instead of guessing.

The two-workflow shape is deliberate. Directly granting status-write access to a workflow that handles pull request changes would cross the trust boundary. The no-permission signal carries no artifacts and performs no checkout; the privileged consumer loads default-branch policy inputs and live API metadata, and fetches contributor-head Rust source only as inert API text for the #9530 proof. Review-event titles are treated as untrusted and ignored.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The complete event chain activates only after these workflows land on the default branch; the pre-merge evidence is the deterministic contract suite and hosted workflow checks. A review signal without native run-to-PR association fails without writing a status, and manual dispatch is the recovery path. Live fork and Dependabot rollout verification must be completed and recorded in #10185 before ruleset activation.

### How I tested

- **CI checks relied on and why they cover this change:** Exact-head Quality Gate run `33299667797` passed all 30 jobs, including `Security` and `CI Required Gate`, on `afb0767ad3bf846b09199b3a237ce064b401a930`. `Security` ran the Python policy fixtures and workflow YAML validation. Focused local actionlint, documentation quality, and documentation link checks also passed.
- **Known CI coverage gap, if any:** Pre-merge CI cannot prove the post-land `workflow_run` chain for fork and Dependabot review events, missing native association recovery, or overlapping head/review updates. These checks must be completed and recorded in #10185 before any required-check ruleset is enabled.
- **Commands run and tail output:**

```text
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/github -p 'pr_risk_policy_test.py'
Ran 32 tests in 0.033s
OK

actionlint .github/workflows/pr-risk-policy.yml .github/workflows/pr-risk-policy-review-signal.yml
# passed with no diagnostics

DOCS_FILES='<four changed docs>' bash scripts/ci/docs_quality_gate.sh
Summary: 0 error(s)

DOCS_FILES='<four changed docs>' bash scripts/ci/docs_links_gate.sh
Collected 1 added link(s) from 4 docs file(s).
Checked 1 local docs link target(s).
No added HTTP(S) links detected in changed docs lines.

python3 -m compileall -q scripts/github/pr_risk_policy.py scripts/github/pr_risk_policy_test.py
python3 -m json.tool .github/risk-labeler.yml
bash scripts/ci/comment_hygiene_gate.sh
git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Inspected the final privilege split, event-specific identity rules, exact status context, default-branch input fetches, PR-number concurrency, review-snapshot recheck, and no-checkout/no-artifact contract. I did not claim live fork or Dependabot event-chain proof.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Cargo was skipped because this change does not touch Rust, Cargo metadata, or runtime behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes.** The privileged policy workflow has only `contents: read`, `pull-requests: read`, and `statuses: write`; the event-signal workflow has empty permissions. Neither workflow checks out contributor content or downloads artifacts.
- New external network calls? **Yes.** The trusted workflow calls GitHub's API to read live PR files, reviews, policy inputs, and inert source text, then writes the bounded commit status.
- Secrets / tokens / credentials handling changed? **Yes.** The trusted workflow passes the limited GitHub workflow token to the helper for API requests; it introduces no stored secret or persistent credential.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.** Fixtures use synthetic handles; the helper reads the existing public maintainer table at runtime.
- Prompt injection or untrusted model-visible text introduced/changed? **No.** No model input is involved.
- If any `Yes`, describe the risk and mitigation: PR-controlled workflow titles are ignored for review events. Target-event metadata comes from the trusted default-branch signal, every identity and SHA is strictly validated, live API state is authoritative, review snapshots are rechecked before publication, and malformed or incomplete inputs fail without producing a passing status.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash-merge commit for this PR. If a ruleset is later activated separately, remove its required-status entry before reverting the workflow.
- **Feature flags or config toggles:** None. The status remains advisory until a separate repository-ruleset change.
- **Observable failure symptoms:** `PR Risk Policy` or `PR Risk Event Signal` workflow failures, a missing or `error` `zeroclaw/pr-risk-policy` status, or the open-PR reconciliation job reporting an evaluation failure.
