### PR TITLE
fix(ci): align CLI and hardware labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -395,7 +395,6 @@
           - "src/peripherals/mod.rs"
           - "crates/zeroclaw-hardware/**"
           - "crates/zeroclaw-api/src/peripherals_traits.rs"
-          - "crates/zeroclaw-runtime/src/firmware/**"
           - "firmware/**"
 
 "web":

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,6 +40,7 @@
           - "src/commands/**"
           - "src/alias_cli/**"
           - "src/cli_input.rs"
+          - "src/memory/cli.rs"
           - "crates/zeroclaw-commands/**"
           - "crates/zeroclaw-runtime/src/cli_input.rs"
 
@@ -391,7 +392,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "src/hardware/**"
+          - "src/peripherals/mod.rs"
           - "crates/zeroclaw-hardware/**"
+          - "crates/zeroclaw-api/src/peripherals_traits.rs"
+          - "crates/zeroclaw-runtime/src/firmware/**"
           - "firmware/**"
 
 "web":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Guard release attestation contract
         run: python3 scripts/ci/release_attestation_contract_test.py
 
+      - name: Test CLI and hardware path-label ownership
+        run: bash scripts/ci/path_labeler_matrix.test.sh
+
   relay-container-smoke-changes:
     name: Detect Relay Container Smoke changes
     needs: [fmt]

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -121,7 +121,7 @@ Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.y
 | `runtime` | `src/runtime/**`, `crates/zeroclaw-runtime/src/**` |
 | `quickstart` | `crates/zeroclaw-runtime/src/quickstart/**`, `crates/zeroclaw-gateway/src/api_quickstart.rs`, `apps/zerocode/src/quickstart_pane.rs`, `web/src/pages/quickstart/**` |
 | `desktop` | `apps/tauri/**` |
-| `hardware` | `src/hardware/**`, `src/peripherals/mod.rs`, `crates/zeroclaw-hardware/**`, `crates/zeroclaw-api/src/peripherals_traits.rs`, `crates/zeroclaw-runtime/src/firmware/**`, `firmware/**` |
+| `hardware` | `src/hardware/**`, `src/peripherals/mod.rs`, `crates/zeroclaw-hardware/**`, `crates/zeroclaw-api/src/peripherals_traits.rs`, `firmware/**` |
 | `web` | `web/**` |
 | `zerocode` | `apps/zerocode/**` |
 | `provider` | `src/providers/**`, `crates/zeroclaw-providers/src/**` |

--- a/docs/book/src/maintainers/labels.md
+++ b/docs/book/src/maintainers/labels.md
@@ -105,7 +105,7 @@ Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.y
 | `dependencies` | `Cargo.toml`, `**/Cargo.toml`, `Cargo.lock`, `**/Cargo.lock`, `deny.toml`, `.github/dependabot.yml` |
 | `ci` | `.github/codeql/**`, `.github/workflows/**`, `.github/*.yaml`, `.github/*.yml`, `.github/*.json`, `.githooks/**` |
 | `core` | `src/*.rs` |
-| `cli` | `src/main.rs`, `src/lib.rs`, `src/commands/**`, `src/alias_cli/**`, `src/cli_input.rs`, `crates/zeroclaw-commands/**`, `crates/zeroclaw-runtime/src/cli_input.rs` |
+| `cli` | `src/main.rs`, `src/lib.rs`, `src/commands/**`, `src/alias_cli/**`, `src/cli_input.rs`, `src/memory/cli.rs` (the `zeroclaw memory` command), `crates/zeroclaw-commands/**`, `crates/zeroclaw-runtime/src/cli_input.rs` |
 | `agent` | `src/agent/**`, `crates/zeroclaw-runtime/src/agent/**` |
 | `channel` | `src/channels/**`, `crates/zeroclaw-channels/src/**` |
 | `gateway` | `src/gateway/**`, `crates/zeroclaw-gateway/src/**` |
