### PR TITLE
feat(docs): add reader and diagram controls

### DIFF
--- a/docs/book/theme/custom.css
+++ b/docs/book/theme/custom.css
@@ -691,8 +691,8 @@ body,
 /* ---------------------------------------------------------------------------
    B1.1. Reader controls
    The scale is set on the root by pc-enhance.js and persisted in localStorage.
-   Keep the menu controls themselves at the normal UI size while the content,
-   sidebar, and page TOC follow the reader's chosen scale. */
+   Keep the controls readable while making them follow the reader's chosen
+   scale alongside the content, sidebar, and page TOC. */
 #mdbook-content main {
   font-size: calc(1.6rem * var(--pc-reader-scale, 1));
 }
@@ -709,7 +709,7 @@ body,
 
 .pc-reader-toggle {
   font-family: var(--pc-font-ui);
-  font-size: 0.78rem;
+  font-size: calc(1rem * var(--pc-reader-scale, 1));
   font-weight: 700;
   letter-spacing: -0.08em;
   padding-inline: 0.6rem;
@@ -727,6 +727,7 @@ body,
   border: 1px solid var(--pc-border-strong);
   border-radius: var(--pc-radius);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  font-size: calc(1.1rem * var(--pc-reader-scale, 1));
 }
 
 .pc-reader-popup[hidden] {
@@ -736,14 +737,14 @@ body,
 .pc-reader-popup-title {
   margin-bottom: 0.65rem;
   color: var(--pc-text-primary);
-  font-size: 0.82rem;
+  font-size: 1em;
   font-weight: 600;
 }
 
 .pc-reader-scale-label {
   margin-bottom: 0.35rem;
   color: var(--pc-text-muted);
-  font-size: 0.72rem;
+  font-size: 0.85em;
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -762,6 +763,7 @@ body,
   border: 1px solid var(--pc-border);
   border-radius: 0.45rem;
   cursor: pointer;
+  font: inherit;
   transition: color 0.18s ease, background 0.18s ease, border-color 0.18s ease;
 }
 
@@ -787,7 +789,7 @@ body,
   min-width: 3.1rem;
   color: var(--pc-text-primary);
   font-family: var(--pc-font-mono);
-  font-size: 0.78rem;
+  font-size: 0.95em;
   text-align: center;
 }
 
@@ -795,7 +797,6 @@ body,
   width: 100%;
   margin-top: 0.65rem;
   padding: 0.35rem 0.55rem;
