### PR TITLE
feat(zerocode): show active log path in payload fallback

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -174,6 +174,7 @@ zc-logs-section-trace = Trace
 zc-logs-section-attribution = Attribution
 zc-logs-section-attributes = Attributes
 zc-logs-preview-only = Full payload unavailable — showing preview fields only.
+zc-logs-persisted-path = Persisted log: { $path }
 zc-logs-no-event-selected = No event selected
 zc-logs-loading = Loading…
 zc-logs-search-action-apply = apply

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -138,6 +138,7 @@ zc-logs-section-trace = Traza
 zc-logs-section-attribution = Atribución
 zc-logs-section-attributes = Atributos
 zc-logs-preview-only = Carga útil completa no disponible — mostrando solo campos de vista previa.
+zc-logs-persisted-path = Registro persistente: { $path }
 zc-logs-no-event-selected = Ningún evento seleccionado
 zc-logs-loading = Cargando…
 zc-logs-search-action-apply = aplicar

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -138,6 +138,7 @@ zc-logs-section-trace = Trace
 zc-logs-section-attribution = Attribution
 zc-logs-section-attributes = Attributs
 zc-logs-preview-only = Charge utile complète indisponible — affichage des champs d'aperçu uniquement.
+zc-logs-persisted-path = Journal persistant : { $path }
 zc-logs-no-event-selected = Aucun événement sélectionné
 zc-logs-loading = Chargement…
 zc-logs-search-action-apply = appliquer

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -138,6 +138,7 @@ zc-logs-section-trace = トレース
 zc-logs-section-attribution = 属性情報
 zc-logs-section-attributes = 属性
 zc-logs-preview-only = 完全なペイロードは利用できません — プレビューフィールドのみ表示しています。
+zc-logs-persisted-path = 永続ログ: { $path }
 zc-logs-no-event-selected = イベントが選択されていません
 zc-logs-loading = 読み込み中…
 zc-logs-search-action-apply = 適用

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -138,6 +138,7 @@ zc-logs-section-trace = 追踪
 zc-logs-section-attribution = 归属
 zc-logs-section-attributes = 属性
 zc-logs-preview-only = 无法获取完整负载 — 仅显示预览字段。
+zc-logs-persisted-path = 持久化日志：{ $path }
 zc-logs-no-event-selected = 未选择事件
 zc-logs-loading = 加载中…
 zc-logs-search-action-apply = 应用

--- a/apps/zerocode/src/client.rs
+++ b/apps/zerocode/src/client.rs
@@ -2953,6 +2953,8 @@ pub struct LogsQueryParams {
 #[serde(rename_all = "snake_case")]
 pub struct LogsQueryResult {
     pub events: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub log_path: Option<String>,
     /// Legacy cursor: `(timestamp, id)` to feed back as `until_ts` +
     /// `until_id` for older. Tie-breaks same-timestamp events by
     /// lexicographic id, which can drop earlier-written events when id
@@ -2974,6 +2976,24 @@ pub struct LogsQueryResult {
 #[serde(rename_all = "snake_case")]
 pub struct LogsGetResult {
     pub event: serde_json::Value,
+}
+
+#[cfg(test)]
+mod logs_query_tests {
+    use super::LogsQueryResult;
+
+    #[test]
+    fn older_response_without_log_path_remains_compatible() {
+        let result: LogsQueryResult = serde_json::from_value(serde_json::json!({
+            "events": [],
+            "next_cursor": null,
+            "next_cursor_line_offset": null,
+            "at_end": true
+        }))
+        .expect("older logs/query response");
+
+        assert!(result.log_path.is_none());
+    }
 }
 
 // ── Session / Agents types ───────────────────────────────────────

--- a/apps/zerocode/src/logs.rs
+++ b/apps/zerocode/src/logs.rs
@@ -315,7 +315,7 @@ impl LogDetail {
         self.raw.get("attributes").unwrap_or(&NULL)
     }
 
-    fn detail_lines(&self) -> Vec<Line<'static>> {
+    fn detail_lines(&self, active_log_path: Option<&str>) -> Vec<Line<'static>> {
         let label_style = theme::dim_style();
         let val_style = theme::body_style();
         let mut lines: Vec<Line<'static>> = Vec::new();
@@ -443,6 +443,12 @@ impl LogDetail {
                 crate::i18n::t("zc-logs-preview-only"),
                 theme::dim_style(),
             )));
+            if let Some(path) = active_log_path {
+                lines.push(Line::from(Span::styled(
+                    crate::i18n::t_args("zc-logs-persisted-path", &[("path", path)]),
+                    theme::dim_style(),
+                )));
+            }
         }
 
         lines
