### PR TITLE
fix(config): correct cost summary periods

### DIFF
--- a/crates/zeroclaw-config/src/cost/tracker.rs
+++ b/crates/zeroclaw-config/src/cost/tracker.rs
@@ -263,8 +263,8 @@ impl CostTracker {
     }
 
     /// Get the current cost summary. When `[cost].track_per_agent` is
-    /// enabled, the response includes a `by_agent` rollup over today's
-    /// records.
+    /// enabled, the response includes a `by_agent` rollup over the current
+    /// month's records.
     pub fn get_summary(&self) -> Result<CostSummary> {
         self.get_summary_filtered(None)
     }
@@ -312,8 +312,16 @@ impl CostTracker {
     /// persisted ledger rows carrying the task-attribution key; no consumed
     /// counters are stored on feature-specific extension records.
     pub fn get_summary_for_task(&self, task_id: &str) -> Result<CostSummary> {
+        self.get_summary_for_task_at_period(task_id, ReportingPeriod::current())
+    }
+
+    fn get_summary_for_task_at_period(
+        &self,
+        task_id: &str,
+        period: ReportingPeriod,
+    ) -> Result<CostSummary> {
         let mut storage = self.lock_storage();
-        storage.summary_for_task(task_id)
+        storage.summary_for_task(task_id, period)
     }
 
     /// Get usage totals for a durable attributed task without building model/agent
@@ -332,10 +340,22 @@ impl CostTracker {
     }
 
     fn get_summary_filtered(&self, agent_filter: Option<&str>) -> Result<CostSummary> {
-        let (daily_cost, monthly_cost, daily_records) = {
+        self.get_summary_filtered_at_period(agent_filter, ReportingPeriod::current())
+    }
+
+    fn get_summary_filtered_at_period(
+        &self,
+        agent_filter: Option<&str>,
+        period: ReportingPeriod,
+    ) -> Result<CostSummary> {
+        let (daily_cost, monthly_cost, period, current_month_records) = {
             let mut storage = self.lock_storage();
-            let (d, m) = storage.get_aggregated_costs()?;
-            (d, m, storage.daily_records()?)
+            storage.ensure_period_cache_current_at(period)?;
+            let period = storage.reporting_period();
+            let daily_cost = storage.daily_cost_usd;
+            let monthly_cost = storage.monthly_cost_usd;
+            let records = storage.current_month_records(period)?;
+            (daily_cost, monthly_cost, period, records)
         };
 
         let (session_cost, total_tokens, request_count) = {
@@ -361,31 +381,31 @@ impl CostTracker {
         };
 
         // Daily-scoped per-model rollup. Filter by agent when scoped.
-        let model_records: Vec<&CostRecord> =
-            daily_records.iter().filter(|r| matches_agent(r)).collect();
-        let by_model = build_model_stats(model_records.iter().copied());
+        let by_model = build_model_stats(
+            current_month_records
+                .iter()
+                .filter(|r| matches_agent(r))
+                .filter(|r| period.contains_day(r.usage.timestamp)),
+        );
 
         let (daily_total, monthly_total, by_agent) = if let Some(alias) = agent_filter {
             // Per-agent view: re-aggregate day/month from persisted records.
             let mut daily_total = 0.0;
             let mut monthly_total = 0.0;
-            let today = Utc::now().date_naive();
-            let now = Utc::now();
-            for record in &daily_records {
+            for record in &current_month_records {
                 if record.agent_alias.as_deref() != Some(alias) {
                     continue;
                 }
-                let ts = record.usage.timestamp.naive_utc();
-                if ts.date() == today {
+                if period.contains_day(record.usage.timestamp) {
                     daily_total += record.usage.cost_usd;
                 }
-                if ts.year() == now.year() && ts.month() == now.month() {
+                if period.contains_month(record.usage.timestamp) {
                     monthly_total += record.usage.cost_usd;
                 }
             }
             (daily_total, monthly_total, HashMap::new())
         } else if self.config_snapshot().track_per_agent {
-            let by_agent = build_agent_stats(&daily_records);
+            let by_agent = build_agent_stats(&current_month_records);
             (daily_cost, monthly_cost, by_agent)
         } else {
             (daily_cost, monthly_cost, HashMap::new())
@@ -613,6 +633,10 @@ fn add_usage_to_agent_stats(entry: &mut AgentCostStats, record: &CostRecord) {
 struct CostSummaryAccumulator {
     /// Aggregated USD cost for the scanned records.
     total_cost: f64,
+    /// Aggregated USD cost for records on the cached UTC day.
+    daily_cost: f64,
+    /// Aggregated USD cost for records in the cached UTC month.
+    monthly_cost: f64,
     /// Aggregated token count for the scanned records.
     total_tokens: u64,
     /// Number of scanned usage records.
@@ -624,8 +648,14 @@ struct CostSummaryAccumulator {
 }
 
 impl CostSummaryAccumulator {
-    fn record(&mut self, record: &CostRecord) {
+    fn record(&mut self, record: &CostRecord, period: ReportingPeriod) {
         self.total_cost += record.usage.cost_usd;
+        if period.contains_day(record.usage.timestamp) {
+            self.daily_cost += record.usage.cost_usd;
+        }
+        if period.contains_month(record.usage.timestamp) {
+            self.monthly_cost += record.usage.cost_usd;
+        }
         self.total_tokens += record.usage.total_tokens;
         self.request_count += 1;
         add_model_stats(&mut self.by_model, record);
@@ -635,8 +665,8 @@ impl CostSummaryAccumulator {
     fn finish(self) -> CostSummary {
         CostSummary {
             session_cost_usd: self.total_cost,
-            daily_cost_usd: self.total_cost,
-            monthly_cost_usd: self.total_cost,
+            daily_cost_usd: self.daily_cost,
+            monthly_cost_usd: self.monthly_cost,
             total_tokens: self.total_tokens,
             request_count: self.request_count,
             by_model: self.by_model,
@@ -660,6 +690,33 @@ struct CostStorage {
     cached_month: u32,
     /// Whether the cached day/month aggregates reflect the current ledger.
     aggregates_current: bool,
+}
+
+#[derive(Clone, Copy)]
+struct ReportingPeriod {
+    day: NaiveDate,
+    year: i32,
+    month: u32,
+}
+
+impl ReportingPeriod {
+    fn current() -> Self {
+        let now = Utc::now();
+        Self {
+            day: now.date_naive(),
+            year: now.year(),
+            month: now.month(),
+        }
+    }
+
+    fn contains_day(self, timestamp: DateTime<Utc>) -> bool {
+        timestamp.naive_utc().date() == self.day
+    }
+
+    fn contains_month(self, timestamp: DateTime<Utc>) -> bool {
+        let timestamp = timestamp.naive_utc();
+        timestamp.year() == self.year && timestamp.month() == self.month
+    }
 }
 
 impl CostStorage {
@@ -780,17 +837,16 @@ impl CostStorage {
     }
 
     fn ensure_period_cache_current(&mut self) -> Result<()> {
-        let now = Utc::now();
-        let day = now.date_naive();
-        let year = now.year();
-        let month = now.month();
+        self.ensure_period_cache_current_at(ReportingPeriod::current())
+    }
 
+    fn ensure_period_cache_current_at(&mut self, period: ReportingPeriod) -> Result<()> {
         if !self.aggregates_current
-            || day != self.cached_day
-            || year != self.cached_year
-            || month != self.cached_month
+            || period.day != self.cached_day
+            || period.year != self.cached_year
+            || period.month != self.cached_month
         {
-            self.rebuild_aggregates(day, year, month)?;
+            self.rebuild_aggregates(period.day, period.year, period.month)?;
         }
 
         Ok(())
@@ -842,17 +898,21 @@ impl CostStorage {
         Ok((self.daily_cost_usd, self.monthly_cost_usd))
     }
 
+    fn reporting_period(&self) -> ReportingPeriod {
+        ReportingPeriod {
+            day: self.cached_day,
+            year: self.cached_year,
+            month: self.cached_month,
+        }
+    }
+
     /// Snapshot every record whose timestamp falls within the current
     /// calendar month. Used to build per-agent rollups without folding a
     /// new aggregate table into the JSONL file.
-    fn daily_records(&mut self) -> Result<Vec<CostRecord>> {
-        self.ensure_period_cache_current()?;
-        let year = self.cached_year;
-        let month = self.cached_month;
+    fn current_month_records(&self, period: ReportingPeriod) -> Result<Vec<CostRecord>> {
         let mut out = Vec::new();
         self.for_each_record(|record| {
-            let ts = record.usage.timestamp.naive_utc();
-            if ts.year() == year && ts.month() == month {
+            if period.contains_month(record.usage.timestamp) {
                 out.push(record);
             }
         })?;
@@ -878,11 +938,13 @@ impl CostStorage {
         Ok(out)
     }
 
-    fn summary_for_task(&mut self, task_id: &str) -> Result<CostSummary> {
+    fn summary_for_task(&mut self, task_id: &str, period: ReportingPeriod) -> Result<CostSummary> {
+        self.ensure_period_cache_current_at(period)?;
+        let period = self.reporting_period();
         let mut summary = CostSummaryAccumulator::default();
         self.for_each_record(|record| {
             if record.task_id.as_deref() == Some(task_id) {
-                summary.record(&record);
+                summary.record(&record, period);
             }
         })?;
         Ok(summary.finish())
@@ -941,7 +1003,7 @@ impl CostStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
+    use chrono::{Duration, TimeZone, Utc};
     use tempfile::TempDir;
 
     fn enabled_config() -> CostConfig {
@@ -949,6 +1011,45 @@ mod tests {
             enabled: true,
             ..Default::default()
         }
+    }
+
+    fn record_at(
+        model: &str,
+        cost_usd: f64,
+        timestamp: DateTime<Utc>,
+        task_id: Option<&str>,
+    ) -> CostRecord {
+        let usage = TokenUsage {
+            model: model.to_string(),
+            input_tokens: 10,
+            output_tokens: 10,
+            cached_input_tokens: 0,
+            total_tokens: 20,
+            cost_usd,
+            pricing_available: true,
+            timestamp,
+        };
+        CostRecord::with_attribution(
+            "fixture-session",
+            Some("fixture-agent".to_string()),
+            task_id.map(str::to_string),
+            usage,
+        )
+    }
+
+    fn write_records(path: &Path, records: &[CostRecord]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        for record in records {
+            writeln!(file, "{}", serde_json::to_string(record).unwrap()).unwrap();
+        }
+        file.sync_all().unwrap();
     }
 
     #[test]
@@ -1246,6 +1347,82 @@ mod tests {
         );
         assert!(summary.by_model.contains_key("session/model"));
         assert!(summary.by_model.contains_key("prior/model"));
+    }
+
+    #[test]
+    fn summaries_use_one_cached_period_for_task_and_model_rollups() {
+        let tmp = TempDir::new().unwrap();
+        let storage_path = resolve_storage_path(tmp.path()).unwrap();
+        let period = ReportingPeriod {
+            day: NaiveDate::from_ymd_opt(2025, 6, 15).unwrap(),
+            year: 2025,
+            month: 6,
+        };
+        let month_start = period.day.with_day(1).unwrap();
+        let other_current_month = month_start;
+        let prior_month = month_start - Duration::days(1);
+        write_records(
+            &storage_path,
+            &[
+                record_at(
+                    "today/model",
+                    1.0,
+                    Utc.from_utc_datetime(&period.day.and_hms_opt(12, 0, 0).unwrap()),
+                    Some("task-periods"),
+                ),
+                record_at(
+                    "earlier-month/model",
+                    2.0,
+                    Utc.from_utc_datetime(&other_current_month.and_hms_opt(0, 0, 0).unwrap()),
+                    Some("task-periods"),
+                ),
+                record_at(
+                    "prior-month/model",
+                    4.0,
+                    Utc.from_utc_datetime(&prior_month.and_hms_opt(0, 0, 0).unwrap()),
+                    Some("task-periods"),
+                ),
+            ],
+        );
+
+        let mut config = enabled_config();
+        config.track_per_agent = true;
+        let tracker = CostTracker::new(config, tmp.path()).unwrap();
+
+        let task = tracker
+            .get_summary_for_task_at_period("task-periods", period)
+            .unwrap();
+        assert_eq!(task.request_count, 3);
+        assert!((task.session_cost_usd - 7.0).abs() < f64::EPSILON);
+        assert!((task.monthly_cost_usd - 3.0).abs() < f64::EPSILON);
+        assert!((task.daily_cost_usd - 1.0).abs() < f64::EPSILON);
+        assert!(task.by_model.contains_key("prior-month/model"));
+
+        let summary = tracker
+            .get_summary_filtered_at_period(None, period)
+            .unwrap();
+        assert_eq!(summary.by_model.len(), 1);
+        assert!(summary.by_model.contains_key("today/model"));
+        assert!(!summary.by_model.contains_key("earlier-month/model"));
+        assert!(!summary.by_model.contains_key("prior-month/model"));
+        assert_eq!(
+            summary
+                .by_agent
+                .get("fixture-agent")
+                .map(|stats| stats.request_count),
+            Some(2),
+            "per-agent aggregation retains current-month rows"
+        );
+
+        let filtered = tracker
+            .get_summary_filtered_at_period(Some("fixture-agent"), period)
+            .unwrap();
+        assert!((filtered.daily_cost_usd - 1.0).abs() < f64::EPSILON);
+        assert!((filtered.monthly_cost_usd - 3.0).abs() < f64::EPSILON);
+        assert_eq!(filtered.by_model.len(), 1);
+        assert!(filtered.by_model.contains_key("today/model"));
+        assert!(!filtered.by_model.contains_key("earlier-month/model"));
+        assert!(!filtered.by_model.contains_key("prior-month/model"));
     }
 
     #[test]

--- a/docs/book/src/ops/cost-tracking.md
+++ b/docs/book/src/ops/cost-tracking.md
@@ -143,10 +143,7 @@ is populated; there's no retroactive repricing of past records.
 
 ## Persistence
 
-`CostTracker::record_usage_with_agent` appends one `CostRecord` per
-priced response to `<workspace>/state/costs.jsonl`, one JSON object
-per line. The file is read on startup to seed `daily_records()` so
-the dashboard's per-agent rollup survives restarts.
+`CostTracker::record_usage_with_agent` appends one `CostRecord` per priced response to `<workspace>/state/costs.jsonl`, one JSON object per line. The ledger is read on startup so the dashboard's current-month per-agent rollup survives restarts.
 
 `cost_usd` is computed at record time from the rate sheet in effect
 **at that moment**. Records are immutable: if the operator adds


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Correct task cost summaries so `session_cost_usd` remains the all-time attributed total while `daily_cost_usd` and `monthly_cost_usd` reflect the current cached UTC day and month. Restrict the ordinary `by_model` rollup to the same cached UTC day, capture one reporting period per summary, and add deterministic multi-day and prior-month regression coverage.
- **Scope boundary:** This PR does not change public APIs, configuration schema, ledger storage or migration, durability, pricing, budgets, or unrelated reporting behavior. A task summary's per-model and per-agent breakdowns remain lifetime-wide beside its lifetime task total.
- **Blast radius:** Cost summaries produced from the existing JSONL ledger, including task-attributed totals and the default model and agent rollups.
- **Linked issue(s):** None.
- **Labels:** `bug`, `config`, `docs`, `risk:medium`, `size:S`

### What this does, simply

ZeroClaw keeps a cost ledger so operators can see how much a task has spent overall and during the current reporting periods. Task summaries were using the all-time total for their daily and monthly fields, and the default per-model breakdown could include earlier days from the same month. This change calculates the daily and monthly totals from one consistent UTC reporting period and limits the default model breakdown to that day. A task's per-model breakdown deliberately stays lifetime-wide beside its lifetime task total.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; deterministic focused tests directly cover the corrected period boundaries.

### How I tested

- **CI checks relied on and why they cover this change:** Required checks passed at `e7485c82b4e20ba646b90a2030415e311a2205ba`, including formatting, lint, tests, MSRV, cross-platform checks, security, and documentation validation. The completed local focused tests directly exercise the changed tracker behavior.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-config cost::tracker::tests -- --nocapture
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 1457 filtered out

$ cargo clippy -p zeroclaw-config --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 47s

$ rustfmt --edition 2024 --check crates/zeroclaw-config/src/cost/tracker.rs
# passed

$ BASE_SHA=HEAD DOCS_FILES='docs/book/src/ops/cost-tracking.md' bash scripts/ci/docs_quality_gate.sh
# passed with 0 Markdown errors

$ BASE_SHA=HEAD DOCS_FILES='docs/book/src/ops/cost-tracking.md' bash scripts/ci/docs_links_gate.sh
# passed; 0 added links
```

- **Beyond CI, what did you manually verify?** Reviewed the final two-file diff for one-period capture, day/month filtering, prior-month exclusion, current-month per-agent preservation, and scope integrity. No visual interface was changed.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Full-workspace Cargo validation is left to required CI because the production change is isolated to `zeroclaw-config` and focused package tests plus all-target package Clippy cover the changed code locally.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- If any Yes, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- If backward compatibility is No or either surface/floor question is Yes: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert commit `e7485c82b4e20ba646b90a2030415e311a2205ba`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Cost summary day/month totals or the default model rollup include records outside their intended current UTC period, or focused tracker regressions fail.

