### PR TITLE
docs(mdbook): pin mdBook 0.5.4

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -171,14 +171,16 @@ jobs:
 
 
       # MDBOOK_BIN_VERSION is scoped to this step only. Workflow-level
-      # `MDBOOK_*` env vars leak into `cargo mdbook build` below — mdbook 0.5.0
+      # `MDBOOK_*` env vars leak into `cargo mdbook build` below — mdbook 0.5.4
       # rejects unknown `MDBOOK_*` env vars as invalid config keys (#2942).
       - name: Install mdBook (aarch64 musl, ~3 MB)
         env:
-          # Pinned to match the mdbook-mermaid 0.17.0 compile target — avoids
-          # "preprocessor was built against 0.5.0, called from 0.5.2" warning.
-          # Revisit when mdbook-mermaid ships against the latest mdbook minor.
-          MDBOOK_BIN_VERSION: v0.5.0
+          # mdBook 0.5.4 provides the built-in keyboard/pointer image zoom used
+          # by ordinary Markdown images. Mermaid SVG expansion remains owned by
+          # the mdbook-mermaid preprocessor and the site's Mermaid theme layer.
+          # The xtask pins mdbook-mermaid 0.17.1 and intentionally resolves its
+          # mdBook 0.5.x preprocessor dependency without the crate's stale lockfile.
+          MDBOOK_BIN_VERSION: v0.5.4
         run: |
           curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_BIN_VERSION}/mdbook-${MDBOOK_BIN_VERSION}-aarch64-unknown-linux-musl.tar.gz" \
             | tar -xz -C /usr/local/bin

--- a/docs/book/src/_snippets/docs-build-commands.md
+++ b/docs/book/src/_snippets/docs-build-commands.md
@@ -47,10 +47,15 @@ cargo mdbook check                       # validate .po format (run before a tra
 
 | Tool | Install |
 |---|---|