-  font-size: 0.78rem;
 }
 
 /* ---------------------------------------------------------------------------
@@ -810,7 +811,7 @@ body,
   width: 15rem;
   max-height: calc(100vh - 8rem);
   overflow-y: auto;
-  font-size: 0.82rem;
+  font-size: calc(1rem * var(--pc-reader-scale, 1));
   padding-left: 0.9rem;
   border-left: 1px solid var(--pc-border);
   display: none;
@@ -839,7 +840,7 @@ body,
     border-radius: 0.55rem;
     cursor: pointer;
     font: inherit;
-    font-size: 0.88em;
+    font-size: calc(1rem * var(--pc-reader-scale, 1));
     text-align: start;
   }
 
@@ -857,7 +858,7 @@ body,
     padding: 0.75rem 0.9rem;
     border: 1px solid var(--pc-border);
     border-radius: var(--pc-radius);
-    font-size: calc(0.82rem * var(--pc-reader-scale, 1));
+    font-size: calc(1rem * var(--pc-reader-scale, 1));
   }
 
   .pc-page-toc.pc-toc-open {
@@ -872,7 +873,7 @@ body,
 .pc-toc-title {
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  font-size: 0.68rem;
+  font-size: 0.9em;
   font-weight: 600;
   color: var(--pc-text-faint);
   margin-bottom: 0.6rem;
@@ -948,20 +949,22 @@ body,
   position: relative;
   display: flex;
   flex-direction: column;
-  width: min(96vw, 90rem);
-  height: min(92vh, 60rem);
+  width: calc(100vw - 2rem);
+  height: calc(100vh - 2rem);
+  box-sizing: border-box;
   padding: 1rem;
   color: var(--pc-text-primary);
   background: var(--pc-bg-elevated);
   border: 1px solid var(--pc-border-strong);
   border-radius: var(--pc-radius-lg);
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  font-size: calc(1rem * var(--pc-reader-scale, 1));
 }
 
 .pc-diagram-modal-title {
   margin: 0 3rem 0.65rem 0.25rem;
   color: var(--pc-text-primary);
-  font-size: 1rem;
+  font-size: 1.25em;
   font-weight: 600;
 }
 
@@ -976,7 +979,8 @@ body,
   border: 1px solid var(--pc-border);
   border-radius: 0.5rem;
   cursor: pointer;
-  font-size: 1.5rem;
+  font: inherit;
+  font-size: 1.75em;
   line-height: 1;
 }
 
@@ -1039,6 +1043,8 @@ body,
   border: 1px solid var(--pc-border);
   border-radius: 0.45rem;
   cursor: pointer;
+  font: inherit;
+  font-size: 1em;
   font-weight: 600;
 }
 
@@ -1050,14 +1056,14 @@ body,
 .pc-diagram-reset {
   margin-left: 0.35rem;
   font-family: var(--pc-font-mono);
-  font-size: 0.75rem;
+  font-size: 0.9em;
 }
 
 .pc-diagram-zoom-value {
   min-width: 3.4rem;
   color: var(--pc-text-primary);
   font-family: var(--pc-font-mono);
-  font-size: 0.78rem;
+  font-size: 0.95em;
   text-align: center;
 }
 
@@ -1072,7 +1078,7 @@ body,
   }
 
   .pc-diagram-surface {
-    width: 100vw;
+    width: 100%;
     height: 96vh;
     padding: 0.65rem;
   }

--- a/docs/book/theme/custom.css
+++ b/docs/book/theme/custom.css
@@ -689,6 +689,116 @@ body,
 }
 
 /* ---------------------------------------------------------------------------
+   B1.1. Reader controls
+   The scale is set on the root by pc-enhance.js and persisted in localStorage.
+   Keep the menu controls themselves at the normal UI size while the content,
+   sidebar, and page TOC follow the reader's chosen scale. */
+#mdbook-content main {
+  font-size: calc(1.6rem * var(--pc-reader-scale, 1));
+}
+
+.sidebar .chapter {
+  font-size: calc(1em * var(--pc-reader-scale, 1));
+}
+
+.pc-reader-controls {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.pc-reader-toggle {
+  font-family: var(--pc-font-ui);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: -0.08em;
+  padding-inline: 0.6rem;
+}
+
+.pc-reader-popup {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 1001;
+  width: 14rem;
+  padding: 0.8rem;
+  color: var(--pc-text-primary);
+  background: var(--pc-bg-elevated);
+  border: 1px solid var(--pc-border-strong);
+  border-radius: var(--pc-radius);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.pc-reader-popup[hidden] {
+  display: none;
+}
+
+.pc-reader-popup-title {
+  margin-bottom: 0.65rem;
+  color: var(--pc-text-primary);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.pc-reader-scale-label {
+  margin-bottom: 0.35rem;
+  color: var(--pc-text-muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.pc-reader-scale-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.pc-reader-scale-button,
+.pc-reader-reset-button {
+  min-height: 2rem;
+  color: var(--pc-text-secondary);
+  background: var(--pc-bg-surface);
+  border: 1px solid var(--pc-border);
+  border-radius: 0.45rem;
+  cursor: pointer;
+  transition: color 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+.pc-reader-scale-button {
+  min-width: 2.5rem;
+  padding: 0.25rem 0.4rem;
+  font-weight: 600;
+}
+
+.pc-reader-scale-button:hover,
+.pc-reader-reset-button:hover {
+  color: var(--pc-accent);
+  background: var(--pc-hover-strong);
+  border-color: var(--pc-accent-dim);
+}
+
+.pc-reader-scale-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.pc-reader-scale-value {
+  min-width: 3.1rem;
+  color: var(--pc-text-primary);
+  font-family: var(--pc-font-mono);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+.pc-reader-reset-button {
+  width: 100%;
+  margin-top: 0.65rem;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.78rem;
+}
+
+/* ---------------------------------------------------------------------------
    B2. Right-hand "On this page" TOC
    The content column already centers via mdBook's max-width; we pin the TOC
    to the right gutter on wide viewports.
@@ -707,8 +817,56 @@ body,
   z-index: 5;
 }
 
+.pc-toc-toggle {
+  display: none;
+}
+
 @media (min-width: 1500px) {
   .pc-page-toc { display: block; }
+}
+
+@media (max-width: 1499px) {
+  .pc-toc-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    margin: 0 0 0.7rem;
+    padding: 0.55rem 0.75rem;
+    color: var(--pc-text-secondary);
+    background: var(--pc-bg-surface);
+    border: 1px solid var(--pc-border);
+    border-radius: 0.55rem;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.88em;
+    text-align: start;
+  }
+
+  .pc-toc-toggle:hover,
+  .pc-toc-toggle:focus-visible {
+    color: var(--pc-accent);
+    border-color: var(--pc-accent-dim);
+  }
+
+  .pc-page-toc {
+    position: static;
+    width: auto;
+    max-height: none;
+    margin: 0 0 1.3rem;
+    padding: 0.75rem 0.9rem;
+    border: 1px solid var(--pc-border);
+    border-radius: var(--pc-radius);
+    font-size: calc(0.82rem * var(--pc-reader-scale, 1));
+  }
+
+  .pc-page-toc.pc-toc-open {
+    display: block;
+  }
+
+  .pc-page-toc:not(.pc-toc-open) {
+    display: none;
+  }
 }
 
 .pc-toc-title {
@@ -750,6 +908,179 @@ body,
   color: var(--pc-accent);
   border-left-color: var(--pc-accent);
   font-weight: 600;
+}
+
+/* ---------------------------------------------------------------------------
+   B2.1. Mermaid diagram zoom
+   Diagrams stay in the document at their normal responsive size. The modal is
+   only created when a reader opens one, so dense SVGs can be inspected without
+   changing the page flow or the Mermaid source. */
+.pc-diagram-zoomable {
+  cursor: zoom-in;
+  border-radius: var(--pc-radius);
+}
+
+.pc-diagram-zoomable:focus-visible {
+  outline: 2px solid var(--pc-accent);
+  outline-offset: 0.25rem;
+}
+
+.pc-diagram-modal[hidden] {
+  display: none;
+}
+
+.pc-diagram-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1002;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.pc-diagram-modal-open {
+  overflow: hidden;
+}
+
+.pc-diagram-surface {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(96vw, 90rem);
+  height: min(92vh, 60rem);
+  padding: 1rem;
+  color: var(--pc-text-primary);
+  background: var(--pc-bg-elevated);
+  border: 1px solid var(--pc-border-strong);
+  border-radius: var(--pc-radius-lg);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+.pc-diagram-modal-title {
+  margin: 0 3rem 0.65rem 0.25rem;
+  color: var(--pc-text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.pc-diagram-close {
+  position: absolute;
+  top: 0.7rem;
+  right: 0.7rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  color: var(--pc-text-secondary);
+  background: var(--pc-bg-surface);
+  border: 1px solid var(--pc-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.pc-diagram-close:hover,
+.pc-diagram-close:focus-visible,
+.pc-diagram-control:hover,
+.pc-diagram-control:focus-visible {
+  color: var(--pc-accent);
+  border-color: var(--pc-accent-dim);
+}
+
+.pc-diagram-stage {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0.5rem;
+  background: var(--pc-bg-base);
+  border: 1px solid var(--pc-border);
+  border-radius: var(--pc-radius);
+  cursor: grab;
+  touch-action: none;
+}
+
+.pc-diagram-stage.pc-diagram-dragging {
+  cursor: grabbing;
+}
+
+.pc-diagram-stage > svg {
+  display: block;
+  flex: 0 0 auto;
+  width: auto;
+  max-width: min(88vw, 84rem);
+  max-height: 74vh;
+  transform-origin: center;
+  transition: transform 0.12s ease;
+  user-select: none;
+}
+
+.pc-diagram-dragging > svg {
+  transition: none;
+}
+
+.pc-diagram-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding-top: 0.75rem;
+}
+
+.pc-diagram-control {
+  min-width: 2.3rem;
+  min-height: 2rem;
+  padding: 0.3rem 0.55rem;
+  color: var(--pc-text-secondary);
+  background: var(--pc-bg-surface);
+  border: 1px solid var(--pc-border);
+  border-radius: 0.45rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.pc-diagram-control:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.pc-diagram-reset {
+  margin-left: 0.35rem;
+  font-family: var(--pc-font-mono);
+  font-size: 0.75rem;
+}
+
+.pc-diagram-zoom-value {
+  min-width: 3.4rem;
+  color: var(--pc-text-primary);
+  font-family: var(--pc-font-mono);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .pc-reader-popup {
+    left: -0.5rem;
+    width: min(14rem, calc(100vw - 1rem));
+  }
+
+  .pc-diagram-modal {
+    padding: 0.35rem;
+  }
+
+  .pc-diagram-surface {
+    width: 100vw;
+    height: 96vh;
+    padding: 0.65rem;
+  }
+
+  .pc-diagram-stage > svg {
+    max-width: 90vw;
+    max-height: 78vh;
+  }
 }
 
 /* ---------------------------------------------------------------------------

--- a/docs/book/theme/pc-enhance.js
+++ b/docs/book/theme/pc-enhance.js
@@ -353,6 +353,7 @@
     if (!main || document.getElementById('pc-diagram-modal')) return;
 
     let activeTrigger = null;
+    let activeDiagram = null;
     let zoom = 1;
     let panX = 0;
     let panY = 0;
@@ -438,6 +439,25 @@
     function closeModal() {
       modal.hidden = true;
       document.documentElement.classList.remove('pc-diagram-modal-open');
+
+      if (activeDiagram) {
+        const {
+          svg,
+          placeholder,
+          originalTransform,
+          originalAriaHidden,
+          originalTabIndex,
+        } = activeDiagram;
+        svg.style.transform = originalTransform;
+        if (originalAriaHidden === null) svg.removeAttribute('aria-hidden');
+        else svg.setAttribute('aria-hidden', originalAriaHidden);
+        if (originalTabIndex === null) svg.removeAttribute('tabindex');
+        else svg.setAttribute('tabindex', originalTabIndex);
+        if (placeholder.isConnected) placeholder.replaceWith(svg);
+        else stage.replaceChildren();
+        activeDiagram = null;
+      }
+
       stage.replaceChildren();
       if (activeTrigger) activeTrigger.focus();
       activeTrigger = null;
@@ -448,10 +468,30 @@
       zoom = 1;
       panX = 0;
       panY = 0;
-      const clone = svg.cloneNode(true);
-      clone.setAttribute('aria-hidden', 'true');
-      clone.removeAttribute('tabindex');
-      stage.replaceChildren(clone);
+      // Keep Mermaid's original SVG node so its generated IDs remain unique.
+      // A sized placeholder preserves the page layout while the node is in the
+      // dialog, then the same node is restored when the dialog closes.
+      const placeholder = document.createElement('span');
+      placeholder.className = 'pc-diagram-placeholder';
+      placeholder.setAttribute('aria-hidden', 'true');
+      const rect = svg.getBoundingClientRect();
+      const computed = window.getComputedStyle(svg);
+      placeholder.style.display = computed.display === 'inline' ? 'inline-block' : computed.display;
+      placeholder.style.width = rect.width + 'px';
+      placeholder.style.height = rect.height + 'px';
+      placeholder.style.margin = computed.margin;
+      placeholder.style.verticalAlign = computed.verticalAlign;
+      activeDiagram = {
+        svg: svg,
+        placeholder: placeholder,
+        originalTransform: svg.style.transform,
+        originalAriaHidden: svg.getAttribute('aria-hidden'),
+        originalTabIndex: svg.getAttribute('tabindex'),
+      };
+      svg.replaceWith(placeholder);
+      svg.setAttribute('aria-hidden', 'true');
+      svg.removeAttribute('tabindex');
+      stage.replaceChildren(svg);
       modal.hidden = false;
       document.documentElement.classList.add('pc-diagram-modal-open');
       applyTransform();

--- a/docs/book/theme/pc-enhance.js
+++ b/docs/book/theme/pc-enhance.js
@@ -1,31 +1,103 @@
 /* ZeroClaw docs enhancement layer (Tier B PoC).
    - Right-hand page TOC built from content headings, with scroll-spy.
+   - Persistent reader text scaling and a narrow-screen TOC toggle.
+   - Keyboard/pointer Mermaid diagram expansion.
    - Hero banner injected on the landing page (introduction).
    - Reading-progress bar under the menu bar.
    No build-time coupling: everything is derived from the rendered DOM. */
 (function () {
   'use strict';
 
+  const READER_SCALE_KEY = 'pc-reader-font-scale';
+  const READER_SCALE_MIN = 0.85;
+  const READER_SCALE_MAX = 1.4;
+  const READER_SCALE_STEP = 0.1;
+
   const LOCALE_TEXT = {
     en: {
       onThisPage: 'On this page',
       quickStart: 'Quickstart',
+      readerControls: 'Reading settings',
+      decreaseText: 'Decrease text size',
+      increaseText: 'Increase text size',
+      resetText: 'Reset text size',
+      textSize: 'Text size',
+      showToc: 'Show page contents',
+      hideToc: 'Hide page contents',
+      expandDiagram: 'Open diagram zoom',
+      closeDiagram: 'Close diagram',
+      zoomIn: 'Zoom in',
+      zoomOut: 'Zoom out',
+      resetZoom: 'Reset zoom',
+      zoomLevel: 'Zoom level',
     },
     es: {
       onThisPage: 'En esta página',
       quickStart: 'Inicio rápido',
+      readerControls: 'Ajustes de lectura',
+      decreaseText: 'Reducir tamaño del texto',
+      increaseText: 'Aumentar tamaño del texto',
+      resetText: 'Restablecer tamaño del texto',
+      textSize: 'Tamaño del texto',
+      showToc: 'Mostrar contenido de la página',
+      hideToc: 'Ocultar contenido de la página',
+      expandDiagram: 'Abrir zoom del diagrama',
+      closeDiagram: 'Cerrar diagrama',
+      zoomIn: 'Ampliar',
+      zoomOut: 'Reducir',
+      resetZoom: 'Restablecer zoom',
+      zoomLevel: 'Nivel de zoom',
     },
     fr: {
       onThisPage: 'Sur cette page',
       quickStart: 'Démarrage rapide',
+      readerControls: 'Réglages de lecture',
+      decreaseText: 'Réduire la taille du texte',
+      increaseText: 'Augmenter la taille du texte',
+      resetText: 'Réinitialiser la taille du texte',
+      textSize: 'Taille du texte',
+      showToc: 'Afficher le contenu de la page',
+      hideToc: 'Masquer le contenu de la page',
+      expandDiagram: 'Ouvrir le zoom du diagramme',
+      closeDiagram: 'Fermer le diagramme',
+      zoomIn: 'Zoom avant',
+      zoomOut: 'Zoom arrière',
+      resetZoom: 'Réinitialiser le zoom',
+      zoomLevel: 'Niveau de zoom',
     },
     ja: {
       onThisPage: 'このページ',
       quickStart: 'クイックスタート',
+      readerControls: '閲覧設定',
+      decreaseText: '文字を小さくする',
+      increaseText: '文字を大きくする',
+      resetText: '文字サイズをリセット',
+      textSize: '文字サイズ',
+      showToc: 'ページ目次を表示',
+      hideToc: 'ページ目次を非表示',
+      expandDiagram: '図を拡大して開く',
+      closeDiagram: '図を閉じる',
+      zoomIn: '拡大',
+      zoomOut: '縮小',
+      resetZoom: 'ズームをリセット',
+      zoomLevel: 'ズーム倍率',
     },
     'zh-CN': {
       onThisPage: '本页目录',
       quickStart: '快速入门',
+      readerControls: '阅读设置',
+      decreaseText: '缩小字号',
+      increaseText: '放大字号',
+      resetText: '重置字号',
+      textSize: '字号',
+      showToc: '显示本页目录',
+      hideToc: '隐藏本页目录',
+      expandDiagram: '打开图表缩放',
+      closeDiagram: '关闭图表',
+      zoomIn: '放大',
+      zoomOut: '缩小',
+      resetZoom: '重置缩放',
+      zoomLevel: '缩放比例',
     },
   };
 
@@ -39,6 +111,144 @@
   function ready(fn) {
     if (document.readyState !== 'loading') fn();
     else document.addEventListener('DOMContentLoaded', fn);
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function readReaderScale() {
+    let value = 1;
+    try {
+      value = Number.parseFloat(localStorage.getItem(READER_SCALE_KEY));
+    } catch (e) {
+      // Storage can be unavailable in private or embedded browser contexts.
+    }
+    if (!Number.isFinite(value)) value = 1;
+    return clamp(Math.round(value * 10) / 10, READER_SCALE_MIN, READER_SCALE_MAX);
+  }
+
+  function saveReaderScale(value) {
+    try {
+      localStorage.setItem(READER_SCALE_KEY, String(value));
+    } catch (e) {
+      // The control still works for this page when persistence is unavailable.
+    }
+  }
+
+  function formatPercent(value) {
+    return Math.round(value * 100) + '%';
+  }
+
+  // ── Persistent text scaling ───────────────────────────────────────────
+  function installReaderControls() {
+    const buttons = document.querySelector('#mdbook-menu-bar .left-buttons');
+    if (!buttons || document.getElementById('pc-reader-controls')) return;
+
+    let scale = readReaderScale();
+    const wrapper = document.createElement('div');
+    wrapper.id = 'pc-reader-controls';
+    wrapper.className = 'pc-reader-controls';
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'icon-button pc-reader-toggle';
+    toggle.textContent = 'Aa';
+    toggle.title = localeText('readerControls', 'Reading settings');
+    toggle.setAttribute('aria-label', toggle.title);
+    toggle.setAttribute('aria-haspopup', 'dialog');
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-controls', 'pc-reader-popup');
+
+    const popup = document.createElement('div');
+    popup.id = 'pc-reader-popup';
+    popup.className = 'pc-reader-popup';
+    popup.hidden = true;
+    popup.setAttribute('role', 'dialog');
+    popup.setAttribute('aria-labelledby', 'pc-reader-popup-title');
+
+    const title = document.createElement('div');
+    title.id = 'pc-reader-popup-title';
+    title.className = 'pc-reader-popup-title';
+    title.textContent = localeText('readerControls', 'Reading settings');
+
+    const label = document.createElement('div');
+    label.className = 'pc-reader-scale-label';
+    label.textContent = localeText('textSize', 'Text size');
+
+    const row = document.createElement('div');
+    row.className = 'pc-reader-scale-row';
+
+    const decrease = document.createElement('button');
+    decrease.type = 'button';
+    decrease.className = 'pc-reader-scale-button';
+    decrease.textContent = 'A−';
+    decrease.title = localeText('decreaseText', 'Decrease text size');
+    decrease.setAttribute('aria-label', decrease.title);
+
+    const value = document.createElement('output');
+    value.className = 'pc-reader-scale-value';
+    value.setAttribute('aria-live', 'polite');
+
+    const increase = document.createElement('button');
+    increase.type = 'button';
+    increase.className = 'pc-reader-scale-button';
+    increase.textContent = 'A+';
+    increase.title = localeText('increaseText', 'Increase text size');
+    increase.setAttribute('aria-label', increase.title);
+
+    const reset = document.createElement('button');
+    reset.type = 'button';
+    reset.className = 'pc-reader-reset-button';
+    reset.textContent = localeText('resetText', 'Reset text size');
+    reset.title = reset.textContent;
+
+    function applyScale(next) {
+      scale = clamp(Math.round(next * 10) / 10, READER_SCALE_MIN, READER_SCALE_MAX);
+      document.documentElement.style.setProperty('--pc-reader-scale', String(scale));
+      value.textContent = formatPercent(scale);
+      decrease.disabled = scale <= READER_SCALE_MIN;
+      increase.disabled = scale >= READER_SCALE_MAX;
+      saveReaderScale(scale);
+    }
+
+    function setOpen(open) {
+      popup.hidden = !open;
+      toggle.setAttribute('aria-expanded', String(open));
+      if (open) decrease.focus();
+    }
+
+    decrease.addEventListener('click', function () {
+      applyScale(scale - READER_SCALE_STEP);
+    });
+    increase.addEventListener('click', function () {
+      applyScale(scale + READER_SCALE_STEP);
+    });
+    reset.addEventListener('click', function () {
+      applyScale(1);
+    });
+    toggle.addEventListener('click', function (e) {
+      e.stopPropagation();
+      setOpen(popup.hidden);
+    });
+    popup.addEventListener('click', function (e) {
+      e.stopPropagation();
+    });
+    document.addEventListener('click', function () {
+      if (!popup.hidden) setOpen(false);
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !popup.hidden) {
+        setOpen(false);
+        toggle.focus();
+      }
+    });
+
+    row.append(decrease, value, increase);
+    popup.append(title, label, row, reset);
+    wrapper.append(toggle, popup);
+    buttons.appendChild(wrapper);
+    applyScale(scale);
   }
 
   // ── Reading progress bar ───────────────────────────────────────────────
@@ -74,6 +284,20 @@
       return;
     }
 
+    const tocToggle = document.createElement('button');
+    tocToggle.type = 'button';
+    tocToggle.className = 'pc-toc-toggle';
+    tocToggle.setAttribute('aria-controls', 'pc-page-toc');
+    tocToggle.setAttribute('aria-expanded', 'false');
+    tocToggle.textContent = localeText('showToc', 'Show page contents');
+    tocToggle.addEventListener('click', function () {
+      const open = !toc.classList.contains('pc-toc-open');
+      toc.classList.toggle('pc-toc-open', open);
+      tocToggle.setAttribute('aria-expanded', String(open));
+      tocToggle.textContent = localeText(open ? 'hideToc' : 'showToc', open ? 'Hide page contents' : 'Show page contents');
+    });
+    toc.parentNode.insertBefore(tocToggle, toc);
+
     const title = document.createElement('div');
     title.className = 'pc-toc-title';
     title.textContent = localeText('onThisPage', 'On this page');
@@ -93,6 +317,9 @@
         e.preventDefault();
         h.scrollIntoView({ behavior: 'smooth', block: 'start' });
         history.replaceState(null, '', '#' + h.id);
+        toc.classList.remove('pc-toc-open');
+        tocToggle.setAttribute('aria-expanded', 'false');
+        tocToggle.textContent = localeText('showToc', 'Show page contents');
       });
       li.appendChild(a);
       list.appendChild(li);
@@ -118,6 +345,187 @@
       { rootMargin: '0px 0px -75% 0px', threshold: 0 },
     );
     headings.forEach((h) => spy.observe(h));
+  }
+
+  // ── Mermaid diagram expansion ─────────────────────────────────────────
+  function installDiagramZoom() {
+    const main = document.querySelector('#mdbook-content main');
+    if (!main || document.getElementById('pc-diagram-modal')) return;
+
+    let activeTrigger = null;
+    let zoom = 1;
+    let panX = 0;
+    let panY = 0;
+    let dragging = false;
+    let dragStartX = 0;
+    let dragStartY = 0;
+
+    const modal = document.createElement('div');
+    modal.id = 'pc-diagram-modal';
+    modal.className = 'pc-diagram-modal';
+    modal.hidden = true;
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-labelledby', 'pc-diagram-modal-title');
+
+    const surface = document.createElement('div');
+    surface.className = 'pc-diagram-surface';
+
+    const heading = document.createElement('h2');
+    heading.id = 'pc-diagram-modal-title';
+    heading.className = 'pc-diagram-modal-title';
+    heading.textContent = localeText('expandDiagram', 'Open diagram zoom');
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'pc-diagram-close';
+    close.textContent = '×';
+    close.title = localeText('closeDiagram', 'Close diagram');
+    close.setAttribute('aria-label', close.title);
+
+    const stage = document.createElement('div');
+    stage.className = 'pc-diagram-stage';
+    stage.setAttribute('role', 'region');
+    stage.setAttribute('aria-label', localeText('expandDiagram', 'Open diagram zoom'));
+
+    const controls = document.createElement('div');
+    controls.className = 'pc-diagram-controls';
+
+    function controlButton(label, text) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'pc-diagram-control';
+      button.title = label;
+      button.setAttribute('aria-label', label);
+      button.textContent = text;
+      return button;
+    }
+
+    const zoomOut = controlButton(localeText('zoomOut', 'Zoom out'), '−');
+    const zoomValue = document.createElement('output');
+    zoomValue.className = 'pc-diagram-zoom-value';
+    zoomValue.setAttribute('aria-live', 'polite');
+    const zoomIn = controlButton(localeText('zoomIn', 'Zoom in'), '+');
+    const zoomReset = controlButton(localeText('resetZoom', 'Reset zoom'), '1:1');
+    zoomReset.classList.add('pc-diagram-reset');
+
+    function diagramSvg() {
+      return stage.querySelector('svg');
+    }
+
+    function applyTransform() {
+      const svg = diagramSvg();
+      if (!svg) return;
+      svg.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + zoom + ')';
+      zoomValue.textContent = formatPercent(zoom);
+      zoomOut.disabled = zoom <= 1;
+      zoomIn.disabled = zoom >= 4;
+    }
+
+    function setZoom(next) {
+      const previous = zoom;
+      zoom = clamp(Math.round(next * 4) / 4, 1, 4);
+      if (zoom === 1) {
+        panX = 0;
+        panY = 0;
+      } else if (previous !== zoom) {
+        panX = clamp(panX, -800, 800);
+        panY = clamp(panY, -800, 800);
+      }
+      applyTransform();
+    }
+
+    function closeModal() {
+      modal.hidden = true;
+      document.documentElement.classList.remove('pc-diagram-modal-open');
+      stage.replaceChildren();
+      if (activeTrigger) activeTrigger.focus();
+      activeTrigger = null;
+    }
+
+    function openModal(svg, trigger) {
+      activeTrigger = trigger;
+      zoom = 1;
+      panX = 0;
+      panY = 0;
+      const clone = svg.cloneNode(true);
+      clone.setAttribute('aria-hidden', 'true');
+      clone.removeAttribute('tabindex');
+      stage.replaceChildren(clone);
+      modal.hidden = false;
+      document.documentElement.classList.add('pc-diagram-modal-open');
+      applyTransform();
+      close.focus();
+    }
+
+    close.addEventListener('click', closeModal);
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) closeModal();
+    });
+    zoomOut.addEventListener('click', function () { setZoom(zoom - 0.25); });
+    zoomIn.addEventListener('click', function () { setZoom(zoom + 0.25); });
+    zoomReset.addEventListener('click', function () { setZoom(1); });
+    stage.addEventListener('wheel', function (e) {
+      if (modal.hidden) return;
+      e.preventDefault();
+      setZoom(zoom + (e.deltaY < 0 ? 0.25 : -0.25));
+    }, { passive: false });
+    stage.addEventListener('pointerdown', function (e) {
+      if (zoom <= 1) return;
+      dragging = true;
+      dragStartX = e.clientX - panX;
+      dragStartY = e.clientY - panY;
+      stage.setPointerCapture(e.pointerId);
+      stage.classList.add('pc-diagram-dragging');
+    });
+    stage.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      panX = clamp(e.clientX - dragStartX, -1200, 1200);
+      panY = clamp(e.clientY - dragStartY, -1200, 1200);
+      applyTransform();
+    });
+    function stopDragging(e) {
+      dragging = false;
+      if (e && stage.hasPointerCapture(e.pointerId)) stage.releasePointerCapture(e.pointerId);
+      stage.classList.remove('pc-diagram-dragging');
+    }
+    stage.addEventListener('pointerup', stopDragging);
+    stage.addEventListener('pointercancel', stopDragging);
+    document.addEventListener('keydown', function (e) {
+      if (!modal.hidden && e.key === 'Escape') closeModal();
+    });
+
+    controls.append(zoomOut, zoomValue, zoomIn, zoomReset);
+    surface.append(heading, close, stage, controls);
+    modal.appendChild(surface);
+    document.body.appendChild(modal);
+
+    function wire() {
+      main.querySelectorAll('.mermaid svg, pre.mermaid svg').forEach(function (svg) {
+        const host = svg.closest('.mermaid, pre.mermaid') || svg;
+        if (host.dataset.pcDiagramZoomWired) return;
+        host.dataset.pcDiagramZoomWired = '1';
+        host.classList.add('pc-diagram-zoomable');
+        host.tabIndex = 0;
+        host.setAttribute('role', 'button');
+        host.setAttribute('aria-label', localeText('expandDiagram', 'Open diagram zoom'));
+        host.setAttribute('aria-keyshortcuts', 'Enter Space');
+        host.addEventListener('click', function (e) {
+          if (e.target.closest('a')) return;
+          openModal(svg, host);
+        });
+        host.addEventListener('keydown', function (e) {
+          if (e.key !== 'Enter' && e.key !== ' ') return;
+          e.preventDefault();
+          openModal(svg, host);
+        });
+      });
+    }
+
+    wire();
+    const observer = new MutationObserver(wire);
+    observer.observe(main, { childList: true, subtree: true });
+    window.setTimeout(wire, 120);
   }
 
   // ── Hero banner on the landing page ────────────────────────────────────
@@ -295,11 +703,13 @@
   }
 
   ready(function () {
+    installReaderControls();
     installProgressBar();
     installHero();
     installToc();
     wrapTables();
     installFoldableRows();
     installOsTabs();
+    installDiagramZoom();
   });
 })();

