### PR TITLE
feat(zerocode): make modifier intent explicit

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -12888,9 +12888,10 @@ mod tests {
 
         let mut chat = chat_with_active_input(PaneKind::Chat);
         assert!(matches!(
-            active_state(&mut chat)
-                .input_bar
-                .handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL)),
+            active_state(&mut chat).input_bar.handle_key(KeyEvent::new(
+                KeyCode::Char('a'),
+                crate::keymap::Chord::primary('a').effective_modifiers(),
+            )),
             InputBarAction::Consumed
         ));
         cases.push(("file explorer", chat));

--- a/apps/zerocode/src/config/keybindings.rs
+++ b/apps/zerocode/src/config/keybindings.rs
@@ -80,14 +80,20 @@ fn emacs_rows() -> Vec<(String, Vec<Chord>)> {
         (action.to_string(), chords)
     };
     from_defaults(vec![
-        with(&DashboardTabAction::Up.action_key(), vec![Chord::ctrl('p')]),
+        with(
+            &DashboardTabAction::Up.action_key(),
+            vec![Chord::primary('p')],
+        ),
         with(
             &DashboardTabAction::Down.action_key(),
             vec![Chord::ctrl('n')],
         ),
-        with(&LogsTabAction::Up.action_key(), vec![Chord::ctrl('p')]),
+        with(&LogsTabAction::Up.action_key(), vec![Chord::primary('p')]),
         with(&LogsTabAction::Down.action_key(), vec![Chord::ctrl('n')]),
-        with(&FileExplorerAction::Up.action_key(), vec![Chord::ctrl('p')]),
+        with(
+            &FileExplorerAction::Up.action_key(),
+            vec![Chord::primary('p')],
+        ),
         with(
             &FileExplorerAction::Down.action_key(),
             vec![Chord::ctrl('n')],
@@ -324,6 +330,30 @@ mod tests {
     }
 
     #[test]
+    fn emacs_preset_preserves_primary_p_and_literal_control_n() {
+        let rows: HashMap<_, _> = emacs_rows().into_iter().collect();
+        for (up, down) in [
+            (
+                DashboardTabAction::Up.action_key(),
+                DashboardTabAction::Down.action_key(),
+            ),
+            (
+                LogsTabAction::Up.action_key(),
+                LogsTabAction::Down.action_key(),
+            ),
+            (
+                FileExplorerAction::Up.action_key(),
+                FileExplorerAction::Down.action_key(),
+            ),
+        ] {
+            assert!(rows[&up].contains(&Chord::primary('p')));
+            assert!(!rows[&up].contains(&Chord::ctrl('p')));
+            assert!(rows[&down].contains(&Chord::ctrl('n')));
+            assert!(!rows[&down].contains(&Chord::primary('n')));
+        }
+    }
+
+    #[test]
     fn preset_names_are_snake_case() {
         let ok = |s: &str| {
             !s.is_empty()
@@ -403,28 +433,27 @@ mod tests {
         assert!(build_override_table(rows).is_err());
     }
 
-    /// The darwin arm of the same rule: `normalise_mods` rewrites `CONTROL` to
-    /// `SUPER` for any chord the host has not reserved.
+    /// The darwin arm of the same rule: platform-primary intent resolves to
+    /// `SUPER`, so it collides with a literal `super` spelling.
     #[cfg(target_os = "macos")]
     #[test]
-    fn normalized_ctrl_super_duplicate_is_rejected_on_darwin() {
+    fn primary_super_duplicate_is_rejected_on_darwin() {
         use crossterm::event::{KeyCode, KeyModifiers};
         let mut rows = HashMap::new();
-        rows.insert("dashboard.up".to_string(), vec![Chord::ctrl('a')]);
+        rows.insert("dashboard.up".to_string(), vec![Chord::primary('a')]);
         rows.insert(
             "dashboard.down".to_string(),
             vec![Chord::with(KeyCode::Char('a'), KeyModifiers::SUPER)],
         );
         assert!(build_override_table(rows).is_err());
 
-        // `ctrl+c` is host-reserved, so CONTROL is never rewritten for it and
-        // the two spellings really are different keys. The check must not
-        // over-reject.
+        // Literal Control remains distinct from literal Super for every key.
+        // The check must not over-reject the two explicit spellings.
         let mut ok = HashMap::new();
-        ok.insert("dashboard.up".to_string(), vec![Chord::ctrl('c')]);
+        ok.insert("dashboard.up".to_string(), vec![Chord::ctrl('a')]);
         ok.insert(
             "dashboard.down".to_string(),
-            vec![Chord::with(KeyCode::Char('c'), KeyModifiers::SUPER)],
+            vec![Chord::with(KeyCode::Char('a'), KeyModifiers::SUPER)],
         );
         assert!(build_override_table(ok).is_ok());
     }

--- a/apps/zerocode/src/config/mod.rs
+++ b/apps/zerocode/src/config/mod.rs
@@ -43,6 +43,68 @@ impl ChordSpec {
     }
 }
 
+fn migrate_legacy_ctrl_bindings(value: &mut toml::Value) -> bool {
+    let Some(rows) = value.as_table_mut() else {
+        return false;
+    };
+    let mut migrated = false;
+    for (_, value) in rows.iter_mut() {
+        migrated |= migrate_legacy_ctrl_value(value);
+    }
+    migrated
+}
+
+fn migrate_legacy_ctrl_value(value: &mut toml::Value) -> bool {
+    match value {
+        toml::Value::String(wire) => migrate_legacy_ctrl_wire(wire),
+        toml::Value::Array(values) => {
+            let mut migrated = false;
+            for value in values {
+                migrated |= migrate_legacy_ctrl_value(value);
+            }
+            migrated
+        }
+        _ => false,
+    }
+}
+
+fn migrate_legacy_ctrl_wire(wire: &mut String) -> bool {
+    let segments: Vec<&str> = wire.trim().split('+').collect();
+    if segments.len() < 2 {
+        return false;
+    }
+    let Some(key) = segments.last() else {
+        return false;
+    };
+    let replacement = if matches!(
+        key.to_ascii_lowercase().as_str(),
+        "c" | "g" | "k" | "n" | "s" | "f1"
+    ) {
+        "control"
+    } else {
+        "primary"
+    };
+    let mut found_legacy = false;
+    let migrated = segments
+        .iter()
+        .map(|segment| {
+            if segment.eq_ignore_ascii_case("ctrl") {
+                found_legacy = true;
+                replacement
+            } else {
+                segment
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("+");
+    if found_legacy && migrated != wire.trim() {
+        *wire = migrated;
+        true
+    } else {
+        false
+    }
+}
+
 fn migrate_legacy_help_binding(rows: &mut HashMap<String, ChordSpec>) -> bool {
     use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -544,7 +606,20 @@ pub(crate) fn load_persisted(config_dir: &Path) -> Result<ZerocodeConfig> {
         }
     }
     if let Some(v) = doc.get("keybindings") {
-        match v.clone().try_into::<HashMap<String, ChordSpec>>() {
+        let mut migrated_value = v.clone();
+        let migrated_legacy = migrate_legacy_ctrl_bindings(&mut migrated_value);
+        if migrated_legacy {
+            // Rewrite legacy spellings before parsing the rows. A malformed,
+            // unrelated row must not leave otherwise valid legacy values in
+            // the file indefinitely; the tolerant loader still falls back to
+            // defaults for the malformed section below.
+            doc.insert("keybindings".to_string(), migrated_value.clone());
+            migrated_keybindings = true;
+        }
+        match migrated_value
+            .clone()
+            .try_into::<HashMap<String, ChordSpec>>()
+        {
             Ok(mut rows) => {
                 if migrate_legacy_help_binding(&mut rows) {
                     let key = GlobalAction::Help.action_key();
@@ -1281,6 +1356,25 @@ mod tests {
     }
 
     #[test]
+    fn persist_keybind_row_emits_only_canonical_modifier_wires() {
+        let dir = tempfile::tempdir().unwrap();
+        persist_keybind_row(
+            dir.path(),
+            "input_bar.clear_input",
+            vec![Chord::ctrl('c'), Chord::primary('u')],
+        )
+        .unwrap();
+
+        let doc: toml::Table = toml::from_str(&read(dir.path())).unwrap();
+        let row = doc["keybindings"]["input_bar.clear_input"]
+            .as_array()
+            .unwrap();
+        assert_eq!(row[0].as_str(), Some("control+c"));
+        assert_eq!(row[1].as_str(), Some("primary+u"));
+        assert!(!read(dir.path()).contains("ctrl+"));
+    }
+
+    #[test]
     fn persist_keybindings_replaces_only_its_section() {
         let dir = tempfile::tempdir().unwrap();
         seed(
@@ -1365,7 +1459,7 @@ mod tests {
     }
 
     #[test]
-    fn customized_help_binding_is_not_migrated() {
+    fn customized_help_binding_migrates_legacy_primary() {
         // Reads the environment via `ensure_and_load`; serialize against the
         // env-mutating tests so a stray override cannot leak in.
         let _guard = env_test_lock();
@@ -1379,9 +1473,102 @@ mod tests {
         let resolved = cfg.resolve_keybindings().unwrap();
         assert_eq!(
             resolved["global"]["help"],
-            vec![Chord::char('?'), Chord::ctrl('h')]
+            vec![Chord::char('?'), Chord::primary('h')]
         );
-        assert!(read(dir.path()).contains("ctrl+h"));
+        assert!(read(dir.path()).contains("primary+h"));
+        assert!(!read(dir.path()).contains("ctrl+h"));
+    }
+
+    #[test]
+    fn legacy_ctrl_migration_preserves_scalar_array_and_unrelated_config() {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        let dir = tempfile::tempdir().unwrap();
+        seed(
+            dir.path(),
+            "locale = \"en\"\n\n[keybindings]\n\"input_bar.clear_input\" = \"ctrl+u\"\n\"global.help\" = [\"ctrl+c\", \"ctrl+f1\"]\n\n[future]\nkeep = true\n",
+        );
+
+        let cfg = ensure_and_load(dir.path()).unwrap();
+        let resolved = cfg.resolve_keybindings().unwrap();
+        assert_eq!(
+            resolved["input_bar"]["clear_input"],
+            vec![Chord::primary('u')]
+        );
+        assert_eq!(
+            resolved["global"]["help"],
+            vec![
+                Chord::ctrl('c'),
+                Chord::with(KeyCode::F(1), KeyModifiers::CONTROL),
+            ]
+        );
+
+        let doc: toml::Table = toml::from_str(&read(dir.path())).unwrap();
+        assert_eq!(doc["locale"].as_str(), Some("en"));
+        assert_eq!(doc["future"]["keep"].as_bool(), Some(true));
+        assert_eq!(
+            doc["keybindings"]["input_bar.clear_input"].as_str(),
+            Some("primary+u")
+        );
+        let global = doc["keybindings"]["global.help"].as_array().unwrap();
+        assert_eq!(global[0].as_str(), Some("control+c"));
+        assert_eq!(global[1].as_str(), Some("control+f1"));
+    }
+
+    #[test]
+    fn legacy_ctrl_migration_uses_the_frozen_key_split() {
+        for key in ["c", "g", "k", "n", "s", "f1"] {
+            let mut wire = format!("ctrl+{key}");
+            assert!(migrate_legacy_ctrl_wire(&mut wire));
+            assert_eq!(wire, format!("control+{key}"));
+        }
+        for key in [
+            "a", "d", "e", "h", "p", "r", "u", "v", "w", "x", "enter", "up",
+        ] {
+            let mut wire = format!("ctrl+{key}");
+            assert!(migrate_legacy_ctrl_wire(&mut wire));
+            assert_eq!(wire, format!("primary+{key}"));
+        }
+        let mut canonical = "control+c".to_string();
+        assert!(!migrate_legacy_ctrl_wire(&mut canonical));
+        assert_eq!(canonical, "control+c");
+    }
+
+    #[test]
+    fn legacy_ctrl_migration_rewrites_before_tolerant_parse() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(
+            dir.path(),
+            "[keybindings]\n\"input_bar.clear_input\" = \"ctrl+u\"\n\"broken\" = [42]\n\n[future]\nkeep = true\n",
+        );
+
+        let cfg = ensure_and_load(dir.path()).unwrap();
+        assert!(
+            cfg.keybindings.is_empty(),
+            "malformed rows still use defaults"
+        );
+
+        let doc: toml::Table = toml::from_str(&read(dir.path())).unwrap();
+        assert_eq!(
+            doc["keybindings"]["input_bar.clear_input"].as_str(),
+            Some("primary+u")
+        );
+        assert_eq!(doc["keybindings"]["broken"][0].as_integer(), Some(42));
+        assert_eq!(doc["future"]["keep"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn canonical_keybindings_reload_idempotently() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(
+            dir.path(),
+            "[keybindings]\n\"input_bar.clear_input\" = \"primary+u\"\n\n[future]\nkeep = 1\n",
+        );
+
+        let _ = ensure_and_load(dir.path()).unwrap();
+        let first = read(dir.path());
+        let _ = ensure_and_load(dir.path()).unwrap();
+        assert_eq!(read(dir.path()), first);
     }
 
     #[test]

--- a/apps/zerocode/src/input_bar.rs
+++ b/apps/zerocode/src/input_bar.rs
@@ -205,7 +205,7 @@ pub(crate) enum InputBarAction {
         text: Option<String>,
         attachments: Vec<PendingAttachment>,
     },
-    /// User requested immediate injection (Ctrl+Enter) — skip the queue.
+    /// User requested immediate injection (platform-primary Enter) — skip the queue.
     Inject {
         text: Option<String>,
         attachments: Vec<PendingAttachment>,
@@ -2293,21 +2293,27 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_u_clears_input() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_u_clears_input() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("scratch this");
-        let act = bar.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
+        let act = bar.handle_key(KeyEvent::new(
+            KeyCode::Char('u'),
+            crate::keymap::Chord::primary('u').effective_modifiers(),
+        ));
         assert!(matches!(act, InputBarAction::Consumed));
         assert_eq!(bar.input(), "");
     }
 
     #[test]
-    fn ctrl_w_deletes_previous_word() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_previous_word() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello world");
-        let action = bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        let action = bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert!(matches!(action, InputBarAction::Consumed));
         assert_eq!(bar.input(), "hello ");
         assert_eq!(bar.cursor(), 6);
@@ -2315,7 +2321,7 @@ mod tests {
 
     #[test]
     fn alt_backspace_deletes_previous_word() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello world");
 
@@ -2438,7 +2444,10 @@ mod tests {
         bar.insert_text("🇺x🇸");
         bar.move_cursor_left();
 
-        let action = bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        let action = bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
 
         assert!(matches!(action, InputBarAction::Consumed));
         assert_eq!(bar.input(), "🇺🇸");
@@ -2447,7 +2456,7 @@ mod tests {
 
     #[test]
     fn backspace_normalizes_cursor_after_joining_emoji_graphemes_with_selection() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("🇺x🇸");
         let selection_start = "🇺".len();
@@ -2468,7 +2477,10 @@ mod tests {
         let selection_start = "🇺".len();
         bar.selection = Some((selection_start, selection_start + 1));
 
-        let action = bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        let action = bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
 
         assert!(matches!(action, InputBarAction::Consumed));
         assert_eq!(bar.input(), "🇺🇸");
@@ -2488,65 +2500,83 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_w_deletes_trailing_space_and_word() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_trailing_space_and_word() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello world   ");
-        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert_eq!(bar.input(), "hello ");
         assert_eq!(bar.cursor(), 6);
     }
 
     #[test]
-    fn ctrl_w_deletes_word_before_cursor() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_word_before_cursor() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello brave world");
         for _ in 0..5 {
             bar.move_cursor_left();
         }
-        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert_eq!(bar.input(), "hello world");
         assert_eq!(bar.cursor(), 6);
     }
 
     #[test]
-    fn ctrl_w_deletes_selection() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_selection() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello world");
         bar.selection = Some((6, 11));
-        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert_eq!(bar.input(), "hello ");
         assert_eq!(bar.cursor(), 6);
     }
 
     #[test]
-    fn ctrl_w_deletes_punctuation_run_like_vim() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_punctuation_run_like_vim() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello world...");
-        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert_eq!(bar.input(), "hello world");
         assert_eq!(bar.cursor(), 11);
     }
 
     #[test]
-    fn ctrl_w_deletes_word_after_punctuation_like_vim() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_word_after_punctuation_like_vim() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("hello-world");
-        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert_eq!(bar.input(), "hello-");
         assert_eq!(bar.cursor(), 6);
     }
 
     #[test]
-    fn ctrl_w_deletes_only_whitespace_before_cursor() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn primary_w_deletes_only_whitespace_before_cursor() {
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("   ");
-        bar.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL));
+        bar.handle_key(KeyEvent::new(
+            KeyCode::Char('w'),
+            crate::keymap::Chord::primary('w').effective_modifiers(),
+        ));
         assert_eq!(bar.input(), "");
         assert_eq!(bar.cursor(), 0);
     }

--- a/apps/zerocode/src/input_bar.rs
+++ b/apps/zerocode/src/input_bar.rs
@@ -2439,7 +2439,7 @@ mod tests {
 
     #[test]
     fn delete_previous_word_normalizes_cursor_after_joining_emoji_graphemes() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("🇺x🇸");
         bar.move_cursor_left();
@@ -2471,7 +2471,7 @@ mod tests {
 
     #[test]
     fn delete_previous_word_normalizes_cursor_after_joining_emoji_graphemes_with_selection() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::{KeyCode, KeyEvent};
         let mut bar = input_bar_with_shared_commands();
         bar.insert_text("🇺x🇸");
         let selection_start = "🇺".len();

--- a/apps/zerocode/src/keymap/actions.rs
+++ b/apps/zerocode/src/keymap/actions.rs
@@ -76,10 +76,10 @@ macro_rules! keyactions {
             /// match in declaration order.
             ///
             /// The claim is tested with `Chord::same_key`, not `==`: dispatch
-            /// compares platform-normalised modifiers, so on darwin an explicit
-            /// `super+a` and a retained `ctrl+a` are one chord there and two
-            /// here. Raw equality left the shadowed default in the table and
-            /// the operator's own binding lost to it.
+            /// compares effective event modifiers, so on darwin an explicit
+            /// `super+a` and a retained `primary+a` are one chord there and
+            /// two here. Raw equality left the shadowed default in the table
+            /// and the operator's own binding lost to it.
             pub fn resolved_bindings() -> Vec<(Chord, $name)> {
                 let Some(over) = super::overrides::lookup(Self::TAG) else {
                     return Self::bindings();
@@ -146,7 +146,7 @@ keyactions! {
         ]                                                              => "help",
         PaneNavLeft  [Chord::with(KeyCode::Left, KeyModifiers::ALT), Chord::with(KeyCode::Char('b'), KeyModifiers::ALT)]  => "prev pane",
         PaneNavRight [Chord::with(KeyCode::Right, KeyModifiers::ALT), Chord::with(KeyCode::Char('f'), KeyModifiers::ALT)] => "next pane",
-        ReloadDaemon [Chord::ctrl('r')]                                 => "reload daemon",
+        ReloadDaemon [Chord::primary('r')]                              => "reload daemon",
         ConfirmYes   []                                                 => "confirm",
         ConfirmNo    []                                                 => "cancel",
     }
@@ -173,8 +173,8 @@ keyactions! {
         BrowseDownVim           [Chord::char('j')] => "browse next (vim)",
         BrowseSelectExtend      [Chord::shift(KeyCode::Up)] => "extend selection up",
         BrowseSelectExtendDown  [Chord::shift(KeyCode::Down)] => "extend selection down",
-        FastScrollUp            [Chord::with(KeyCode::Up, KeyModifiers::CONTROL.union(KeyModifiers::SHIFT))] => "fast scroll up",
-        FastScrollDown          [Chord::with(KeyCode::Down, KeyModifiers::CONTROL.union(KeyModifiers::SHIFT))] => "fast scroll down",
+        FastScrollUp            [Chord::with_primary(KeyCode::Up, KeyModifiers::SHIFT)] => "fast scroll up",
+        FastScrollDown          [Chord::with_primary(KeyCode::Down, KeyModifiers::SHIFT)] => "fast scroll down",
         BrowseExitSelection     [Chord::key(KeyCode::Esc)] => "exit selection",
         CopySelection           [
             Chord::char('y'),
@@ -182,11 +182,11 @@ keyactions! {
         ] => "copy selection",
         CopyAllVisible          [Chord::with(KeyCode::Char('C'), KeyModifiers::CONTROL.union(KeyModifiers::SHIFT))] => "copy all visible",
         ToggleThoughts          [Chord::char('t')] => "toggle thoughts",
-        TodoToggle              [Chord::ctrl('p')] => "toggle todo tracker",
+        TodoToggle              [Chord::primary('p')] => "toggle todo tracker",
         NewSession              [Chord::ctrl('n')] => "new session",
         SwitchSession           [Chord::ctrl('s')] => "switch session",
         DeleteSession           [] => "delete session",
-        CancelTurn              [Chord::ctrl('d')] => "cancel turn",
+        CancelTurn              [Chord::primary('d')] => "cancel turn",
         ApprovalApprove         [Chord::key(KeyCode::Enter)] => "approve",
         ApprovalDeny            [] => "deny",
         ApprovalApproveAll      [Chord::char('a')] => "approve all",
@@ -347,20 +347,20 @@ keyactions! {
 keyactions! {
     pub enum InputBarAction ("input_bar") {
         Submit             [Chord::key(KeyCode::Enter)] => "send",
-        Inject             [Chord::with(KeyCode::Enter, KeyModifiers::CONTROL)] => "send now",
+        Inject             [Chord::with_primary(KeyCode::Enter, KeyModifiers::NONE)] => "send now",
         NewLine            [Chord::shift(KeyCode::Enter)] => "new line",
         CursorLeft         [Chord::key(KeyCode::Left)] => "cursor left",
         CursorRight        [Chord::key(KeyCode::Right)] => "cursor right",
         CursorWordLeft     [Chord::with(KeyCode::Left, KeyModifiers::ALT), Chord::with(KeyCode::Char('b'), KeyModifiers::ALT)] => "word left",
         CursorWordRight    [Chord::with(KeyCode::Right, KeyModifiers::ALT), Chord::with(KeyCode::Char('f'), KeyModifiers::ALT)] => "word right",
         CursorStart        [Chord::key(KeyCode::Home)] => "line start",
-        CursorEnd          [Chord::key(KeyCode::End), Chord::ctrl('e')] => "line end",
-        OpenFileBrowser    [Chord::ctrl('a')] => "browse files",
+        CursorEnd          [Chord::key(KeyCode::End), Chord::primary('e')] => "line end",
+        OpenFileBrowser    [Chord::primary('a')] => "browse files",
         Backspace          [Chord::key(KeyCode::Backspace)] => "backspace",
-        DeletePreviousWord [Chord::ctrl('w'), Chord::with(KeyCode::Backspace, KeyModifiers::ALT)] => "delete previous word",
-        ClearInput         [Chord::ctrl('u')] => "clear input",
+        DeletePreviousWord [Chord::primary('w'), Chord::with(KeyCode::Backspace, KeyModifiers::ALT)] => "delete previous word",
+        ClearInput         [Chord::primary('u')] => "clear input",
         SelectAll          [] => "select all",
-        Paste              [Chord::ctrl('v')] => "paste",
+        Paste              [Chord::primary('v')] => "paste",
         HistoryPrev        [Chord::key(KeyCode::Up)] => "history prev",
         HistoryNext        [Chord::key(KeyCode::Down)] => "history next",
         AutocompleteNext   [] => "autocomplete next",

--- a/apps/zerocode/src/keymap/chord.rs
+++ b/apps/zerocode/src/keymap/chord.rs
@@ -8,14 +8,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 /// A single keystroke pattern.
-///
-/// On darwin, most `CONTROL` chords are translated to `SUPER` at match time.
-/// Terminal-owned chords such as Ctrl+C, Ctrl+G, and Ctrl+K stay literal so
-/// host shortcuts do not shadow ZeroCode actions.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Chord {
     pub code: KeyCode,
     pub modifiers: KeyModifiers,
+    primary: bool,
 }
 
 impl Chord {
@@ -23,6 +20,7 @@ impl Chord {
         Self {
             code,
             modifiers: KeyModifiers::NONE,
+            primary: false,
         }
     }
 
@@ -31,11 +29,27 @@ impl Chord {
     }
 
     pub const fn with(code: KeyCode, modifiers: KeyModifiers) -> Self {
-        Self { code, modifiers }
+        Self {
+            code,
+            modifiers,
+            primary: false,
+        }
     }
 
     pub const fn ctrl(c: char) -> Self {
         Self::with(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    pub const fn primary(c: char) -> Self {
+        Self::with_primary(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    pub const fn with_primary(code: KeyCode, modifiers: KeyModifiers) -> Self {
+        Self {
+            code,
+            modifiers,
+            primary: true,
+        }
     }
 
     pub const fn shift(code: KeyCode) -> Self {
@@ -44,38 +58,47 @@ impl Chord {
 
     pub fn matches(&self, event: &KeyEvent) -> bool {
         event.code == self.code
-            && normalise_mods(self.code, self.modifiers)
-                == normalise_mods(event.code, event.modifiers)
+            && self.effective_modifiers() == effective_event_modifiers(event.code, event.modifiers)
     }
 
     /// Whether two chords claim the same key event.
     ///
-    /// Not `==`. [`matches`](Self::matches) compares platform-normalised
+    /// Not `==`. [`matches`](Self::matches) compares effective event
     /// modifiers, so two chords that differ on the wire can still own one
-    /// event: on darwin `normalise_mods` rewrites `CONTROL` to `SUPER` for
-    /// every chord the host has not reserved, which makes `ctrl+a` and
-    /// `super+a` two entries in config and one chord at dispatch. Anything
-    /// deciding which of two chords owns a key asks this, or it arbitrates a
-    /// collision the dispatcher cannot see and leaves the loser advertised in
-    /// Help.
+    /// event when one uses platform-primary intent.
     #[must_use]
     pub fn same_key(&self, other: &Self) -> bool {
-        self.code == other.code
-            && normalise_mods(self.code, self.modifiers)
-                == normalise_mods(other.code, other.modifiers)
+        self.code == other.code && self.effective_modifiers() == other.effective_modifiers()
     }
 
-    /// `Ctrl+K` on most platforms; `⌘K` on darwin. On darwin, a
-    /// host-reserved chord's control label is the literal word `Ctrl`
-    /// (not the `⌘` glyph) and needs a separator to stay readable —
-    /// see `control_display_label`.
+    pub(crate) fn effective_modifiers(&self) -> KeyModifiers {
+        effective_event_modifiers(self.code, self.modifiers_for_event())
+    }
+
+    fn modifiers_for_event(&self) -> KeyModifiers {
+        let mut modifiers = self.modifiers;
+        if self.primary {
+            #[cfg(target_os = "macos")]
+            modifiers.insert(KeyModifiers::SUPER);
+            #[cfg(not(target_os = "macos"))]
+            modifiers.insert(KeyModifiers::CONTROL);
+        }
+        modifiers
+    }
+
     pub fn display(&self) -> String {
         let mut parts: Vec<&str> = Vec::new();
         let mut literal_word_control = false;
+        if self.primary {
+            parts.push(if cfg!(target_os = "macos") {
+                "⌘"
+            } else {
+                "Ctrl"
+            });
+        }
         if self.modifiers.contains(KeyModifiers::CONTROL) {
-            let label = control_display_label(&self.code);
-            literal_word_control = cfg!(target_os = "macos") && label == "Ctrl";
-            parts.push(label);
+            literal_word_control = true;
+            parts.push("Ctrl");
         }
         if self.modifiers.contains(KeyModifiers::SUPER) {
             parts.push(if cfg!(target_os = "macos") {
@@ -106,8 +129,9 @@ impl Chord {
 
     pub fn wire(&self) -> String {
         let mut out = String::new();
-        // Modifier tokens walk the canonical registry so render and
-        // parse share one source of truth — no string-literal arms.
+        if self.primary {
+            out.push_str("primary+");
+        }
         for (token, flag) in MOD_TOKENS {
             if self.modifiers.contains(*flag) {
                 out.push_str(token);
@@ -119,12 +143,10 @@ impl Chord {
     }
 }
 
-/// Canonical modifier token registry. Walked by both `wire()` (render)
-/// and `from_str` (parse), so the two directions can never drift.
-/// `super` is accepted on parse but never emitted on non-darwin; the
-/// Ctrl→Super normalisation stays purely at match time.
+/// Canonical non-primary modifier token registry. Walked by both `wire()`
+/// (render) and `from_str` (parse), so the two directions can never drift.
 const MOD_TOKENS: &[(&str, KeyModifiers)] = &[
-    ("ctrl", KeyModifiers::CONTROL),
+    ("control", KeyModifiers::CONTROL),
     ("alt", KeyModifiers::ALT),
     ("shift", KeyModifiers::SHIFT),
     ("super", KeyModifiers::SUPER),
@@ -215,10 +237,7 @@ impl FromStr for Chord {
         // `"+"` yields two empty segments and the parse fails.
         if trimmed.chars().count() == 1 {
             let code = parse_keycode(trimmed)?;
-            return Ok(Chord {
-                code,
-                modifiers: KeyModifiers::NONE,
-            });
+            return Ok(Chord::key(code));
         }
         let mut segments: Vec<&str> = trimmed.split('+').collect();
         // Last segment is the key (case preserved so 'G' stays distinct
@@ -227,16 +246,25 @@ impl FromStr for Chord {
             .pop()
             .ok_or_else(|| ChordParseError(s.to_string()))?;
         let mut modifiers = KeyModifiers::NONE;
+        let mut primary = false;
         for seg in segments {
             let lower = seg.to_lowercase();
-            let flag = MOD_TOKENS
-                .iter()
-                .find_map(|(t, f)| (*t == lower).then_some(*f))
-                .ok_or_else(|| ChordParseError(s.to_string()))?;
-            modifiers.insert(flag);
+            if lower == "primary" {
+                primary = true;
+            } else {
+                let flag = MOD_TOKENS
+                    .iter()
+                    .find_map(|(t, f)| (*t == lower).then_some(*f))
+                    .ok_or_else(|| ChordParseError(s.to_string()))?;
+                modifiers.insert(flag);
+            }
         }
         let code = parse_keycode(key_token)?;
-        Ok(Chord { code, modifiers })
+        Ok(Chord {
+            code,
+            modifiers,
+            primary,
+        })
     }
 }
 
@@ -253,39 +281,7 @@ impl<'de> Deserialize<'de> for Chord {
     }
 }
 
-#[cfg(target_os = "macos")]
-fn normalise_mods(code: KeyCode, mut m: KeyModifiers) -> KeyModifiers {
-    if m.contains(KeyModifiers::CONTROL) && !is_host_reserved_chord(&code) {
-        m.remove(KeyModifiers::CONTROL);
-        m.insert(KeyModifiers::SUPER);
-    }
-    strip_redundant_shift(code, m)
-}
-
-#[cfg(target_os = "macos")]
-fn is_host_reserved_chord(code: &KeyCode) -> bool {
-    matches!(
-        code,
-        KeyCode::Char('c' | 'C' | 'g' | 'G' | 'k' | 'K' | 'n' | 'N' | 's' | 'S') | KeyCode::F(1)
-    )
-}
-
-#[cfg(target_os = "macos")]
-fn control_display_label(code: &KeyCode) -> &'static str {
-    if is_host_reserved_chord(code) {
-        "Ctrl"
-    } else {
-        "⌘"
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn control_display_label(_code: &KeyCode) -> &'static str {
-    "Ctrl"
-}
-
-#[cfg(not(target_os = "macos"))]
-fn normalise_mods(code: KeyCode, m: KeyModifiers) -> KeyModifiers {
+fn effective_event_modifiers(code: KeyCode, m: KeyModifiers) -> KeyModifiers {
     strip_redundant_shift(code, m)
 }
 
@@ -388,12 +384,30 @@ mod tests {
         assert!(chord.matches(&event));
     }
 
+    #[test]
+    fn ctrl_chord_stays_literal_control_on_every_platform() {
+        let chord = Chord::ctrl('x');
+        let control = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        assert!(chord.matches(&control));
+        assert_eq!(chord.display(), "Ctrl+x");
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
-    fn ctrl_chord_matches_super_event_on_darwin() {
-        let chord = Chord::ctrl('x');
+    fn primary_chord_matches_super_event_on_darwin() {
+        let chord = Chord::primary('x');
         let event = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::SUPER);
         assert!(chord.matches(&event));
+        assert_eq!(chord.display(), "⌘x");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn primary_chord_matches_control_event_on_non_darwin() {
+        let chord = Chord::primary('x');
+        let event = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        assert!(chord.matches(&event));
+        assert_eq!(chord.display(), "Ctrl+x");
     }
 
     #[cfg(target_os = "macos")]
@@ -407,12 +421,8 @@ mod tests {
         assert!(chord.matches(&quit));
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
-    fn terminal_safe_chords_stay_literal_ctrl_on_darwin() {
-        // Terminal-owned chords must retain literal Control
-        // matching (not the host-reserved Command event) and display
-        // with the literal word "Ctrl" plus a separator on darwin.
+    fn literal_control_is_key_independent() {
         for c in ['n', 's', 'g', 'k'] {
             let chord = Chord::ctrl(c);
             let ctrl = KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL);
@@ -439,12 +449,6 @@ mod tests {
     #[test]
     fn display_ctrl_on_non_darwin() {
         assert_eq!(Chord::ctrl('k').display(), "Ctrl+k");
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn display_ctrl_on_darwin() {
-        assert_eq!(Chord::ctrl('x').display(), "⌘x");
     }
 
     #[cfg(target_os = "macos")]
@@ -482,6 +486,8 @@ mod tests {
     fn wire_round_trips_modifiers() {
         for c in [
             Chord::ctrl('k'),
+            Chord::primary('r'),
+            Chord::with_primary(KeyCode::Char('x'), KeyModifiers::CONTROL),
             Chord::with(KeyCode::Char('c'), KeyModifiers::SUPER),
             Chord::shift(KeyCode::Up),
             Chord::with(
@@ -513,7 +519,12 @@ mod tests {
     #[test]
     fn wire_is_os_independent_lowercase() {
         // Never emits the darwin glyphs — same on every platform.
-        assert_eq!(Chord::ctrl('k').wire(), "ctrl+k");
+        assert_eq!(Chord::ctrl('k').wire(), "control+k");
+        assert_eq!(Chord::primary('r').wire(), "primary+r");
+        assert_eq!(
+            Chord::with_primary(KeyCode::Char('x'), KeyModifiers::CONTROL).wire(),
+            "primary+control+x"
+        );
         assert_eq!(Chord::key(KeyCode::PageUp).wire(), "pageup");
         assert_eq!(Chord::char(' ').wire(), "space");
     }
@@ -539,9 +550,9 @@ mod tests {
             Chord::from_str("Enter").unwrap(),
             Chord::key(KeyCode::Enter)
         );
-        assert_eq!(Chord::from_str("CTRL+k").unwrap(), Chord::ctrl('k'));
-        assert_eq!(Chord::from_str("ctrl+k").unwrap(), Chord::ctrl('k'));
-        assert_eq!(Chord::from_str("Ctrl+K").unwrap(), Chord::ctrl('K'));
+        assert_eq!(Chord::from_str("CONTROL+k").unwrap(), Chord::ctrl('k'));
+        assert_eq!(Chord::from_str("primary+k").unwrap(), Chord::primary('k'));
+        assert_eq!(Chord::from_str("Control+K").unwrap(), Chord::ctrl('K'));
         assert_eq!(
             Chord::from_str("Shift+Up").unwrap(),
             Chord::shift(KeyCode::Up)
@@ -550,6 +561,7 @@ mod tests {
 
     #[test]
     fn parse_rejects_unknown_modifier_and_key() {
+        assert!(Chord::from_str("ctrl+k").is_err());
         assert!(Chord::from_str("hyper+k").is_err());
         assert!(Chord::from_str("ctrl+nope").is_err());
         assert!(Chord::from_str("").is_err());
@@ -559,7 +571,7 @@ mod tests {
     fn serde_round_trips_through_json() {
         let c = Chord::ctrl('s');
         let json = serde_json::to_string(&c).unwrap();
-        assert_eq!(json, "\"ctrl+s\"");
+        assert_eq!(json, "\"control+s\"");
         let back: Chord = serde_json::from_str(&json).unwrap();
         assert_eq!(c, back);
     }

--- a/apps/zerocode/src/keymap/mod.rs
+++ b/apps/zerocode/src/keymap/mod.rs
@@ -4,8 +4,8 @@
 //! Consumers call `ChatTabAction::from_chord(&key)` directly — no
 //! `Keymap` struct, no plumbed argument.
 //!
-//! On darwin, `Chord::matches` translates most `CTRL` modifiers to
-//! `SUPER`; terminal-owned control chords remain literal.
+//! Chords carry literal Control, platform-primary, and literal Super intent
+//! explicitly; dispatch compares their effective event modifiers.
 
 pub mod actions;
 mod chord;
@@ -22,7 +22,7 @@ fn chord_bypasses_text_input(chord: &Chord) -> bool {
         return true;
     }
 
-    let mut modifiers = chord.modifiers;
+    let mut modifiers = chord.effective_modifiers();
     modifiers.remove(KeyModifiers::SHIFT);
     !modifiers.is_empty()
 }
@@ -283,16 +283,17 @@ mod tests {
     }
 
     #[test]
-    fn delete_previous_word_answers_to_both_ctrl_w_and_alt_backspace() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn delete_previous_word_answers_to_both_primary_w_and_alt_backspace() {
+        use crossterm::event::{KeyCode, KeyEvent};
 
         with_default_bindings(|| {
             // Both chords resolve to the one action, so the existing
             // Unicode-aware deletion stays the single behavior owner.
+            let primary_w = Chord::primary('w');
             assert_eq!(
                 InputBarAction::from_chord(&KeyEvent::new(
                     KeyCode::Char('w'),
-                    KeyModifiers::CONTROL
+                    primary_w.effective_modifiers(),
                 )),
                 Some(InputBarAction::DeletePreviousWord)
             );
@@ -311,7 +312,7 @@ mod tests {
             // Help and the rebinding surface read the defaults, so both chords
             // have to be advertised there, not just accepted at match time.
             let defaults = InputBarAction::DeletePreviousWord.default_chords();
-            assert!(defaults.contains(&Chord::ctrl('w')));
+            assert!(defaults.contains(&primary_w));
             assert!(defaults.contains(&Chord::with(KeyCode::Backspace, KeyModifiers::ALT)));
             assert_eq!(
                 action_key_labels(InputBarAction::DeletePreviousWord).len(),
@@ -371,17 +372,21 @@ mod tests {
 
     /// `same_key` has to answer exactly what dispatch would: two chords are one
     /// chord iff either matches the event the other describes. Asserted on both
-    /// platforms, so the Linux run still pins the contract even though only
-    /// darwin makes the ctrl/super pair equivalent.
+    /// platforms, so the Linux run still pins the contract even though the
+    /// platform-primary event differs by OS.
     #[test]
     fn same_key_agrees_with_dispatch() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         let pairs = [
             (
+                Chord::primary('a'),
+                Chord::with(KeyCode::Char('a'), KeyModifiers::SUPER),
+            ),
+            (
                 Chord::ctrl('a'),
                 Chord::with(KeyCode::Char('a'), KeyModifiers::SUPER),
             ),
-            // Host-reserved on darwin, so CONTROL is never rewritten for it.
+            // Literal Control and literal Super remain distinct on every OS.
             (
                 Chord::ctrl('c'),
                 Chord::with(KeyCode::Char('c'), KeyModifiers::SUPER),
@@ -398,7 +403,7 @@ mod tests {
             ),
         ];
         for (a, b) in pairs {
-            let as_event = KeyEvent::new(b.code, b.modifiers);
+            let as_event = KeyEvent::new(b.code, b.effective_modifiers());
             assert_eq!(
                 a.same_key(&b),
                 a.matches(&as_event),
@@ -410,10 +415,10 @@ mod tests {
         }
     }
 
-    /// The darwin-only half of the precedence contract. `normalise_mods`
-    /// rewrites CONTROL to SUPER for every chord the host has not reserved, so
+    /// The darwin-only half of the precedence contract. Platform-primary
+    /// intent resolves to the same event as literal Super there, so
     /// an operator's explicit `super+a` and the earlier-declared
-    /// `OpenFileBrowser`'s retained `ctrl+a` default are one chord at dispatch
+    /// `OpenFileBrowser`'s retained `primary+a` default are one chord at dispatch
     /// and two on the wire. Comparing raw values left the shadowed default in
     /// the table, and the operator's own binding lost to it by declaration
     /// order while Help advertised the chord twice.
@@ -423,7 +428,7 @@ mod tests {
     /// the part that runs everywhere.
     #[cfg(target_os = "macos")]
     #[test]
-    fn a_super_override_outranks_a_normalized_ctrl_default_on_darwin() {
+    fn a_super_override_outranks_a_primary_default_on_darwin() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         let super_a = Chord::with(KeyCode::Char('a'), KeyModifiers::SUPER);
 
@@ -435,7 +440,7 @@ mod tests {
             );
             assert!(
                 !action_key_labels(InputBarAction::OpenFileBrowser).contains(&super_a.display()),
-                "the shadowed ctrl+a default must leave Help too"
+                "the shadowed primary+a default must leave Help too"
             );
             assert_eq!(
                 action_key_labels(InputBarAction::DeletePreviousWord),
@@ -471,10 +476,11 @@ mod tests {
             );
 
             // The default that was not claimed is untouched.
+            let primary_w = Chord::primary('w');
             assert_eq!(
                 InputBarAction::from_chord(&KeyEvent::new(
                     KeyCode::Char('w'),
-                    KeyModifiers::CONTROL
+                    primary_w.effective_modifiers(),
                 )),
                 Some(InputBarAction::DeletePreviousWord)
             );
@@ -483,23 +489,23 @@ mod tests {
 
     #[test]
     fn override_precedence_does_not_depend_on_declaration_order() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::{KeyCode, KeyEvent};
 
         // The mirror of the case above: the override is on the *earlier*
         // declared action and the retained default on the later one. Both
         // directions must land on the explicit binding, or the contract is
         // just an artifact of enum ordering.
-        let ctrl_u = Chord::ctrl('u');
-        with_input_bar_override("backspace", vec![ctrl_u.clone()], || {
+        let primary_u = Chord::primary('u');
+        with_input_bar_override("backspace", vec![primary_u.clone()], || {
             assert_eq!(
                 InputBarAction::from_chord(&KeyEvent::new(
                     KeyCode::Char('u'),
-                    KeyModifiers::CONTROL
+                    primary_u.effective_modifiers(),
                 )),
                 Some(InputBarAction::Backspace)
             );
             assert!(
-                !action_key_labels(InputBarAction::ClearInput).contains(&ctrl_u.display()),
+                !action_key_labels(InputBarAction::ClearInput).contains(&primary_u.display()),
                 "ClearInput's retained default lost the chord to an explicit binding"
             );
         });

--- a/apps/zerocode/src/zerocode_pane.rs
+++ b/apps/zerocode/src/zerocode_pane.rs
@@ -1807,10 +1807,7 @@ impl ZerocodePane {
             self.capture = None;
             return;
         }
-        let chord = Chord {
-            code: key.code, // keyguard: capture widget records the pressed chord verbatim
-            modifiers: key.modifiers,
-        };
+        let chord = Chord::with(key.code, key.modifiers); // keyguard: capture widget records the pressed chord verbatim
         if let Some(reason) = reserved_reason(&chord) {
             if let Some(cap) = &mut self.capture {
                 cap.error = Some(format!("'{}' is {reason}", chord.display()));
@@ -2270,18 +2267,18 @@ mod tests {
         crate::keymap::overrides::reset();
     }
 
-    /// The editor half of the darwin normalization case. `ctrl+a` and `super+a`
+    /// The editor half of the darwin primary case. `primary+a` and `super+a`
     /// are one chord at dispatch there, so capturing `super+a` for an action
-    /// while another explicit row owns `ctrl+a` would install two rows that
+    /// while another explicit row owns `primary+a` would install two rows that
     /// only the dispatcher can tell apart.
     #[cfg(target_os = "macos")]
     #[test]
-    fn binding_editor_refuses_a_normalized_collision_on_darwin() {
+    fn binding_editor_refuses_a_primary_collision_on_darwin() {
         let _g = crate::keymap::overrides::TEST_GUARD
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         crate::keymap::overrides::reset();
-        given_explicit_row("input_bar.clear_input", vec![Chord::ctrl('a')]);
+        given_explicit_row("input_bar.clear_input", vec![Chord::primary('a')]);
 
         let dir = tempfile::tempdir().unwrap();
         let mut pane = ZerocodePane::new(dir.path());

--- a/docs/book/src/zerocode/config.md
+++ b/docs/book/src/zerocode/config.md
@@ -13,6 +13,10 @@ instruction to open the file in an editor. Hand editing is a fallback for
 headless hosts and scripted provisioning, where the docs call it out
 explicitly.
 
+### Keybinding modifiers
+
+Keybindings use canonical modifier names: `control` is literal Control, `primary` is Command on macOS and Control elsewhere, and `super` is literal Super/Command. For example, `control+c`, `primary+r`, and `alt+shift+up` are portable persisted values. Older `ctrl+...` values are migrated once when the config loads and rewritten to the corresponding canonical spelling.
+
 ## Why the pane over the file
 
 - **Validation.** Controls reject malformed values before they reach the

--- a/docs/book/src/zerocode/config.md
+++ b/docs/book/src/zerocode/config.md
@@ -13,7 +13,7 @@ instruction to open the file in an editor. Hand editing is a fallback for
 headless hosts and scripted provisioning, where the docs call it out
 explicitly.
 
-### Keybinding modifiers
+## Keybinding modifiers
 
 Keybindings use canonical modifier names: `control` is literal Control, `primary` is Command on macOS and Control elsewhere, and `super` is literal Super/Command. For example, `control+c`, `primary+r`, and `alt+shift+up` are portable persisted values. Older `ctrl+...` values are migrated once when the config loads and rewritten to the corresponding canonical spelling.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Give literal Control, platform-primary, and literal Super explicit keybinding meanings instead of deriving Control behavior from the bound key character.
  - Migrate legacy persisted `ctrl+...` values once to canonical `control+...` or `primary+...` spellings while preserving their former effective behavior.
  - Update built-in defaults, matching, collision identity, display, persistence, tests, and operator documentation to use the same modifier authority.
- **Scope boundary:** This PR does not add keybinding-editor policy or effective-collision UX, and it does not edit `apps/zerocode/src/app.rs` or the resolved-binding API used by quit-confirmation rendering. Changes in `input_bar.rs` and `chat.rs` are limited to modifier-aligned tests plus one terminology comment.
- **Blast radius:** ZeroCode keybinding parsing, persisted config migration, default bindings, event matching, collision detection, and rendered key labels. Other ZeroClaw apps and runtime crates are unchanged.
- **Linked issue(s):** Closes #9171
- **Labels:** `enhancement`, `risk:medium`, `size:L`, `zerocode`, `docs`

### What this does, simply

ZeroCode lets users bind actions to keyboard shortcuts and shows those shortcuts in Help. Previously, a stored `ctrl+...` binding could mean literal Control for some keys but Command on macOS for other keys because the interpretation depended on a private key list.

This PR makes that intent explicit: `control` always means literal Control, `primary` means Command on macOS and Control elsewhere, and `super` remains literal Super/Command. Existing `ctrl+...` config values are translated once to the canonical spelling that preserves their previous behavior, so users do not need to rewrite their config by hand.

### Scope and maintenance tradeoff

The historical key-dependent rule cannot be removed safely without first preserving existing configs. The smallest coherent implementation therefore has two parts: one explicit modifier model used by parse, display, matching, collision checks, and persistence; and one bounded compatibility migration that contains the old six-key split. Canonical runtime behavior never consults that historical split.

The PR deliberately leaves collision-policy UX and other keybinding surfaces to their existing owners. Its size is mostly compatibility and regression coverage across the existing ZeroCode keymap/config boundary rather than a new subsystem.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes; an A/B check on macOS usefully confirms that canonical literal Control and platform-primary bindings render and dispatch differently.
- **Interface(s) exercised:** `tui`
- **Setup / preconditions:** Use a temporary ZeroCode config directory. On `master`, add representative `ctrl+a`, `ctrl+c`, and `super+a` overrides. On this branch, use `primary+a`, `control+c`, and `super+a`; a copied legacy config may retain the old `ctrl` spellings for the migration check.
- **Steps to run:** Start ZeroCode with the temporary config, open Help, compare the displayed labels, trigger each binding, exit, and inspect the persisted keybinding rows. Restart once to confirm the canonical file is stable.
- **Expected on this branch (after):** `primary+a` uses and displays Command+A on macOS, `control+c` remains literal Control+C, `super+a` remains literal Super/Command+A, legacy `ctrl` rows are rewritten canonically, and a second load does not rewrite them again.
- **Prior behavior on `master` (before):** The meaning and label of `ctrl+...` depend on the key character; unrelated bindings inherit either literal-Control or Command behavior from the private allowlist.

### How I tested

- **CI checks relied on and why they cover this change:** Required exact-head CI passed on `ea700c75adc133cde87f36284ecbf68c35647265`, covering repository formatting, lint, cross-platform compilation, and the full test job. The prior head exposed two unused test imports and one Markdown heading-level error; this head contains only those mechanical repairs beyond the locally tested implementation.
- **Known CI coverage gap, if any:** A real macOS terminal rendering/interaction capture is not yet attached.
- **Commands run and tail output:**

  ```text
  cargo fmt --all -- --check
  Result: passed

  cargo test --locked -p zerocode
  Result: passed (209 library tests; 864 binary tests; no failures)
  ```

- **Beyond CI, what did you manually verify?** Source-level aggregate review verified that default constructors preserve the historical literal-versus-primary split, migration rewrites every scalar/array row before parsing, and canonical persistence is idempotent. The changed `input_bar.rs` and `chat.rs` lines were inspected as test/comment-only alignment. I did not run an interactive TUI smoke.
- **Visual interface changed?** Yes; macOS key labels can change from key-dependent Control/Command rendering to the explicit configured intent.
- **Tested revision, interface, and terminal or viewport dimensions:** Local package tests ran on `919c20536c188344bd75dd8b5764abd00982fde3`; current PR head `ea700c75adc133cde87f36284ecbf68c35647265` adds only unused-import and Markdown-heading repairs and passed exact-head CI. Interface: `tui`; no direct terminal capture yet.
- **Screenshot evidence:**

  > **Screenshot placeholder:** Attach a macOS ZeroCode Help view showing representative literal-Control, platform-primary, and literal-Super labels here.

- **Action or changed state and observed result:** Automated display and matching assertions passed; a direct rendered-interface observation is still pending.
- **If any command was intentionally skipped, why:** No broader workspace Cargo run was selected because the complete `zerocode` package suite covers the changed crate; exact-head required CI supplies cross-platform compilation and repository-wide gates. An interactive TUI smoke was not run in this validation pass.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes; canonical ZeroCode keybinding modifier tokens add `control` and `primary`, while legacy `ctrl` is migrated during config load.
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: Existing users do not need a manual upgrade. Start ZeroCode once with the existing config; legacy `ctrl+...` rows are rewritten to the canonical spelling that preserves their former effective behavior. Back up the config before testing only if the user wants to compare the before/after text.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** After merge, run `git revert <merge-commit-sha>`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** A configured shortcut displays a different modifier than the event it matches, a legacy row changes effective behavior after migration, the config rewrites repeatedly, or two effective chords are accepted as distinct and one shadows the other.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another PR.
