### PR TITLE
fix(runtime): say what an operator denial means instead of Denied by user.

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -5208,7 +5208,7 @@ mod tests {
     /// The operator-denial result has to carry its own meaning, because the
     /// model will otherwise supply one. Handed the bare three-word form, it
     /// reported the decline correctly on one run and offered three invented
-    /// causes on the next, none of them what happened (#9654).
+    /// causes on the next, none of them what happened.
     ///
     /// Three separate obligations, asserted separately so a regression names
     /// which one broke: the call did not run, the operator is named as the

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -5205,6 +5205,73 @@ mod tests {
         }
     }
 
+    /// The operator-denial result has to carry its own meaning, because the
+    /// model will otherwise supply one. Handed the bare three-word form, it
+    /// reported the decline correctly on one run and offered three invented
+    /// causes on the next, none of them what happened (#9654).
+    ///
+    /// Three separate obligations, asserted separately so a regression names
+    /// which one broke: the call did not run, the operator is named as the
+    /// one who declined, and the model is told not to guess at a reason.
+    #[tokio::test]
+    async fn operator_deny_states_the_outcome_and_forbids_inventing_a_cause() {
+        let content =
+            tool_results_for_denying_channel(::zeroclaw_api::channel::ApprovalSource::Operator)
+                .await;
+
+        assert!(
+            content.contains("the call did not run"),
+            "the result must say the tool did not execute: {content}"
+        );
+        assert!(
+            content.contains("operator was asked to approve") && content.contains("declined"),
+            "the result must attribute the decision to the operator: {content}"
+        );
+        assert!(
+            content.contains("do not speculate about why"),
+            "the result must forbid inventing a cause: {content}"
+        );
+    }
+
+    /// A denial the model is invited to retry is a denial that does not hold.
+    /// The gate is the only place that knows the operator has already answered,
+    /// so the instruction against retrying belongs in its result rather than in
+    /// the system prompt, which cannot see this turn.
+    #[tokio::test]
+    async fn operator_deny_tells_the_model_not_to_retry_the_call() {
+        let content =
+            tool_results_for_denying_channel(::zeroclaw_api::channel::ApprovalSource::Operator)
+                .await;
+        assert!(
+            content.contains("Do not retry this call"),
+            "the result must tell the model not to retry: {content}"
+        );
+    }
+
+    /// The result is read by the MODEL, so it must not hand it the vocabulary
+    /// for lobbying its way past the gate. `auto_approve` bypasses operator
+    /// approval for one tool and `level = "full"` removes the gate for every
+    /// tool and drops workspace confinement; naming either invites the model to
+    /// argue for expanding its own privileges. The operator gets that advice
+    /// through the WARN record and the UI, where the decision is theirs.
+    #[tokio::test]
+    async fn no_denial_result_names_a_setting_that_would_permit_the_call() {
+        for source in [
+            ::zeroclaw_api::channel::ApprovalSource::Operator,
+            ::zeroclaw_api::channel::ApprovalSource::TimedOut,
+            ::zeroclaw_api::channel::ApprovalSource::Unreachable,
+            ::zeroclaw_api::channel::ApprovalSource::Unavailable,
+        ] {
+            let content = tool_results_for_denying_channel(source).await;
+            for forbidden in ["auto_approve", "level = \"full\"", "risk profile"] {
+                assert!(
+                    !content.contains(forbidden),
+                    "{source:?} denial names `{forbidden}` to the model: {content}"
+                );
+            }
+        }
+    }
+
     struct CredentialOutputTool;
 
     #[async_trait]