-| [`mdbook`](https://rust-lang.github.io/mdBook/) | `cargo install mdbook --locked` |
+| [`mdbook`](https://rust-lang.github.io/mdBook/) | `cargo install mdbook --version 0.5.4 --locked` |
+| [`mdbook-mermaid`](https://github.com/badboy/mdbook-mermaid) | `cargo install mdbook-mermaid --version 0.17.1` |
 | [`mdbook-i18n-helpers`](https://github.com/google/mdbook-i18n-helpers) | `cargo install mdbook-i18n-helpers --locked` |
 | `cargo` | <https://rustup.rs> |
 | `gettext` (msgfmt, msgmerge) | `apt install gettext` / `brew install gettext` |
+
+The `mdbook-mermaid` version is pinned, but its published lockfile still
+selects the mdBook 0.5.0 preprocessor. Leave off `--locked` for that tool so
+Cargo resolves the compatible 0.5.x preprocessor used by mdBook 0.5.4.
 
 ## What gets built where
 

--- a/docs/book/theme/index.hbs
+++ b/docs/book/theme/index.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-{{!-- Forked from mdBook v0.5.0 default index.hbs, with the theme switcher,
+{{!-- Forked from mdBook v0.5.4 default index.hbs, with the theme switcher,
       Discord link, and reskin structure added. When upgrading mdBook, diff
       this against the new upstream default and re-merge any changes. --}}
 <html lang="{{ language }}" class="{{ default_theme }} sidebar-visible" dir="{{ text_direction }}">

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -136,13 +136,25 @@ pub fn require_tool(cmd: &str, install_hint: &str) -> anyhow::Result<()> {
 }
 
 /// Like `require_tool`, but if the binary is a cargo-installable crate that's missing,
-/// auto-install it via `cargo install --locked <crate>`. Idempotent — a no-op when present.
+/// auto-install it. Idempotent — a no-op when present.
+///
+/// `mdbook-mermaid` is pinned separately because its published lockfile still
+/// compiles against mdBook 0.5.0. Resolving its 0.5.x preprocessor dependency
+/// against the pinned mdBook release avoids a protocol-version warning during
+/// the docs build.
 pub fn ensure_cargo_tool(cmd: &str, crate_name: &str) -> anyhow::Result<()> {
     if tool_on_path(cmd) {
         return Ok(());
     }
     println!("==> installing '{crate_name}' (missing '{cmd}')");
-    run_cmd(Command::new("cargo").args(["install", "--locked", crate_name]))
+    let mut install = Command::new("cargo");
+    install.args(["install"]);
+    if cmd == "mdbook-mermaid" {
+        install.args(["--version", "0.17.1", crate_name]);
+    } else {
+        install.args(["--locked", crate_name]);
+    }
+    run_cmd(&mut install)
 }
 
 fn tool_on_path(cmd: &str) -> bool {
@@ -175,7 +187,7 @@ pub fn mdbook_program() -> anyhow::Result<PathBuf> {
         }
     }
     anyhow::bail!(
-        "'mdbook' not found on PATH\n  install: cargo install mdbook --version 0.5.0 --locked"
+        "'mdbook' not found on PATH\n  install: cargo install mdbook --version 0.5.4 --locked"
     )
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Pin the docs-deploy mdBook binary and contributor install guidance to mdBook 0.5.4, which supplies built-in ordinary-image zoom.
  - Pin mdbook-mermaid to 0.17.1 and resolve its compatible mdBook 0.5.x preprocessor dependency without the stale published lockfile.
  - Update the forked theme provenance note so future mdBook upgrades start from the actual upstream template version.
- **Scope boundary:** Mermaid expansion remains owned by mdbook-mermaid and the custom Mermaid theme layer; this PR does not add a second custom ordinary-image zoom implementation or change application code.
- **Blast radius:** Docs deployment, the `cargo mdbook build/serve` helper, and contributor setup instructions; application runtime and generated source content are unaffected.
- **Linked issue(s):** Closes #10510
- **Labels:** `ci`, `docs`, `dependencies`, `experienced contributor`, `risk:medium`, `size:XS`, `type:docs`, `type:ci`, `type:dependencies`.

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `web` (generated docs site)
- **Setup / preconditions:** Install mdBook 0.5.4 and mdbook-mermaid 0.17.1 using the documented commands, then run `cargo mdbook build`.
- **Steps to run:** Open a generated page containing an ordinary Markdown image, click the image, and press Escape.
- **Expected on this branch (after):** The image enters mdBook's built-in zoom view and Escape returns to the inline image; Mermaid diagrams continue to render through the existing preprocessor/theme path.
- **Prior behavior on master (before):** The docs build uses mdBook 0.5.0, so ordinary-image built-in zoom is unavailable and the docs tooling is not aligned with the requested release.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed, including format, lint, tests, and docs style. The locally reported full docs build below exercised the xtask wrapper, rustdoc generation, all five locales, mdBook rendering, Mermaid preprocessing, internal links, and site assembly.
- **Known CI coverage gap, if any:** The changed tool-install argument selection has no dedicated regression test. The ARM64 deployment runner and the final GitHub Pages publication were not run locally.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
status: passed

$ cargo test -p xtask --locked
cargo test: 215 passed (6 suites, 1.45s)
status: passed

$ cargo mdbook build
==> Internal link check passed
==> Done. Open: generated master docs
status: passed

$ git diff --check
status: passed
```

- **Beyond CI, what did I manually verify?** With mdBook 0.5.4, a minimal generated fixture emitted the built-in `checkbox-img` image markup; Chromium click changed the image wrapper to visible, and Escape restored the unchecked/hidden state. The live deployment and ARM binary were not exercised.
- **If any command was intentionally skipped, why:** No project validation command was skipped; deployment publication was intentionally not performed under the human approval gate.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No; the existing missing-tool installation path remains the only networked setup path, with versions made explicit.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes, for the application and generated docs surface; docs contributors should use the documented mdBook 0.5.4 and mdbook-mermaid 0.17.1 commands.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: exact upgrade steps for existing users: N/A

## Rollback

- **Fast rollback command/path:** `git revert d7c9298ccb656c621eaa7b9056df5c8485648bee` and rerun the docs deployment validation.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Docs deployment fails while installing mdBook tools, the build reports mdBook/preprocessor version mismatch, or ordinary images lose the expected built-in zoom behavior.