--- a/docs/book/theme/pc-enhance.js
+++ b/docs/book/theme/pc-enhance.js
@@ -550,14 +550,22 @@
         host.setAttribute('role', 'button');
         host.setAttribute('aria-label', localeText('expandDiagram', 'Open diagram zoom'));
         host.setAttribute('aria-keyshortcuts', 'Enter Space');
+        // Mermaid can replace the rendered SVG while the page is settling.
+        // Resolve the current child at activation time so the dialog moves the
+        // live node rather than a stale render captured during wiring.
+        function openCurrentDiagram() {
+          const currentSvg =
+            host.matches('svg') ? host : host.querySelector('svg');
+          if (currentSvg) openModal(currentSvg, host);
+        }
         host.addEventListener('click', function (e) {
           if (e.target.closest('a')) return;
-          openModal(svg, host);
+          openCurrentDiagram();
         });
         host.addEventListener('keydown', function (e) {
           if (e.key !== 'Enter' && e.key !== ' ') return;
           e.preventDefault();
-          openModal(svg, host);
+          openCurrentDiagram();
         });
       });
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add persistent reader text scaling from 85% to 140% through an accessible `Aa` settings control backed by local storage.
  - Add a narrow-screen page-contents toggle while keeping the right-hand scroll-spy TOC on wide screens.
  - Add keyboard- and pointer-accessible Mermaid diagram zoom, pan, reset, and Escape-to-close behavior without a new dependency.
