### PR TITLE
docs(adr): define how holding-crate exceptions are granted

### DIFF
--- a/crates/zeroclaw-runtime/AGENTS.md
+++ b/crates/zeroclaw-runtime/AGENTS.md
@@ -2,6 +2,22 @@
 
 This crate is a **temporary holding area**, not a permanent home. It contains 126K LOC of subsystems extracted from the original monolith that have not yet been decomposed into their final crate structure.
 
-Do not add new functionality here. The RFC's Phase 2-4 roadmap defines the decomposition plan: agent loop, gateway, channels orchestrator, daemon, cron, security, observability, hardware, TUI, skills, and doctor will each be extracted into dedicated crates or converted to WASM plugins.
+Do not add new functionality here, unless the Core Team has granted a recorded exception (see below). The RFC's Phase 2-4 roadmap defines the decomposition plan: agent loop, gateway, channels orchestrator, daemon, cron, security, observability, hardware, TUI, skills, and doctor will each be extracted into dedicated crates or converted to WASM plugins.
+
+## Exceptions
+
+Extraction is the default. The Core Team may grant a bounded exception when immediate extraction would require a disproportionate refactor, or would establish a crate boundary the roadmap does not intend. See [ADR-016](../../docs/book/src/architecture/decisions/ADR-016-holding-crate-exceptions.md).
+
+An exception must name its permitted scope, intended destination, approving authority, and expiry or review condition, and must be recorded before the feature it covers merges. A feature pull request cannot grant itself one: the contract it would be waiving is the one constraining it.
+
+An exception requires a concrete supported use case. Code with no receiving caller does not qualify; retirement or an explicit ownership decision is the right answer there.
+
+An exception permits continued work on a subsystem already held here. It never permits introducing a new subsystem, and it does not generalise from one subsystem to another.
+
+### Active exceptions
+
+| Scope | Destination | Approved by | Expires |
+| --- | --- | --- | --- |
+| _(none)_ | | | |
 
 **Stability tier:** Experimental — no stability guarantee. Decomposition begins at v0.8.0.

--- a/crates/zeroclaw-runtime/AGENTS.md
+++ b/crates/zeroclaw-runtime/AGENTS.md
@@ -8,7 +8,9 @@ Do not add new functionality here, unless the Core Team has granted a recorded e
 
 Extraction is the default. The Core Team may grant a bounded exception when immediate extraction would require a disproportionate refactor, or would establish a crate boundary the roadmap does not intend. See [ADR-016](../../docs/book/src/architecture/decisions/ADR-016-holding-crate-exceptions.md).
 
-An exception must name its permitted scope, intended destination, approving authority, and expiry or review condition, and must be recorded before the feature it covers merges. A feature pull request cannot grant itself one: the contract it would be waiving is the one constraining it.
+An exception must name its permitted scope, intended destination, approving authority, and either an expiry or a review condition, and must be recorded before the feature it covers merges. An expiry ends the permission, so further additions need Core Team renewal; it does not require removing code that already landed. A review condition only obliges reconsideration.
+
+An exception is granted by adding its row to the table below through normal review, approved by the Core Team. The row is the record: a decision that lives only in a review thread has not been made. A feature pull request cannot grant itself one: the contract it would be waiving is the one constraining it.
 
 An exception requires a concrete supported use case. Code with no receiving caller does not qualify; retirement or an explicit ownership decision is the right answer there.
 
@@ -16,7 +18,7 @@ An exception permits continued work on a subsystem already held here. It never p
 
 ### Active exceptions
 
-| Scope | Destination | Approved by | Expires |
+| Scope | Destination | Approved by | Expires or reviewed |
 | --- | --- | --- | --- |
 | _(none)_ | | | |
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -53,6 +53,7 @@
     - [ADR-012: Generation-scoped live config apply](./architecture/decisions/ADR-012-generation-scoped-live-config-apply.md)
     - [ADR-013: Key-source authority](./architecture/decisions/ADR-013-key-source-authority.md)
     - [ADR-015: Unified capability catalog](./architecture/decisions/ADR-015-unified-capability-catalog.md)
+    - [ADR-016: Holding-crate exceptions](./architecture/decisions/ADR-016-holding-crate-exceptions.md)
   - [Logging](./architecture/logging.md)
   - [Runtime state and persistence](./architecture/runtime-state-and-persistence.md)
   - [Memory and payload lifecycle](./architecture/memory-payload-lifecycle.md)

