### PR TITLE
docs(plugins): clarify experimental WIT version skew

### DIFF
--- a/docs/book/src/plugins/writing-a-tool-plugin.md
+++ b/docs/book/src/plugins/writing-a-tool-plugin.md
@@ -398,6 +398,15 @@ coexist, each generating its own bindings. And waki emits `wasi:http@0.2.4`
 imports while the current toolchain baseline is `@0.2.6`; the host links
 both without issue. Neither requires action.
 
+One version fact that **is** breakage, and gives no useful error: the world you
+vendor must match the host's exported world exactly. `wit/v0` is experimental and
+can gain a variant under the same `@0.1.0` (for example `zeroclaw:plugin/logging`
+carries a `memory-audit` log level). Build against a copy that is one variant
+behind and the component compiles clean, then fails to instantiate with
+`registered: 0` and `no matching implementation in the linker`, naming nothing.
+Vendor `wit/` from the same host revision you run, and if a load fails this way,
+diff your `wit/v0` against the host's before looking anywhere else.
+
 Remember the trust framing from the [overview](./index.md): `http_client` is
 all-or-nothing. The sandbox does not bound where a granted plugin sends
 data, so operators running `strict` signature policy are trusting your code,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Explain that experimental `wit/v0` changes can cause plugin instantiation failures, direct authors to the preserved Wasmtime error chain and conditional WIT-drift hint, and identify `memory-audit` as a `plugin-action` enum case.
- **Scope boundary:** Nine added lines in one plugin-authoring guide. No runtime or WIT changes.
- **Blast radius:** Plugin authors checking whether their vendored WIT matches the host they run.
- **Linked issue(s):** Related #10505. This guide does not resolve the reported diagnostic gap.
- **Labels:** `docs`, `type:docs`, `risk:low`, `size:XS`, `topic:plugins`

### What this does, simply

A plugin can compile successfully but fail to load if it was built against a different experimental interface from the host. The guide now tells authors to inspect the host's error details and compare their vendored interface with the host revision.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; documentation-only guidance.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on `ff8245f598455b8c51a7392252811740103469fd` in [run 35186572673](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35186572673). The local docs-quality and link checks below cover the nine-line documentation correction; the refreshed required gate clears the earlier CI blocker.
- **Known CI coverage gap, if any:** Passing documentation checks does not resolve the separate runtime diagnostic report in #10505.
- **Commands run and tail output:** On the prepared merge with master `59596767ebaf1264f0782de1cdf7ae4940a8a728`, `git diff --cached --check` passed; `bash scripts/ci/docs_quality_gate.sh` reported `Summary: 0 error(s)`; `bash scripts/ci/docs_links_gate.sh` passed six tests and found no added links.
- **Beyond CI, what did you manually verify?** The resulting change remains nine added lines in one guide, preserving the contributor's note and the subsequent factual corrections.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** No Cargo build or test was run locally because this change affects documentation only.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Remove the added WIT-skew paragraph, or revert the landed documentation commit after merge.
