### PR TITLE
fix(zerocode): show configured quit binding in confirmation

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -2011,7 +2011,7 @@ fn draw_quit_confirm_modal(frame: &mut ratatui::Frame, area: Rect) {
     let footer = format!(
         "{} = {confirm}   {} = {quit}   {} = {cancel}",
         chords_for(ModalAction::bindings(), ModalAction::Confirm),
-        chords_for(GlobalAction::bindings(), GlobalAction::Quit),
+        chords_for(GlobalAction::resolved_bindings(), GlobalAction::Quit),
         chords_for(ModalAction::bindings(), ModalAction::Cancel),
         confirm = ModalAction::Confirm.label(),
         quit = GlobalAction::Quit.label(),
@@ -2428,6 +2428,47 @@ mod tests {
             true,
             false
         ));
+    }
+
+    #[test]
+    fn quit_confirmation_renders_the_resolved_quit_binding() {
+        use std::collections::HashMap;
+
+        use crate::keymap::{Chord, overrides};
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let _guard = overrides::TEST_GUARD
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        overrides::set_active(HashMap::from([(
+            GlobalAction::TAG.to_string(),
+            HashMap::from([("quit".to_string(), vec![Chord::ctrl('q')])]),
+        )]));
+
+        let backend = TestBackend::new(80, 12);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| draw_quit_confirm_modal(frame, frame.area()))
+            .expect("draw quit confirmation");
+
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        let configured = Chord::ctrl('q').display();
+        let default = Chord::ctrl('c').display();
+        assert!(
+            rendered.contains(&format!("{configured} = quit")),
+            "rendered modal should advertise configured binding: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(&format!("{default} = quit")),
+            "rendered modal should not advertise default binding: {rendered:?}"
+        );
+        overrides::reset();
     }
 
     #[test]

--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -2442,7 +2442,10 @@ mod tests {
             .unwrap_or_else(|error| error.into_inner());
         overrides::set_active(HashMap::from([(
             GlobalAction::TAG.to_string(),
-            HashMap::from([("quit".to_string(), vec![Chord::ctrl('q')])]),
+            HashMap::from([(
+                "quit".to_string(),
+                vec![Chord::with(KeyCode::Char('q'), KeyModifiers::ALT)],
+            )]),
         )]));
 
         let backend = TestBackend::new(80, 12);
@@ -2458,7 +2461,7 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
-        let configured = Chord::ctrl('q').display();
+        let configured = Chord::with(KeyCode::Char('q'), KeyModifiers::ALT).display();
         let default = Chord::ctrl('c').display();
         assert!(
             rendered.contains(&format!("{configured} = quit")),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Make the quit-confirmation footer read the resolved live `global.quit` binding instead of the compile-time default table.
  - Add a rendered modal regression proving a configured quit chord is shown and the stale Ctrl+C hint is absent.
- **Scope boundary:** This PR does not change key dispatch, modifier semantics, collision handling, configuration persistence, or modal layout.
- **Blast radius:** Limited to the ZeroCode quit-confirmation footer and its focused regression.
- **Linked issue(s):** Fixes #10470.
- **Labels:** `bug`, `priority:p3`, `risk:medium`, `size:XS`, `zerocode`.

### What this does, simply

ZeroCode lets people replace its default quit shortcut. The configured shortcut already opened the quit confirmation, but the confirmation footer still told them to press Ctrl+C. This PR makes that footer use the same resolved shortcut as dispatch, so the instruction matches the key that actually opened the modal. It does not change which shortcuts are valid or how ZeroCode decides which action owns a key.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes — the same short A/B check directly shows the stale instruction on `master` and the corrected instruction on this branch.
- **Interface(s) exercised:** `surface=tui`
- **Setup / preconditions:** In ZeroCode Config, assign `global.quit` to a non-default chord such as Alt+Q, then start or restart ZeroCode so that binding is active.
- **Steps to run:** Press the configured quit chord once to open the quit confirmation and inspect its footer.
- **Expected on this branch (after):** The footer labels the configured chord as `quit`; it does not advertise Ctrl+C unless Ctrl+C is the resolved binding.
- **Prior behavior on `master` (before):** The configured chord opens the modal, but the footer still labels Ctrl+C as `quit`.

### How I tested

- **CI checks relied on and why they cover this change:** Required exact-head CI passed with 4 intentional skips. The Test, Lint, Format, cross-platform check, security, and CI Required Gate paths cover the changed ZeroCode Rust surface.
- **Known CI coverage gap, if any:** No direct real-interface screenshot was captured. For this exact head, the remaining screenshot gap is accepted based on the production-renderer regression, the shared resolved-binding owner used by dispatch and the footer, and green exact-head CI.
- **Commands run and tail output:**

```text
cargo test --locked -p zerocode quit_confirmation_renders_the_resolved_quit_binding
test app::tests::quit_confirmation_renders_the_resolved_quit_binding ... ok
test result: ok. 1 passed; 0 failed

cargo fmt --all -- --check
Result: passed
```

- **Command-evidence revision:** These focused commands passed at `8133c239783bee21632af701da5de702e73778c6`. The current head changes only the regression's non-default fixture chord from Ctrl+Q to Alt+Q to avoid coupling the test to legacy modifier migration; exact-head CI passed for that mechanical test-only delta.
- **Beyond CI, what did you manually verify?** Source inspection confirmed dispatch and the repaired footer now consume the same resolved `GlobalAction::Quit` owner. No live terminal smoke is claimed yet.
- **Visual interface changed?** Yes.
- **Tested revision, interface, and terminal or viewport dimensions:** Revision `8133c239783bee21632af701da5de702e73778c6`; automated production renderer regression at `80x12`. Current head `5b324101854a40d4c26d98e06ec10da199aa4dfd` changes only the fixture chord, and exact-head CI passed that regression.
- **Action or changed state and observed result:** The automated regression rendered the production quit modal with a non-default quit override and observed the configured label instead of the default. The current test uses Alt+Q for that same assertion. This is technical evidence, not screenshot proof.
- **If any command was intentionally skipped, why:** Broad local workspace validation was not duplicated because focused local evidence covers the changed contract and exact-head CI covers the repository checks. A direct screenshot was waived for this exact head because the one-line production change does not alter modal layout, styling, configuration loading, or input handling, while the production renderer directly asserts the corrected visible token.

### Visual evidence

No direct screenshot was captured. For exact head `5b324101854a40d4c26d98e06ec10da199aa4dfd`, the remaining visual-evidence gap is accepted because this PR changes only the binding source for one existing footer token: the production Ratatui renderer at `80x12` asserts that Alt+Q is present and the stale Ctrl+C quit label is absent, dispatch and the footer share `resolved_bindings()`, and exact-head CI is green. No modal layout, styling, configuration loading, or input handling changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert commits `5b324101854a40d4c26d98e06ec10da199aa4dfd` and `8133c239783bee21632af701da5de702e73778c6`.
- **Feature flags or config toggles:** None. Restoring the default `global.quit` binding avoids the stale-label mismatch on the prior implementation.
- **Observable failure symptoms:** A configured non-default quit chord opens the confirmation modal, but the footer labels a different chord as `quit`.
