### PR TITLE
fix(plugins): cap root config schema properties

### DIFF
--- a/crates/zeroclaw-plugins/src/config.rs
+++ b/crates/zeroclaw-plugins/src/config.rs
@@ -21,6 +21,8 @@ use crate::{PluginCapability, PluginManifest, PluginPermission};
 
 const MAX_SCHEMA_BYTES: usize = 64 * 1024;
 const MAX_SCHEMA_DEPTH: usize = 32;
+/// Keep admission-time validator compilation bounded for wide object schemas.
+const MAX_SCHEMA_PROPERTIES: usize = 256;
 const DRAFT_2020_12: &str = "https://json-schema.org/draft/2020-12/schema";
 
 /// Ceiling on one compiled `pattern` program, in bytes.
@@ -278,14 +280,6 @@ fn compile_manifest_config(
         )));
     }
 
-    let validator = manifest_schema_options().build(schema).map_err(|error| {
-        invalid_manifest(format!(
-            "plugin '{}' config_schema cannot be compiled: {}",
-            manifest.name,
-            error.masked()
-        ))
-    })?;
-
     let properties = schema
         .get("properties")
         .and_then(Value::as_object)
@@ -295,6 +289,22 @@ fn compile_manifest_config(
                 manifest.name
             ))
         })?;
