### PR TITLE
fix(runtime): preserve PowerShell module path

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -21,6 +21,7 @@ pub mod scoped;
 pub mod security_ops;
 pub mod send_message_to_peer;
 pub mod shell;
+pub(crate) mod shell_env;
 pub mod skill_http;
 pub mod skill_manage;
 pub mod skill_tool;

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -65,7 +65,8 @@ const SAFE_ENV_VARS: &[&str] = &[
 ];
 
 /// Environment variables safe to pass to shell commands on Windows.
-/// Includes Windows-specific variables needed for cmd.exe and program resolution.
+/// Includes Windows-specific variables needed for cmd.exe, PowerShell module discovery,
+/// and program resolution.
 #[cfg(target_os = "windows")]
 const SAFE_ENV_VARS: &[&str] = &[
     "PATH",
@@ -78,6 +79,7 @@ const SAFE_ENV_VARS: &[&str] = &[
     "SYSTEMDRIVE",
     "WINDIR",
     "COMSPEC",
+    "PSModulePath",
     "TEMP",
     "TMP",
     "TERM",
@@ -1860,6 +1862,12 @@ mod tests {
             SAFE_ENV_VARS.contains(&"TERM"),
             "TERM must be in safe env vars"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shell_safe_env_vars_preserves_powershell_module_discovery() {
+        assert!(SAFE_ENV_VARS.contains(&"PSModulePath"));
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -1,6 +1,7 @@
 use crate::platform::RuntimeAdapter;
 use crate::security::SecurityPolicy;
 use crate::security::traits::Sandbox;
+use crate::tools::shell_env::SAFE_SHELL_ENV_VARS;
 use async_trait::async_trait;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
@@ -56,36 +57,6 @@ impl Drop for ChildGroupGuard {
         }
     }
 }
-
-/// Environment variables safe to pass to shell commands.
-/// Only functional variables are included — never API keys or secrets.
-#[cfg(not(target_os = "windows"))]
-const SAFE_ENV_VARS: &[&str] = &[
-    "PATH", "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
-];
-
-/// Environment variables safe to pass to shell commands on Windows.
-/// Includes Windows-specific variables needed for cmd.exe, PowerShell module discovery,
-/// and program resolution.
-#[cfg(target_os = "windows")]
-const SAFE_ENV_VARS: &[&str] = &[
-    "PATH",
-    "PATHEXT",
-    "HOME",
-    "USERPROFILE",
-    "HOMEDRIVE",
-    "HOMEPATH",
-    "SYSTEMROOT",
-    "SYSTEMDRIVE",
-    "WINDIR",
-    "COMSPEC",
-    "PSModulePath",
-    "TEMP",
-    "TMP",
-    "TERM",
-    "LANG",
-    "USERNAME",
-];
 
 /// Shell command execution tool with sandboxing
 pub struct ShellTool {
@@ -220,7 +191,7 @@ fn is_valid_env_var_name(name: &str) -> bool {
 fn collect_allowed_shell_env_vars(security: &SecurityPolicy) -> Vec<String> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
-    for key in SAFE_ENV_VARS
+    for key in SAFE_SHELL_ENV_VARS
         .iter()
         .copied()
         .chain(security.shell_env_passthrough.iter().map(|s| s.as_str()))
@@ -1837,39 +1808,6 @@ mod tests {
         assert!(!decoded.contains('\u{FFFD}'));
     }
 
-    #[test]
-    fn shell_safe_env_vars_excludes_secrets() {
-        for var in SAFE_ENV_VARS {
-            let lower = var.to_lowercase();
-            assert!(
-                !lower.contains("key") && !lower.contains("secret") && !lower.contains("token"),
-                "SAFE_ENV_VARS must not include sensitive variable: {var}"
-            );
-        }
-    }
-
-    #[test]
-    fn shell_safe_env_vars_includes_essentials() {
-        assert!(
-            SAFE_ENV_VARS.contains(&"PATH"),
-            "PATH must be in safe env vars"
-        );
-        assert!(
-            SAFE_ENV_VARS.contains(&"HOME") || SAFE_ENV_VARS.contains(&"USERPROFILE"),
-            "HOME or USERPROFILE must be in safe env vars"
-        );
-        assert!(
-            SAFE_ENV_VARS.contains(&"TERM"),
-            "TERM must be in safe env vars"
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn shell_safe_env_vars_preserves_powershell_module_discovery() {
-        assert!(SAFE_ENV_VARS.contains(&"PSModulePath"));
-    }
-
     #[tokio::test]
     async fn shell_blocks_rate_limited() {
         let security = Arc::new(SecurityPolicy {
@@ -1998,7 +1936,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn shell_tui_env_is_passed_to_subprocess() {
-        // A var that is NOT in SAFE_ENV_VARS and NOT in passthrough —
+        // A var that is NOT in SAFE_SHELL_ENV_VARS and NOT in passthrough —
         // it should only appear if tui_env injects it.
         let tool =
             ShellTool::new(test_security_with_env_cmd(), test_runtime()).with_tui_env(Some({
@@ -2039,7 +1977,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn shell_tui_env_overrides_safe_var() {
-        // tui_env wins over the process-level value for a var that is also in SAFE_ENV_VARS.
+        // tui_env wins over the process-level value for a var that is also in SAFE_SHELL_ENV_VARS.
         // This lets the TUI's PATH (e.g. with nix/brew) win over the daemon's PATH.
         let home_key = home_env_key();
         let _guard = EnvGuard::set(home_key, "daemon-home");
@@ -2076,7 +2014,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn shell_tui_env_none_behaves_like_existing() {
         // with_tui_env(None) must be identical to no tui_env at all —
-        // only SAFE_ENV_VARS + passthrough reach the subprocess.
+        // only SAFE_SHELL_ENV_VARS + passthrough reach the subprocess.
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime()).with_tui_env(None);
 
         let result = tool
@@ -2095,7 +2033,7 @@ mod tests {
     async fn shell_tui_env_secrets_reach_subprocess_but_not_safe_list() {
         // The whole point: secrets from the TUI env (e.g. SSH_AUTH_SOCK)
         // DO reach the subprocess via tui_env even though they are not
-        // in SAFE_ENV_VARS.
+        // in SAFE_SHELL_ENV_VARS.
         let tool =
             ShellTool::new(test_security_with_env_cmd(), test_runtime()).with_tui_env(Some({
                 let mut m = std::collections::HashMap::new();
@@ -2105,8 +2043,8 @@ mod tests {
 
         // Confirm SSH_AUTH_SOCK is not in the safe list (would be a bug if it were)
         assert!(
-            !SAFE_ENV_VARS.contains(&"SSH_AUTH_SOCK"),
-            "SSH_AUTH_SOCK must not be in SAFE_ENV_VARS"
+            !SAFE_SHELL_ENV_VARS.contains(&"SSH_AUTH_SOCK"),
+            "SSH_AUTH_SOCK must not be in SAFE_SHELL_ENV_VARS"
         );
 
         let result = tool

--- a/crates/zeroclaw-runtime/src/tools/shell_env.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell_env.rs
@@ -1,0 +1,60 @@
+//! Shared baseline environment for shell child processes.
+
+/// Environment variables safe to copy into shell child processes after `env_clear`.
+/// Only functional variables are included — never API keys or secrets.
+#[cfg(not(target_os = "windows"))]
+pub(crate) const SAFE_SHELL_ENV_VARS: &[&str] = &[
+    "PATH", "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+];
+
+/// Windows variables needed for cmd.exe, PowerShell module discovery, and program resolution.
+#[cfg(target_os = "windows")]
+pub(crate) const SAFE_SHELL_ENV_VARS: &[&str] = &[
+    "PATH",
+    "PATHEXT",
+    "HOME",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "COMSPEC",
+    "PSModulePath",
+    "TEMP",
+    "TMP",
+    "TERM",
+    "LANG",
+    "USERNAME",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::SAFE_SHELL_ENV_VARS;
+
+    #[test]
+    fn safe_shell_env_vars_exclude_secrets() {
+        for var in SAFE_SHELL_ENV_VARS {
+            let lower = var.to_lowercase();
+            assert!(
+                !lower.contains("key") && !lower.contains("secret") && !lower.contains("token"),
+                "SAFE_SHELL_ENV_VARS must not include sensitive variable: {var}"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_shell_env_vars_include_essentials() {
+        assert!(SAFE_SHELL_ENV_VARS.contains(&"PATH"));
+        assert!(
+            SAFE_SHELL_ENV_VARS.contains(&"HOME") || SAFE_SHELL_ENV_VARS.contains(&"USERPROFILE")
+        );
+        assert!(SAFE_SHELL_ENV_VARS.contains(&"TERM"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn safe_shell_env_vars_preserve_powershell_module_discovery() {
+        assert!(SAFE_SHELL_ENV_VARS.contains(&"PSModulePath"));
+    }
+}

--- a/crates/zeroclaw-runtime/src/tools/skill_tool.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_tool.rs
@@ -32,6 +32,7 @@ const SAFE_ENV_VARS: &[&str] = &[
     "SYSTEMDRIVE",
     "WINDIR",
     "COMSPEC",
+    "PSModulePath",
     "TEMP",
     "TMP",
     "TERM",
@@ -640,6 +641,50 @@ mod tests {
         let result = tool.execute(serde_json::json!({})).await.unwrap();
         assert!(result.success);
         assert!(result.output.contains("hello-skill"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn skill_shell_safe_env_vars_preserves_powershell_module_discovery() {
+        assert!(SAFE_ENV_VARS.contains(&"PSModulePath"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn skill_shell_tool_executes_powershell_safe_pipeline_with_sanitized_env() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: workspace.path().to_path_buf(),
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: true,
+            ..SecurityPolicy::default()
+        });
+        let skill = SkillTool {
+            name: "safe_pipeline".to_string(),
+            description: "Run a safe PowerShell pipeline".to_string(),
+            kind: "shell".to_string(),
+            command: "Write-Output \"quoted safe value\" | Select-Object -First 1".to_string(),
+            args: HashMap::new(),
+            target: None,
+            locked_args: HashMap::new(),
+            timeout_secs: None,
+        };
+        let runtime: Arc<dyn RuntimeAdapter> =
+            Arc::new(NativeRuntime::with_shell("powershell".into()));
+        let tool = SkillShellTool::new_with_runtime("test", &skill, security, runtime);
+
+        let result = tool
+            .execute(serde_json::json!({}))
+            .await
+            .expect("safe PowerShell pipeline should return a tool result");
+
+        assert!(result.success, "{:?}", result.error);
+        assert!(
+            result.output.contains("quoted safe value"),
+            "{}",
+            result.output
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/skill_tool.rs
+++ b/crates/zeroclaw-runtime/src/tools/skill_tool.rs
@@ -2,6 +2,7 @@
 
 use crate::platform::{NativeRuntime, RuntimeAdapter};
 use crate::security::SecurityPolicy;
+use crate::tools::shell_env::SAFE_SHELL_ENV_VARS;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -14,31 +15,6 @@ use zeroclaw_api::tool::{Tool, ToolOutput, ToolResult};
 const SKILL_SHELL_TIMEOUT_SECS: u64 = 60;
 /// Maximum output size in bytes (1 MB).
 const MAX_OUTPUT_BYTES: usize = 1_048_576;
-
-#[cfg(not(target_os = "windows"))]
-const SAFE_ENV_VARS: &[&str] = &[
-    "PATH", "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
-];
-
-#[cfg(target_os = "windows")]
-const SAFE_ENV_VARS: &[&str] = &[
-    "PATH",
-    "PATHEXT",
-    "HOME",
-    "USERPROFILE",
-    "HOMEDRIVE",
-    "HOMEPATH",
-    "SYSTEMROOT",
-    "SYSTEMDRIVE",
-    "WINDIR",
-    "COMSPEC",
-    "PSModulePath",
-    "TEMP",
-    "TMP",
-    "TERM",
-    "LANG",
-    "USERNAME",
-];
 
 const MAX_TOOL_NAME_LEN: usize = 64;
 
@@ -238,7 +214,7 @@ impl Tool for SkillShellTool {
         cmd.env_clear();
 
         // Only pass safe environment variables
-        for var in SAFE_ENV_VARS {
+        for var in SAFE_SHELL_ENV_VARS {
             if let Ok(val) = std::env::var(var) {
                 cmd.env(var, val);
             }
@@ -641,12 +617,6 @@ mod tests {
         let result = tool.execute(serde_json::json!({})).await.unwrap();
         assert!(result.success);
         assert!(result.output.contains("hello-skill"));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn skill_shell_safe_env_vars_preserves_powershell_module_discovery() {
-        assert!(SAFE_ENV_VARS.contains(&"PSModulePath"));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Preserve the inherited Windows `PSModulePath` value when ZeroClaw runs shell commands through its sanitized environment, and consolidate the duplicated base child-environment allowlists into one private shared owner. PowerShell needs that value to find standard modules used by safe pipelines such as `Select-Object`; the non-Windows allowlist contents are unchanged.
- **Scope boundary:** This does not change command policy, timeouts, process draining, shell selection, configured passthrough, or output handling.
- **Blast radius:** Windows PowerShell execution through the agent shell and skill-defined shell tools; the unchanged non-Windows base list now uses the same shared owner.
- **Linked issue(s):** None; this is a self-contained Windows shell-environment repair.
- **Labels:** `bug`, `runtime`, `tool:shell`, `risk:medium`, `size:XS`

### What this does, simply

ZeroClaw intentionally starts shell commands with a small, safe environment. On Windows, that environment was missing the list of folders where PowerShell looks for its own modules. This PR keeps that one inherited functional value in one shared base allowlist used by both shell-tool paths so standard-module pipelines can resolve normally, while continuing to exclude secrets and leaving execution policy unchanged.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the existing agent-shell pipeline regression, the new skill-shell pipeline regression, and static allowlist checks cover the two affected paths when run on Windows.

### How I tested

- **CI checks relied on and why they cover this change:** All required PR CI passed on this published shared-owner repair head, including the Windows compile/check leg. The prior head's separately dispatched Windows platform-test run established the unchanged behavior boundary: the skill-shell regression passed in 51.352s and the agent-shell regression passed in 52.810s.
- **Known CI coverage gap, if any:** Required exact-head CI is complete. The prior behavior run passed both regressions but they remain close to their 60s threshold (51.352s and 52.810s); retain that as residual flake risk. That prior full Windows platform suite also reported two unrelated pre-existing failures: `policy::readable_includes_posix_device_files` (POSIX `/dev` assertion) and `cron::scheduler::agent_cron_run_keeps_workspace_through_shell_on_retry_and_concurrency` (Windows-vs-`/tmp` workspace path expectation).
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# passed

cargo test --locked -p zeroclaw-runtime tools::shell_env::tests::safe_shell_env_vars_exclude_secrets -- --exact
# test tools::shell_env::tests::safe_shell_env_vars_exclude_secrets ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3961 filtered out

cargo test --locked -p zeroclaw-runtime tools::skill_tool::tests::skill_shell_tool_executes_echo -- --exact
# test tools::skill_tool::tests::skill_shell_tool_executes_echo ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3961 filtered out

git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Confirmed the one shared base allowlist is consumed by both independently sanitized Windows paths, retains only inherited `PSModulePath` for module discovery, and leaves timeout, policy, drains, configured passthrough, TUI overlays, session injection, and output handling unchanged.
- **Visual interface changed?** N/A; this changes process execution behavior only.
- **If any command was intentionally skipped, why:** Broad local Cargo validation would not exercise the Windows-only behavior; fresh hosted Windows CI on this head is the required evidence boundary.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: Windows shell child processes retain only their inherited `PSModulePath` value so PowerShell can discover standard modules. This is a bounded child-process capability expansion, not new host file-system access; the fixed allowlist still excludes secrets and leaves command policy unchanged.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **Yes**; Windows shell child processes retain the pre-existing inherited `PSModulePath` value solely for PowerShell module discovery.
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: No upgrade action is required. Existing Windows PowerShell commands can resume resolving their standard modules through the existing shell interfaces.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the landed squash commit through the normal review path.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A Windows safe PowerShell pipeline using a standard module, such as `Select-Object`, times out through the agent shell or a skill-defined shell tool.

