### PR TITLE
fix(runtime): honor allowed roots in Seatbelt

### DIFF
--- a/crates/zeroclaw-runtime/src/security/detect.rs
+++ b/crates/zeroclaw-runtime/src/security/detect.rs
@@ -8,8 +8,8 @@ use zeroclaw_config::schema::{SandboxBackend, SandboxConfig};
 /// Extra filesystem roots beyond the primary workspace that a sandbox should
 /// also grant access to, mirroring `SecurityPolicy`'s allowed-roots tiers
 /// (`allowed_roots`, `allowed_roots_read_only`, `allowed_roots_write_only`).
-/// Only backends that build per-path rulesets (currently Landlock) consume
-/// this; others ignore it.
+/// Backends that build per-path rulesets (Landlock and macOS Seatbelt)
+/// consume this; others ignore it.
 #[derive(Debug, Clone, Default)]
 pub struct SandboxExtraRoots {
     pub read_write: Vec<PathBuf>,
@@ -350,10 +350,8 @@ fn create_selected_sandbox(
             }
             #[cfg(not(all(feature = "sandbox-landlock", target_os = "linux")))]
             {
-                // Landlock is the only backend that consumes the extra roots, so
-                // without it the parameter is genuinely unused. Bind it here to
-                // keep the signature uniform across cfgs without tripping
-                // `-D warnings` on the feature-disabled build.
+                // This Landlock branch does not consume extra roots when its
+                // feature/platform implementation is unavailable.
                 let _ = extra_roots;
                 None
             }
@@ -404,9 +402,14 @@ fn create_selected_sandbox(
         SelectedSandboxBackend::SandboxExec => {
             #[cfg(target_os = "macos")]
             {
-                super::seatbelt::SeatbeltSandbox::with_workspace(workspace_dir)
-                    .map(|sandbox| Arc::new(sandbox) as Arc<dyn Sandbox>)
-                    .ok()
+                super::seatbelt::SeatbeltSandbox::with_roots(
+                    workspace_dir,
+                    &extra_roots.read_write,
+                    &extra_roots.read_only,
+                    &extra_roots.write_only,
+                )
+                .map(|sandbox| Arc::new(sandbox) as Arc<dyn Sandbox>)
+                .ok()
             }
             #[cfg(not(target_os = "macos"))]
             {

--- a/crates/zeroclaw-runtime/src/security/detect.rs
+++ b/crates/zeroclaw-runtime/src/security/detect.rs
@@ -329,6 +329,33 @@ fn detect_best_sandbox(
     Arc::new(super::traits::NoopSandbox)
 }
 
+#[cfg(target_os = "macos")]
+struct FailedSeatbeltSandbox {
+    error: std::io::Error,
+}
+
+#[cfg(target_os = "macos")]
+impl Sandbox for FailedSeatbeltSandbox {
+    fn wrap_command(&self, _cmd: &mut std::process::Command) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            self.error.kind(),
+            format!("Seatbelt initialization failed: {}", self.error),
+        ))
+    }
+
+    fn is_available(&self) -> bool {
+        false
+    }
+
+    fn name(&self) -> &str {
+        "sandbox-exec"
+    }
+
+    fn description(&self) -> &str {
+        "Seatbelt initialization failed; commands are blocked"
+    }
+}
+
 fn create_selected_sandbox(
     selected: SelectedSandboxBackend,
     workspace_dir: Option<&Path>,
@@ -402,14 +429,19 @@ fn create_selected_sandbox(
         SelectedSandboxBackend::SandboxExec => {
             #[cfg(target_os = "macos")]
             {
-                super::seatbelt::SeatbeltSandbox::with_roots(
+                let result = super::seatbelt::SeatbeltSandbox::with_roots(
                     workspace_dir,
                     &extra_roots.read_write,
                     &extra_roots.read_only,
                     &extra_roots.write_only,
-                )
-                .map(|sandbox| Arc::new(sandbox) as Arc<dyn Sandbox>)
-                .ok()
+                );
+                // Once Seatbelt is selected, initialization failure must block
+                // execution rather than trigger the unsandboxed fallback.
+                let sandbox: Arc<dyn Sandbox> = match result {
+                    Ok(sandbox) => Arc::new(sandbox),
+                    Err(error) => Arc::new(FailedSeatbeltSandbox { error }),
+                };
+                Some(sandbox)
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -532,6 +564,99 @@ pub fn linux_memcg_available() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn failed_seatbelt_preserves_error_and_rejects_repeated_commands() {
+        let sandbox = FailedSeatbeltSandbox {
+            error: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "policy unavailable"),
+        };
+        assert!(!sandbox.is_available());
+        assert_eq!(sandbox.name(), "sandbox-exec");
+        for _ in 0..2 {
+            let mut command = std::process::Command::new("/bin/echo");
+            command.arg("must not run");
+            let error = sandbox.wrap_command(&mut command).unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+            assert!(
+                error
+                    .to_string()
+                    .contains("Seatbelt initialization failed: policy unavailable")
+            );
+            assert_eq!(command.get_program(), "/bin/echo");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_factory_keeps_resolution_failures_confined() {
+        if !Path::new(super::super::seatbelt::SANDBOX_EXEC_PATH).is_file() {
+            return;
+        }
+        let fixture = tempfile::tempdir().unwrap();
+        let cycle = fixture.path().join("cycle");
+        std::os::unix::fs::symlink("cycle", &cycle).unwrap();
+        let extra_roots = SandboxExtraRoots {
+            read_only: vec![cycle],
+            ..SandboxExtraRoots::default()
+        };
+        // With Bubblewrap disabled, macOS auto-selection chooses Seatbelt.
+        let backends = [
+            SandboxBackend::SandboxExec,
+            #[cfg(not(feature = "sandbox-bubblewrap"))]
+            SandboxBackend::Auto,
+        ];
+        for backend in backends {
+            let mut config = SandboxConfig {
+                enabled: Some(true),
+                backend,
+                firejail_args: Vec::new(),
+            };
+            let sandbox = create_sandbox(&config, "native", Some(fixture.path()), &extra_roots);
+            assert_eq!(sandbox.name(), "sandbox-exec");
+            assert!(!sandbox.is_available());
+            let mut command = std::process::Command::new("/bin/echo");
+            let error = sandbox.wrap_command(&mut command).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("Seatbelt root symlink limit exceeded")
+            );
+
+            config.enabled = Some(false);
+            let disabled = create_sandbox(&config, "native", Some(fixture.path()), &extra_roots);
+            assert_eq!(disabled.name(), "none");
+            assert!(disabled.wrap_command(&mut command).is_ok());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_factory_still_wraps_valid_roots() {
+        if !Path::new(super::super::seatbelt::SANDBOX_EXEC_PATH).is_file() {
+            return;
+        }
+        let fixture = tempfile::tempdir().unwrap();
+        let config = SandboxConfig {
+            enabled: Some(true),
+            backend: SandboxBackend::SandboxExec,
+            firejail_args: Vec::new(),
+        };
+        let sandbox = create_sandbox(
+            &config,
+            "native",
+            Some(fixture.path()),
+            &SandboxExtraRoots::default(),
+        );
+        assert_eq!(sandbox.name(), "sandbox-exec");
+        assert!(sandbox.is_available());
+        let mut command = std::process::Command::new("/bin/echo");
+        sandbox.wrap_command(&mut command).unwrap();
+        assert_eq!(
+            command.get_program(),
+            super::super::seatbelt::SANDBOX_EXEC_PATH
+        );
+    }
 
     #[test]
     fn detect_best_sandbox_returns_something() {

--- a/crates/zeroclaw-runtime/src/security/seatbelt.rs
+++ b/crates/zeroclaw-runtime/src/security/seatbelt.rs
@@ -1,7 +1,8 @@
 //! macOS sandbox-exec (Seatbelt) sandbox backend.
 
 use crate::security::traits::Sandbox;
-use std::path::{Path, PathBuf};
+use std::collections::{BTreeSet, VecDeque};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 pub(super) const SANDBOX_EXEC_PATH: &str = "/usr/bin/sandbox-exec";
@@ -42,6 +43,8 @@ impl SeatbeltSandbox {
     /// application layer already resolved, and every path is interpolated
     /// through the Seatbelt string-literal escaping seam so a configured root
     /// cannot break out of its SBPL string literal.
+    /// Existing symlinks are resolved before granting or restricting access;
+    /// missing descendants are retained, but resolution errors are returned.
     pub fn with_roots(
         workspace: Option<&Path>,
         read_write: &[PathBuf],
@@ -55,16 +58,38 @@ impl SeatbeltSandbox {
             ));
         }
 
+        let workspace = match workspace {
+            Some(path) => path.to_path_buf(),
+            None => std::env::current_dir()?,
+        };
+        let mut symlinks = BTreeSet::new();
+        let workspace = resolve_policy_root(&workspace, &mut symlinks)?;
+        let mut resolve_roots = |roots: &[PathBuf]| {
+            roots
+                .iter()
+                .map(|root| resolve_policy_root(root, &mut symlinks))
+                .collect::<std::io::Result<Vec<_>>>()
+        };
+        let read_write = resolve_roots(read_write)?;
+        let read_only = resolve_roots(read_only)?;
+        let write_only = resolve_roots(write_only)?;
+        let mut policy = generate_policy(&workspace, &read_write, &read_only, &write_only);
+        // Traversal must survive tier denials, without granting the contents of
+        // a regular file that replaces a configured symlink after construction.
+        policy.push_str(&ancestor_metadata_rules(
+            symlinks.iter().map(PathBuf::as_path),
+        ));
+        for symlink in &symlinks {
+            let literal = seatbelt_string_literal(&symlink.to_string_lossy());
+            policy.push_str(&format!(
+                "(allow file-read-metadata (require-all (literal \"{literal}\") (vnode-type SYMLINK)))\n"
+            ));
+        }
+
         let policy_dir = std::env::temp_dir().join("zeroclaw-seatbelt");
         std::fs::create_dir_all(&policy_dir)?;
-
         let session_id = uuid::Uuid::new_v4();
         let policy_path = policy_dir.join(format!("{session_id}.sb"));
-
-        let workspace = workspace
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")));
-        let policy = generate_policy(&workspace, read_write, read_only, write_only);
         std::fs::write(&policy_path, &policy)?;
 
         Ok(Self {
@@ -137,6 +162,53 @@ impl Sandbox for SeatbeltSandbox {
     fn description(&self) -> &str {
         "macOS Seatbelt sandbox (built-in sandbox-exec)"
     }
+}
+
+/// Resolve existing symlinks while retaining absent suffixes for future writes.
+fn resolve_policy_root(path: &Path, symlinks: &mut BTreeSet<PathBuf>) -> std::io::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut pending: VecDeque<_> = absolute
+        .components()
+        .map(|c| c.as_os_str().to_owned())
+        .collect();
+    let mut resolved = PathBuf::new();
+    let mut hops = 0;
+    while let Some(part) = pending.pop_front() {
+        match Path::new(&part).components().next() {
+            Some(Component::RootDir) => resolved.push(Path::new("/")),
+            Some(Component::CurDir) => {}
+            Some(Component::ParentDir) => {
+                resolved.pop();
+            }
+            Some(Component::Normal(_)) => {
+                let next = resolved.join(&part);
+                match next.symlink_metadata() {
+                    Ok(metadata) if metadata.file_type().is_symlink() => {
+                        hops += 1;
+                        if hops > 64 {
+                            return Err(std::io::Error::other(
+                                "Seatbelt root symlink limit exceeded",
+                            ));
+                        }
+                        let target = std::fs::read_link(&next)?;
+                        symlinks.insert(next);
+                        for component in target.components().rev() {
+                            pending.push_front(component.as_os_str().to_owned());
+                        }
+                    }
+                    Ok(_) => resolved = next.canonicalize()?,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => resolved = next,
+                    Err(error) => return Err(error),
+                }
+            }
+            _ => return Err(std::io::Error::other("Invalid Seatbelt root component")),
+        }
+    }
+    Ok(resolved)
 }
 
 fn seatbelt_string_literal(value: &str) -> String {
@@ -696,6 +768,148 @@ mod tests {
         );
         // The raw, unescaped path must never be interpolated into the SBPL.
         assert!(!policy.contains("zc\"quote\\slash\nnewline"));
+    }
+
+    #[test]
+    fn resolve_policy_root_follows_alias_chain_and_missing_suffix() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().canonicalize().unwrap();
+        std::fs::create_dir(root.join("target")).unwrap();
+        std::os::unix::fs::symlink("target", root.join("inner")).unwrap();
+        std::os::unix::fs::symlink("inner", root.join("outer")).unwrap();
+        let mut symlinks = BTreeSet::new();
+        assert_eq!(
+            resolve_policy_root(&root.join("outer/new/child"), &mut symlinks).unwrap(),
+            root.join("target/new/child")
+        );
+        assert_eq!(
+            symlinks,
+            BTreeSet::from([root.join("inner"), root.join("outer")])
+        );
+        std::os::unix::fs::symlink("target/not-created", root.join("dangling")).unwrap();
+        assert_eq!(
+            resolve_policy_root(&root.join("dangling/file"), &mut symlinks).unwrap(),
+            root.join("target/not-created/file")
+        );
+    }
+
+    #[test]
+    fn resolve_policy_root_rejects_symlink_cycles() {
+        let fixture = tempfile::tempdir().unwrap();
+        let cycle = fixture.path().join("cycle");
+        std::os::unix::fs::symlink("cycle", &cycle).unwrap();
+        assert!(resolve_policy_root(&cycle, &mut BTreeSet::new()).is_err());
+        if SeatbeltSandbox::is_installed() {
+            assert!(
+                SeatbeltSandbox::with_roots(
+                    Some(fixture.path()),
+                    std::slice::from_ref(&cycle),
+                    &[],
+                    &[],
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn seatbelt_alias_roots_enforce_tiers_at_process_boundary() {
+        if !SeatbeltSandbox::is_installed() {
+            return;
+        }
+        let fixture = HomeFixture::new("aliases");
+        let workspace = fixture.child("workspace");
+        let temp = tempfile::tempdir_in("/tmp").unwrap();
+        // Home proves positive grants are not masked by the baseline. Temp
+        // proves restrictions still override the broad compatibility grants.
+        for parent in [fixture.path.as_path(), temp.path()] {
+            let root = parent.canonicalize().unwrap();
+            let mut canonical = Vec::new();
+            let mut aliases = Vec::new();
+            for tier in ["rw", "ro", "wo"] {
+                let target = root.join(tier);
+                std::fs::create_dir(&target).unwrap();
+                std::fs::write(target.join("input.txt"), "content").unwrap();
+                let intermediate = root.join(format!("{tier}-intermediate"));
+                std::os::unix::fs::symlink(tier, &intermediate).unwrap();
+                let alias = root.join(format!("{tier}-alias"));
+                std::os::unix::fs::symlink(&intermediate, &alias).unwrap();
+                canonical.push(target);
+                aliases.push(alias);
+            }
+            let sandbox = SeatbeltSandbox::with_roots(
+                Some(&workspace),
+                &aliases[0..1],
+                &aliases[1..2],
+                &aliases[2..3],
+            )
+            .unwrap();
+            for paths in [&canonical, &aliases] {
+                for (index, path) in paths.iter().enumerate() {
+                    let read =
+                        sandboxed_sh(&sandbox, &workspace, r#"cat "$0""#, &path.join("input.txt"));
+                    assert_eq!(
+                        read.status.success(),
+                        index != 2,
+                        "read tier {index} at {path:?}: {}",
+                        String::from_utf8_lossy(&read.stderr)
+                    );
+                    let write = sandboxed_sh(
+                        &sandbox,
+                        &workspace,
+                        r#"printf x > "$0""#,
+                        &path.join("output.txt"),
+                    );
+                    assert_eq!(
+                        write.status.success(),
+                        index != 1,
+                        "write tier {index} at {path:?}: {}",
+                        String::from_utf8_lossy(&write.stderr)
+                    );
+                }
+            }
+            assert_eq!(
+                std::fs::read_to_string(canonical[1].join("input.txt")).unwrap(),
+                "content"
+            );
+            assert!(!canonical[1].join("output.txt").exists());
+        }
+    }
+
+    #[test]
+    fn seatbelt_alias_traversal_does_not_grant_replacement_contents() {
+        if !SeatbeltSandbox::is_installed() {
+            return;
+        }
+        let fixture = HomeFixture::new("alias-replacement");
+        let workspace = fixture.child("workspace");
+        let target = fixture.child("target");
+        let outside = fixture.child("outside");
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+        let alias = fixture.path.join("alias");
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+        let sandbox =
+            SeatbeltSandbox::with_roots(Some(&workspace), std::slice::from_ref(&alias), &[], &[])
+                .unwrap();
+        std::fs::remove_file(&alias).unwrap();
+        std::fs::write(&alias, "replacement-secret").unwrap();
+        let out = sandboxed_sh(&sandbox, &workspace, r#"cat "$0""#, &alias);
+        assert!(
+            !out.status.success(),
+            "alias traversal must not authorize replacement file contents"
+        );
+        std::fs::remove_file(&alias).unwrap();
+        std::os::unix::fs::symlink(&outside, &alias).unwrap();
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"cat "$0""#,
+            &alias.join("secret.txt"),
+        );
+        assert!(
+            !out.status.success(),
+            "retargeted alias must not authorize an unlisted root"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/security/seatbelt.rs
+++ b/crates/zeroclaw-runtime/src/security/seatbelt.rs
@@ -26,6 +26,28 @@ impl SeatbeltSandbox {
     /// If no workspace is provided, falls back to the process current
     /// directory for compatibility with direct construction.
     pub fn with_workspace(workspace: Option<&Path>) -> std::io::Result<Self> {
+        Self::with_roots(workspace, &[], &[], &[])
+    }
+
+    /// Create a new Seatbelt sandbox for the provided workspace root plus the
+    /// extra filesystem roots resolved from `SecurityPolicy` (carried in
+    /// `SandboxExtraRoots`).
+    ///
+    /// Tier semantics mirror the Landlock backend:
+    /// - `read_write` roots receive `file-read*` and `file-write*` grants;
+    /// - `read_only` roots receive `file-read*` grants only;
+    /// - `write_only` roots receive `file-write*` grants only.
+    ///
+    /// Seatbelt is defense in depth: this grants nothing beyond the tiers the
+    /// application layer already resolved, and every path is interpolated
+    /// through the Seatbelt string-literal escaping seam so a configured root
+    /// cannot break out of its SBPL string literal.
+    pub fn with_roots(
+        workspace: Option<&Path>,
+        read_write: &[PathBuf],
+        read_only: &[PathBuf],
+        write_only: &[PathBuf],
+    ) -> std::io::Result<Self> {
         if !Self::is_installed() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -42,7 +64,7 @@ impl SeatbeltSandbox {
         let workspace = workspace
             .map(Path::to_path_buf)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/tmp")));
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, read_write, read_only, write_only);
         std::fs::write(&policy_path, &policy)?;
 
         Ok(Self {
@@ -133,8 +155,68 @@ fn seatbelt_string_literal(value: &str) -> String {
     escaped
 }
 
-fn generate_policy(workspace: &Path) -> String {
+/// Build one `(<decision> <filter> (subpath "<root>"))` rule per root, routing
+/// every path through the Seatbelt string-literal escaping seam.
+fn subpath_rules(decision: &str, filter: &str, roots: &[PathBuf]) -> String {
+    let mut rules = String::new();
+    for root in roots {
+        let literal = seatbelt_string_literal(&root.to_string_lossy());
+        rules.push_str(&format!("({decision} {filter} (subpath \"{literal}\"))\n"));
+    }
+    rules
+}
+
+fn ancestor_metadata_rules<'a>(roots: impl IntoIterator<Item = &'a Path>) -> String {
+    let mut ancestors = std::collections::BTreeSet::new();
+    for root in roots {
+        for ancestor in root.ancestors().skip(1) {
+            if ancestor != Path::new("/") {
+                ancestors.insert(ancestor.to_path_buf());
+            }
+        }
+    }
+
+    let mut rules = String::new();
+    for ancestor in ancestors {
+        let literal = seatbelt_string_literal(&ancestor.to_string_lossy());
+        rules.push_str(&format!(
+            "(allow file-read-metadata (literal \"{literal}\"))\n"
+        ));
+    }
+    rules
+}
+
+fn generate_policy(
+    workspace: &Path,
+    read_write: &[PathBuf],
+    read_only: &[PathBuf],
+    write_only: &[PathBuf],
+) -> String {
     let workspace_str = seatbelt_string_literal(&workspace.to_string_lossy());
+    let root_ancestor_rules = ancestor_metadata_rules(
+        std::iter::once(workspace)
+            .chain(read_write.iter().map(PathBuf::as_path))
+            .chain(read_only.iter().map(PathBuf::as_path))
+            .chain(write_only.iter().map(PathBuf::as_path)),
+    );
+    let mut extra_root_restrictions = String::new();
+    extra_root_restrictions.push_str(&subpath_rules("deny", "file-write*", read_only));
+    extra_root_restrictions.push_str(&subpath_rules("deny", "file-read*", write_only));
+
+    // Seatbelt uses the last matching rule. Put policy-derived grants after the
+    // restrictions so workspace and overlapping configured tiers retain the
+    // union of rights authorized by SecurityPolicy.
+    let mut policy_root_grants = String::new();
+    policy_root_grants.push_str(&format!(
+        "(allow file-read* (subpath \"{workspace_str}\"))\n"
+    ));
+    policy_root_grants.push_str(&format!(
+        "(allow file-write* (subpath \"{workspace_str}\"))\n"
+    ));
+    policy_root_grants.push_str(&subpath_rules("allow", "file-read*", read_write));
+    policy_root_grants.push_str(&subpath_rules("allow", "file-write*", read_write));
+    policy_root_grants.push_str(&subpath_rules("allow", "file-read*", read_only));
+    policy_root_grants.push_str(&subpath_rules("allow", "file-write*", write_only));
     format!(
         r#"(version 1)
 
@@ -189,6 +271,18 @@ fn generate_policy(workspace: &Path) -> String {
 (allow file-write* (subpath "/dev/null"))
 (allow file-write* (subpath "/dev/tty"))
 
+;; ── Configured extra roots ─────────────────────────────────
+;; Tiered grants mirroring SecurityPolicy's resolved allowed-roots tiers:
+;; read-write roots receive file-read* and file-write*, read-only roots
+;; file-read* only, and write-only roots file-write* only. Seatbelt is
+;; defense in depth: no root outside the resolved tiers is granted here.
+;; Literal metadata grants on root ancestors permit path traversal and Git
+;; canonicalization without exposing ancestor directory contents.
+{root_ancestor_rules}
+;; Restrictions come after the broad compatibility grants above. Policy-owned
+;; workspace and tier grants follow them so overlapping policy roots compose.
+{extra_root_restrictions}{policy_root_grants}
+
 ;; ── Network ────────────────────────────────────────────────
 ;; Deny all network by default (inherited from deny default)
 ;; Allow DNS resolution only
@@ -223,6 +317,57 @@ fn generate_policy(workspace: &Path) -> String {
 mod tests {
     use super::*;
 
+    /// RAII fixture directory under the user's home directory.
+    ///
+    /// Deliberately NOT under the policy's broad `/tmp`, `/private/tmp`,
+    /// `/private/var/folders`, system, or hidden-dotfile (`^/Users/<name>/\.`)
+    /// grants: a fixture the baseline policy can already touch would make the
+    /// negative sibling assertions vacuous.
+    struct HomeFixture {
+        path: PathBuf,
+    }
+
+    impl HomeFixture {
+        fn new(label: &str) -> Self {
+            let home = std::env::var("HOME")
+                .map(PathBuf::from)
+                .expect("$HOME must be set for seatbelt integration fixtures");
+            let path = home.join(format!(
+                "zeroclaw-seatbelt-it-{}-{label}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&path).expect("failed to create fixture directory under $HOME");
+            Self { path }
+        }
+
+        fn child(&self, name: &str) -> PathBuf {
+            let path = self.path.join(name);
+            std::fs::create_dir_all(&path).expect("failed to create fixture child directory");
+            path
+        }
+    }
+
+    impl Drop for HomeFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    /// Run `sh -c <script>` with `$0` bound to `path` inside `sandbox`'s policy.
+    fn sandboxed_sh(
+        sandbox: &SeatbeltSandbox,
+        cwd: &Path,
+        script: &str,
+        path: &Path,
+    ) -> std::process::Output {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", script]);
+        cmd.arg(path);
+        cmd.current_dir(cwd);
+        sandbox.wrap_command(&mut cmd).expect("wrap_command failed");
+        cmd.output().expect("failed to spawn sandboxed command")
+    }
+
     #[test]
     fn seatbelt_sandbox_name() {
         let sandbox = SeatbeltSandbox {
@@ -245,14 +390,14 @@ mod tests {
     #[test]
     fn generate_policy_contains_workspace_path() {
         let workspace = PathBuf::from("/Users/test/project");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.contains("/Users/test/project"));
     }
 
     #[test]
     fn generate_policy_escapes_workspace_path_string_literal() {
         let workspace = PathBuf::from("/tmp/zc\"quote\\slash\nnewline");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
 
         assert!(policy.contains(r#"(subpath "/tmp/zc\"quote\\slash\nnewline")"#));
         assert!(!policy.contains("zc\"quote\\slash\nnewline"));
@@ -261,7 +406,7 @@ mod tests {
     #[test]
     fn generate_policy_uses_provided_workspace_for_access_rules() {
         let workspace = PathBuf::from("/tmp/zeroclaw-seatbelt-test-workspace");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
 
         assert!(
             policy.contains(
@@ -274,14 +419,14 @@ mod tests {
     #[test]
     fn generate_policy_denies_by_default() {
         let workspace = PathBuf::from("/tmp/workspace");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.contains("(deny default)"));
     }
 
     #[test]
     fn generate_policy_allows_workspace_writes() {
         let workspace = PathBuf::from("/home/user/code");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.contains("(allow file-write*"));
         assert!(policy.contains("/home/user/code"));
     }
@@ -289,7 +434,7 @@ mod tests {
     #[test]
     fn generate_policy_restricts_network() {
         let workspace = PathBuf::from("/tmp/workspace");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.contains("localhost"));
         assert!(!policy.contains("127.0.0.1"));
         assert!(!policy.contains("(allow network*)"));
@@ -298,7 +443,7 @@ mod tests {
     #[test]
     fn generate_policy_allows_system_reads() {
         let workspace = PathBuf::from("/tmp/workspace");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.contains("(subpath \"/usr\")"));
         assert!(policy.contains("(subpath \"/bin\")"));
         assert!(policy.contains("(subpath \"/System\")"));
@@ -307,7 +452,7 @@ mod tests {
     #[test]
     fn generate_policy_allows_process_execution() {
         let workspace = PathBuf::from("/tmp/workspace");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.contains("(allow process-exec)"));
         assert!(policy.contains("(allow process-fork)"));
     }
@@ -508,10 +653,331 @@ mod tests {
     #[test]
     fn generate_policy_is_valid_sb_format() {
         let workspace = PathBuf::from("/tmp/workspace");
-        let policy = generate_policy(&workspace);
+        let policy = generate_policy(&workspace, &[], &[], &[]);
         assert!(policy.starts_with("(version 1)"));
         let open = policy.chars().filter(|c| *c == '(').count();
         let close = policy.chars().filter(|c| *c == ')').count();
         assert_eq!(open, close, "parentheses must be balanced in .sb policy");
+    }
+
+    #[test]
+    fn generate_policy_grants_tier_specific_extra_root_rules() {
+        let workspace = PathBuf::from("/ws");
+        let read_write = vec![PathBuf::from("/srv/rw-root")];
+        let read_only = vec![PathBuf::from("/srv/ro-root")];
+        let write_only = vec![PathBuf::from("/srv/wo-root")];
+        let policy = generate_policy(&workspace, &read_write, &read_only, &write_only);
+
+        // Read-write roots receive both grants.
+        assert!(policy.contains(r#"(allow file-read* (subpath "/srv/rw-root"))"#));
+        assert!(policy.contains(r#"(allow file-write* (subpath "/srv/rw-root"))"#));
+
+        // Read-only roots receive the read grant only.
+        assert!(policy.contains(r#"(allow file-read* (subpath "/srv/ro-root"))"#));
+        assert!(!policy.contains(r#"(allow file-write* (subpath "/srv/ro-root"))"#));
+        assert!(policy.contains(r#"(deny file-write* (subpath "/srv/ro-root"))"#));
+
+        // Write-only roots receive the write grant only.
+        assert!(policy.contains(r#"(allow file-write* (subpath "/srv/wo-root"))"#));
+        assert!(!policy.contains(r#"(allow file-read* (subpath "/srv/wo-root"))"#));
+        assert!(policy.contains(r#"(deny file-read* (subpath "/srv/wo-root"))"#));
+    }
+
+    #[test]
+    fn generate_policy_escapes_extra_root_paths() {
+        let tricky = PathBuf::from("/srv/zc\"quote\\slash\nnewline");
+        let policy = generate_policy(&PathBuf::from("/ws"), &[tricky], &[], &[]);
+
+        assert!(
+            policy.contains(r#"(allow file-read* (subpath "/srv/zc\"quote\\slash\nnewline"))"#)
+        );
+        assert!(
+            policy.contains(r#"(allow file-write* (subpath "/srv/zc\"quote\\slash\nnewline"))"#)
+        );
+        // The raw, unescaped path must never be interpolated into the SBPL.
+        assert!(!policy.contains("zc\"quote\\slash\nnewline"));
+    }
+
+    #[test]
+    fn seatbelt_extra_root_tiers_grant_and_deny_in_real_sandbox() {
+        if !SeatbeltSandbox::is_installed() {
+            return;
+        }
+
+        let fixture = HomeFixture::new("tiers");
+        let workspace = fixture.child("workspace");
+        let read_write = fixture.child("rw-root");
+        let read_only = fixture.child("ro-root");
+        let write_only = fixture.child("wo-root");
+        let sibling = fixture.child("unlisted-sibling");
+
+        std::fs::write(read_only.join("readable.txt"), "ro-content").unwrap();
+        std::fs::write(sibling.join("secret.txt"), "sibling-secret").unwrap();
+
+        let sandbox = SeatbeltSandbox::with_roots(
+            Some(workspace.as_path()),
+            std::slice::from_ref(&read_write),
+            std::slice::from_ref(&read_only),
+            std::slice::from_ref(&write_only),
+        )
+        .unwrap();
+        assert!(sandbox.is_available());
+
+        // The primary workspace keeps its read-write grants.
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"printf ws > "$0" && cat "$0""#,
+            &workspace.join("ws-file.txt"),
+        );
+        assert!(
+            out.status.success(),
+            "workspace read/write must keep working: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // Read-write root: write then read back inside the sandbox.
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"printf hello > "$0" && cat "$0""#,
+            &read_write.join("written.txt"),
+        );
+        assert!(
+            out.status.success(),
+            "read-write root must allow write and read: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), "hello");
+
+        // Read-only root: read succeeds.
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"cat "$0""#,
+            &read_only.join("readable.txt"),
+        );
+        assert!(
+            out.status.success(),
+            "read-only root must allow read: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim_end(),
+            "ro-content"
+        );
+
+        // Read-only root: writes are denied.
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"printf x >> "$0""#,
+            &read_only.join("readable.txt"),
+        );
+        assert!(
+            !out.status.success(),
+            "write to a read-only root must be denied"
+        );
+
+        // Write-only root: write succeeds, reading it back is denied.
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"printf wo > "$0""#,
+            &write_only.join("written.txt"),
+        );
+        assert!(
+            out.status.success(),
+            "write-only root must allow write: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"cat "$0""#,
+            &write_only.join("written.txt"),
+        );
+        assert!(
+            !out.status.success(),
+            "read from a write-only root must be denied"
+        );
+
+        // An unlisted visible sibling of the configured roots stays denied.
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"cat "$0""#,
+            &sibling.join("secret.txt"),
+        );
+        assert!(
+            !out.status.success(),
+            "unlisted sibling of the configured roots must stay denied"
+        );
+    }
+
+    #[test]
+    fn seatbelt_restricted_tiers_override_broad_temp_grants() {
+        if !SeatbeltSandbox::is_installed() {
+            return;
+        }
+
+        let workspace_fixture = HomeFixture::new("temp-overlap-workspace");
+        let workspace = workspace_fixture.child("workspace");
+        let temp_fixture = tempfile::tempdir_in("/tmp").unwrap();
+        let temp_root = temp_fixture.path().canonicalize().unwrap();
+        let read_only = temp_root.join("read-only");
+        let write_only = temp_root.join("write-only");
+        std::fs::create_dir_all(&read_only).unwrap();
+        std::fs::create_dir_all(&write_only).unwrap();
+        std::fs::write(read_only.join("readable.txt"), "ro-content").unwrap();
+
+        let sandbox = SeatbeltSandbox::with_roots(
+            Some(workspace.as_path()),
+            &[],
+            std::slice::from_ref(&read_only),
+            std::slice::from_ref(&write_only),
+        )
+        .unwrap();
+
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"cat "$0""#,
+            &read_only.join("readable.txt"),
+        );
+        assert!(out.status.success(), "read-only temp root must be readable");
+
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"printf x >> "$0""#,
+            &read_only.join("readable.txt"),
+        );
+        assert!(!out.status.success(), "broad temp write grant must not win");
+
+        let written = write_only.join("written.txt");
+        let out = sandboxed_sh(&sandbox, &workspace, r#"printf wo > "$0""#, &written);
+        assert!(
+            out.status.success(),
+            "write-only temp root must be writable"
+        );
+
+        let out = sandboxed_sh(&sandbox, &workspace, r#"cat "$0""#, &written);
+        assert!(!out.status.success(), "broad temp read grant must not win");
+    }
+
+    #[test]
+    fn seatbelt_git_worktree_status_with_main_checkout_read_write() {
+        if !SeatbeltSandbox::is_installed() {
+            return;
+        }
+
+        let fixture = HomeFixture::new("git-worktree");
+        let main = fixture.child("main");
+        // `git worktree add` creates the worktree directory itself.
+        let worktree = fixture.path.join("linked-worktree");
+
+        // Fixture setup runs unsandboxed; only `git status` below is confined.
+        let main_s = main.to_string_lossy().into_owned();
+        let worktree_s = worktree.to_string_lossy().into_owned();
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .output()
+                .expect("git on PATH");
+            assert!(
+                out.status.success(),
+                "git fixture setup failed ({args:?}): {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", main_s.as_str()]);
+        run(&[
+            "-C",
+            main_s.as_str(),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ]);
+        run(&[
+            "-C",
+            main_s.as_str(),
+            "worktree",
+            "add",
+            worktree_s.as_str(),
+            "-b",
+            "side",
+        ]);
+        // Make the worktree dirty so a successful `git status --short` must
+        // have inspected THIS worktree, not some ambient checkout.
+        std::fs::write(worktree.join("notes.txt"), "dirty\n").unwrap();
+
+        let sandbox = SeatbeltSandbox::with_roots(
+            Some(worktree.as_path()),
+            std::slice::from_ref(&main),
+            &[],
+            &[],
+        )
+        .unwrap();
+        assert!(sandbox.is_available());
+
+        // Pass the worktree via `git -C` rather than `Command::current_dir`:
+        // `wrap_command` reconstructs the command, so this regression must not
+        // depend on the configured current directory surviving the wrap.
+        let mut cmd = Command::new("/usr/bin/env");
+        cmd.args([
+            "GIT_CONFIG_GLOBAL=/dev/null",
+            "GIT_CONFIG_NOSYSTEM=1",
+            "/usr/bin/git",
+            "-C",
+            worktree_s.as_str(),
+            "-c",
+            "status.showUntrackedFiles=normal",
+            "status",
+            "--short",
+        ]);
+        sandbox.wrap_command(&mut cmd).unwrap();
+        let out = cmd.output().unwrap();
+        assert!(
+            out.status.success(),
+            "git status --short in a linked worktree must succeed when the main checkout \
+             git metadata root is configured read-write: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("?? notes.txt"),
+            "status must report the untracked file, proving it inspected the linked \
+             worktree rather than the ambient directory: {stdout}"
+        );
+    }
+
+    #[test]
+    fn seatbelt_with_workspace_grants_no_extra_roots() {
+        if !SeatbeltSandbox::is_installed() {
+            return;
+        }
+
+        let fixture = HomeFixture::new("empty-tiers");
+        let workspace = fixture.child("workspace");
+        let sibling = fixture.child("outside");
+        std::fs::write(sibling.join("secret.txt"), "secret").unwrap();
+
+        let sandbox = SeatbeltSandbox::with_workspace(Some(workspace.as_path())).unwrap();
+        let out = sandboxed_sh(
+            &sandbox,
+            &workspace,
+            r#"cat "$0""#,
+            &sibling.join("secret.txt"),
+        );
+        assert!(
+            !out.status.success(),
+            "with_workspace must grant nothing outside the workspace"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Pass the existing read-write, read-only, and write-only root tiers into the macOS Seatbelt backend. Resolve existing symlinks before generating its grants and restrictions, and retain missing suffixes for future writes.
- **Scope boundary:** No configuration, application-layer `SecurityPolicy` authorization, backend-selection order, command-context forwarding, or non-macOS backend changes. Once Seatbelt is selected, initialization failure now blocks command preparation instead of falling back to an unsandboxed command. Startup error propagation is not added.
- **Blast radius:** macOS shell and coding CLI commands using `sandbox-exec`. Constructors without extra roots still grant no additional root content access, but gain the metadata access needed to traverse workspace ancestors and aliases.
- **Linked issue(s):** Related #10536. This implements allowed-root enforcement and linked-worktree access; the issue's requested startup/agent-construction error reporting remains outside this PR.
- **Labels:** `bug`, `runtime`, `security`, `distinguished contributor`, `domain:security`, `risk:high`, `size:L`

### What this does, simply

ZeroClaw already lets an operator authorize directories outside an agent's workspace, but the macOS process sandbox ignored that list. An allowed shared cache or linked Git worktree could still fail with `Operation not permitted`.

This PR gives Seatbelt those same directory permissions. It resolves configured symlinks to their targets so read-only and write-only restrictions apply to the files a command actually reaches. Small metadata grants let commands traverse the aliases without granting their replacement file contents. Workspace and overlapping configured permissions retain their existing union semantics.

If a root cannot be resolved or the policy file cannot be created, commands stop with a preparation error. ZeroClaw does not silently run them without the selected sandbox. This is not a new startup check, and it does not change application-layer authorization or which sandbox is selected.

### Scope and maintenance tradeoff

The production change stays in the Seatbelt policy generator and sandbox factory. It reuses `SandboxExtraRoots` and the existing sandbox interface rather than adding configuration or another policy owner. Most of the diff is macOS-only coverage for permission tiers, aliases, failed initialization, escaping, and linked-worktree Git behavior.

Restrictions follow the profile's broad compatibility grants. Workspace and configured policy grants come last to preserve overlapping authorized rights. Ancestor access is metadata-only; alias metadata grants require a symlink rather than a regular file. The profile resolves roots when it is constructed, not dynamically on each filesystem operation. Existing baseline system and temporary-directory permissions remain; this PR does not turn Seatbelt into a complete replica of every application-policy rule.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; focused macOS tests exercise the installed `sandbox-exec` process boundary, with positive and negative filesystem controls.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI and the macOS compilation check passed at `fbfe2514a64cc37b649ac71eb79cf7ca5ade83ee`. This refresh integrates master `c10496d632a31d0bffa35bde9bb0569325875738` and adapts factory tests to its `RuntimeKind` and `SandboxConfig` contracts. Seatbelt implementation remains unchanged from the previously reviewed head. The advisory Windows nextest job failed; this macOS run does not establish its cause or disposition.
- **Known CI coverage gap, if any:** CI's macOS job compiles but does not run the sandbox-exec process tests. The September 18 local retry at the exact published head closes that selected gap: all 53 Seatbelt and factory tests passed.
- **Commands run and tail output:**

```bash
rustfmt --edition 2024 --check crates/zeroclaw-runtime/src/security/detect.rs crates/zeroclaw-runtime/src/security/seatbelt.rs
git diff --check
bash scripts/ci/comment_hygiene_gate.sh crates/zeroclaw-runtime/src/security/detect.rs crates/zeroclaw-runtime/src/security/seatbelt.rs
CARGO_INCREMENTAL=0 cargo test --locked -j 2 -p zeroclaw-runtime --lib -- security::seatbelt::tests security::detect::tests
```

```text
Formatting, diff integrity, and comment hygiene passed on the refresh.
September 18 retry at fbfe2514a64:
Finished test profile in 28m 08s.
53 passed; 0 failed; 0 ignored; 4404 filtered out; finished in 1.88s.
```

- **Beyond CI, what did you manually verify?** The automated macOS process tests verify all three root tiers through canonical paths and alias chains, restricted tiers beneath broad temporary-directory grants, denial of unlisted sibling contents, alias replacement/retargeting denial outside baseline grants, and `git status --short` in a linked worktree with an allowed main checkout. Factory tests verify repeated preparation failure, valid construction, intentional disablement, and native/Docker runtime selection. I did not run a separate interactive session smoke.
- **Warnings and interruptions:** The previous refreshed-basis attempt stopped during compilation after SIGKILL, with no tests executed and no confirmed cause. The September 18 two-job retry passed without source changes. The linker again warned that `__eh_frame` exceeded the compact-unwind encoding limit; linking and all selected tests succeeded.
- **Visual interface changed?** N/A; no rendered interface changed.
- **If any command was intentionally skipped, why:** Required CI supplies broad workspace evidence. No additional broad local suite was run.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes.** Seatbelt now grants the extra root permissions already authorized by configuration and the application policy, plus limited traversal metadata.
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **No.**
- If any `Yes`, describe the risk and mitigation: Incorrect path resolution or rule ordering could widen access or deny an intended workflow. Configured aliases are resolved before rule generation, interpolated paths are escaped, restricted tiers override baseline grants, and real sandboxed processes exercise both permission and denial controls. A selected Seatbelt initialization error is retained and blocks command preparation.

## Compatibility (required)

- Backward compatible? **No for failed Seatbelt initialization:** commands now fail instead of silently falling back to unsandboxed execution. Existing valid configuration and sandbox trait/factory signatures are unchanged.
- Config / env / CLI surface changed? **No.**
- Rust/MSRV/toolchain floor changed? **No.**
- If backward compatibility is `No` or either surface/floor question is `Yes`: Correct the root-resolution or policy-file error and recreate the session. No configuration migration is required. The failure appears during command preparation, not at startup.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR as a unit and redeploy the prior binary. Reverting only its original allowed-root commit would leave the dependent repair behind.
- **Feature flags or config toggles:** No new toggle. Correct failing configured roots and recreate the session while retaining sandboxing. Disabling the sandbox removes confinement and is not an equivalent workaround; no other backend is claimed to provide these same root tiers.
- **Observable failure symptoms:** `Seatbelt initialization failed:` during command preparation, unexpected `Operation not permitted` for a configured root, inaccessible linked-worktree Git metadata, or unexpected access to restricted/unlisted contents.
