### PR TITLE
fix(tools): reuse configured provider refs for agents

### DIFF
--- a/crates/zeroclaw-tools/src/model_routing_config.rs
+++ b/crates/zeroclaw-tools/src/model_routing_config.rs
@@ -873,10 +873,37 @@ impl ModelRoutingConfigTool {
     async fn handle_upsert_agent(&self, args: &Value) -> anyhow::Result<ToolResult> {
         let name = Self::parse_non_empty_string(args, "name")?;
         let model_provider = Self::parse_non_empty_string(args, "model_provider")?;
-        let model = Self::parse_non_empty_string(args, "model")?;
-
-        let api_key_update = Self::parse_optional_string_update(args, "api_key")?;
-        let temperature_update = Self::parse_optional_f64_update(args, "temperature")?;
+        let provider_ref_parts = model_provider.split_once('.');
+        let model = if provider_ref_parts.is_some() {
+            if args.get("model").is_some() {
+                anyhow::bail!(
+                    "'model' cannot be supplied when reusing a configured model provider ref"
+                );
+            }
+            None
+        } else {
+            Some(Self::parse_non_empty_string(args, "model")?)
+        };
+        let api_key_update = if provider_ref_parts.is_some() {
+            if args.get("api_key").is_some() {
+                anyhow::bail!(
+                    "'api_key' cannot be supplied when reusing a configured model provider ref"
+                );
+            }
+            MaybeSet::Unset
+        } else {
+            Self::parse_optional_string_update(args, "api_key")?
+        };
+        let temperature_update = if provider_ref_parts.is_some() {
+            if args.get("temperature").is_some() {
+                anyhow::bail!(
+                    "'temperature' cannot be supplied when reusing a configured model provider ref"
+                );
+            }
+            MaybeSet::Unset
+        } else {
+            Self::parse_optional_f64_update(args, "temperature")?
+        };
         let max_depth_update = Self::parse_optional_u32_update(args, "max_depth")?;
         let max_iterations_update = Self::parse_optional_usize_update(args, "max_iterations")?;
         let agentic_update = Self::parse_optional_bool(args, "agentic")?;
@@ -897,43 +924,76 @@ impl ModelRoutingConfigTool {
 
         let mut cfg = self.load_config_without_env()?;
 
-        // synthesize providers.models[model_provider_family][name] from inline brain params.
-        // The arg is the family name (e.g. "openai"); the agent's `model_provider`
-        // reference becomes the dotted form (e.g. "openai.coder").
-        let model_provider_family = model_provider;
-        let agent_model_provider_ref = format!("{model_provider_family}.{name}");
+        // Validate the provider route before mutating any provider, profile, or agent state.
+        let agent_model_provider_ref = if let Some((family, alias)) = provider_ref_parts {
+            if !zeroclaw_config::providers::ModelProviders::slot_names().contains(&family) {
+                anyhow::bail!(
+                    "unknown model_provider type `{family}`. no typed slot in ModelProviders"
+                );
+            }
+            if cfg.providers.models.find(family, alias).is_none() {
+                anyhow::bail!(
+                    "model_provider ref `{model_provider}` is not configured in ModelProviders"
+                );
+            }
+            model_provider.clone()
+        } else {
+            if !zeroclaw_config::providers::ModelProviders::slot_names()
+                .contains(&model_provider.as_str())
+            {
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "model_provider_family": &model_provider,
+                            "name": &name,
+                        })),
+                    "model_routing_config: unknown model_provider family"
+                );
+                anyhow::bail!(
+                    "unknown model_provider type `{model_provider}`. no typed slot in ModelProviders"
+                );
+            }
+            format!("{model_provider}.{name}")
+        };
+
+        // Validate all bounded updates before mutating the loaded config.
+        if let MaybeSet::Set(value) = temperature_update
+            && !(0.0..=2.0).contains(&value)
         {
-            let provider_entry =
-                cfg.providers.models
-                    .ensure(&model_provider_family, &name)
-                    .ok_or_else(|| {
-                        ::zeroclaw_log::record!(
-                            ERROR,
-                            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
-                                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                                .with_attrs(::serde_json::json!({
-                                    "model_provider_family": &model_provider_family,
-                                    "name": &name,
-                                })),
-                            "model_routing_config: unknown model_provider family"
-                        );
-                        anyhow::Error::msg(format!(
-                            "unknown model_provider type `{model_provider_family}`. no typed slot in ModelProviders"
-                        ))
-                    })?;
-            provider_entry.model = Some(model.clone());
+            anyhow::bail!("'temperature' must be between 0.0 and 2.0");
+        }
+        if let MaybeSet::Set(iters) = max_iterations_update
+            && iters == 0
+        {
+            anyhow::bail!("'max_iterations' must be greater than 0");
+        }
+        if let MaybeSet::Set(depth) = max_depth_update
+            && depth == 0
+        {
+            anyhow::bail!("'max_depth' must be greater than 0");
+        }
+
+        // Bare families synthesize providers.models[family][agent] from inline params.
+        if let Some(model) = model {
+            let provider_entry = cfg
+                .providers
+                .models
+                .ensure(&model_provider, &name)
+                .ok_or_else(|| {
+                    anyhow::Error::msg(format!(
+                        "unknown model_provider type `{model_provider}`. no typed slot in ModelProviders"
+                    ))
+                })?;
+            provider_entry.model = Some(model);
             match api_key_update {
                 MaybeSet::Set(ref v) => provider_entry.api_key = Some(v.clone()),
                 MaybeSet::Null => provider_entry.api_key = None,
                 MaybeSet::Unset => {}
             }
             match temperature_update {
-                MaybeSet::Set(value) => {
-                    if !(0.0..=2.0).contains(&value) {
-                        anyhow::bail!("'temperature' must be between 0.0 and 2.0");
-                    }
-                    provider_entry.temperature = Some(value);
-                }
+                MaybeSet::Set(value) => provider_entry.temperature = Some(value),
                 MaybeSet::Null => provider_entry.temperature = None,
                 MaybeSet::Unset => {}
             }
@@ -954,17 +1014,11 @@ impl ModelRoutingConfigTool {
                 runtime.agentic = agentic;
             }
             if let MaybeSet::Set(iters) = max_iterations_update {
-                if iters == 0 {
-                    anyhow::bail!("'max_iterations' must be greater than 0");
-                }
                 runtime.max_tool_iterations = iters;
             } else if runtime.max_tool_iterations == 0 {
                 runtime.max_tool_iterations = DEFAULT_AGENT_MAX_ITERATIONS;
             }
             if let MaybeSet::Set(depth) = max_depth_update {
-                if depth == 0 {
-                    anyhow::bail!("'max_depth' must be greater than 0");
-                }
                 runtime.max_delegation_depth = depth;
             } else if runtime.max_delegation_depth == 0 {
                 runtime.max_delegation_depth = DEFAULT_AGENT_MAX_DEPTH;
@@ -1084,7 +1138,7 @@ impl Tool for ModelRoutingConfigTool {
                 },
                 "model": {
                     "type": "string",
-                    "description": "Model for set_default/upsert_scenario/upsert_agent"
+                    "description": "Model for set_default/upsert_scenario or bare-family upsert_agent; omitted when upsert_agent reuses an existing dotted provider ref"
                 },
                 "temperature": {
                     "type": ["number", "null"],
@@ -1383,6 +1437,152 @@ mod tests {
         let get_result = tool.execute(json!({"action": "get"})).await.unwrap();
         let output: Value = serde_json::from_str(&get_result.output).unwrap();
         assert!(output["agents"]["coder"].is_null());
+    }
+
+    #[tokio::test]
+    async fn upsert_agent_reuses_configured_dotted_provider_ref() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("config.toml");
+        let tool = ModelRoutingConfigTool::new(Box::pin(test_config(&tmp)).await, test_security());
+
+        let provision = tool
+            .execute(json!({
+                "action": "upsert_agent",
+                "name": "truefoundry",
+                "model_provider": "custom",
+                "model": "provider-model",
+                "temperature": 0.4
+            }))
+            .await
+            .unwrap();
+        assert!(provision.success, "{:?}", provision.error);
+
+        let provider_before = serde_json::to_value(
+            read_saved_provider_entry(&cfg_path, "custom", "truefoundry")
+                .expect("bare family upsert must create custom.truefoundry"),
+        )
+        .unwrap();
+
+        let reuse = tool
+            .execute(json!({
+                "action": "upsert_agent",
+                "name": "coder",
+                "model_provider": "custom.truefoundry",
+                "allowed_tools": ["file_read"]
+            }))
+            .await
+            .unwrap();
+        assert!(reuse.success, "{:?}", reuse.error);
+
+        let provider_after = serde_json::to_value(
+            read_saved_provider_entry(&cfg_path, "custom", "truefoundry")
+                .expect("reused provider must remain configured"),
+        )
+        .unwrap();
+        assert_eq!(provider_after, provider_before);
+
+        let get_result = tool.execute(json!({"action": "get"})).await.unwrap();
+        let output: Value = serde_json::from_str(&get_result.output).unwrap();
+        assert_eq!(
+            output["agents"]["coder"]["model_provider"],
+            json!("custom.truefoundry")
+        );
+    }
+
+    #[tokio::test]
+    async fn upsert_agent_rejects_invalid_provider_requests_without_mutation() {
+        let cases = [
+            ("unknown family", json!("unknown"), true),
+            ("missing dotted alias", json!("custom.missing"), false),
+            ("bare family without model", json!("custom"), false),
+        ];
+
+        for (case, model_provider, has_model) in cases {
+            let tmp = TempDir::new().unwrap();
+            let cfg_path = tmp.path().join("config.toml");
+            let tool =
+                ModelRoutingConfigTool::new(Box::pin(test_config(&tmp)).await, test_security());
+            let before = std::fs::read_to_string(&cfg_path).unwrap();
+
+            let mut args = json!({
+                "action": "upsert_agent",
+                "name": "coder",
+                "model_provider": model_provider
+            });
+            if has_model {
+                args["model"] = json!("model");
+            }
+
+            let result = tool.execute(args).await.unwrap();
+            assert!(!result.success, "{case} unexpectedly succeeded");
+            assert_eq!(
+                std::fs::read_to_string(&cfg_path).unwrap(),
+                before,
+                "{case}"
+            );
+
+            let get_result = tool.execute(json!({"action": "get"})).await.unwrap();
+            let output: Value = serde_json::from_str(&get_result.output).unwrap();
+            assert!(output["agents"].as_object().unwrap().is_empty(), "{case}");
+            assert!(
+                read_saved_provider_entry(&cfg_path, "custom", "missing").is_none(),
+                "{case} must not create a provider alias"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_agent_rejects_provider_mutations_on_reused_ref() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("config.toml");
+        let tool = ModelRoutingConfigTool::new(Box::pin(test_config(&tmp)).await, test_security());
+
+        for (name, model_provider) in [("truefoundry", "custom"), ("coder", "openai")] {
+            let result = tool
+                .execute(json!({
+                    "action": "upsert_agent",
+                    "name": name,
+                    "model_provider": model_provider,
+                    "model": "original-model"
+                }))
+                .await
+                .unwrap();
+            assert!(result.success, "{:?}", result.error);
+        }
+
+        let before = std::fs::read_to_string(&cfg_path).unwrap();
+        let provider_before = serde_json::to_value(
+            read_saved_provider_entry(&cfg_path, "custom", "truefoundry")
+                .expect("provider setup must create custom.truefoundry"),
+        )
+        .unwrap();
+
+        for (field, value) in [
+            ("model", json!("replacement-model")),
+            ("api_key", json!("replacement-key")),
+            ("temperature", json!(1.2)),
+        ] {
+            let mut args = json!({
+                "action": "upsert_agent",
+                "name": "coder",
+                "model_provider": "custom.truefoundry"
+            });
+            args[field] = value;
+
+            let result = tool.execute(args).await.unwrap();
+            assert!(!result.success, "{field} unexpectedly accepted");
+            assert_eq!(
+                std::fs::read_to_string(&cfg_path).unwrap(),
+                before,
+                "{field}"
+            );
+            let provider_after = serde_json::to_value(
+                read_saved_provider_entry(&cfg_path, "custom", "truefoundry")
+                    .expect("reused provider must remain configured"),
+            )
+            .unwrap();
+            assert_eq!(provider_after, provider_before, "{field}");
+        }
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-tools/src/model_routing_config.rs
+++ b/crates/zeroclaw-tools/src/model_routing_config.rs
@@ -189,6 +189,20 @@ impl ModelRoutingConfigTool {
         Ok(value.to_string())
     }
 
+    fn reject_unknown_model_provider_family(family: &str, name: &str) -> anyhow::Result<()> {
+        ::zeroclaw_log::record!(
+            ERROR,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                .with_attrs(::serde_json::json!({
+                    "model_provider_family": family,
+                    "name": name,
+                })),
+            "model_routing_config: unknown model_provider family"
+        );
+        anyhow::bail!("unknown model_provider type `{family}`. no typed slot in ModelProviders")
+    }
+
     fn parse_optional_string_update(args: &Value, field: &str) -> anyhow::Result<MaybeSet<String>> {
         let Some(raw) = args.get(field) else {
             return Ok(MaybeSet::Unset);
@@ -927,9 +941,7 @@ impl ModelRoutingConfigTool {
         // Validate the provider route before mutating any provider, profile, or agent state.
         let agent_model_provider_ref = if let Some((family, alias)) = provider_ref_parts {
             if !zeroclaw_config::providers::ModelProviders::slot_names().contains(&family) {
-                anyhow::bail!(
-                    "unknown model_provider type `{family}`. no typed slot in ModelProviders"
-                );
+                Self::reject_unknown_model_provider_family(family, &name)?;
             }
             if cfg.providers.models.find(family, alias).is_none() {
                 anyhow::bail!(
@@ -941,19 +953,7 @@ impl ModelRoutingConfigTool {
             if !zeroclaw_config::providers::ModelProviders::slot_names()
                 .contains(&model_provider.as_str())
             {
-                ::zeroclaw_log::record!(
-                    ERROR,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
-                        .with_attrs(::serde_json::json!({
-                            "model_provider_family": &model_provider,
-                            "name": &name,
-                        })),
-                    "model_routing_config: unknown model_provider family"
-                );
-                anyhow::bail!(
-                    "unknown model_provider type `{model_provider}`. no typed slot in ModelProviders"
-                );
+                Self::reject_unknown_model_provider_family(&model_provider, &name)?;
             }
             format!("{model_provider}.{name}")
         };
@@ -1493,6 +1493,7 @@ mod tests {
     async fn upsert_agent_rejects_invalid_provider_requests_without_mutation() {
         let cases = [
             ("unknown family", json!("unknown"), true),
+            ("unknown dotted family", json!("unknown.alias"), false),
             ("missing dotted alias", json!("custom.missing"), false),
             ("bare family without model", json!("custom"), false),
         ];


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `model_routing_config upsert_agent` now distinguishes a bare provider family from an existing `family.alias` reference. Bare input keeps creating the agent-specific provider entry; an existing dotted reference is validated and attached to the agent without overwriting its provider settings. Invalid references and rejected provider-setting arguments are checked before any configuration state is changed.
- **Scope boundary:** This does not add a provider family, change runtime provider dispatch, or depend on the broader #8396 provider-reference RFC.
- **Blast radius:** The model-routing configuration tool and persisted delegate-agent configuration. Existing bare-family upserts retain their current behavior.
- **Linked issue(s):** Closes #10533
- **Labels:** `bug`, `tool`, `distinguished contributor`, `domain:architecture`, `needs-maintainer-review`, `risk:high`, `size:M`

### What this does, simply

ZeroClaw lets operators configure delegate agents through the model-routing tool. Before this change, the tool treated every provider value as a bare provider family and created an agent-specific entry. That meant an operator could not tell an agent to reuse an already configured provider such as `custom.truefoundry`, even though the rest of ZeroClaw could use that configuration.

This PR recognizes that existing two-part provider reference and connects the agent to it without changing the provider's model, key, or temperature. It also rejects bad requests before any partial agent configuration is saved. It does not create a new provider system or accept the broader nested reference syntax proposed elsewhere.

## Testing

### How you can test

- **Reviewer testing requested?** N/A; the tool behavior is covered by focused unit tests and does not need a live provider account.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed on the exact PR head. The focused local test directly covers the changed tool operation and its persistence contract.
- **Known CI coverage gap, if any:** No live provider call was made; this change only resolves and persists already configured provider aliases.
- **Commands and recorded results:** The original local runs used environment-specific Cargo wrappers. Repository-reproducible equivalents and the retained result summaries are listed below; these summaries are not raw terminal tails.
  - `cargo test -p zeroclaw-tools --lib upsert_agent`: 4 passed at implementation head `bd0d73b42966422a031324bc90f5f02079ab6957`.
  - `cargo test -p zeroclaw-tools --lib upsert_agent_rejects_invalid_provider_requests_without_mutation`: passed for the audit-log repair at `d2245e7a96ca5ecc658e3b9a01aedcd3495e4019`, as recorded in [my repair update](https://github.com/zeroclaw-labs/zeroclaw/pull/10554#issuecomment-5543200841).
  - `cargo fmt --all -- --check` and `git diff --check`: passed for that repair.
  - `scripts/ci/comment_hygiene_gate.sh`: passed during the original implementation validation.
- **Current-head hosted evidence:** [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33892138251/job/101096670695) passed at `d2245e7a96ca5ecc658e3b9a01aedcd3495e4019`, including the required Test and Lint checks. No new local test run was performed for this description correction.
- **Beyond CI, what did you manually verify?** The tests prove bare-family provisioning remains available, configured dotted aliases are reused without provider mutation, missing aliases do not write partial state, and `model`, `api_key`, and `temperature` are rejected for a reused alias. No live provider or visual interface was exercised.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Broad workspace validation was not selected because the focused crate tests exercise the only changed behavior; required CI passed on the exact PR head.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? Yes: the existing configuration tool can now bind an agent to an already configured provider alias with a different name. No permission grant or file system scope is added.
- New external network calls? No
- Secrets / tokens / credentials handling changed? Yes: reference selection can select an existing provider's endpoint and credentials for runtime use. The tool does not return those secrets or overwrite the reused provider.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: Access to this configuration-writing tool permits provider bindings; it is not per-agent or per-alias credential isolation. The existing bare-family path already accepts an arbitrary agent name and can reuse that name's provider entry while retaining its credentials. The new dotted-reference path validates that the configured entry exists and rejects `model`, `api_key`, and `temperature` overrides. Existing non-read-only and rate-limit checks still apply, but do not constitute per-binding approval. I am retaining this configuration-authority model in this PR rather than adding an alias-ownership policy.

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? Yes. `upsert_agent` now accepts an existing configured dotted provider reference and rejects provider-setting fields when that reference is reused; existing bare-family requests are unchanged.
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: No migration is required. Continue using bare provider families with `model` to provision an agent-specific entry, or use an existing configured `family.alias` without `model`, `api_key`, or `temperature`.

## Rollback

- **Fast rollback command/path:** Revert this PR to restore the prior bare-family-only `upsert_agent` behavior.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** A dotted reference unexpectedly reports it is not configured, or an `upsert_agent` error is followed by a changed provider, risk profile, runtime profile, or agent entry.
