### PR TITLE
fix(runtime): stop advertising self-approval in tool schemas

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/mod.rs
@@ -30,6 +30,15 @@ pub use turn::{
     semantic_empty_terminal_completion_message, terminal_completion_error_message,
 };
 
+/// Tools whose execution policy consumes a runtime-owned `approved` bit.
+///
+/// The `approved` arg is runtime plumbing, NOT a model-facing parameter: no
+/// tool schema advertises it (RFC #7155 — a model must never be told it can
+/// self-approve). [`set_runtime_approved_arg`] is the only writer on the tool
+/// loop path: `call_prep` overwrites the key unconditionally before the
+/// approval gate (stripping any model-supplied value) and rewrites it with the
+/// gate's decision after, so a model-supplied `approved` can never survive
+/// into tool execution.
 pub(crate) fn is_runtime_approved_arg_tool(tool_name: &str) -> bool {
     matches!(
         tool_name,
@@ -37,6 +46,11 @@ pub(crate) fn is_runtime_approved_arg_tool(tool_name: &str) -> bool {
     )
 }
 
+/// Overwrite the runtime-owned `approved` arg for an approval-gated tool.
+///
+/// Callers must treat this as the sole authority for the bit: the tool loop
+/// always calls it (first with `false` to strip model input, then with the
+/// approval gate's decision) before dispatching the tool.
 pub(crate) fn set_runtime_approved_arg(
     tool_name: &str,
     args: &mut serde_json::Value,

--- a/crates/zeroclaw-runtime/src/tools/cron_add.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_add.rs
@@ -307,11 +307,6 @@ impl Tool for CronAddTool {
                     "type": "boolean",
                     "description": "If true (default), recall and inject memory context before agent job runs. Set to false for stateless digest/report jobs that should not accumulate or consume memory entries.",
                     "default": true
-                },
-                "approved": {
-                    "type": "boolean",
-                    "description": "Set true to explicitly approve medium/high-risk shell commands in supervised mode",
-                    "default": false
                 }
             },
             "required": ["schedule"]
@@ -1339,6 +1334,28 @@ mod tests {
         );
         assert!(error.contains("at_local="), "{error}");
         assert!(error.contains("delta_seconds="), "{error}");
+    }
+
+    #[test]
+    fn schema_does_not_advertise_self_approval() {
+        // `approved` is runtime plumbing injected by the approval gate,
+        // never a model-facing parameter (RFC #7155).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cfg = Arc::new(Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        });
+        let security = Arc::new(SecurityPolicy::from_risk_profile(
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            &cfg.data_dir,
+        ));
+        let tool = CronAddTool::new(cfg, security, TEST_AGENT);
+        assert!(
+            tool.parameters_schema()["properties"]
+                .get("approved")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/tools/cron_run.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_run.rs
@@ -58,12 +58,7 @@ impl Tool for CronRunTool {
         json!({
             "type": "object",
             "properties": {
-                "job_id": { "type": "string" },
-                "approved": {
-                    "type": "boolean",
-                    "description": "Set true to explicitly approve medium/high-risk shell commands in supervised mode",
-                    "default": false
-                }
+                "job_id": { "type": "string" }
             },
             "required": ["job_id"]
         })
@@ -219,6 +214,26 @@ mod tests {
         Arc::new(
             SecurityPolicy::for_agent(cfg, TEST_AGENT).expect("test-agent has resolvable profiles"),
         )
+    }
+
+    #[test]
+    fn schema_does_not_advertise_self_approval() {
+        // `approved` is runtime plumbing injected by the approval gate,
+        // never a model-facing parameter (RFC #7155).
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            data_dir: tmp.path().join("data"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        seed_test_agent(&mut config);
+        let cfg = Arc::new(config);
+        let tool = CronRunTool::new(cfg.clone(), test_security(&cfg), TEST_AGENT);
+        assert!(
+            tool.parameters_schema()["properties"]
+                .get("approved")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/cron_update.rs
+++ b/crates/zeroclaw-runtime/src/tools/cron_update.rs
@@ -204,11 +204,6 @@ impl Tool for CronUpdateTool {
                             }
                         }
                     }
-                },
-                "approved": {
-                    "type": "boolean",
-                    "description": "Set true to explicitly approve medium/high-risk shell commands in supervised mode",
-                    "default": false
                 }
             },
             "required": ["job_id", "patch"]
@@ -349,6 +344,20 @@ mod tests {
         Arc::new(
             SecurityPolicy::for_agent(cfg, TEST_AGENT).expect("test-agent has resolvable profiles"),
         )
+    }
+
+    #[tokio::test]
+    async fn schema_does_not_advertise_self_approval() {
+        // `approved` is runtime plumbing injected by the approval gate,
+        // never a model-facing parameter (RFC #7155).
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronUpdateTool::new(cfg.clone(), test_security(&cfg), TEST_AGENT);
+        assert!(
+            tool.parameters_schema()["properties"]
+                .get("approved")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/schedule.rs
+++ b/crates/zeroclaw-runtime/src/tools/schedule.rs
@@ -85,11 +85,6 @@ impl Tool for ScheduleTool {
                     "type": "string",
                     "description": "Shell command to execute. Required for create/add/once."
                 },
-                "approved": {
-                    "type": "boolean",
-                    "description": "Set true to explicitly approve medium/high-risk shell commands in supervised mode",
-                    "default": false
-                },
                 "id": {
                     "type": "string",
                     "description": "Task ID. Required for get/cancel/remove/pause/resume."
@@ -605,6 +600,9 @@ mod tests {
         assert_eq!(tool.name(), "schedule");
         let schema = tool.parameters_schema();
         assert!(schema["properties"]["action"].is_object());
+        // `approved` is runtime plumbing injected by the approval gate,
+        // never a model-facing parameter (RFC #7155).
+        assert!(schema["properties"].get("approved").is_none());
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -263,11 +263,6 @@ impl Tool for ShellTool {
                 "command": {
                     "type": "string",
                     "description": "The shell command to execute"
-                },
-                "approved": {
-                    "type": "boolean",
-                    "description": "Set true to explicitly approve medium/high-risk commands in supervised mode",
-                    "default": false
                 }
             },
             "required": ["command"]
@@ -765,7 +760,10 @@ mod tests {
                 .expect("schema required field should be an array")
                 .contains(&json!("command"))
         );
-        assert!(schema["properties"]["approved"].is_object());
+        // The runtime-owned `approved` arg is intentionally absent from the
+        // schema: the model must never be told it can self-approve (RFC #7155).
+        // `agent::set_runtime_approved_arg` is the only writer on the loop path.
+        assert!(schema["properties"].get("approved").is_none());
     }
 
     #[cfg(all(any(unix, windows), not(target_os = "android")))]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `approved` arg consumed by `shell`, `schedule`, `cron_add`, `cron_update`, and `cron_run` is runtime plumbing: `call_prep` already strips any model-supplied value before the approval gate and overwrites it with the gate's decision (`crates/zeroclaw-runtime/src/agent/turn/call_prep.rs:176,238`), so model-supplied `approved` never reaches tool execution.
  - The five tool schemas still advertised `approved` as a settable parameter with a "Set true to explicitly approve…" description — telling the model it could self-approve. That is exactly the trusted-provenance violation RFC #7155 Phase 1 removes: "an approval result never comes from model-supplied tool arguments" (normative goal 4).
  - This PR drops the `approved` property from all five schemas, documents the runtime-owned contract on `is_runtime_approved_arg_tool` / `set_runtime_approved_arg`, and adds per-tool tests asserting the schema no longer advertises self-approval.
- **Scope boundary:** Does NOT change approval-gate behavior, `RiskProfileConfig`, the strip/rewrite plumbing (pre-existing on `master`), or any tool's consumption of the runtime-injected bit. Desktop/node capabilities (`node_capabilities.rs`, `node_tool.rs`) keep their model-facing `approved` arg — their authorization is explicitly roadmap Phase 2 in #7155 and that arg is currently their only gate; removing it without a replacement approval route would make those capabilities unusable. The skill_tool path's hardcoded approval is a policy-routing question for the later unified-entry work, not model self-certification.
- **Blast radius:** Model-visible tool schemas only. Any external consumer that validated tool-call arguments against these schemas would now see `approved` rejected as unknown — but since the runtime overwrites the key unconditionally, honoring it was never possible for the model in the first place. No config, CLI, or wire-format change.
- **Linked issue(s):** Related #7155 (normative goal 4), Related #10339 (tracker: "Remove or ignore model-supplied shell approval" — the ignore half already shipped on master; this is the remove-from-surface half). Not marked `Closes` because #10339 has further close criteria this PR does not complete.
- **Labels:** runtime, security, tool, security:policy (snapshot request; actual labels set by maintainers via sidebar)

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — schema-only removal; the behavior boundary is covered by the new unit tests and existing gate tests.
- **Interface(s) exercised:** N/A
- **Setup / preconditions:** N/A
- **Steps to run:** N/A
- **Expected on this branch (after):** N/A
- **Prior behavior on `master` (before):** N/A

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
cargo test -p zeroclaw-runtime --lib
```

- **CI checks relied on and why they cover this change:** Full workspace build/clippy/test CI covers the changed crate; the new per-tool schema tests run in the standard test job.
- **Known CI coverage gap, if any:** None — the change is confined to `zeroclaw-runtime` schemas/tests plus doc comments.
- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (exit 0)
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` → `Finished dev profile [unoptimized + debuginfo] target(s) in 9m 55s` (no warnings)
  - `cargo test -p zeroclaw-runtime --lib` → `test result: ok. 4093 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 45.32s`
- **Beyond CI, what did you manually verify?** Grepped the workspace for the removed schema description text ("Set true to explicitly approve") — zero remaining hits in `crates/`. Confirmed the five tool implementations still consume the runtime-injected `approved` arg and that `call_prep.rs` calls `set_runtime_approved_arg` both before (strip) and after (gate decision) the approval gate, matching the doc comments added in this PR. Audited the non-loop consumers of `add_shell_job_with_approval` / `update_shell_job_with_approval`: the gateway API passes hardcoded `false`, so no path outside the agent loop honors a model-derived `approved`. Confirmed the parser-level test at `loop_.rs` that preserves a parsed `approved: true` key is parser behavior only — the key is overwritten downstream before dispatch. Did NOT verify against a live model session end-to-end.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `Yes` — this PR *removes* model-visible text that invited self-approval ("Set true to explicitly approve medium/high-risk shell commands"). Risk note: none introduced; the change closes a prompt-injection-shaped surface (the schema told the model a self-approval knob existed) rather than opening one. Runtime behavior was already fail-safe (the key is overwritten), so the exposure was misleading advertisement, not an exploitable gate bypass.

## Compatibility (required)

- Backward compatible? `Yes` (for the runtime). Model clients that previously emitted `"approved": true` see no behavior change — the value was already discarded and overwritten before this PR.
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk, behavior-neutral schema/doc change: `git revert <sha>` restores the schema advertisements. No feature flags or config toggles involved.