### PR TITLE
chore(zerocode): drop the dead sop-authoring feature

### DIFF
--- a/apps/zerocode/Cargo.toml
+++ b/apps/zerocode/Cargo.toml
@@ -8,12 +8,7 @@ repository.workspace = true
 publish = true
 
 [features]
-# The SOP pane is unconditionally reachable from mode-bar navigation as a
-# read-only status surface; mutating run, authoring, delete, and checkpoint
-# actions stay disabled there. This flag gates no exposure today and is
-# reserved as the seam for future authoring and run-control work.
 default = []
-sop-authoring = []
 
 [[bin]]
 name = "zerocode"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `apps/zerocode`'s `sop-authoring` feature gated no code. `grep -rn 'feature = "sop-authoring"' apps/zerocode/src` returns nothing, so its own declaration was the only mention, and building with or without it produced the same binary.
  - The comment above it made that hard to see. It described the SOP pane as a read-only status surface whose mutating actions "stay disabled there", sitting directly above a flag that reads as the mechanism doing the disabling.
  - The actual gate is `SopPane::read_only`, hardcoded `true`, with `blocked_when_read_only` naming the blocked actions. That field carries its own accurate comment, so the true statement survives where it belongs and only the misleading adjacency goes.
- **Scope boundary:** Deletes a declaration and its comment. No behavior change, no source touched, and no position taken on whether the pane should stay read-only.
- **Blast radius:** None reachable. Nothing selected the feature, so no build configuration changes shape. `cargo check -p zerocode --all-features` still resolves, which would have failed had anything depended on it existing.
- **Linked issue(s):** Related #10535 (whether the pane's read-only gate should be lifted; this removes the decoy mechanism so that decision has one place to land)
- **Labels:** applied after opening; suggested `zerocode`, `tool:sop`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A`. Deleting an unreferenced feature declaration has no observable behavior for a reviewer to exercise.

### How I tested

- **CI checks relied on and why they cover this change:** the target checks and `Lint` build `zerocode` across feature configurations, and `Test` runs its suite; a feature that something depended on would fail there. `Zerocode RPC Boundary` covers the manifest itself.
- **Known CI coverage gap, if any:** none. `taplo` is not installed locally so TOML formatting was not checked here, but the edit only deletes whole lines and CI's formatting check covers it.
- **Commands run and tail output:**

  ```text
  $ grep -rn 'feature = "sop-authoring"' apps/zerocode/src
  (no output)

  $ cargo build -p zerocode --bin zerocode
  Finished `dev` profile

  $ cargo test -p zerocode --bins
  test result: ok. 963 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

  $ cargo check -p zerocode --all-features
  Finished `dev` profile

  $ cargo fmt --all -- --check          # clean
  $ cargo clippy -p zerocode --all-targets    # no warnings
  $ bash scripts/ci/zerocode_no_zeroclaw_dep_gate.sh
  zerocode gate passed: no zeroclaw-* dependencies.
  ```

- **Beyond CI, what did you manually verify?** That the feature was genuinely unreferenced before deleting it. A first grep for the bare string looked like three hits; two were `.sop-authoring.lock`, the SOP authoring lock *file* name in `zeroclaw-runtime`, which is unrelated to the Cargo feature. Only the declaration itself matched the feature.
- **Visual interface changed?** `N/A`

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: n/a

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`. A Cargo feature nothing selected; `zerocode` is `publish = false`, so no downstream crate could have named it.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: n/a

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>` restores the declaration and its comment.
