### PR TITLE
test(runtime): harden daemon startup deadlock guards

### DIFF
--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -2465,6 +2465,8 @@ mod tests {
     use tempfile::TempDir;
     use zeroclaw_config::schema::MattermostListenMode;
 
+    const DAEMON_DEADLOCK_GUARD: Duration = Duration::from_secs(30);
+
     fn test_config(tmp: &TempDir) -> Config {
         let config = Config {
             data_dir: tmp.path().join("data"),
@@ -3441,8 +3443,6 @@ mod tests {
 
     #[tokio::test]
     async fn registry_gateway_starter_can_trigger_daemon_reload() {
-        use tokio::time::{Duration, timeout};
-
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp);
         let expected_data_dir = config.data_dir.clone();
@@ -3477,20 +3477,22 @@ mod tests {
             },
         ));
 
-        let exit = timeout(
-            Duration::from_secs(2),
-            run(
-                config,
-                "127.0.0.1".to_string(),
-                4242,
-                registry,
-                false,
-                false,
-            ),
-        )
+        let (exit, seen) = tokio::time::timeout(DAEMON_DEADLOCK_GUARD, async {
+            tokio::join!(
+                run(
+                    config,
+                    "127.0.0.1".to_string(),
+                    4242,
+                    registry,
+                    false,
+                    false,
+                ),
+                seen_rx.recv(),
+            )
+        })
         .await
-        .expect("daemon should return after gateway-triggered reload")
-        .expect("daemon run should succeed");
+        .expect("daemon must not deadlock after a gateway-triggered reload");
+        let exit = exit.expect("daemon run should succeed");
 
         assert_eq!(exit, DaemonExit::Reload);
         let (
@@ -3501,9 +3503,7 @@ mod tests {
             has_gateway_shutdown_tx,
             has_reload_tx,
             has_tui_registry,
-        ) = seen_rx
-            .try_recv()
-            .expect("gateway starter should record its daemon inputs");
+        ) = seen.expect("gateway starter should record its daemon inputs");
         assert_eq!(host, "127.0.0.1");
         assert_eq!(port, 4242);
         assert_eq!(data_dir, expected_data_dir);
@@ -3516,15 +3516,19 @@ mod tests {
     #[tokio::test]
     async fn initial_socket_addr_in_use_fails_daemon_startup() {
         use std::io;
-        use tokio::time::{Duration, timeout};
 
         for startup_feedback_enabled in [false, true] {
             let tmp = TempDir::new().unwrap();
             let config = test_config(&tmp);
+            let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
 
             let mut registry = DaemonRegistry::new();
             registry.register_socket(Box::new(move |_ctx, _cancel, _client_count, _readiness| {
+                let started_tx = started_tx.clone();
                 Box::pin(async move {
+                    started_tx
+                        .send(())
+                        .expect("record initial socket startup attempt");
                     Err(io::Error::new(
                         io::ErrorKind::AddrInUse,
                         "local IPC endpoint lifecycle is already owned",
@@ -3533,20 +3537,24 @@ mod tests {
                 })
             }));
 
-            let error = timeout(
-                Duration::from_secs(2),
-                run(
-                    config,
-                    "127.0.0.1".to_string(),
-                    0,
-                    registry,
-                    false,
-                    startup_feedback_enabled,
-                ),
-            )
+            let (result, started) = tokio::time::timeout(DAEMON_DEADLOCK_GUARD, async {
+                tokio::join!(
+                    run(
+                        config,
+                        "127.0.0.1".to_string(),
+                        0,
+                        registry,
+                        false,
+                        startup_feedback_enabled,
+                    ),
+                    started_rx.recv(),
+                )
+            })
             .await
-            .expect("initial socket ownership conflict should fail daemon startup promptly")
-            .expect_err("daemon startup should fail on an initially owned socket");
+            .expect("daemon must not deadlock on an initial socket ownership conflict");
+            started.expect("socket starter should observe the initial startup attempt");
+            let error =
+                result.expect_err("daemon startup should fail on an initially owned socket");
 
             assert!(
                 error


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Replace two daemon tests' two-second whole-run timeouts with direct observations of the injected gateway and socket starters, while keeping one named 30-second outer bound for genuine deadlocks.
- **Scope boundary:** Test-only; no production daemon behavior, registry API, parallel-test configuration, retry policy, or supervision behavior changes.
- **Blast radius:** The two daemon startup regression tests and their behavior under parallel test scheduling.
- **Linked issue(s):** Fixes #10434
- **Labels:** `bug`, `daemon`, `runtime`, `risk:low`, `size:XS`, `type:test`

### What this does, simply

ZeroClaw's daemon starts background services and reloads them when needed. Two tests could fail on a busy CI runner merely because the full scenario took more than two seconds, even when the daemon was working.

This PR makes each test wait for the simulated service to report that startup was attempted, while retaining a 30-second timeout to catch a genuine hang. It changes the tests, not the daemon users run.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is deterministic test-only orchestration with no user-facing or manually exercised runtime behavior.

### How I tested

- **CI checks relied on and why they cover this change:** The required Parallel Runtime Test passed at this PR's current head. Its 16-thread runtime run exercises the parallel scheduling condition this change hardens, and the CI Required Gate also passed.
- **Known CI coverage gap, if any:** The complete three-run runtime-and-channels Parallel Runtime Test was not run locally; it passed in required CI at this PR's current head. Local validation ran both exact tests and all daemon module tests with 16 test threads.
- **Commands run and tail output:**

  ```text
  cargo fmt --all -- --check
  PASS

  cargo test --locked -p zeroclaw-runtime registry_gateway_starter_can_trigger_daemon_reload -- --test-threads=16
  test daemon::tests::registry_gateway_starter_can_trigger_daemon_reload ... ok
  test result: ok. 1 passed; 0 failed

  cargo test --locked -p zeroclaw-runtime initial_socket_addr_in_use_fails_daemon_startup -- --test-threads=16
  test daemon::tests::initial_socket_addr_in_use_fails_daemon_startup ... ok
  test result: ok. 1 passed; 0 failed

  cargo test --locked -p zeroclaw-runtime daemon::tests:: -- --test-threads=16
  test result: ok. 74 passed; 0 failed; 1 ignored

  git diff --check
  PASS
  ```

- **Beyond CI, what did you manually verify?** Source review confirmed that each test requires both the injected starter's observation and the daemon outcome, both startup-feedback modes remain covered, and the 30-second timeout encloses each complete scenario rather than serving as its behavioral assertion.
- **Visual interface changed?** N/A — no rendered or interactive surface changes.
- **If any command was intentionally skipped, why:** The complete Parallel Runtime Test was deferred to required CI because the focused exact-test and 16-thread daemon-module runs cover the changed local invariant without repeating the broader runtime-and-channels matrix locally.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is No or either surface/floor question is Yes: N/A