- **Scope boundary:** This changes the custom docs theme only. It does not change mdBook's version or ordinary Markdown image zoom, which are handled by #10510.
- **Blast radius:** The shared docs theme runs for all generated locales and all pages with headings or Mermaid diagrams; it does not change application runtime, generated content, or external services.
- **Linked issue(s):** Closes #10509
- **Labels:** `enhancement`, `docs`, `experienced contributor`, `risk:low`, `size:L`, `type:docs`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `web` (static docs site)
- **Setup / preconditions:** Run `cargo mdbook build`, serve the generated book with a local HTTP server, and use a Chromium browser.
- **Steps to run:**
  1. Open the Architecture or Request lifecycle page at the default viewport and select `Aa`.
  2. Select `A+`, navigate to another page, and reopen `Aa`.
  3. Activate a Mermaid diagram with click or Enter, select `+`, then press Escape.
  4. Resize to a narrow viewport, close the main sidebar if needed, and open `Show page contents`.
- **Expected on this branch (after):** The reader control reports 110% after `A+` and keeps that value on the next page; Mermaid opens in a modal, reaches 125% after one zoom action, and closes on Escape; the narrow-screen page TOC expands and collapses from its button.
- **Prior behavior on master (before):** There is no persistent reader-size control, Mermaid diagrams are not keyboard/pointer zoom targets, and the custom on-page TOC has no narrow-screen disclosure control.

### How I tested

- **CI checks relied on and why they cover this change:** The docs build exercises the shared theme across five locales, rustdoc assembly, and internal-link checking; the JavaScript syntax check and browser smoke cover the custom runtime behavior.
- **Known CI coverage gap, if any:** The browser smoke used Chromium only; no cross-browser visual matrix was available locally.
- **Commands run and tail output:**

```text
$ node --check docs/book/theme/pc-enhance.js
status: passed

$ cargo mdbook build
==> Internal link check passed
==> Done. Open: generated master docs
status: passed

$ git diff --check
status: passed
```

- **Beyond CI, what did I manually verify?** Chromium smoke verified 100% → 110% reader scaling, persistence after navigation, Mermaid modal zoom from 100% → 125%, Escape dismissal, a 390×844 narrow viewport, and the expanded page-contents panel. The local-storage fallback path was not forced through a private/blocked-storage browser context.
- **If any command was intentionally skipped, why:** No project validation command was skipped; cross-browser coverage remains a CI/environment gap.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: exact upgrade steps for existing users: N/A

## Rollback

Low-risk change: revert the eventual squash-merge commit.