--- a/docs/book/src/architecture/decisions/ADR-016-holding-crate-exceptions.md
+++ b/docs/book/src/architecture/decisions/ADR-016-holding-crate-exceptions.md
@@ -1,0 +1,71 @@
+---
+id: ADR-016
+title: Holding-crate exceptions are bounded, recorded, and granted by the Core Team
+date: 2026-09-02
+status: proposed
+relates-to:
+  - ADR-007
+  - crates/zeroclaw-runtime/AGENTS.md
+  - docs/book/src/foundations/fnd-001-intentional-architecture.md
+  - https://github.com/zeroclaw-labs/zeroclaw/pull/10557
+  - https://github.com/zeroclaw-labs/zeroclaw/pull/10410
+  - https://github.com/zeroclaw-labs/zeroclaw/pull/10179
+---
+
+# ADR-016: Holding-Crate Exceptions Are Bounded, Recorded, and Granted by the Core Team
+
+## Context
+
+`crates/zeroclaw-runtime/AGENTS.md` declares that crate a transitional holding area, instructs contributors not to add new functionality there, and names the subsystems awaiting extraction. The instruction is unconditional and has no exception process.
+
+That combination has no answer for the ordinary case: accepted work lands on a subsystem that still lives in the holding crate, and the crate it is supposed to move to has not been built. The contract forbids the only available home, and the destination does not exist yet. Three pull requests reached that state and resolved it three different ways.
+
+The cron precondition gate went through [#10220](https://github.com/zeroclaw-labs/zeroclaw/pull/10220), then a proposed one-off exception, and finally the full extraction in [#10557](https://github.com/zeroclaw-labs/zeroclaw/pull/10557). The extraction was the right outcome, but it was reached by building two complete alternatives and discarding one. A contributor should be able to establish whether extraction is required before implementing it twice.
+
+[#10410](https://github.com/zeroclaw-labs/zeroclaw/pull/10410) kept shared config and agent-lifecycle coordination in the runtime rather than invent a lifecycle crate ahead of the planned daemon extraction. Moving that code to `zeroclaw-infra` would invert an existing dependency, since config already depends on infra. Extracting early would therefore establish a boundary the roadmap does not want. That decision is still waiting on repository-level acceptance.
+
+[#10179](https://github.com/zeroclaw-labs/zeroclaw/pull/10179) hit the same rule, but its transport had no receiving caller. Retirement, or an explicit ownership decision, was the better answer there than any exception.
+
+Those three cases differ in kind, not just in size. Extraction was proportionate for one, would have produced the wrong boundary for another, and was beside the point for the third. A single unconditional instruction cannot separate them, and silence about exceptions has meant each contributor guesses.
+
+The alternatives are to keep the instruction unconditional and require extraction in every case, to relax it generally, or to keep extraction as the default and define how a bounded exception is granted.
+
+## Decision
+
+Extraction remains the default. The Core Team may approve a bounded exception when immediate extraction would require a disproportionate refactor, or would establish a crate boundary the roadmap does not intend.
+
+### What an exception must state
+
+An approved exception names all four of:
+
+- **Permitted scope.** The specific paths the exception covers. Not a subsystem in the abstract.
+- **Intended destination.** The crate the code is expected to move to, so the exception describes a delay rather than a reversal.
+- **Approving authority.** Who granted it.
+- **Expiry or review condition.** What ends it: a named extraction landing, a release, or a review date.
+
+### How it is granted
+
+The record is created before the feature merges, and separately from it. A feature pull request cannot grant itself an exception, because the contract it would be waiving is the one constraining it.
+
+An exception requires a concrete supported use case. Code with no receiving caller does not qualify; retirement or an explicit ownership decision is the correct answer there.
+
+### What an exception is not
+
+An exception permits continued work on a subsystem the holding crate already contains. It never permits introducing a new subsystem there, and it does not generalise from one subsystem to another. Granting one for cron says nothing about the daemon.
+
+## Consequences
+
+Contributors get a decision path that can be resolved before implementation rather than after. The cron case cost two complete implementations to answer a question that a short record could have settled first.
+
+Every exception is visible and dated. The active-exception table in the holding-crate contract makes the accumulated debt legible, and each entry names what ends it, so an exception that has quietly become permanent is apparent rather than buried.
+
+The Core Team takes on judging proportionality case by case. That is deliberate: the three cases above show the judgment cannot be reduced to a size threshold, because "disproportionate refactor" and "wrong boundary" are different reasons that happen to share a symptom.
+
+The holding-crate instruction keeps its force. This does not weaken it; it supplies the process the instruction assumed but never defined.
+
+## Acceptance
+
+ADR-016 remains proposed until:
+
+- `crates/zeroclaw-runtime/AGENTS.md` states the exception rule and carries an active-exception table;
+- at least one exception has been granted or refused through this process, demonstrating it is usable rather than only written down.

--- a/docs/book/src/architecture/decisions/ADR-016-holding-crate-exceptions.md
+++ b/docs/book/src/architecture/decisions/ADR-016-holding-crate-exceptions.md
@@ -22,7 +22,7 @@ That combination has no answer for the ordinary case: accepted work lands on a s
 
 The cron precondition gate went through [#10220](https://github.com/zeroclaw-labs/zeroclaw/pull/10220), then a proposed one-off exception, and finally the full extraction in [#10557](https://github.com/zeroclaw-labs/zeroclaw/pull/10557). The extraction was the right outcome, but it was reached by building two complete alternatives and discarding one. A contributor should be able to establish whether extraction is required before implementing it twice.
 
-[#10410](https://github.com/zeroclaw-labs/zeroclaw/pull/10410) kept shared config and agent-lifecycle coordination in the runtime rather than invent a lifecycle crate ahead of the planned daemon extraction. Moving that code to `zeroclaw-infra` would invert an existing dependency, since config already depends on infra. Extracting early would therefore establish a boundary the roadmap does not want. That decision is still waiting on repository-level acceptance.
+[#10410](https://github.com/zeroclaw-labs/zeroclaw/pull/10410) kept shared config and agent-lifecycle coordination in the runtime rather than invent a lifecycle crate ahead of the planned daemon extraction. The rationale offered for that placement is that moving the code to `zeroclaw-infra` would invert an existing dependency, since config already depends on infra, and that extracting early would establish a boundary the roadmap does not intend. That is the argument for an exception there, not a settled conclusion: the placement has not been accepted, and #10410 needs its own explicit disposition under whatever process this record establishes.
 
 [#10179](https://github.com/zeroclaw-labs/zeroclaw/pull/10179) hit the same rule, but its transport had no receiving caller. Retirement, or an explicit ownership decision, was the better answer there than any exception.
 
@@ -41,7 +41,15 @@ An approved exception names all four of:
 - **Permitted scope.** The specific paths the exception covers. Not a subsystem in the abstract.
 - **Intended destination.** The crate the code is expected to move to, so the exception describes a delay rather than a reversal.
 - **Approving authority.** Who granted it.
-- **Expiry or review condition.** What ends it: a named extraction landing, a release, or a review date.
+- **Expiry or review condition.** What ends it, or when it is reconsidered. The record must say which of the two it is, because they behave differently (see below).
+
+### What expiry means
+
+An exception either **expires** or comes up for **review**, and the record says which.
+
+An expiry ends the permission. Further additions to the covered scope then need Core Team renewal. It does not require removing code that already landed under the exception: the permission lapses forward, not backward, and unwinding what was already accepted is the extraction's job rather than a consequence of a date passing.
+
+A review condition does not end anything by itself. It obliges the Core Team to reconsider, and the outcome of that reconsideration is renewal, expiry, or extraction.
 
 ### How it is granted
 
@@ -49,9 +57,21 @@ The record is created before the feature merges, and separately from it. A featu
 
 An exception requires a concrete supported use case. Code with no receiving caller does not qualify; retirement or an explicit ownership decision is the correct answer there.
 
+### How an individual exception is recorded
+
+An exception is granted the same way any other repository decision is: through review on a pull request that adds the entry to the active-exception table in the owning crate's `AGENTS.md`, approved by the Core Team. No separate mechanism, and no approval outside the normal review rules.
+
+The entry is the record. A decision that exists only in a review thread has not been made, because nothing later reading the contract would find it.
+
 ### What an exception is not
 
 An exception permits continued work on a subsystem the holding crate already contains. It never permits introducing a new subsystem there, and it does not generalise from one subsystem to another. Granting one for cron says nothing about the daemon.
+
+## Adoption
+
+This record turns an unconditional prohibition into a permission under stated conditions, which makes it a governance and contribution-process change rather than an ordinary documentation edit. [FND-003 §8](../../foundations/fnd-003-governance.md) governs that route.
+
+Adopting it is therefore the Core Team's decision to take and record explicitly, including which route under FND-003 §8 applies. This pull request is the concrete proposal, not the adoption. Until that decision is recorded, the unconditional instruction stands and no exception has been granted.
 
 ## Consequences
 

--- a/docs/book/src/architecture/decisions/index.md
+++ b/docs/book/src/architecture/decisions/index.md
@@ -30,6 +30,7 @@ Accepted ADRs are immutable. If the architecture changes, write a new ADR and ma
 | [ADR-012](./ADR-012-generation-scoped-live-config-apply.md) | proposed | Live config application uses canonical generations and target-specific results. |
 | [ADR-013](./ADR-013-key-source-authority.md) | proposed | Master key acquisition uses one configured key-source authority. |
 | [ADR-015](./ADR-015-unified-capability-catalog.md) | proposed | The unified capability catalog is a read-only projection over package, capability, implementation, configuration, and runtime owners. |
+| [ADR-016](./ADR-016-holding-crate-exceptions.md) | proposed | Extraction is the default for holding-crate subsystems; bounded exceptions are recorded, scoped, and granted by the Core Team. |
 
 ADR-006 and ADR-007 are implementation-gated roadmap decisions from [FND-002](../../foundations/fnd-002-documentation-standards.md). Their target directions are recorded, but they remain proposed until the acceptance boundaries in each record ship.
 
@@ -40,3 +41,5 @@ ADR-012 remains proposed until canonical config publication, generation-scoped r
 ADR-013 remains proposed until the canonical key-source boundary, safe file compatibility, configured fail-closed selection, and a supported non-file source meet the acceptance gates in the record.
 
 ADR-015 remains proposed until unified catalog projections preserve source-of-truth evidence, artifact provenance, compatibility bridges, and the rule that visibility cannot grant invocation authority.
+
+ADR-016 remains proposed until the holding-crate contract states the exception rule and carries an active-exception table, and at least one exception has been granted or refused through the process.


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `crates/zeroclaw-runtime/AGENTS.md` forbids adding functionality to the holding crate and names the subsystems awaiting extraction, but defines no exception process. That leaves the ordinary case unanswered: accepted work lands on a subsystem still held there while its destination crate does not exist, so the contract forbids the only available home.
  - Three PRs reached that state and resolved it three different ways. The cron gate built two complete alternatives before extraction won (#10220, then a proposed one-off exception, then #10557). #10410 kept config and agent-lifecycle coordination in the runtime because moving it to `zeroclaw-infra` would invert an existing dependency and establish a boundary the roadmap does not want. #10179 hit the rule with no receiving caller, where retirement was a better answer than any exception.
  - Those cases differ in kind rather than in size, which is why an unconditional instruction cannot separate them and why a size threshold would not either. ADR-016 keeps extraction as the default and defines how a bounded exception is granted.
  - The contract now states the rule and carries an active-exception table.
- **Scope boundary:** This defines the mechanism and grants nothing. The active-exception table ships empty on purpose: approving any specific exception, including #10410's, is the Core Team's act and should not ride along with the process that authorizes it. No code changes, no crate moves.
- **Blast radius:** Contributor-facing process and one scoped `AGENTS.md`. The risk is misreading rather than breakage: a relaxation like this is easy to cite later as general permission, so the limits are stated inline in the contract rather than only in the ADR.
- **Linked issue(s):** Related #10557, #10410, #10179. Written at @Audacity88's suggestion on #10545, which is closed; this carries the general mechanism forward as a separate policy change rather than reviving a cron-specific record.
- **Labels:** `type:docs`, `domain:architecture`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. Documentation and a scoped contract file; there is no runtime behaviour to exercise.

### How I tested

- **CI checks relied on and why they cover this change:** `Docs Style` covers the changed Markdown; the links gate covers the new cross-reference from the contract into the ADR and from the decisions index and `SUMMARY.md` into the new record. There is no code change for the Rust gates to cover.
- **Known CI coverage gap, if any:** None. Optional HTTP(S) link validation was skipped locally because `lychee` is not installed; the added links are local-file links and were checked.
- **Commands run and tail output:**

  ```
  $ bash scripts/ci/docs_quality_gate.sh
  Linting: 5 file(s)
  Summary: 0 error(s)

  $ bash scripts/ci/docs_links_gate.sh
  Collected 1 added link(s) from 6 docs file(s).
  Added HTTP(S) links detected, but lychee is not installed; skipping optional HTTP(S) validation.
  ```

- **Beyond CI, what did you manually verify?** That `ADR-016` is free: the earlier cron-scoped record using that number was closed unmerged and never landed, and the number appears nowhere in `docs/`. That the record is registered in both the decisions index with an acceptance note, matching how ADR-010, ADR-012, ADR-013 and ADR-015 record theirs, and in the mdBook `SUMMARY.md` nav. What I did NOT verify: whether the Core Team wants this mechanism at all, or wants to author it themselves, which is why it is `proposed`.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A. The governance risk is worth naming instead: this relaxes a previously unconditional instruction, and relaxations get over-read. Mitigations are that the exception is bounded by construction (it must name an expiry), that it cannot be self-granted, that it never covers a new subsystem, and that the active-exception table makes accumulated debt visible and dated rather than buried.

## Compatibility (required)

- Backward compatible? **Yes.** Documentation and contributor-facing contract text only.
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>` restores the unconditional instruction. Reverting returns the repository to the state where the ordinary case has no answer, which is what prompted this.

---

**Note on status and authorship.** ADR-016 is `proposed`. Drafting a record is something a contributor can do; adopting repository policy is the Core Team's. Approving this PR is what adopts it. @Audacity88 — you described this mechanism on #10545 and this is an attempt to write it down faithfully, including your point that an exception requires a concrete supported use case and that the three cases differ in kind rather than size. If you would rather own the text yourself, say so and I will close this; the draft is useful either way.
