### PR TITLE
fix(providers): thread operator multimodal config into provider adapters

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -44,6 +44,9 @@ pub struct OpenAiCompatibleModelProvider {
     pub auth_header: AuthStyle,
     supports_vision: bool,
     tool_result_image_policy: ToolResultImagePolicy,
+    /// Operator `[multimodal]` policy for this provider's image-marker
+    /// expansion pass. Resolved once at build time.
+    multimodal: zeroclaw_config::schema::MultimodalConfig,
     user_agent: Option<String>,
     /// When true, collect all `system` messages and prepend their content
     /// to the first `user` message, then drop the system messages.
@@ -407,6 +410,7 @@ pub struct OpenAiCompatibleBuilder {
     auth_style: Option<AuthStyle>,
     supports_vision: bool,
     tool_result_image_policy: ToolResultImagePolicy,
+    multimodal: zeroclaw_config::schema::MultimodalConfig,
     user_agent: Option<String>,
     /// Set via [`OpenAiCompatibleBuilder::merge_system_into_user`] — the
     /// combined "merge + drop native tool calling" preset. Distinct from
@@ -488,6 +492,14 @@ impl OpenAiCompatibleBuilder {
     /// Set the policy for image markers in native role=`tool` results.
     pub fn tool_result_image_policy(mut self, policy: ToolResultImagePolicy) -> Self {
         self.tool_result_image_policy = policy;
+        self
+    }
+
+    /// Set the root `[multimodal]` policy used when expanding `[IMAGE:...]`
+    /// markers into inline data URIs. Without this the provider falls back to
+    /// library defaults and operator limits never reach the outbound request.
+    pub fn multimodal(mut self, config: zeroclaw_config::schema::MultimodalConfig) -> Self {
+        self.multimodal = config;
         self
     }
 
@@ -684,6 +696,7 @@ impl OpenAiCompatibleBuilder {
             auth_header: auth_style,
             supports_vision: self.supports_vision,
             tool_result_image_policy: self.tool_result_image_policy,
+            multimodal: self.multimodal,
             user_agent: self.user_agent,
             native_tool_calling,
             merge_system_into_user,
@@ -722,6 +735,7 @@ impl OpenAiCompatibleModelProvider {
             auth_style: None,
             supports_vision: false,
             tool_result_image_policy: ToolResultImagePolicy::default(),
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
             user_agent: None,
             merge_system_into_user: false,
             merge_system_into_user_preserve_native: false,
@@ -2325,7 +2339,7 @@ impl OpenAiCompatibleModelProvider {
         &self,
         messages: &[ChatMessage],
     ) -> anyhow::Result<Vec<ChatMessage>> {
-        let config = zeroclaw_config::schema::MultimodalConfig::default();
+        let config = self.multimodal.clone();
         let sanitized;
         let messages = if self.tool_result_image_policy == ToolResultImagePolicy::Omit {
             sanitized = messages
@@ -6281,6 +6295,77 @@ mod tests {
             converted[0].content.as_ref(),
             Some(MessageContent::Text(value)) if value == "done"
         ));
+    }
+
+    #[tokio::test]
+    async fn operator_max_images_bounds_the_outbound_request() {
+        // Behaviour boundary: the number of images that survive into the
+        // messages this provider is about to send upstream. Asserting the
+        // config field alone would still pass if the expansion pass kept
+        // using library defaults.
+        let temp = tempfile::tempdir().unwrap();
+        // Minimal PNG signature bytes are enough for MIME detection.
+        let png = [0x89u8, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'];
+        let first = temp.path().join("first.png");
+        let second = temp.path().join("second.png");
+        std::fs::write(&first, png).unwrap();
+        std::fs::write(&second, png).unwrap();
+
+        // One image per message: `trim_old_images` evicts whole messages, so
+        // co-locating both in a single message would exercise that eviction
+        // granularity rather than whether the operator's cap is honoured.
+        let messages = vec![
+            ChatMessage::user(format!("first [IMAGE:{}]", first.display())),
+            ChatMessage::user(format!("second [IMAGE:{}]", second.display())),
+        ];
+
+        let build = |multimodal| {
+            OpenAiCompatibleModelProvider::builder("test")
+                .display_name("test")
+                .base_url("https://example.com")
+                .credential(None)
+                .auth_style(AuthStyle::Bearer)
+                .multimodal(multimodal)
+                .build()
+        };
+
+        let permissive = build(zeroclaw_config::schema::MultimodalConfig::default());
+        let prepared = permissive
+            .normalize_messages_for_upstream(&messages)
+            .await
+            .expect("default policy prepares both images");
+        assert_eq!(
+            crate::multimodal::count_image_markers(&prepared),
+            2,
+            "default policy admits both images"
+        );
+
+        let capped = build(zeroclaw_config::schema::MultimodalConfig {
+            max_images: 1,
+            ..Default::default()
+        });
+        let prepared = capped
+            .normalize_messages_for_upstream(&messages)
+            .await
+            .expect("capped policy still prepares the message");
+        assert_eq!(
+            crate::multimodal::count_image_markers(&prepared),
+            1,
+            "an operator capping max_images must bound the outbound request"
+        );
+    }
+
+    #[test]
+    fn builder_without_multimodal_falls_back_to_library_defaults() {
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url("https://example.com")
+            .credential(None)
+            .auth_style(AuthStyle::Bearer)
+            .build();
+
+        let defaults = zeroclaw_config::schema::MultimodalConfig::default();
+        assert_eq!(provider.multimodal.max_images, defaults.max_images);
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -251,6 +251,7 @@ pub fn apply_compat_options(
         b = b.tls_ca_cert_path(cert_path);
     }
     b = b.tool_result_image_policy(opts.tool_result_image_policy);
+    b = b.multimodal(opts.multimodal.clone());
     if opts.replay_assistant_reasoning == Some(false) {
         b = b.without_assistant_reasoning_replay();
     }

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -658,6 +658,15 @@ pub struct ModelProviderRuntimeOptions {
     /// How compatible chat-completions providers handle image markers in
     /// native role=`tool` results.
     pub tool_result_image_policy: zeroclaw_config::schema::ToolResultImagePolicy,
+    /// Root `[multimodal]` policy applied when a provider expands
+    /// `[IMAGE:...]` markers into inline data URIs.
+    ///
+    /// Provider adapters run their own `prepare_messages_for_provider` pass, so
+    /// without this they silently fall back to `MultimodalConfig::default()` and
+    /// an operator's `max_images` / `max_image_size_mb` / `max_image_turns`
+    /// never reach the request that actually carries the images. Root-scoped,
+    /// not per-entry: every alias resolves the same section.
+    pub multimodal: zeroclaw_config::schema::MultimodalConfig,
 }
 
 impl Default for ModelProviderRuntimeOptions {
@@ -684,6 +693,7 @@ impl Default for ModelProviderRuntimeOptions {
             chat_template_kwargs: None,
             tls_ca_cert_path: None,
             tool_result_image_policy: Default::default(),
+            multimodal: Default::default(),
         }
     }
 }
@@ -750,6 +760,7 @@ pub fn model_provider_runtime_options_from_model_provider_entry(
         tool_result_image_policy: entry
             .map(|e| e.tool_result_image_policy)
             .unwrap_or_default(),
+        multimodal: config.multimodal.clone(),
     }
 }
 
@@ -817,6 +828,10 @@ pub fn options_for_provider_ref(
             // fallback family must use its own default rather than inherit
             // the previous provider alias's policy.
             options.tool_result_image_policy = Default::default();
+            // `multimodal` is deliberately NOT reset: it is the root
+            // `[multimodal]` section, identical for every alias, so a bare
+            // family ref inherits the same operator policy rather than
+            // silently reverting to library defaults.
             options
         }
     }
@@ -2734,6 +2749,40 @@ mod tests {
             Some(&entry),
         );
         assert_eq!(opts.tool_result_image_policy, ToolResultImagePolicy::Omit);
+    }
+
+    #[test]
+    fn root_multimodal_section_maps_into_runtime_options() {
+        use zeroclaw_config::schema::{Config, ModelProviderConfig};
+        let mut config = Config::default();
+        config.multimodal.max_images = 1;
+        config.multimodal.max_image_size_mb = 2;
+        config.multimodal.max_image_turns = 3;
+
+        let opts = model_provider_runtime_options_from_model_provider_entry(
+            &config,
+            Some(&ModelProviderConfig::default()),
+        );
+
+        // Operator limits must reach the adapter that expands `[IMAGE:...]`
+        // markers; library defaults here mean the section is inert.
+        assert_eq!(opts.multimodal.max_images, 1);
+        assert_eq!(opts.multimodal.max_image_size_mb, 2);
+        assert_eq!(opts.multimodal.max_image_turns, 3);
+    }
+
+    #[test]
+    fn bare_family_provider_ref_inherits_root_multimodal_policy() {
+        use zeroclaw_config::schema::Config;
+        let mut config = Config::default();
+        config.multimodal.max_images = 1;
+
+        let fallback = model_provider_runtime_options_from_model_provider_entry(&config, None);
+        let options = options_for_provider_ref(&config, "ollama", &fallback);
+
+        // `[multimodal]` is root-scoped, so unlike the provider-specific
+        // `tool_result_image_policy` it must survive a bare family ref.
+        assert_eq!(options.multimodal.max_images, 1);
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -837,6 +837,28 @@ pub fn options_for_provider_ref(
     }
 }
 
+/// Runtime options for a **bare family** reference (`ollama`) or an inline
+/// `custom:<url>` reference, neither of which resolves a configured entry.
+///
+/// Everything provider-specific (kind, URI, credentials, `vision`, ...) stays at
+/// its default because there is no entry to read it from. The root
+/// `[multimodal]` policy is not provider-specific, so it must still reach the
+/// adapter: `ModelProviderRuntimeOptions::default()` embeds
+/// `MultimodalConfig::default()`, and an adapter built that way re-applies
+/// library image limits to messages the runtime already prepared under the
+/// operator's policy — silently dropping attachments the operator allowed.
+///
+/// This path is reached in production by `resolve_vision_provider` for a
+/// configured `multimodal.vision_model_provider`.
+fn bare_family_runtime_options(
+    config: &zeroclaw_config::schema::Config,
+) -> ModelProviderRuntimeOptions {
+    ModelProviderRuntimeOptions {
+        multimodal: config.multimodal.clone(),
+        ..ModelProviderRuntimeOptions::default()
+    }
+}
+
 fn is_secret_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':')
 }
@@ -1782,7 +1804,7 @@ pub fn create_model_provider_from_ref_with_model(
         "default",
         None,
         None,
-        &ModelProviderRuntimeOptions::default(),
+        &bare_family_runtime_options(config),
     )?;
     Ok(ResolvedModelProviderRef {
         provider,
@@ -3484,6 +3506,106 @@ mod tests {
                 panic!("Expected error when custom model model_provider has no URI configured")
             }
         }
+    }
+
+    #[tokio::test]
+    async fn bare_family_ref_carries_multimodal_policy_into_prepared_images() {
+        // `resolve_vision_provider` builds the configured vision provider through
+        // this factory, and a bare/`custom:<url>` ref resolves no entry. Building
+        // it with default runtime options made the adapter re-apply library image
+        // limits to messages the runtime had already prepared under the
+        // operator's policy, dropping allowed attachments. Drive a real request
+        // and count the images that actually leave.
+        use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+        use serde_json::{Value, json};
+        use std::sync::{Arc, Mutex};
+        use zeroclaw_api::model_provider::ChatRequest;
+        use zeroclaw_config::schema::Config;
+
+        type Capture = Arc<Mutex<Option<String>>>;
+
+        async fn capture_chat_request(
+            State(capture): State<Capture>,
+            Json(body): Json<Value>,
+        ) -> (StatusCode, Json<Value>) {
+            *capture.lock().expect("capture lock poisoned") = Some(body.to_string());
+            (
+                StatusCode::OK,
+                Json(json!({"choices": [{"message": {"content": "ok"}}]})),
+            )
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut markers = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("bare-{index}.png"));
+            std::fs::write(&path, [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']).unwrap();
+            markers.push(format!("[IMAGE:{}]", path.display()));
+        }
+        // One image per message: `trim_old_images` evicts whole messages, so
+        // co-locating both would measure that eviction granularity instead of
+        // whether the operator policy reached this adapter at all.
+        let prompts: Vec<String> = markers
+            .iter()
+            .map(|marker| format!("look {marker}"))
+            .collect();
+
+        // Same server, same ref, same messages; only the operator policy differs.
+        let outbound_images = |max_images: usize, prompts: Vec<String>| async move {
+            let capture: Capture = Arc::new(Mutex::new(None));
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind test server");
+            let addr = listener.local_addr().expect("test server addr");
+            let app = Router::new()
+                .route("/chat/completions", post(capture_chat_request))
+                .with_state(capture.clone());
+            let server = ::zeroclaw_spawn::spawn!(async move {
+                axum::serve(listener, app).await.expect("serve test server");
+            });
+
+            let mut config = Config::default();
+            config.multimodal.max_images = max_images;
+
+            let resolved = create_model_provider_from_ref_with_model(
+                &config,
+                &format!("custom:http://{addr}"),
+            )
+            .expect("bare custom:<url> ref builds a provider");
+
+            let messages: Vec<ChatMessage> = prompts.into_iter().map(ChatMessage::user).collect();
+            let _ = resolved
+                .provider
+                .chat(
+                    ChatRequest {
+                        messages: &messages,
+                        tools: None,
+                        thinking: None,
+                    },
+                    "test-model",
+                    None,
+                )
+                .await;
+
+            let body = capture
+                .lock()
+                .expect("capture lock poisoned")
+                .clone()
+                .expect("provider must have sent a request");
+            server.abort();
+            body.matches("data:image/png;base64,").count()
+        };
+
+        assert_eq!(
+            outbound_images(2, prompts.clone()).await,
+            2,
+            "a policy admitting both images must send both"
+        );
+        assert_eq!(
+            outbound_images(1, prompts).await,
+            1,
+            "an operator cap of one must reach the adapter built from a bare ref"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -36,6 +36,10 @@ pub struct OpenAiCodexModelProvider {
     custom_endpoint: bool,
     gateway_api_key: Option<String>,
     reasoning_effort: Option<String>,
+    /// Operator `[multimodal]` policy for this provider's own image-marker
+    /// expansion pass. Resolved once at construction from
+    /// `ModelProviderRuntimeOptions`.
+    multimodal: zeroclaw_config::schema::MultimodalConfig,
 }
 
 #[derive(Debug, Serialize)]
@@ -139,6 +143,7 @@ impl OpenAiCodexModelProvider {
             responses_url,
             gateway_api_key: gateway_api_key.map(ToString::to_string),
             reasoning_effort: options.reasoning_effort.clone(),
+            multimodal: options.multimodal.clone(),
         })
     }
 
@@ -1500,8 +1505,8 @@ impl ModelProvider for OpenAiCodexModelProvider {
         messages.push(ChatMessage::user(message));
 
         // Normalize images: convert file paths to data URIs
-        let config = zeroclaw_config::schema::MultimodalConfig::default();
-        let prepared = crate::multimodal::prepare_messages_for_provider(&messages, &config).await?;
+        let prepared =
+            crate::multimodal::prepare_messages_for_provider(&messages, &self.multimodal).await?;
 
         let (instructions, input) = build_responses_input(&prepared.messages);
         self.send_responses_request(input, instructions, None, model)
@@ -1516,8 +1521,8 @@ impl ModelProvider for OpenAiCodexModelProvider {
         _temperature: Option<f64>,
     ) -> anyhow::Result<String> {
         // Normalize image markers: convert file paths to data URIs
-        let config = zeroclaw_config::schema::MultimodalConfig::default();
-        let prepared = crate::multimodal::prepare_messages_for_provider(messages, &config).await?;
+        let prepared =
+            crate::multimodal::prepare_messages_for_provider(messages, &self.multimodal).await?;
 
         let (instructions, input) = build_responses_input(&prepared.messages);
         self.send_responses_request(input, instructions, None, model)
@@ -1531,9 +1536,9 @@ impl ModelProvider for OpenAiCodexModelProvider {
         model: &str,
         _temperature: Option<f64>,
     ) -> anyhow::Result<ProviderChatResponse> {
-        let config = zeroclaw_config::schema::MultimodalConfig::default();
         let prepared =
-            crate::multimodal::prepare_messages_for_provider(request.messages, &config).await?;
+            crate::multimodal::prepare_messages_for_provider(request.messages, &self.multimodal)
+                .await?;
         let (instructions, input) = build_responses_input(&prepared.messages);
         let response = self
             .send_responses_request(input, instructions, convert_tools(request.tools), model)
@@ -1574,17 +1579,20 @@ impl ModelProvider for OpenAiCodexModelProvider {
         let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
 
         let handle = ::zeroclaw_spawn::spawn!(async move {
-            let config = zeroclaw_config::schema::MultimodalConfig::default();
-            let prepared =
-                match crate::multimodal::prepare_messages_for_provider(&messages, &config).await {
-                    Ok(prepared) => prepared,
-                    Err(err) => {
-                        let _ = tx
-                            .send(Err(StreamError::ModelProvider(err.to_string())))
-                            .await;
-                        return;
-                    }
-                };
+            let prepared = match crate::multimodal::prepare_messages_for_provider(
+                &messages,
+                &provider.multimodal,
+            )
+            .await
+            {
+                Ok(prepared) => prepared,
+                Err(err) => {
+                    let _ = tx
+                        .send(Err(StreamError::ModelProvider(err.to_string())))
+                        .await;
+                    return;
+                }
+            };
 
             let creds = match provider.resolve_credentials().await {
                 Ok(c) => c,
@@ -1752,6 +1760,26 @@ mod tests {
         let provider = OpenAiCodexModelProvider::new("test", &options, Some("test-key")).unwrap();
 
         (provider, captured, server_handle, temp_dir, proxy_guard)
+    }
+
+    #[test]
+    fn provider_construction_carries_operator_multimodal_policy() {
+        let multimodal = zeroclaw_config::schema::MultimodalConfig {
+            max_images: 1,
+            max_image_size_mb: 2,
+            ..Default::default()
+        };
+
+        let options = ModelProviderRuntimeOptions {
+            multimodal,
+            ..ModelProviderRuntimeOptions::default()
+        };
+        let provider = OpenAiCodexModelProvider::new("test", &options, None).unwrap();
+
+        // Every `prepare_messages_for_provider` call in this adapter uses this
+        // field; defaults would drop the operator's image limits.
+        assert_eq!(provider.multimodal.max_images, 1);
+        assert_eq!(provider.multimodal.max_image_size_mb, 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Provider adapters run their own `prepare_messages_for_provider` pass to expand `[IMAGE:...]` markers into inline base64 data URIs, but every call site built `MultimodalConfig::default()` rather than resolving the operator's root `[multimodal]` section.
  - The runtime already prepares history under the operator's policy before dispatch (`vision_route::prepare_messages_for_iteration`), so the section was **not** globally inert. The defect is narrower: the adapter's *second* preparation pass re-applies library defaults on top, so a policy more permissive than the defaults silently loses attachments the runtime already accepted — and an adapter invoked directly, with no runtime pass in front of it, gets defaults outright.
  - This resolves the config from its canonical source (`Config::multimodal`) into `ModelProviderRuntimeOptions` and carries it into the OpenAI Codex and OpenAI-compatible adapters at construction time, including the bare-family / `custom:<url>` reference path that `resolve_vision_provider` uses.
  - `multimodal` is root-scoped, so `options_for_provider_ref` intentionally keeps it on a bare family ref instead of resetting it the way the provider-specific `tool_result_image_policy` is reset.
- **Scope boundary:** This PR only makes the existing `[multimodal]` limits reach the provider adapters. It does NOT change any default, does NOT add a new config key, does NOT change how markers are created from tool output (`canonicalize_tool_result_media_markers`), and does NOT change how the context budget is estimated before expansion. Those are separate concerns and are noted below.
- **Blast radius:** `ModelProviderRuntimeOptions` gains a field, so any struct-literal construction must supply it; all in-tree constructions already use `..Default::default()`. Behavior is unchanged for deployments with no `[multimodal]` section, since the resolved value equals the previous hardcoded default. Deployments that *do* set `[multimodal]` will now have those limits enforced on the provider request — that is the intended fix, and it can reduce the number of images sent where an operator asked for that.
- **Linked issue(s):** None
- **Labels:** `bug`, `provider`, `provider:openai`, `provider:compatible`, `domain:security`, `risk:high`, `size:S`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `channel` (any messaging channel routed to an `openai_codex` or OpenAI-compatible provider)
- **Setup / preconditions:** A provider entry using `openai_codex` (or any OpenAI-compatible family), plus a root section:

  ```toml
  [multimodal]
  max_images = 1
  ```

- **Steps to run:** Set `multimodal.max_image_size_mb = 10` and a `multimodal.vision_model_provider`, then send a turn carrying an image between 5 and 10 MiB. The runtime accepts it under the operator policy; observe whether it survives adapter preparation.
- **Expected on this branch (after):** the image reaches the provider, because the adapter is built with the operator's 10 MiB limit.
- **Prior behavior on `master` (before):** the adapter is built from default options and re-applies its own 5 MiB limit, so the image is dropped after the runtime already accepted it.

  I previously described this as "`max_images = 1` is inert, four images sent before / one after". That was wrong: the runtime pass already applies the operator cap before dispatch, so a *stricter* setting was largely honoured. The real exposure is a *more permissive* setting being clamped back to library defaults by the adapter's second pass, plus adapters invoked directly with no runtime pass in front.

### How I tested

Focused on the changed crate, plus a compile check of every in-tree consumer of the changed struct.

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
cargo test -p zeroclaw-providers
cargo check -p zeroclaw-runtime -p zeroclaw-channels -p zeroclaw-tools --all-targets
```

- **CI checks relied on and why they cover this change:** the standard Rust fmt/clippy/test jobs cover the changed surface; the change is confined to `zeroclaw-providers` with a struct-field addition whose consumers are compile-checked above.
- **Known CI coverage gap, if any:** `cargo check --workspace` does not complete in my environment because `glib-sys` fails its build script on missing system GLib development packages. That failure is environmental and independent of this diff (it is a desktop-app dependency and reproduces without these changes); full-workspace CI covers it.
- **Commands run and tail output:**

  ```text
  test result: ok. 1486 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
  ```

  Six tests added by this PR:

  ```text
  test tests::root_multimodal_section_maps_into_runtime_options ... ok
  test tests::bare_family_provider_ref_inherits_root_multimodal_policy ... ok
  test compatible::tests::operator_max_images_bounds_the_outbound_request ... ok
  test compatible::tests::builder_without_multimodal_falls_back_to_library_defaults ... ok
  test openai_codex::tests::provider_construction_carries_operator_multimodal_policy ... ok
  test tests::bare_family_ref_carries_multimodal_policy_into_prepared_images ... ok
  ```

  `operator_max_images_bounds_the_outbound_request` is the behaviour-boundary test: it drives `normalize_messages_for_upstream` and asserts how many images survive into the messages the adapter is about to send. It fails on the tested base (the cap is ignored, both images go out) and passes here.

  `bare_family_ref_carries_multimodal_policy_into_prepared_images` drives the bare-family / custom-URL construction path through a local capture server and verifies that the configured image cap reaches the outbound request.

  `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings` and `cargo fmt --all -- --check` both exit clean.
- **Beyond CI, what did you manually verify?** I verified by reading each call site that the four `prepare_messages_for_provider` calls in `openai_codex.rs` and the one in `compatible.rs` are the only production expansion sites that were constructing a default config; the remaining `MultimodalConfig::default()` in `anthropic.rs` is inside a test. I did NOT run a live end-to-end request against a real provider, and I did NOT measure the resulting token reduction on a real oversized payload.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

Privacy note in favor of this change: because tool output that prints local image paths is canonicalized into `[IMAGE:...]` markers and base64-inlined, image bytes that would otherwise stay local are uploaded to the configured provider. `MultimodalConfig` bounds that exposure (see the "Privacy and cost note" on the struct). The ordinary runtime already enforced its policy; this patch carries the same policy into configured adapters rather than allowing a second pass to impose different defaults. Direct adapter calls also honor the configured settings. Existing remote-fetch permission checks remain in place.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No (no new keys; existing `[multimodal]` keys simply take effect where they previously did not)
- Rust/MSRV/toolchain floor changed? No

The runtime already applies the operator's `[multimodal]` policy. This fix also applies it during adapter preparation, including direct adapter calls, instead of silently substituting library defaults. Operators with nondefault settings can therefore see different outbound image counts or sizes; defaults remain unchanged.

## Rollback

Revert this PR's squash commit to restore the previous adapter defaults. Watch for unexpected image loss, payload-size changes, or provider request failures when nondefault multimodal settings are configured.

## Follow-ups (not in this PR)

Related work kept separate from this PR:

1. Context-budget accounting before marker expansion remains separate. #9332 tracks accounting for the multimodal payload actually sent, rather than presenting image-heavy requests as safely below budget. This PR does not fix that accounting.
2. Merged #10555 bounds image-path promotion from generic tool output so large path listings are left as text.

3. Merged #10564 changes image eviction from whole-message removal to per-image trimming. This PR's one-image-per-message fixtures still isolate configuration propagation.
