### PR TITLE
fix(docs): route mdBook preprocessors through xtask

### DIFF
--- a/xtask/src/cmd/mdbook/build.rs
+++ b/xtask/src/cmd/mdbook/build.rs
@@ -42,7 +42,7 @@ pub fn build_locales(root: &std::path::Path, tag: Option<&str>) -> anyhow::Resul
     );
     prepare_generated_book_inputs(root, &entries)?;
     let mdbook = mdbook_program()?;
-    let preprocessor_env = peer_groups_preprocessor_env();
+    let preprocessor_env = mdbook_xtask_preprocessor_env();
     let tag_dir = tag.unwrap_or(DEFAULT_TAG);
     let primary_locale = entries.first().map(|e| e.code.clone());
     for entry in &entries {
@@ -54,8 +54,8 @@ pub fn build_locales(root: &std::path::Path, tag: Option<&str>) -> anyhow::Resul
         if Some(&entry.code) != primary_locale.as_ref() {
             cmd.env("MDBOOK_OUTPUT__HTML__SEARCH__ENABLE", "false");
         }
-        if let Some((key, value)) = &preprocessor_env {
-            cmd.env(key, value);
+        if let Some(env) = &preprocessor_env {
+            cmd.envs(env.iter().map(|(key, value)| (key, value)));
         }
         run_cmd(&mut cmd)?;
     }

--- a/xtask/src/cmd/mdbook/serve.rs
+++ b/xtask/src/cmd/mdbook/serve.rs
@@ -67,8 +67,8 @@ pub fn run(locale: Option<&str>, tag: Option<&str>) -> anyhow::Result<()> {
         .current_dir(&book)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    if let Some((key, value)) = peer_groups_preprocessor_env() {
-        watch_cmd.env(key, value);
+    if let Some(env) = mdbook_xtask_preprocessor_env() {
+        watch_cmd.envs(env);
     }
     let mut watch = watch_cmd.spawn()?;
 
@@ -135,8 +135,8 @@ fn build_one_locale(book: &Path, tag_dir: &str, locale: &str) -> anyhow::Result<
     cmd.args(["build", "-d", &dest])
         .env("MDBOOK_BOOK__LANGUAGE", locale)
         .current_dir(book);
-    if let Some((key, value)) = peer_groups_preprocessor_env() {
-        cmd.env(key, value);
+    if let Some(env) = mdbook_xtask_preprocessor_env() {
+        cmd.envs(env);
     }
     run_cmd(&mut cmd)
 }

--- a/xtask/src/cmd/mdbook/sync.rs
+++ b/xtask/src/cmd/mdbook/sync.rs
@@ -36,8 +36,8 @@ pub fn run(
         .args(["build", "-d", "po-extract"])
         .env("MDBOOK_OUTPUT__XGETTEXT__POT_FILE", "messages.pot")
         .current_dir(&book);
-    if let Some((key, value)) = peer_groups_preprocessor_env() {
-        extract.env(key, value);
+    if let Some(env) = mdbook_xtask_preprocessor_env() {
+        extract.envs(env);
     }
     run_cmd(&mut extract)?;
 

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -179,22 +179,29 @@ pub fn mdbook_program() -> anyhow::Result<PathBuf> {
     )
 }
 
-pub fn peer_groups_preprocessor_env() -> Option<(String, String)> {
+pub fn mdbook_xtask_preprocessor_env() -> Option<[(String, String); 2]> {
     let exe = std::env::current_exe().ok()?;
     let exe_str = exe.to_string_lossy();
-    Some(peer_groups_preprocessor_env_for(&exe_str))
+    Some(mdbook_xtask_preprocessor_env_for(&exe_str))
 }
 
-/// Pure form of [`peer_groups_preprocessor_env`] over an explicit helper path,
-/// so the mdBook env-key mapping and shlex quoting are unit-testable without
-/// resolving `current_exe`.
-fn peer_groups_preprocessor_env_for(helper_path: &str) -> (String, String) {
+/// Pure form of [`mdbook_xtask_preprocessor_env`] over an explicit helper path,
+/// so mdBook's env-key mapping and shlex quoting are unit-testable without
+/// resolving `current_exe`. Both in-tree preprocessors must follow the routed
+/// Cargo target rather than the relative fallback paths in `book.toml`.
+fn mdbook_xtask_preprocessor_env_for(helper_path: &str) -> [(String, String); 2] {
     let quoted =
         shlex::try_quote(helper_path).map_or_else(|_| helper_path.to_string(), |q| q.into_owned());
-    (
-        "MDBOOK_PREPROCESSOR__PEER_GROUPS__COMMAND".to_string(),
-        format!("{quoted} preprocess"),
-    )
+    [
+        (
+            "MDBOOK_PREPROCESSOR__PEER_GROUPS__COMMAND".to_string(),
+            format!("{quoted} preprocess"),
+        ),
+        (
+            "MDBOOK_PREPROCESSOR__PLACEHOLDERS__COMMAND".to_string(),
+            format!("{quoted} placeholders"),
+        ),
+    ]
 }
 
 pub fn run_cmd(cmd: &mut Command) -> anyhow::Result<()> {
@@ -382,23 +389,38 @@ mod tests {
     }
 
     #[test]
-    fn peer_groups_env_key_matches_mdbook_mapping() {
-        let (key, value) = peer_groups_preprocessor_env_for("/some/dir/mdbook");
+    fn preprocessor_env_keys_match_mdbook_mapping() {
+        let env = mdbook_xtask_preprocessor_env_for("/some/dir/mdbook");
         // mdBook lowercases, maps `__` -> `.` and `_` -> `-`, so this key must
         // resolve to `preprocessor.peer-groups.command`.
         assert_eq!(
-            key.strip_prefix("MDBOOK_")
+            env[0]
+                .0
+                .strip_prefix("MDBOOK_")
                 .map(|k| k.to_lowercase().replace("__", ".").replace('_', "-")),
             Some("preprocessor.peer-groups.command".to_string())
         );
-        assert_eq!(value, "/some/dir/mdbook preprocess");
+        assert_eq!(env[0].1, "/some/dir/mdbook preprocess");
+        assert_eq!(
+            env[1]
+                .0
+                .strip_prefix("MDBOOK_")
+                .map(|k| k.to_lowercase().replace("__", ".").replace('_', "-")),
+            Some("preprocessor.placeholders.command".to_string())
+        );
+        assert_eq!(env[1].1, "/some/dir/mdbook placeholders");
     }
 
     #[test]
-    fn peer_groups_env_quotes_paths_with_spaces() {
-        let (_, value) = peer_groups_preprocessor_env_for("/tmp/my target/release/mdbook");
-        let words: Vec<String> = shlex::Shlex::new(&value).collect();
-        assert_eq!(words, ["/tmp/my target/release/mdbook", "preprocess"]);
+    fn preprocessor_env_quotes_paths_with_spaces() {
+        let env = mdbook_xtask_preprocessor_env_for("/tmp/my target/release/mdbook");
+        let peer_groups: Vec<String> = shlex::Shlex::new(&env[0].1).collect();
+        let placeholders: Vec<String> = shlex::Shlex::new(&env[1].1).collect();
+        assert_eq!(peer_groups, ["/tmp/my target/release/mdbook", "preprocess"]);
+        assert_eq!(
+            placeholders,
+            ["/tmp/my target/release/mdbook", "placeholders"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The mdBook launcher now overrides both in-tree preprocessor commands with the current xtask executable. The previous override covered only `peer-groups`, so an external `CARGO_TARGET_DIR` left `placeholders` pointing at the repository-relative fallback binary. Build, serve, and sync now consume the same two-command mapping, with focused coverage for mdBook's environment-key conversion and shell quoting.
- **Scope boundary:** This PR does not change mdBook or mdbook-mermaid versions, `book.toml`, either preprocessor's behavior, or general external-target compatibility. The serve API-copy path and sync translation-binary path remain separate concerns.
- **Blast radius:** Local and CI documentation tooling that launches mdBook through xtask. Runtime, application behavior, documentation content, and rendered presentation are unchanged.
- **Linked issue(s):** None. This self-contained tooling defect was discovered while validating #10510, but it does not implement or close that issue.
- **Labels:** `ci`, `docs`, `scripts`, `risk:low`, `size:XS`, `type:docs`

### What this does, simply

When ZeroClaw builds its documentation, it runs two built-in helpers to prepare the pages. One helper already used the program Cargo had just built, while the other looked only in the repository's usual build folder. This change makes both helpers use the built program, so documentation builds also work when Cargo stores build output elsewhere. It does not change the documentation's appearance or tool versions.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** Documentation build CLI
- **Setup / preconditions:** Install the repository's documented mdBook preprocessors.
- **Steps to run:** `CARGO_TARGET_DIR=/tmp/zeroclaw-mdbook-target cargo mdbook build`
- **Expected on this branch (after):** The command builds all five locale books and completes the internal link check while launching both in-tree preprocessors from the externally built xtask binary.
- **Prior behavior on `master` (before):** The `placeholders` preprocessor still resolves through the relative `target/release/mdbook` fallback and the external-target build can fail before the books are assembled.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed on current head `5ef7035cdfecfd17d173faa5e3d3fd604756c03f`, including the final `CI Required Gate`, repository tests, lint, Linux build, benchmark compilation, and the declared MSRV check.
- **Known CI coverage gap, if any:** Hosted CI does not specifically force an external Cargo target. The local five-locale build below covers that process boundary.
- **Commands run and tail output:**

```text
$ cargo test --locked -p xtask preprocessor_env -- --nocapture
running 2 tests
test util::tests::preprocessor_env_keys_match_mdbook_mapping ... ok
test util::tests::preprocessor_env_quotes_paths_with_spaces ... ok
test result: ok. 2 passed; 0 failed

$ cargo fmt --all -- --check
exit 0

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ cargo mdbook build
==> Building mdBook for locales: en fr ja es zh-CN
==> Internal link check passed
==> Done. Open: docs/book/book/master/index.html
```

- **Beyond CI, what did you manually verify?** The real build ran through an SSD-backed external Cargo target, generated rustdoc, built `en`, `fr`, `ja`, `es`, and `zh-CN`, passed the internal link check, and assembled the site. It emitted the existing local-tool warning that mdbook-mermaid 0.17.0 was compiled against mdBook 0.5.0 while the local mdBook binary is 0.5.3; this PR changes neither version nor protocol. I did not separately run long-lived serve/watch or translation sync sessions.
- **Visual interface changed?** N/A; this changes child-process routing only.
- **If any command was intentionally skipped, why:** Full workspace tests were not duplicated locally because the focused xtask tests and real documentation build cover the changed contract; required exact-head CI remains the repository-wide check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`; the added environment override is internal to xtask-spawned mdBook processes.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low risk: revert the merge commit.