--- a/crates/zeroclaw-runtime/src/agent/turn/approval_gate.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/approval_gate.rs
@@ -125,7 +125,23 @@ pub(crate) async fn gate_tool_approval(
                      a user's decision."
                 )
             } else {
-                "Denied by user.".to_string()
+                // A real operator said no. The three-word form this replaces
+                // carried the fact and none of its meaning, so the model
+                // supplied the meaning itself and did not do it the same way
+                // twice: on one run it reported the decline correctly, on the
+                // next it offered three invented causes, none of them what
+                // happened. The host owns the fact, so the host states what it
+                // means. `Denied by user.` is kept as the opening sentence
+                // because it is the phrase that distinguishes this path from
+                // the runtime-generated denial above, and dropping it would
+                // lose that distinction for every reader that already looks
+                // for it.
+                format!(
+                    "Denied by user. The operator was asked to approve \
+                     '{tool_name}' and declined, so the call did not run. Tell \
+                     the user the request was declined. Do not retry this call \
+                     and do not speculate about why it was declined."
+                )
             };
             ::zeroclaw_log::record!(
                 WARN,


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - A genuine operator denial reached the model as `Denied by user.` — the fact with none of its meaning — so the model supplied the meaning itself and did not do it the same way twice. Same host input, two sessions: one reported the decline correctly, the next offered three invented causes, none of them what happened. The trace shows the gate handed over the identical string both times, so the variance is generated rather than inherited.
  - The result now states the three things the model was left to infer: the operator was asked and declined, the call did not run, and it must neither retry nor guess at a reason.
  - `Denied by user.` is kept as the opening sentence. It is the phrase that distinguishes this path from the runtime-generated denial beside it, and existing readers already look for it, including this crate's own `operator_sourced_deny_is_still_reported_as_a_user_denial`.
  - Three gate tests, each asserting one obligation so a regression names which one broke. The third checks all four denial sources and guards a boundary the surrounding comment already argued for but nothing enforced: no denial result may name `auto_approve`, `level = "full"` or the risk profile to the model.
- **Scope boundary:** No config surface, no change to when a denial happens, no change to the `unanswerable` branch that #9423 introduced, and no system-prompt edit. A prompt line cannot recover information the result never carried, which is why the fix belongs in the result. Nothing outside `approval_gate.rs` and the tests in `loop_.rs` changes.
- **Blast radius:** Only the model-visible text and `error_reason` on the operator-denial path, plus the `StreamDelta::Status` line that echoes it. The runtime-denial branch already carries a sentence of comparable length, so the surfaces that render it were exercised by that path first. No exact-equality comparison against the old literal exists in the workspace; the readers that look for it use `contains`.
- **Linked issue(s):** Closes #9654
- **Labels (after review):** `bug`, `agent`, `runtime`, `security`, `tool`, `domain:security`, `risk:high`, `size:S`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `channel` (any approval-capable channel), and `cli` for the prompt path
- **Setup / preconditions:** A tool that requires approval, and a session store reset so the model has no prior conversation to lean on.
- **Steps to run:** Ask for the tool. Tap Deny. Read what the agent says. Repeat in a session that already contains an earlier denial and compare the two answers.
- **Expected on this branch (after):** The host result states that the operator declined and that the call did not run, and instructs the model not to retry or speculate. The tests verify this result; real-provider compliance and consistency between warm and cold sessions remain unverified.
- **Prior behavior on `master` (before):** The same steps return `Denied by user.` to the model. A cold session tends to produce speculation about the cause; a warm one does better only because earlier turns are in context.

### How I tested

Focused on the changed surface: the gate's denial path and its existing coverage in `zeroclaw-runtime`.

```sh
cargo test -p zeroclaw-runtime --lib deny
...
test agent::loop_::tests::operator_deny_tells_the_model_not_to_retry_the_call ... ok
test agent::loop_::tests::operator_sourced_deny_is_still_reported_as_a_user_denial ... ok
test agent::loop_::tests::operator_deny_states_the_outcome_and_forbids_inventing_a_cause ... ok
test agent::loop_::tests::runtime_sourced_deny_is_not_reported_as_a_user_denial ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 3835 filtered out
```

```sh
cargo test -p zeroclaw-runtime --lib no_denial_result_names
test agent::loop_::tests::no_denial_result_names_a_setting_that_would_permit_the_call ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3866 filtered out
```

```sh
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 38s
```

`rustfmt --edition 2024 --check` is clean on both changed files.

**Each new test was proved by breaking it, not only by watching it pass.**

- Reverting the result to the bare `"Denied by user.".to_string()` fails exactly the two tests that assert the new content, by name: `the result must tell the model not to retry` and `the result must say the tool did not execute`. `operator_sourced_deny_is_still_reported_as_a_user_denial` stays green under that mutation, which is the point — it guards a different thing.
- Appending `Set auto_approve to skip this.` to the result fails the third test with `Operator denial names 'auto_approve' to the model`. Worth recording that my first run of this mutation reported all green because the filter I used did not match that test's name and never ran it; the failure above is from the run that actually executed it.

- **CI checks relied on and why they cover this change:** the Rust test and clippy jobs cover `zeroclaw-runtime`, which is where both changed files live.
- **Known CI coverage gap, if any:** None for this surface. I did not run the full workspace suite or a cross-platform build, because nothing outside this crate is touched.
- **Beyond CI, what did you manually verify?** The four assertions above, plus a check that no exact-equality comparison against the old literal exists anywhere in `crates/` or `src/`. What I did NOT verify: live model behaviour against a real provider. The claim this PR makes is about what the host says, and the tests assert exactly that; whether a given model then behaves better is the thing the issue's evidence already argues and this change cannot prove on its own.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? Yes, in the narrow sense that this is model-visible text and it changed. It moves in the safe direction: the text is host-authored, carries no operator or tool-supplied content beyond the tool name that was already interpolated, and the third test enforces that it never names a setting the model could push the operator toward. That boundary was previously an argument in a comment with nothing checking it.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Rollback: `git revert <sha>`. The current review classification is `risk:high`.