@@ -549,6 +555,7 @@ pub(crate) struct Logs {
     next_cursor_legacy: Option<(String, String)>,
     at_end: bool,
     loading: bool,
+    active_log_path: Option<String>,
     // Viewport
     list_height: u16,
     last_list_area: Rect,
@@ -586,6 +593,7 @@ impl Logs {
             next_cursor_legacy: None,
             at_end: false,
             loading: false,
+            active_log_path: None,
             list_height: 0,
             last_list_area: Rect::default(),
             last_detail_area: None,
@@ -636,6 +644,7 @@ impl Logs {
         let has_cursor = cursor_offset.is_some() || cursor_legacy.is_some();
         match self.rpc.logs_query(params).await {
             Ok(result) => {
+                self.active_log_path = result.log_path;
                 // Events come newest-first from the daemon; reverse to chronological
                 let new_entries: Vec<LogEntry> = result
                     .events
@@ -960,7 +969,7 @@ impl Logs {
                 theme::dim_style(),
             ))]
         } else if let Some(detail) = self.current_resolved_detail() {
-            detail.detail_lines()
+            detail.detail_lines(self.active_log_path.as_deref())
         } else {
             vec![Line::from(Span::styled(
                 crate::i18n::t("zc-logs-loading"),
@@ -1943,7 +1952,7 @@ mod tests {
     #[test]
     fn preview_fallback_is_not_empty_and_notes_partial_payload() {
         let detail = LogDetail::from_preview(&sample_entry());
-        let lines = detail.detail_lines();
+        let lines = detail.detail_lines(None);
         assert!(!lines.is_empty());
         // The fallback must visibly signal the payload is partial so
         // the pane never silently masquerades as a full detail view.
@@ -1958,6 +1967,22 @@ mod tests {
     }
 
     #[test]
+    fn preview_fallback_render_shows_active_persisted_path() {
+        let entry = sample_entry();
+        let detail = LogDetail::from_preview(&entry);
+        let rendered: String = detail
+            .detail_lines(Some("/var/lib/zeroclaw/runtime-trace.jsonl"))
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(rendered.contains(&crate::i18n::t_args(
+            "zc-logs-persisted-path",
+            &[("path", "/var/lib/zeroclaw/runtime-trace.jsonl")],
+        )));
+    }
+
+    #[test]
     fn full_payload_is_not_marked_preview_only() {
         let raw = serde_json::json!({
             "@timestamp": "2026-05-29T11:31:43.543Z",
@@ -1968,12 +1993,13 @@ mod tests {
         let detail = LogDetail::new(raw);
         assert!(!detail.is_preview_only());
         let text: String = detail
-            .detail_lines()
+            .detail_lines(Some("/tmp/runtime-trace.jsonl"))
             .iter()
             .flat_map(|l| l.spans.iter())
             .map(|s| s.content.as_ref())
             .collect();
         assert!(!text.contains(&crate::i18n::t("zc-logs-preview-only")));
+        assert!(!text.contains("runtime-trace.jsonl"));
     }
 
     #[test]
@@ -1994,7 +2020,7 @@ mod tests {
         assert_eq!(detail.attributes()["model"], "switched-model");
 
         let text: String = detail
-            .detail_lines()
+            .detail_lines(None)
             .iter()
             .flat_map(|l| l.spans.iter())
             .map(|s| s.content.as_ref())

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -4107,6 +4107,8 @@ impl RpcDispatcher {
 
         to_result(LogsQueryResult {
             events,
+            log_path: zeroclaw_log::active_log_path()
+                .map(|path| path.to_string_lossy().into_owned()),
             next_cursor: page.next_cursor,
             next_cursor_line_offset: page.next_cursor_line_offset,
             at_end: page.at_end,

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -1304,6 +1304,9 @@ rpc_type! {
 rpc_type! {
     pub struct LogsQueryResult {
         pub events: Vec<serde_json::Value>,
+        /// Resolved path of the active installed persistence writer.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub log_path: Option<String>,
         /// Legacy cursor. Deprecated since 0.8.0; tracked for removal in
         /// <https://github.com/zeroclaw-labs/zeroclaw/issues/8012>.
         #[deprecated(
@@ -1815,5 +1818,23 @@ mod tests {
         assert_eq!(params.run_id, "r1");
         assert_eq!(params.surface, Surface::Tui);
         assert!(params.last_step.is_none());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn logs_query_result_exposes_active_log_path_when_present() {
+        let result = LogsQueryResult {
+            events: Vec::new(),
+            log_path: Some("/var/lib/zeroclaw/runtime-trace.jsonl".into()),
+            next_cursor: None,
+            next_cursor_line_offset: None,
+            at_end: true,
+        };
+
+        let value = serde_json::to_value(result).expect("logs/query result");
+        assert_eq!(
+            value["log_path"],
+            json!("/var/lib/zeroclaw/runtime-trace.jsonl")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The Logs detail fallback now shows the active resolved persisted-log path when the full event payload is unavailable. The existing `logs/query` response carries the installed writer path as an optional field so ZeroCode does not need to run Doctor or infer the path from mutable config.
- **Scope boundary:** This does not change log persistence, retention, rotation, daemon reload behavior, Dashboard, Doctor, or keymaps.
- **Blast radius:** `logs/query` gains one optional backward-compatible response field, and ZeroCode caches it for preview-only detail rendering.
- **Linked issue(s):** Closes #8650
- **Labels:** `enhancement`, `runtime`, `zerocode`, `risk:low`, `size:S`

### What this does, simply

ZeroCode can sometimes show only a log event's preview because the complete persisted event is unavailable. That fallback now tells the operator exactly which active log file to inspect instead of requiring them to know an internal default or reconstruct a relative config path. Full event details remain unchanged, and the hint is absent when persistence is disabled.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `tui`
- **Setup / preconditions:** Run the daemon with file log persistence enabled and open ZeroCode's Logs pane. Select a newly streamed event before its complete persisted payload is available so the detail pane enters the preview-only fallback.
- **Steps to run:** Open the event detail and inspect the lines beneath the preview-only notice.
- **Expected on this branch (after):** The detail includes `Persisted log: <resolved active path>`.
- **Prior behavior on `master` (before):** The detail reports that only preview fields are available but does not identify the backing log file.

### How I tested

```sh
cargo fmt --all -- --check
# Finished successfully.

cargo test -p zerocode preview_fallback_render_shows_active_persisted_path
# test result: ok. 1 passed; 0 failed.

cargo test -p zerocode older_response_without_log_path_remains_compatible
# test result: ok. 1 passed; 0 failed. (library target)
# test result: ok. 1 passed; 0 failed. (binary target)
```

- **CI checks relied on and why they cover this change:** Required Rust build, test, lint, format, and ZeroCode RPC boundary checks compile and exercise the changed runtime and TUI surfaces on the published head.
- **Known CI coverage gap, if any:** None. Required exact-head CI is green.
- **Commands run and tail output:** Included above.
- **Beyond CI, what did you manually verify?** Source inspection confirms both Doctor and Logs read the existing installed-writer `active_log_path()` authority. A direct ZeroCode TUI smoke confirmed the preview-only fallback displays the resolved persisted-log path.
- **Visual interface changed?** Yes
- **Tested revision, interface, and terminal or viewport dimensions:** `052af48cede7b8425fe69407ec1762dad22b2125`; ZeroCode Logs detail pane in a representative desktop terminal viewport.
- **Screenshot evidence:**

<img width="1375" height="870" alt="ZeroCode Logs preview-only detail showing the persisted log path" src="https://github.com/user-attachments/assets/f48c30c6-6623-4dc1-bdc6-b83799c681e5" />

- **Action or changed state and observed result:** After the persisted event became unavailable, opening an older Logs entry showed the preview-only notice followed by the resolved `Persisted log:` path. Full-payload detail behavior remains covered by the focused regression.
- **If any command was intentionally skipped, why:** No additional local runtime harness was run; the focused regressions and required exact-head CI cover the changed RPC and TUI code.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes. The new response field is optional and defaults to `None` for older daemons.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: `git revert <squash-commit-sha>`.
