### PR TITLE
fix(zerocode): satisfy Rust 1.98 drain lint

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -195,7 +195,7 @@ impl SgrMouseEventDecoder {
 
     fn replay_candidate(&mut self) -> Vec<Event> {
         self.candidate_started_at = None;
-        self.candidate.drain(..).collect()
+        std::mem::take(&mut self.candidate)
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace `Vec::drain(..).collect()` with `std::mem::take` in the split SGR mouse decoder, satisfying Rust 1.98's `clippy::drain_collect` diagnostic without changing replay order or clearing semantics.
- **Scope boundary:** This does not change mouse parsing, terminal rendering, toolchain pins, MSRV, or any non-ZeroCode crate.
- **Blast radius:** Limited to replaying buffered terminal events when an SGR mouse escape candidate is incomplete or invalid.
- **Linked issue(s):** Related #9527
- **Labels:** `ci`, `distinguished contributor`, `zerocode`, `risk:low`, `size:XS`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a behavior-preserving Clippy compatibility change.

### How I tested

- **CI checks relied on and why they cover this change:** `Format`, `Lint`, `Test`, and `CI Required Gate` pass at head `29099d29ab6862dd7bf5d04c347f19f4676403a0`. Hosted CI uses Rust 1.96.1 and covers the existing SGR decoder regressions. The Rust 1.98 Clippy result below is author-reported local validation.
- **Known CI coverage gap, if any:** None for the changed Rust surface.
- **Commands run and tail output:**

```sh
cargo +1.98.0 fmt --all -- --check
# exit 0

RUSTC_WRAPPER= cargo +1.98.0 clippy -p zerocode --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 32s

RUSTC_WRAPPER= cargo +1.98.0 test -p zerocode
# lib: 199 passed; 0 failed
# main ordinary tests passed; the command was stopped after sandbox-specific
# signal/subprocess lifecycle tests continued waiting beyond 60 seconds.
```

- **Beyond CI, what did you manually verify?** Confirmed the replacement returns the complete buffered vector in order and leaves the canonical buffer empty. No interactive TUI smoke was needed because rendered or interactive behavior is unchanged.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** The full-workspace Clippy run was stopped after the changed crate passed because final workspace test-target compilation remained silent for an extended period; the focused Rust 1.98 Clippy command completed successfully. The focused test command was stopped only after environment-sensitive signal/subprocess tests exceeded 60 seconds; completed tests were green.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: after squash merge, identify and verify this PR's landed squash commit, then run `git revert <landed-squash-sha>`.