+    if properties.len() > MAX_SCHEMA_PROPERTIES {
+        return Err(invalid_manifest(format!(
+            "plugin '{}' config_schema declares {} root properties, exceeding the maximum of {MAX_SCHEMA_PROPERTIES}",
+            manifest.name,
+            properties.len()
+        )));
+    }
+
+    let validator = manifest_schema_options().build(schema).map_err(|error| {
+        invalid_manifest(format!(
+            "plugin '{}' config_schema cannot be compiled: {}",
+            manifest.name,
+            error.masked()
+        ))
+    })?;
+
     for (name, property) in properties {
         let kind = property_type(schema, property).map_err(|message| {
             invalid_manifest(format!(
@@ -1367,6 +1377,37 @@ x-secret = true
         let mut too_deep = object_schema(json!({}));
         too_deep["annotation"] = nested;
         assert!(validate_manifest_config(&manifest(Some(too_deep), true)).is_err());
+    }
+
+    #[test]
+    fn root_property_count_limit_is_enforced_at_admission() {
+        let at_limit = (0..MAX_SCHEMA_PROPERTIES)
+            .map(|index| (format!("key_{index}"), json!({"type": "string"})))
+            .collect::<serde_json::Map<_, _>>();
+        assert!(
+            validate_manifest_config(&manifest(
+                Some(object_schema(Value::Object(at_limit))),
+                true
+            ))
+            .is_ok()
+        );
+
+        let over_limit = (0..=MAX_SCHEMA_PROPERTIES)
+            .map(|index| {
+                (
+                    format!("key_{index}"),
+                    json!({"type": "string", "pattern": "(?=x)"}),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        let error = validate_manifest_config(&manifest(
+            Some(object_schema(Value::Object(over_limit))),
+            true,
+        ))
+        .expect_err("schema over the root property cap must fail closed");
+        assert!(matches!(error, PluginError::InvalidManifest(_)));
+        assert!(error.to_string().contains("root properties"));
+        assert!(error.to_string().contains("maximum of 256"));
     }
 
     #[test]

--- a/docs/book/src/plugins/migrating-to-typed-config.md
+++ b/docs/book/src/plugins/migrating-to-typed-config.md
@@ -78,8 +78,11 @@ type = "array"
 ```
 
 The host enforces these limits on the schema itself: 64 KiB serialized, at most
-32 levels of nesting, no `$id`, and `$ref` targets must be local JSON Pointers.
-Remote references are rejected, so a schema never causes a network fetch.
+32 levels of nesting, no more than 256 root properties, no `$id`, and `$ref`
+targets must be local JSON Pointers. Remote references are rejected, so a
+schema never causes a network fetch. A schema that exceeds any of these limits
+is refused with fail-closed behavior during package install/admission, before
+validator compilation.
 
 Dynamic-key keywords are not part of this dialect: `patternProperties`,
 `propertyNames`, and `unevaluatedProperties` are rejected at the root, because


### PR DESCRIPTION
## Summary

- **Base branch:** `master` at the current base `dc5b968e8de052ac26e74ae05f210bd1c776770f`
- **Labels:** `enhancement`, `docs`, `experienced contributor`, `tool:schema`, `domain:architecture`, `needs-maintainer-review`, `risk:high`, `size:XS`

- Add a 256-entry cap for root `config_schema.properties` maps.
- Check the cap during manifest admission, before `jsonschema` builds the validator, so an over-wide schema cannot impose the expensive compile cost on the execution path.
- Add a regression that accepts the boundary and rejects an over-cap schema with a named `InvalidManifest` error.
- Document the new limit in the typed-config migration guide.

## Scope boundary

This PR does not add a validator cache, change the linear-time regex dialect or its size limits, or cap nested property maps. Operator config remains resolved from canonical state on every call.

## Blast radius

Only plugin packages whose manifest declares more than 256 root properties are affected: they now fail closed during install/admission. Existing packages within the limit and all live operator-config updates retain their current behavior.

## Linked issue(s)

Refs #10195

## Testing

### Reviewer testing requested?

N/A — admission behavior is covered by focused unit tests and has no separate user-facing interface to exercise.

### How I tested

- `cargo fmt --all -- --check`
- `cargo test --locked -p zeroclaw-plugins --lib` — 110 passed, 0 failed.
- `cargo clippy --locked -p zeroclaw-plugins --all-targets -- -D warnings` — passed.
- `scripts/ci/docs_quality_gate.sh` — changed Markdown lint passed with 0 errors.
- `scripts/ci/docs_links_gate.sh` — 6 checks passed; no added links detected.

The release-mode measurement used to choose the cap compiled the same bounded-pattern schema shape in approximately 2.1 ms at 256 properties, 3.6 ms at 512, and 4.6 ms at 1,024 on the measurement host. The cap is checked before validator construction; the regression uses an unsupported look-around pattern in the over-cap schema so the test would expose a later compile instead of the named cap error.

### CI checks relied on and why they cover this change
The focused plugin test and clippy runs cover the changed admission path and regression; the documentation gates cover the migration-guide wording and links. For exact head `7d869773598bc3d481309931babb986b22d8f0dc`, `CI Required Gate` and all required checks in Quality Gate run `34686701910` succeeded, and Code Analysis run `34686701951` passed. The non-required Windows advisory with `plugin-host=true` has now also completed successfully; no hosted check remains pending.
### Known CI coverage gap, if any

None known for the changed Rust and Markdown surfaces.

### Beyond CI, what did I manually verify?

Reviewed the final diff for scope, secret/PII exposure, and public-text hygiene. No interface or runtime UI changed.

### If any command was intentionally skipped, why:

The full workspace test and clippy matrix were not run because this change is isolated to `zeroclaw-plugins` admission and its migration documentation; the focused crate checks exercise the affected code and tests directly.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.

## Compatibility

- Backward compatible? No — manifests with more than 256 root properties are no longer admitted.
- Config / env / CLI surface changed? Yes — the manifest admission contract now includes a root-property limit; operator config storage and CLI commands are unchanged.
- Rust/MSRV/toolchain floor changed? No.

### Upgrade steps

Plugin authors with more than 256 root properties should remove unused entries or split the contract across a new package/version so each admitted manifest stays at or below the limit. No operator config migration is required for schemas already within the limit.

## Rollback

- Fast rollback command/path: Revert the eventual squash-merge commit; no operator-side migration is needed.
- Feature flags or config toggles: None.
- Observable failure symptoms: admission reports `InvalidManifest` with `root properties` and the configured maximum when a package exceeds the limit; reverting restores the previous acceptance behavior.
