### PR TITLE
fix(config): refuse unproven config saves over an existing operator file

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -1803,6 +1803,9 @@ async fn load_runtime_config_and_defaults(
     let mut parsed: Config = zeroclaw_config::migration::migrate_to_current(&contents)
         .with_context(|| format!("Failed to migrate {}", path.display()))?;
     parsed.config_path = path.to_path_buf();
+    // This value was parsed from the file at `path`; it holds save-over
+    // provenance for the guard in `Config::save`.
+    parsed.loaded_from = Some(path.to_path_buf());
 
     if let Some(zeroclaw_dir) = path.parent() {
         let store =

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -143,6 +143,18 @@ pub struct Config {
     /// CLI surfaces upgrade guidance without retaining the retired secret.
     #[serde(skip)]
     pub retired_node_transport_config: bool,
+    /// The config file this value was populated from — set by
+    /// `load_or_init` (both the existing-file read and the fresh-init
+    /// write) and by loaders that re-read a config file before mutating.
+    /// `Default`/programmatic construction leaves it `None`, and `save()`
+    /// then refuses to overwrite an existing file this value cannot prove
+    /// it read, so a near-empty snapshot cannot wipe an operator's config;
+    /// `force_save()` is the explicit intentional-overwrite path. Binding
+    /// provenance to the path (not a boolean) also refuses a value loaded
+    /// from file A that is later repointed at a different existing file B.
+    /// Never serialized — a load-time signal.
+    #[serde(skip)]
+    pub loaded_from: Option<PathBuf>,
     /// Config file schema version.
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
@@ -19163,6 +19175,7 @@ impl Default for Config {
             degraded_sections: Vec::new(),
             retired_wati_config_sections: Vec::new(),
             retired_node_transport_config: false,
+            loaded_from: None,
             schema_version: crate::migration::CURRENT_SCHEMA_VERSION,
             providers: crate::providers::Providers::default(),
             model_routes: Vec::new(),
@@ -20475,6 +20488,7 @@ impl Config {
             // Set computed paths that are skipped during serialization
             config.config_path = config_path.clone();
             config.data_dir = workspace_dir;
+            config.loaded_from = Some(config_path.clone());
 
             // Ensure each configured skill-bundle's resolved directory
             // exists on disk so the bundle has somewhere for skills to
@@ -20548,6 +20562,9 @@ impl Config {
             // freshly-created config file. Env overrides apply post-save to
             // populate the in-memory Config for the running process.
             config.save().await?;
+            // This value just wrote the file; mark provenance so later full
+            // saves of the same value stay legitimate.
+            config.loaded_from = Some(config_path.clone());
 
             // Restrict permissions on newly created config file (may contain API keys)
             #[cfg(unix)]
@@ -23267,7 +23284,25 @@ impl Config {
         Ok(resolved)
     }
 
+    /// Full save. Refuses to overwrite an existing config file unless this
+    /// value was loaded from that exact file (`loaded_from`), so a default,
+    /// programmatically built, or repointed `Config` cannot replace an
+    /// operator's config with a near-empty snapshot (#10495). Creating a
+    /// missing file (first run) always succeeds — a value that never read
+    /// a file gets exactly one create and must then reload or use
+    /// `force_save()`; `force_save()` is the explicit overwrite path.
     pub async fn save(&self) -> Result<()> {
+        self.save_impl(false).await.map(|_| ())
+    }
+
+    /// Same as `save()`, but skips the loaded-provenance guard. Only for
+    /// callers that verifiably intend to replace an existing file with a
+    /// `Config` that never read it.
+    pub async fn force_save(&self) -> Result<()> {
+        self.save_impl(true).await.map(|_| ())
+    }
+
+    async fn save_impl(&self, force: bool) -> Result<PathBuf> {
         // Encrypt secrets before serialization
         let mut config_to_save = self.clone();
         // Stamp the current schema version on every write. The in-memory
@@ -23276,6 +23311,35 @@ impl Config {
         // emit a body-newer-than-label file. See `save_dirty` and.
         config_to_save.schema_version = crate::migration::CURRENT_SCHEMA_VERSION;
         let config_path = self.resolve_config_path_for_save().await?;
+        // Fail closed: a metadata error must not read as "file absent" and
+        // slip an unproven save past the guard.
+        let target_exists = config_path.try_exists().with_context(|| {
+            format!(
+                "Cannot check config target {}; refusing to save",
+                config_path.display()
+            )
+        })?;
+        if !force && target_exists && self.loaded_from.as_ref() != Some(&config_path) {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                    .with_attrs(::serde_json::json!({
+                        "error_key": "config.save_refused_unproven_overwrite",
+                        "path": config_path.display().to_string(),
+                    })),
+                "refusing to overwrite an existing config this Config was never loaded from"
+            );
+            anyhow::bail!(
+                "Refusing to overwrite existing config at {}: this Config was \
+                 not loaded from that file (default-constructed, built \
+                 programmatically, or loaded from a different file), so saving \
+                 would replace the operator's file with a near-empty snapshot. \
+                 Load it first (e.g. `Config::load_or_init`) or call \
+                 `force_save()` to overwrite deliberately.",
+                config_path.display()
+            );
+        }
         let zeroclaw_dir = config_path
             .parent()
             .context("Config path must have a parent directory")?;
@@ -23341,7 +23405,11 @@ impl Config {
             new_toml
         };
 
-        write_config_atomically(&config_path, &toml_str).await
+        write_config_atomically(&config_path, &toml_str).await?;
+        // Report the path actually written so `save_dirty`'s create
+        // fallback can record provenance without re-resolving (the
+        // resolver re-reads the environment for parentless paths).
+        Ok(config_path)
     }
 
     /// Incremental save: only the paths in `self.dirty_paths` are written
@@ -23357,11 +23425,16 @@ impl Config {
 
         let config_path = self.resolve_config_path_for_save().await?;
         if !config_path.exists() {
-            let result = self.save().await;
-            if result.is_ok() {
-                self.clear_dirty();
-            }
-            return result;
+            return match self.save_impl(false).await {
+                Ok(written) => {
+                    // This value just created the file; `written` is the
+                    // path the full save actually wrote.
+                    self.loaded_from = Some(written);
+                    self.clear_dirty();
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
         }
 
         let mut config_to_save = self.clone();
@@ -28091,6 +28164,7 @@ auto_save = true
             degraded_sections: Vec::new(),
             retired_wati_config_sections: Vec::new(),
             retired_node_transport_config: false,
+            loaded_from: None,
             schema_version: crate::migration::CURRENT_SCHEMA_VERSION,
             providers: {
                 let mut p = crate::providers::Providers::default();
@@ -29163,6 +29237,7 @@ default_temperature = 0.7
             degraded_sections: Vec::new(),
             retired_wati_config_sections: Vec::new(),
             retired_node_transport_config: false,
+            loaded_from: None,
             schema_version: crate::migration::CURRENT_SCHEMA_VERSION,
             providers,
             model_routes: Vec::new(),
@@ -29677,6 +29752,10 @@ default_temperature = 0.7
         );
         config.save().await.unwrap();
         assert!(config_path.exists());
+        // This value just wrote the file; mirror load_or_init's fresh-init
+        // provenance so the second save exercises the atomic-write path,
+        // not the unproven-overwrite guard.
+        config.loaded_from = Some(config_path.clone());
 
         config
             .providers
@@ -33443,6 +33522,139 @@ group_policy = "disabled"
         );
     }
 
+    #[test]
+    async fn save_refuses_unproven_overwrite_of_existing_config() {
+        // #10495 regression bar: a Config that never read the target file
+        // must not be able to overwrite an operator's populated config, and
+        // the refusal must leave the existing bytes untouched.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        let operator_bytes = "# operator's hand-written config\n[observability]\nenabled = false\n";
+        tokio::fs::write(&config_path, operator_bytes)
+            .await
+            .unwrap();
+
+        let config = Config {
+            config_path: config_path.clone(),
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+
+        let err = config
+            .save()
+            .await
+            .expect_err("unproven overwrite must fail");
+        assert!(
+            err.to_string().contains("Refusing to overwrite"),
+            "error should name the refusal, got: {err:#}"
+        );
+        let after = tokio::fs::read_to_string(&config_path).await.unwrap();
+        assert_eq!(
+            after, operator_bytes,
+            "refused save must leave the existing file byte-identical"
+        );
+    }
+
+    #[test]
+    async fn force_save_overwrites_without_provenance() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        tokio::fs::write(&config_path, "old = true\n")
+            .await
+            .unwrap();
+
+        let config = Config {
+            config_path: config_path.clone(),
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        config.force_save().await.unwrap();
+        let after = tokio::fs::read_to_string(&config_path).await.unwrap();
+        assert!(
+            !after.contains("old = true"),
+            "force_save must actually replace the file content, got: {after}"
+        );
+        assert!(
+            after.contains("schema_version"),
+            "force_save must write a real config body, got: {after}"
+        );
+    }
+
+    #[test]
+    async fn save_refuses_when_provenance_points_at_a_different_file() {
+        // Path-bound provenance: a value loaded from file A that is later
+        // repointed at a different existing file B must not overwrite B.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path_a = tmp.path().join("a-config.toml");
+        let path_b = tmp.path().join("b-config.toml");
+        let b_bytes = "# operator's file B\n[observability]\nenabled = false\n";
+        tokio::fs::write(&path_a, "# source file A\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&path_b, b_bytes).await.unwrap();
+
+        let mut config = Config {
+            config_path: path_a.clone(),
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        config.loaded_from = Some(path_a.clone());
+        config.config_path = path_b.clone();
+
+        let err = config.save().await.expect_err("repointed save must fail");
+        assert!(
+            err.to_string().contains("Refusing to overwrite"),
+            "error should name the refusal, got: {err:#}"
+        );
+        let after = tokio::fs::read_to_string(&path_b).await.unwrap();
+        assert_eq!(after, b_bytes, "file B must stay byte-identical");
+    }
+
+    #[test]
+    async fn save_creates_missing_file_without_provenance() {
+        // First-run creation stays open: the guard only protects an
+        // existing file.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        let config = Config {
+            config_path: config_path.clone(),
+            data_dir: tmp.path().join("data"),
+            ..Default::default()
+        };
+        config.save().await.unwrap();
+        assert!(config_path.exists());
+    }
+
+    #[test]
+    async fn load_or_init_config_saves_over_existing_file() {
+        // load_or_init establishes provenance in both branches: a value
+        // that read the file (or just created it) keeps full-save rights.
+        let _env_guard = env_override_lock().await;
+        let temp_home =
+            std::env::temp_dir().join(format!("zeroclaw_test_home_{}", uuid::Uuid::new_v4()));
+        // ZEROCLAW_* vars outrank HOME in path resolution; remove them so an
+        // inherited developer environment cannot redirect this test at a
+        // real operator config. RAII guards restore on panic.
+        let _home = EnvValueGuard::set("HOME", &temp_home);
+        let _config_dir = EnvValueGuard::remove("ZEROCLAW_CONFIG_DIR");
+        let _data_dir = EnvValueGuard::remove("ZEROCLAW_DATA_DIR");
+        let _workspace = EnvValueGuard::remove("ZEROCLAW_WORKSPACE");
+
+        let fresh = Box::pin(Config::load_or_init()).await.unwrap();
+        fresh
+            .save()
+            .await
+            .expect("fresh-init value keeps save rights");
+        let loaded = Box::pin(Config::load_or_init()).await.unwrap();
+        loaded
+            .save()
+            .await
+            .expect("loaded config keeps save rights");
+
+        let _ = fs::remove_dir_all(temp_home).await;
+    }
+
     #[cfg(unix)]
     #[test]
     async fn save_restricts_existing_world_readable_config_to_owner_only() {
@@ -33454,6 +33666,10 @@ group_policy = "disabled"
             ..Default::default()
         };
         config.save().await.unwrap();
+        // This value just wrote the file; mirror load_or_init's fresh-init
+        // provenance so the second save below exercises the permission
+        // repair, not the unproven-overwrite guard.
+        config.loaded_from = Some(config_path.clone());
 
         // Simulate the regression state observed in issue.
         std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
@@ -37357,6 +37573,9 @@ stream_tool_arguments = [
         let mut reloaded: Config = crate::migration::migrate_to_current(&raw).unwrap();
         reloaded.config_path = config.config_path.clone();
         reloaded.data_dir = config.data_dir.clone();
+        // Parsed from the on-disk file, like load_or_init's existing-file
+        // branch; keep full-save provenance for the save below.
+        reloaded.loaded_from = Some(reloaded.config_path.clone());
         let store = crate::secrets::SecretStore::new(dir.path(), reloaded.secrets.encrypt);
         reloaded.decrypt_secrets(&store).unwrap();
         assert_eq!(

--- a/crates/zeroclaw-gateway/src/api_config.rs
+++ b/crates/zeroclaw-gateway/src/api_config.rs
@@ -2400,7 +2400,7 @@ pub async fn handle_migrate(State(state): State<AppState>, headers: HeaderMap) -
             }
 
             // Re-read into memory so subsequent requests see the migrated state.
-            let new_cfg: zeroclaw_config::schema::Config = match toml::from_str(&new_content) {
+            let mut new_cfg: zeroclaw_config::schema::Config = match toml::from_str(&new_content) {
                 Ok(c) => c,
                 Err(e) => {
                     return error_response(ConfigApiError::new(
@@ -2409,6 +2409,11 @@ pub async fn handle_migrate(State(state): State<AppState>, headers: HeaderMap) -
                     ));
                 }
             };
+            // serde skips the path fields, so restore the concrete path and
+            // record save provenance: this handler just wrote `config_path`,
+            // and the shared value's later full saves must keep save rights.
+            new_cfg.config_path = config_path.clone();
+            new_cfg.loaded_from = Some(config_path.clone());
             *state.config.write() = new_cfg;
 
             axum::Json(MigrateResponse {

--- a/crates/zeroclaw-tools/src/model_routing_config.rs
+++ b/crates/zeroclaw-tools/src/model_routing_config.rs
@@ -59,6 +59,9 @@ impl ModelRoutingConfigTool {
             })?;
         parsed.config_path = self.config.config_path.clone();
         parsed.data_dir = self.config.data_dir.clone();
+        // This value was parsed from the file at `config_path`; it holds
+        // save-over provenance for the guard in `Config::save`.
+        parsed.loaded_from = Some(parsed.config_path.clone());
         Ok(parsed)
     }
 

--- a/crates/zeroclaw-tools/src/proxy_config.rs
+++ b/crates/zeroclaw-tools/src/proxy_config.rs
@@ -55,6 +55,9 @@ impl ProxyConfigTool {
         })?;
         parsed.config_path = self.config.config_path.clone();
         parsed.data_dir = self.config.data_dir.clone();
+        // This value was parsed from the file at `config_path`; it holds
+        // save-over provenance for the guard in `Config::save`.
+        parsed.loaded_from = Some(parsed.config_path.clone());
         Ok(parsed)
     }
 

--- a/docs/book/src/architecture/config-lifecycle.md
+++ b/docs/book/src/architecture/config-lifecycle.md
@@ -95,6 +95,21 @@ When reviewing a config write, check that:
 - `schema_version` remains current after incremental writes;
 - the changed value survives `save_dirty()` followed by reload.
 
+## Full saves need load provenance
+
+`Config::save()` refuses to overwrite an existing `config.toml` unless the
+in-memory value was populated from that exact file (`loaded_from`, set by
+`load_or_init` in both its existing-file and fresh-init branches, and by the
+loaders that re-read a config file before mutating it). A
+default-constructed, programmatically built, or repointed `Config` therefore
+cannot replace an operator's populated config with a near-empty snapshot.
+Creating a missing file (first run) still succeeds: a value that never read
+a file gets exactly one create and must then reload or force, and
+`force_save()` is the explicit path for a verified intentional overwrite.
+When reviewing a code path that builds a fresh `Config` and expects to write
+it over an existing file, either load first or justify the `force_save()`
+call.
+
 ## Saved vs applied
 
 A successful save means the file changed. It does not always mean every runtime

--- a/tests/architecture/config_save_isolation.rs
+++ b/tests/architecture/config_save_isolation.rs
@@ -12,6 +12,8 @@ const PERSIST_CALLS: &[&str] = &[
     ".save().await",
     ".save_dirty()",
     ".save_dirty().await",
+    ".force_save()",
+    ".force_save().await",
     "set_prop_persistent",
     "set_secret_persistent",
 ];


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `Config::save()` now refuses to overwrite an existing `config.toml` unless the in-memory value carries path-bound load provenance — closing the P0 data-loss path where a default or programmatically built (near-empty) `Config` replaced an operator's populated config.
  - Provenance is a new `#[serde(skip)] loaded_from: Option<PathBuf>` field, set by every constructor that reads or creates the target file: `load_or_init`'s existing-file branch and post-fresh-init write, `save_dirty`'s create-fallback (recording the path the fallback actually wrote), the zeroclaw-tools re-reading loaders (`proxy_config`, `model_routing_config`), the channels orchestrator runtime reload, and the gateway migrate handler (which now also restores `config_path` after serde skips it — previously left empty).
  - `Config::force_save()` is the explicit intentional-overwrite path. First-run creation (target absent) always succeeds. The existence check fails closed (`try_exists` with error propagation), so a metadata error cannot read as "file absent" and slip a save past the guard.
- **Scope boundary:** does not change `save_dirty`'s dirty-path patching on existing files, path resolution itself (that is #10521), the parentless-path fallback branch (that is #10498), or any on-disk serialization format.
- **Blast radius:** every `Config::save()` caller. All 26 production call sites were audited (gateway `persist_and_swap` / channel bind, channels identity persistence, runtime RPC flush/swap, quickstart, doctor, tools handlers) and all carry provenance after this PR; `save_dirty`-only flows are unaffected. External code constructing `Config` exhaustively must add the new field.
- **Linked issue(s):** Closes #10495. Related #10498 (narrow parentless-path guard), #10521 (env-aware `Config::default()` path), #9284 (channel-side stale-snapshot overwrite).
- **Labels:** bug, config, priority:p0, risk:high, status:accepted (carried from the issue; maintainers adjust).

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (config save paths behind `zeroclaw config` flows and the tools).
- **Setup / preconditions:** none beyond a Rust toolchain.
- **Steps to run:** `cargo test -p zeroclaw-config save_` (filters to the save-related suite).
- **Expected on this branch (after):** `save_refuses_unproven_overwrite_of_existing_config` and `save_refuses_when_provenance_points_at_a_different_file` pass — an unloaded or repointed `Config` gets `Refusing to overwrite existing config ...` and the target file's bytes are unchanged.
- **Prior behavior on `master` (before):** the same call succeeds and the populated file is replaced by the pruned near-empty snapshot (the data loss).

### How I tested

- **CI checks relied on and why they cover this change:** workspace fmt / clippy (`--all-targets -D warnings`) / test gates on the pinned toolchain cover the touched crates and the architecture scanner.
- **Known CI coverage gap, if any:** none for the changed surface; two local-toolchain notes below are environment artifacts, not coverage gaps.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check                       # clean
cargo clippy -p zeroclaw-config -p zeroclaw-tools --all-targets -- -D warnings
#     Finished `dev` profile ... (default toolchain)
cargo test -p zeroclaw-config -p zeroclaw-tools
#     test result: ok. 1288 passed; 0 failed   (zeroclaw-config)
#     test result: ok. 1720 passed; 0 failed   (zeroclaw-tools)
cargo +1.98.0-aarch64-apple-darwin check -p zeroclaw-gateway -p zeroclaw-channels -p zeroclaw-runtime --all-targets
#     Finished `dev` profile ...
cargo +1.98.0-aarch64-apple-darwin test -p zeroclaw-gateway -p zeroclaw-channels
#     test result: ok. 372 passed; 0 failed    (gateway, incl. migrate handler)
#     test result: ok. 973 passed; 0 failed    (channels)
cargo +1.98.0-aarch64-apple-darwin test --test architecture
#     test result: ok. 10 passed; 0 failed     (config-save isolation scanner)
bash scripts/ci/docs_quality_gate.sh            # 0 error(s)
bash scripts/ci/docs_links_gate.sh              # no added links
```

- **Beyond CI, what did you manually verify?** Three read-only adversarial review rounds on a different vendor (codex) against the frozen candidate commits, with per-finding adjudication. Round 1 drove the bool→path-bound provenance redesign (load-A/repoint-B overwrite), round 2 surfaced and fixed the gateway migrate handler's provenance loss plus the isolation-scanner gap, round 3 confirmed all repairs after the `save_impl` written-path return was introduced (its item 4 was closed by returning the actually-written path instead of a third resolution). Not verified locally: full-workspace `--all-targets` on the default toolchain (blocked by the pre-existing MSRV floor — `zeroclaw-coordinator`/`zeroclawlabs` require rustc 1.96.1 while the local default is 1.94.1; used 1.98.0 for the downstream suites) and channels/gateway clippy under 1.98 (blocked by a pre-existing new-toolchain lint inside `zeroclaw-memory`, unrelated to this diff; CI's pinned clippy covers both).
- **If any command was intentionally skipped, why:** see the two toolchain notes above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No** (the guard runs before any encryption or write path)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **No, by design:** a flow that saves a `Config` over an existing file it never read now errors instead of overwriting — that is the fix. Every in-repo production flow was audited and carries provenance; external callers with an intentional overwrite must switch to `force_save()`.
- Config / env / CLI surface changed? No new config keys; public API adds `Config::force_save()` and the `loaded_from` field. `zeroclaw-config` is Beta (breaking changes allowed in MINOR with changelog notes); exhaustive `Config { .. }` literals must add the field.
- Rust/MSRV/toolchain floor changed? **No.**
- Upgrade steps: callers doing deliberate default-over-existing saves (none in-tree) use `force_save()`; everyone else is unaffected.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge sha>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** WARN log with `error_key: config.save_refused_unproven_overwrite`; a wrongly-refused legitimate save would surface as `Refusing to overwrite existing config` from gateway bind/persist or tool save paths. If that appears, the caller is building a Config without loading it — load first or `force_save()`.

## Known residuals (adjudicated during review; follow-up material, not blockers)

- **Create race (TOCTOU):** the guard checks then writes non-exclusively, so two racing first-run writers can still interleave. The window is narrowed from "always overwrites" to a create race; a full fix needs cross-platform exclusive-create semantics.
- **Directory-symlink swap** between load and save passes textual path equality for a redirected target.
- **Textual path comparison (no canonicalization)** is deliberate — canonicalization would introduce false refusals (e.g. macOS `/tmp` symlink drift).
- **In-process field forging** is equivalent to calling the public `force_save()`; not a security boundary.
