### PR TITLE
fix(zerocode): satisfy Rust 1.98 drain-collect lint

### DIFF
--- a/apps/zerocode/src/app.rs
+++ b/apps/zerocode/src/app.rs
@@ -195,7 +195,7 @@ impl SgrMouseEventDecoder {
 
     fn replay_candidate(&mut self) -> Vec<Event> {
         self.candidate_started_at = None;
-        self.candidate.drain(..).collect()
+        std::mem::take(&mut self.candidate)
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Rust 1.98 reports `clippy::drain_collect` in `SgrMouseEventDecoder::replay_candidate`, which blocks the routine-toolchain update in #9527.
  - Replace `drain(..).collect()` with `std::mem::take` so the decoder moves its existing event vector directly instead of allocating and collecting an equivalent replacement.
- **Scope boundary:** This does not change SGR parsing, event ordering, terminal input behavior, public APIs, toolchain pins, or the declared MSRV.
- **Blast radius:** One private ZeroCode decoder method used by five invalid or incomplete SGR replay paths.
- **Linked issue(s):** Related #9527
- **Labels:** `bug`, `zerocode`, `release-gate`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — existing decoder regressions cover the observable replay behavior; no interface behavior changes.

### How I tested

- **CI checks relied on and why they cover this change:** None at submission time. Hosted CI must still pass on the PR head.
- **Known CI coverage gap, if any:** The local evidence covers the changed private method on both the routine Rust 1.98 toolchain and the supported Rust 1.96 floor. Hosted CI supplies the full workspace gate.
- **Commands run and tail output:**

  ```text
  RUSTC_WRAPPER= cargo +1.98.0 clippy --locked -p zerocode --all-targets -- -D warnings
  Finished successfully

  RUSTC_WRAPPER= cargo +1.98.0 test --locked -p zerocode sgr_mouse
  test result: ok. 7 passed; 0 failed

  RUSTC_WRAPPER= cargo +1.98.0 test --locked -p zerocode app::tests::drag_read_ahead_reassembles_split_sgr_drag_without_leaking_escape -- --exact
  test result: ok. 1 passed; 0 failed

  RUSTC_WRAPPER= cargo +1.96.0 check --locked -p zerocode --all-targets
  Finished successfully

  cargo fmt --all -- --check
  git diff --check
  Both passed
  ```

- **Beyond CI, what did you manually verify?** The code graph reports five production callers, all inside `decode_candidate`. `mem::take` returns the same ordered `Vec<Event>`, leaves the candidate empty, and preserves the existing timestamp reset.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** I did not repeat full workspace tests locally for this one-line private-method change. Exact Rust 1.98 Clippy, the owning package's behavior tests, the Rust 1.96 floor check, and hosted CI cover the changed boundary.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: `N/A`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge-sha>`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Invalid or incomplete split SGR input is not replayed in order, or the Rust 1.98 ZeroCode Clippy check regresses.
