### PR TITLE
fix(zerocode): let local sessions fall back to agent workspace cwd

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -477,9 +477,9 @@ impl Chat {
         //
         // A fresh session also passes no cwd unless the user explicitly picked
         // one (the remote ACP CWD picker). That lets the daemon resolve the
-        // selected agent's configured workspace (issue #9534 / PR #9536)
-        // instead of forcing the TUI's launch directory — for Local and WSS
-        // alike. An explicit caller-supplied cwd still wins over that default.
+        // selected agent's configured workspace instead of forcing the TUI's
+        // launch directory — for Local and WSS alike. An explicit
+        // caller-supplied cwd still wins over that default.
         let cwd_str: Option<String> = if resume.is_some() {
             None
         } else {
@@ -588,9 +588,8 @@ impl Chat {
 
         // A restart mints a fresh session: pass no cwd so the daemon resolves
         // the selected agent's configured workspace rather than the TUI's
-        // launch directory (issue #9534 / PR #9536). The remote ACP path above
-        // re-prompts via the CWD picker, so only that explicit choice overrides
-        // the agent workspace.
+        // launch directory. The remote ACP path above re-prompts via the CWD
+        // picker, so only that explicit choice overrides the agent workspace.
         let new_session = if pane_kind == PaneKind::Acp {
             rpc.session_new_acp(&alias, None, None).await
         } else {
@@ -9729,8 +9728,8 @@ mod tests {
         let params = &request["params"];
         assert_eq!(params["agent_alias"], "alpha");
         assert!(params["session_id"].is_null());
-        // Regression guard for #10537: a fresh local session must not send the
-        // TUI's launch directory as cwd. Omitting it lets the daemon resolve the
+        // Regression guard: a fresh local session must not send the TUI's
+        // launch directory as cwd. Omitting it lets the daemon resolve the
         // selected agent's configured workspace.
         assert!(params["cwd"].is_null());
 
@@ -9796,8 +9795,8 @@ mod tests {
         let params = &request["params"];
         assert_eq!(params["agent_alias"], "alpha");
         assert!(params["session_id"].is_null());
-        // Regression guard for #10537: restart must not re-point the session at
-        // the TUI's launch directory either.
+        // Regression guard: restart must not re-point the session at the TUI's
+        // launch directory either.
         assert!(params["cwd"].is_null());
         respond_ok(
             &rpc,

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -473,19 +473,16 @@ impl Chat {
         // the daemon-retained session, its persisted history, and its cwd.
         let resume = self.resume_session_id.take();
         // A resume must not re-point the session at the TUI's launch directory:
-        // pass no cwd so the daemon keeps the retained session's own cwd. Only
-        // a fresh session derives a cwd from the transport / caller.
+        // pass no cwd so the daemon keeps the retained session's own cwd.
+        //
+        // A fresh session also passes no cwd unless the user explicitly picked
+        // one (the remote ACP CWD picker). That lets the daemon resolve the
+        // selected agent's configured workspace (issue #9534 / PR #9536)
+        // instead of forcing the TUI's launch directory — for Local and WSS
+        // alike. An explicit caller-supplied cwd still wins over that default.
         let cwd_str: Option<String> = if resume.is_some() {
             None
-        } else if self.rpc.transport() == crate::client::Transport::Local {
-            // Over Unix socket, pass local CWD so the agent works in the
-            // directory the TUI was launched from.
-            std::env::current_dir()
-                .ok()
-                .and_then(|p| p.to_str().map(str::to_string))
         } else {
-            // Over WSS the server uses the agent's workspace dir unless the
-            // user supplies one.
             cwd_override
                 .filter(|s| !s.trim().is_empty())
                 .map(str::to_string)
@@ -589,16 +586,15 @@ impl Chat {
             });
         }
 
-        let local_cwd = if rpc.transport() == crate::client::Transport::Local {
-            std::env::current_dir().ok()
-        } else {
-            None
-        };
-        let cwd_str = local_cwd.as_deref().and_then(|p| p.to_str());
+        // A restart mints a fresh session: pass no cwd so the daemon resolves
+        // the selected agent's configured workspace rather than the TUI's
+        // launch directory (issue #9534 / PR #9536). The remote ACP path above
+        // re-prompts via the CWD picker, so only that explicit choice overrides
+        // the agent workspace.
         let new_session = if pane_kind == PaneKind::Acp {
-            rpc.session_new_acp(&alias, cwd_str, None).await
+            rpc.session_new_acp(&alias, None, None).await
         } else {
-            rpc.session_new(&alias, cwd_str).await
+            rpc.session_new(&alias, None).await
         };
         match new_session {
             Ok(s) => {
@@ -9700,6 +9696,129 @@ mod tests {
         };
         assert_eq!(state.session_id, "sess-fresh");
         assert_eq!(state.agent_alias, "alpha");
+    }
+
+    #[tokio::test]
+    async fn fresh_local_chat_session_omits_cwd_so_agent_workspace_wins() {
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        // `with_rpc` defaults to Local transport — the path that used to leak
+        // the TUI's launch directory into `session/new`.
+        let client = Arc::new(RpcClient::with_rpc(Arc::clone(&rpc)));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+
+        let init = tokio::spawn(async move {
+            let _ = chat.init().await;
+            chat
+        });
+
+        let request = next_rpc_request(&mut rx, "init should request agents/status").await;
+        assert_eq!(request["method"], method::AGENTS_STATUS);
+        respond_ok(
+            &rpc,
+            &request,
+            serde_json::json!({
+                "agents": [
+                    {"alias": "alpha", "enabled": true, "live_sessions": 0, "persisted_sessions": 0}
+                ]
+            }),
+        );
+
+        let request = next_rpc_request(&mut rx, "fresh chat should start a session").await;
+        assert_eq!(request["method"], method::SESSION_NEW);
+        let params = &request["params"];
+        assert_eq!(params["agent_alias"], "alpha");
+        assert!(params["session_id"].is_null());
+        // Regression guard for #10537: a fresh local session must not send the
+        // TUI's launch directory as cwd. Omitting it lets the daemon resolve the
+        // selected agent's configured workspace.
+        assert!(params["cwd"].is_null());
+
+        init.abort();
+    }
+
+    #[tokio::test]
+    async fn fresh_local_acp_session_omits_cwd_so_agent_workspace_wins() {
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(Arc::clone(&rpc)));
+        let mut chat = Chat::new(client, PaneKind::Acp);
+
+        let init = tokio::spawn(async move {
+            let _ = chat.init().await;
+            chat
+        });
+
+        let request = next_rpc_request(&mut rx, "init should request agents/status").await;
+        assert_eq!(request["method"], method::AGENTS_STATUS);
+        respond_ok(
+            &rpc,
+            &request,
+            serde_json::json!({
+                "agents": [
+                    {"alias": "alpha", "enabled": true, "live_sessions": 0, "persisted_sessions": 0}
+                ]
+            }),
+        );
+
+        let request = next_rpc_request(&mut rx, "ACP init should list recent sessions").await;
+        assert_eq!(request["method"], method::SESSION_LIST_ACP);
+        respond_ok(&rpc, &request, serde_json::json!({ "sessions": [] }));
+
+        let request = next_rpc_request(&mut rx, "fresh ACP should start a session").await;
+        assert_eq!(request["method"], method::SESSION_NEW);
+        let params = &request["params"];
+        assert_eq!(params["agent_alias"], "alpha");
+        assert!(params["session_id"].is_null());
+        assert_eq!(params["chat_mode"], "acp");
+        assert!(params["cwd"].is_null());
+
+        init.abort();
+    }
+
+    #[tokio::test]
+    async fn restart_local_chat_session_omits_cwd_so_agent_workspace_wins() {
+        let (tx, mut rx) = mpsc::channel::<String>(16);
+        let rpc = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(Arc::clone(&rpc)));
+        let mut state = ChatState::new(
+            "sess-old".to_string(),
+            "alpha".to_string(),
+            crate::todo_tracker::TodoTrackerSettings::default(),
+        );
+
+        let restart = tokio::spawn(async move {
+            Chat::restart_session_for_state(&client, PaneKind::Chat, &mut state).await
+        });
+
+        let request = next_rpc_request(&mut rx, "restart should start a fresh session").await;
+        assert_eq!(request["method"], method::SESSION_NEW);
+        let params = &request["params"];
+        assert_eq!(params["agent_alias"], "alpha");
+        assert!(params["session_id"].is_null());
+        // Regression guard for #10537: restart must not re-point the session at
+        // the TUI's launch directory either.
+        assert!(params["cwd"].is_null());
+        respond_ok(
+            &rpc,
+            &request,
+            serde_json::json!({ "session_id": "sess-fresh", "workspace_dir": "/tmp/alpha" }),
+        );
+
+        let request = next_rpc_request(&mut rx, "restart should close the old session").await;
+        assert_eq!(request["method"], method::SESSION_CLOSE);
+        assert_eq!(request["params"]["session_id"], "sess-old");
+        respond_ok(&rpc, &request, serde_json::json!({}));
+
+        let request = next_rpc_request(&mut rx, "restart should refresh model identity").await;
+        assert_eq!(request["method"], method::CONFIG_LIST);
+        respond_ok(&rpc, &request, serde_json::json!([]));
+
+        let phase = tokio::time::timeout(Duration::from_secs(2), restart)
+            .await
+            .expect("restart should finish")
+            .unwrap();
+        assert!(phase.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - ZeroCode local fresh Chat/ACP session creation no longer sends the TUI process launch directory as `cwd`.
  - Local restart follows the same rule: it starts a fresh session without `cwd`, so the daemon applies the selected agent workspace default.
  - Resume remains unchanged: resumed sessions still pass no `cwd`, allowing the daemon to keep the retained session's own working directory.
  - Explicit user-picked working directories still flow through the remote ACP picker and the RPC client, so caller-supplied `cwd` values continue to win over the agent workspace default.
- **Scope boundary:** This does not change the daemon `session/new` fallback, agent workspace resolution, remote ACP directory picker, stored-session restore, or runtime security policy. It changes only ZeroCode's local caller behavior for fresh and restarted sessions.
- **Blast radius:** ZeroCode Chat/ACP local session creation and restart. Downstream shell/file work sees the daemon-returned `workspaceDir`. WSS ACP explicit picker behavior and daemon fallback behavior remain governed by existing code.
- **Linked issue(s):** Fixes #10537
- **Labels:** `bug`, `config`, `risk:medium`, `zerocode`, `size:S`, `cli`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes.
- **Interface(s) exercised:** `surface:tui` over the local daemon socket; ZeroCode Chat and ACP session creation/restart.
- **Setup / preconditions:** Configure two agents with different workspaces, launch ZeroCode from a third directory, then select each agent in a fresh local session.
- **Steps to run:**
  1. Configure agent aliases `alpha` and `beta` with different `[agents.<alias>.workspace.path]` values.
  2. Launch `zerocode` from a directory that is not either agent workspace.
  3. Start a fresh local Chat session for `alpha`, then ask the agent to run `pwd` or inspect the returned `workspaceDir`.
  4. Repeat for `beta`.
  5. Restart a local session and inspect the new session's returned `workspaceDir`.
- **Expected on this branch (after):** Fresh and restarted local sessions use the selected agent's workspace, not the directory where ZeroCode was launched.
- **Prior behavior on `master` (before):** Fresh and restarted local sessions used the ZeroCode launch directory because the local caller sent that directory as an explicit `cwd`.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is green on ce61cb7e7beff6f3b1221f7b3f08816e48052887. The `Test` job runs the `zerocode` regression tests that inspect the outgoing `session/new` JSON-RPC params for fresh local Chat, fresh local ACP, and local restart; `Lint`, `Format`, platform check, and MSRV jobs also pass on this head.
- **Known CI coverage gap, if any:** No blocker. The new tests exercise the changed ZeroCode request boundary directly, and existing daemon/gateway tests cover the omitted-`cwd` fallback to the agent workspace plus explicit-`cwd` precedence.
- **Commands run and tail output:** Author-reported validation from the original body:

```text
cargo test -p zerocode
cargo clippy -p zerocode --all-targets
cargo fmt --all -- --check
```

- **Beyond CI, what did you manually verify?** Not manually smoked in a live TUI for this PR body update. The reviewed evidence is the exact-head automated request-boundary coverage and green required CI.
- **Visual interface changed?** N/A. This changes session request behavior, not rendered layout, color, focus, selection, or other static terminal presentation.
- **If any command was intentionally skipped, why:** No additional local maintainer Cargo was run; required CI covers the changed package and the central request-boundary regression on the reviewed head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes**. The default local ZeroCode session working directory changes from the TUI launch directory to the selected agent's workspace when no explicit `cwd` is chosen. This uses the existing daemon workspace fallback and avoids accidentally rooting shell/file behavior in the wrong project.
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: The changed default is intentional and covered by tests that assert `cwd` is omitted for local fresh/restart requests. Explicit caller-supplied `cwd` values are still serialized by the RPC client and continue to override the fallback.

## Compatibility (required)

- Backward compatible? **Yes** for the intended selected-agent workspace contract. Users who relied on launching ZeroCode from a directory to implicitly choose the session working directory will see changed behavior because that implicit override was the bug fixed here.
- Config / env / CLI surface changed? **Yes**. No new config keys or flags are added, but the local ZeroCode session default changes.
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: No migration is required for the intended behavior. Configure the agent workspace to the directory that should be used by default; explicit user-picked CWDs continue to override where the interface supports them.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge-sha>` from a fresh `master` branch, then open a revert PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Fresh or restarted local ZeroCode sessions report/use the TUI launch directory instead of the selected agent workspace, or explicit `cwd` overrides stop winning over the daemon fallback.