@@ -121,7 +121,7 @@ Applied automatically by `pr-path-labeler.yml`. Globs live in `.github/labeler.y
 | `runtime` | `src/runtime/**`, `crates/zeroclaw-runtime/src/**` |
 | `quickstart` | `crates/zeroclaw-runtime/src/quickstart/**`, `crates/zeroclaw-gateway/src/api_quickstart.rs`, `apps/zerocode/src/quickstart_pane.rs`, `web/src/pages/quickstart/**` |
 | `desktop` | `apps/tauri/**` |
-| `hardware` | `src/hardware/**`, `crates/zeroclaw-hardware/**`, `firmware/**` |
+| `hardware` | `src/hardware/**`, `src/peripherals/mod.rs`, `crates/zeroclaw-hardware/**`, `crates/zeroclaw-api/src/peripherals_traits.rs`, `crates/zeroclaw-runtime/src/firmware/**`, `firmware/**` |
 | `web` | `web/**` |
 | `zerocode` | `apps/zerocode/**` |
 | `provider` | `src/providers/**`, `crates/zeroclaw-providers/src/**` |

--- a/scripts/ci/path_labeler_matrix.test.sh
+++ b/scripts/ci/path_labeler_matrix.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This harness deliberately uses the same matcher dependency as the pinned
+# actions/labeler release. Keep the versions together when that action moves.
+readonly ACTION_REF='actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13'
+readonly ACTION_VERSION='v7.0.0'
+readonly MINIMATCH_VERSION='10.2.5'
+readonly JS_YAML_VERSION='5.1.0'
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+npm install --prefix "$tmp_dir" --no-save --ignore-scripts --package-lock=false \
+  "minimatch@${MINIMATCH_VERSION}" "js-yaml@${JS_YAML_VERSION}" >/dev/null
+
+REPO_ROOT="$repo_root" NODE_PATH="$tmp_dir/node_modules" \
+  PATH_LABELER_ACTION_REF="$ACTION_REF" PATH_LABELER_ACTION_VERSION="$ACTION_VERSION" \
+  PATH_LABELER_MINIMATCH_VERSION="$MINIMATCH_VERSION" node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const yaml = require('js-yaml');
+const { Minimatch } = require('minimatch');
+
+const root = process.env.REPO_ROOT;
+const labelerPath = path.join(root, '.github', 'labeler.yml');
+const workflowPath = path.join(root, '.github', 'workflows', 'pr-path-labeler.yml');
+const config = yaml.load(fs.readFileSync(labelerPath, 'utf8'));
+const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+assert.match(workflow, new RegExp(`${process.env.PATH_LABELER_ACTION_REF} \\# ${process.env.PATH_LABELER_ACTION_VERSION}`));
+
+function matchesLabel(label, files) {
+  const changedFiles = (config[label] || []).flatMap((entry) => entry['changed-files'] || []);
+  return changedFiles.some((rule) => {
+    const patterns = rule['any-glob-to-any-file'] || [];
+    return patterns.some((pattern) => {
+      const matcher = new Minimatch(pattern, { dot: true });
+      return files.some((file) => matcher.match(file));
+    });
+  });
+}
+
+const positives = [
+  ['cli', 'src/memory/cli.rs'],
+  ['cli', 'src/commands/memory.rs'],
+  ['hardware', 'src/peripherals/mod.rs'],
+  ['hardware', 'crates/zeroclaw-api/src/peripherals_traits.rs'],
+  ['hardware', 'crates/zeroclaw-runtime/src/firmware/transport.rs'],
+  ['hardware', 'firmware/src/main.rs'],
+];
+const negatives = [
+  ['cli', 'src/memory/mod.rs'],
+  ['cli', 'crates/zeroclaw-memory/src/cli.rs'],
+  ['hardware', 'src/peripherals/driver.rs'],
+  ['hardware', 'crates/zeroclaw-api/src/channel.rs'],
+  ['hardware', 'crates/zeroclaw-runtime/src/agent/history.rs'],
+  ['hardware', 'docs/book/src/hardware/subsystem.md'],
+];
+
+for (const [label, file] of positives) {
+  assert.equal(matchesLabel(label, [file]), true, `${label} should match ${file}`);
+}
+for (const [label, file] of negatives) {
+  assert.equal(matchesLabel(label, [file]), false, `${label} should not match ${file}`);
+}
+
+console.log(`Pinned matcher: minimatch ${process.env.PATH_LABELER_MINIMATCH_VERSION} (${process.env.PATH_LABELER_ACTION_REF} # ${process.env.PATH_LABELER_ACTION_VERSION})`);
+console.log(`${positives.length}/${positives.length} configured positives matched.`);
+console.log(`${negatives.length}/${negatives.length} boundary negatives stayed unmatched.`);
+NODE

--- a/scripts/ci/path_labeler_matrix.test.sh
+++ b/scripts/ci/path_labeler_matrix.test.sh
@@ -21,6 +21,7 @@ REPO_ROOT="$repo_root" NODE_PATH="$tmp_dir/node_modules" \
 const fs = require('node:fs');
 const path = require('node:path');
 const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
 const yaml = require('js-yaml');
 const { Minimatch } = require('minimatch');
 
@@ -29,6 +30,11 @@ const labelerPath = path.join(root, '.github', 'labeler.yml');
 const workflowPath = path.join(root, '.github', 'workflows', 'pr-path-labeler.yml');
 const config = yaml.load(fs.readFileSync(labelerPath, 'utf8'));
 const workflow = fs.readFileSync(workflowPath, 'utf8');
+const trackedFiles = new Set(
+  execFileSync('git', ['-C', root, 'ls-files', '-z'], { encoding: 'utf8' })
+    .split('\0')
+    .filter(Boolean),
+);
 
 assert.match(workflow, new RegExp(`${process.env.PATH_LABELER_ACTION_REF} \\# ${process.env.PATH_LABELER_ACTION_VERSION}`));
 
@@ -45,11 +51,10 @@ function matchesLabel(label, files) {
 
 const positives = [
   ['cli', 'src/memory/cli.rs'],
-  ['cli', 'src/commands/memory.rs'],
+  ['cli', 'src/commands/update.rs'],
   ['hardware', 'src/peripherals/mod.rs'],
   ['hardware', 'crates/zeroclaw-api/src/peripherals_traits.rs'],
-  ['hardware', 'crates/zeroclaw-runtime/src/firmware/transport.rs'],
-  ['hardware', 'firmware/src/main.rs'],
+  ['hardware', 'firmware/esp32-ui/src/main.rs'],
 ];
 const negatives = [
   ['cli', 'src/memory/mod.rs'],
@@ -61,6 +66,7 @@ const negatives = [
 ];
 
 for (const [label, file] of positives) {
+  assert.equal(trackedFiles.has(file), true, `${file} must be a tracked repository path`);
   assert.equal(matchesLabel(label, [file]), true, `${label} should match ${file}`);
 }
 for (const [label, file] of negatives) {


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Assign `src/memory/cli.rs` to the `cli` path label.
  - Assign the peripheral trait/module paths and the canonical `firmware/**` tree to the `hardware` path label.
  - Add a pinned `minimatch` boundary matrix that proves tracked positive paths and nearby negatives, and run it in CI.
  - Keep the maintainer label table aligned with the executable ownership rules.
- **Scope boundary:** This changes path-label ownership and its deterministic test only. It does not apply labels to existing PRs, change the labeler action, treat the runtime firmware symlink as a source tree, or broaden unrelated subsystem globs.
- **Blast radius:** PR path labeling gains coverage for the memory CLI and hardware abstractions; the new CI script fails if the configured ownership boundaries or tracked positive inventory drift.
- **Linked issue(s):** Closes #9680
- **Labels:** `enhancement`, `ci`, `docs`, `scripts`, `experienced contributor`, `risk:medium`, `size:S`, `type:ci`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the executable matcher matrix covers the changed rules and boundary cases.

### How I tested

- **CI checks relied on and why they cover this change:** The required CI step runs the same script that parses `.github/labeler.yml`, verifies the pinned `actions/labeler` ref, confirms positive cases are tracked repository paths, and evaluates positive/negative paths with the matching `minimatch` options.
- **Known CI coverage gap, if any:** The live GitHub labeler action was not invoked against a remote PR locally; the matrix is the deterministic local/CI proof of the configured ownership.
- **Commands run and tail output:**

```text
$ bash -n scripts/ci/path_labeler_matrix.test.sh
status: passed

$ bash scripts/ci/path_labeler_matrix.test.sh
Pinned matcher: minimatch 10.2.5 (actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0)
5/5 configured positives matched.
6/6 boundary negatives stayed unmatched.
status: passed

$ git diff --check
status: passed

$ cargo fmt --all -- --check
status: passed

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
status: passed

$ cargo test --locked
test result: ok; all test targets completed with no failures.
status: passed
```

- **Beyond CI, what did I manually verify?** Compared every positive matrix path with `git ls-files`, confirmed the runtime firmware entry is a tracked symlink rather than a source directory, and reviewed the related open PR file lists for adjacent CI/labels overlap.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? Yes. The test harness installs exact `minimatch` and `js-yaml` versions when its temporary test environment is absent; scripts are disabled and the packages are used only for local matching/config parsing.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: The temporary npm install is limited to pinned package versions, runs with lifecycle scripts disabled, and is removed after the test process exits.

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: exact upgrade steps for existing users: N/A

## Rollback

- **Fast rollback command/path:** After squash merge, run `git revert <squash-merge-sha>` on `master`; this removes the label rules, documentation, and required matrix step together.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** The required `Test CLI and hardware path-label ownership` job fails, or affected PRs receive missing or incorrect `cli`/`hardware` labels.
