### PR TITLE
fix(rpc): drive manually started SOP runs

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -4567,7 +4567,21 @@ impl RpcDispatcher {
 
         for result in &results {
             match result {
-                crate::sop::dispatch::DispatchResult::Started { run_id, .. } => {
+                crate::sop::dispatch::DispatchResult::Started { run_id, action, .. } => {
+                    let needs_driver = matches!(
+                        action.as_ref(),
+                        crate::sop::SopRunAction::ExecuteStep { .. }
+                            | crate::sop::SopRunAction::DeterministicStep { .. }
+                    );
+                    if needs_driver {
+                        let config = self.ctx.config.read().clone();
+                        crate::sop::spawn_headless_run_driver(
+                            config,
+                            Arc::clone(engine),
+                            Some(Arc::clone(audit)),
+                            action.as_ref().clone(),
+                        );
+                    }
                     return to_result(SopRunResponse {
                         run_id: run_id.clone(),
                     });
@@ -6005,6 +6019,93 @@ mod tests {
             .await
             .expect_err("missing engine must error");
         assert_eq!(err.code, INTERNAL_ERROR);
+    }
+
+    #[tokio::test]
+    async fn sops_run_drives_started_execute_step() {
+        use crate::sop::{
+            Sop, SopExecutionMode, SopPriority, SopRunStatus, SopStep, SopStepKind, SopTrigger,
+        };
+        use std::sync::{Arc, Mutex};
+        use zeroclaw_config::schema::Config;
+        use zeroclaw_infra::session_queue::SessionActorQueue;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        let mut engine = crate::sop::SopEngine::new(config.sop.clone());
+        engine.set_sops_for_test(vec![Sop {
+            name: "rpc-headless-driver".into(),
+            description: "RPC headless driver regression".into(),
+            version: "1.0.0".into(),
+            priority: SopPriority::Normal,
+            execution_mode: SopExecutionMode::Auto,
+            triggers: vec![SopTrigger::Manual],
+            steps: vec![SopStep {
+                number: 1,
+                title: "Execute first step".into(),
+                kind: SopStepKind::Execute,
+                ..SopStep::default()
+            }],
+            cooldown_secs: 0,
+            max_concurrent: 1,
+            location: None,
+            deterministic: false,
+            admission_policy: crate::sop::types::SopAdmissionPolicy::Parallel,
+            max_pending_approvals: 0,
+            agent: None,
+        }]);
+        let engine = Arc::new(Mutex::new(engine));
+        let audit = Arc::new(crate::sop::SopAuditLogger::new(Arc::new(
+            zeroclaw_memory::NoneMemory::new("rpc-test"),
+        )));
+        let queue = Arc::new(SessionActorQueue::new(4, 10, 60));
+        let sessions = Arc::new(crate::rpc::session::SessionStore::new(16, queue));
+        let ctx = Arc::new(crate::rpc::context::RpcContext {
+            config: Arc::new(parking_lot::RwLock::new(config)),
+            config_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            sessions,
+            session_backend: None,
+            memory: None,
+            cost_tracker: None,
+            event_tx: None,
+            reload_tx: None,
+            gateway_shutdown_tx: None,
+            approval_pending: Arc::new(crate::rpc::context::ApprovalPendingMap::default()),
+            tui_registry: Arc::new(crate::rpc::tui_identity::TuiRegistry::new_unsigned()),
+            acp_session_store: None,
+            sop_engine: Some(Arc::clone(&engine)),
+            sop_audit: Some(audit),
+            hooks: None,
+            cert_audit: None,
+        });
+        let (tx, _rx) = tokio::sync::mpsc::channel(64);
+        let dispatcher = RpcDispatcher::new(ctx, tx, "test-peer-rpc-sop:pid=1".into());
+
+        let response = dispatcher
+            .handle_sops_run(&json!({ "name": "rpc-headless-driver" }))
+            .await
+            .expect("RPC SOP start should return the run id");
+        let run: SopRunResponse = serde_json::from_value(response).unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let status = engine
+                    .lock()
+                    .expect("engine lock")
+                    .get_run(&run.run_id)
+                    .map(|run| run.status);
+                if status == Some(SopRunStatus::Failed) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("RPC SOP start must schedule the executable first step");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Route the `sops.run` RPC response's started `ExecuteStep` and `DeterministicStep` actions into the shared headless run driver.
  - Reuse the current daemon config, SOP engine, and audit logger so manually started runs follow the same execution path as other headless surfaces.
  - Add an RPC regression proving a started executable step is consumed and reaches a terminal state instead of remaining `running` indefinitely.
- **Scope boundary:** This changes only the manual RPC start path. Approval responses and the existing `Coalesced`, `Skipped`, `Deferred`, `BlockedUnsafe`, and `NoMatch` response semantics are unchanged.
- **Blast radius:** RPC-triggered SOP execution; no config, protocol, or permission surface changes.
- **Linked issue(s):** Fixes #10513
- **Labels:** `bug`, `daemon`, `runtime`, `trusted contributor`, `tool:sop`, `risk:high`, `size:S`, `needs-author-action`, `domain:security`

## Testing (required)

### How I tested

- **CI checks relied on and why they cover this change:** The runtime crate checks cover the changed RPC dispatcher and the shared SOP executor used by the new handoff.
- **Known CI coverage gap, if any:** Hosted CI has passed for this head. The focused RPC regression does not cover successful agent execution, step-tool restrictions, or daemon-generation ownership.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` -> clean
  - `cargo test -p zeroclaw-runtime rpc::dispatch::tests::sops_run_ -- --nocapture` -> `3 passed; 0 failed`
  - `cargo test -p zeroclaw-runtime sop::executor::tests:: --no-fail-fast` -> `7 passed; 0 failed`
  - `cargo clippy -p zeroclaw-runtime --lib --tests -- -D warnings` -> clean
- **Beyond CI, what did you manually verify?** The regression uses a real `sops.run` dispatcher call and waits for the returned run ID to reach `Failed` through the headless driver when no model provider is configured. On the unfixed path it would remain `Running`, so the test distinguishes action dispatch from the prior log-only behavior.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** No full workspace test was run because the change is isolated to the runtime RPC/SOP path; the focused runtime tests and clippy cover the touched code.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 415f3367e217bfcdd664d3b7c4679184a6ee8253`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Manually started SOP runs would again return a run ID while remaining `running` until another caller advances them.
