### PR TITLE
fix(providers): evict images per image, not per message

### DIFF
--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -962,26 +962,57 @@ fn trim_old_images(messages: &[ChatMessage], max_images: usize) -> Vec<ChatMessa
                 return replay_message_without_stale_tool_images(i, m, &latest_tool_indices);
             };
 
-            let (cleaned, refs) = parse_image_markers(&m.content);
-            // Newest images within the message survive, matching the
-            // oldest-first eviction order across messages.
-            let retained = refs.get(drop_here..).unwrap_or(&[]);
-            let content = if retained.is_empty() {
-                if cleaned.trim().is_empty() {
-                    "[image removed from history]".to_string()
-                } else {
-                    cleaned
-                }
-            } else {
-                compose_multimodal_message(&cleaned, retained)
-            };
-
-            ChatMessage {
-                role: m.role.clone(),
-                content,
-            }
+            trim_message_images(m, drop_here)
         })
         .collect()
+}
+
+/// Drop the `drop_here` oldest image markers from `text`, keeping the newest.
+fn trim_image_markers(text: &str, drop_here: usize) -> String {
+    let (cleaned, refs) = parse_image_markers(text);
+    // Newest images within the message survive, matching the oldest-first
+    // eviction order across messages.
+    let retained = refs.get(drop_here..).unwrap_or(&[]);
+    if retained.is_empty() {
+        if cleaned.trim().is_empty() {
+            "[image removed from history]".to_string()
+        } else {
+            cleaned
+        }
+    } else {
+        compose_multimodal_message(&cleaned, retained)
+    }
+}
+
+/// Apply [`trim_image_markers`] to a message, keeping a native tool-result JSON
+/// envelope intact.
+///
+/// A `role = "tool"` message may carry a serialized `{"tool_call_id": ..,
+/// "content": ..}` object. Trimming the serialized form would strip markers out
+/// of the JSON *and* append the retained ones after the closing brace, leaving
+/// text that no longer parses — the provider serializers then lose
+/// `tool_call_id` and cannot emit a native tool result. Unwrap first, trim the
+/// inner `content`, and re-serialize with the rest of the envelope untouched,
+/// mirroring [`strip_tool_result_image_markers`] and
+/// [`normalize_native_tool_result_json`].
+fn trim_message_images(message: &ChatMessage, drop_here: usize) -> ChatMessage {
+    if message.role == "tool"
+        && let Ok(serde_json::Value::Object(mut obj)) =
+            serde_json::from_str::<serde_json::Value>(&message.content)
+        && let Some(serde_json::Value::String(inner)) = obj.get("content").cloned()
+    {
+        let trimmed = trim_image_markers(&inner, drop_here);
+        obj.insert("content".to_string(), serde_json::Value::String(trimmed));
+        return ChatMessage {
+            role: message.role.clone(),
+            content: serde_json::Value::Object(obj).to_string(),
+        };
+    }
+
+    ChatMessage {
+        role: message.role.clone(),
+        content: trim_image_markers(&message.content, drop_here),
+    }
 }
 
 fn compose_multimodal_message(text: &str, data_uris: &[String]) -> String {
@@ -1967,6 +1998,75 @@ mod tests {
         assert!(cleaned.contains("Generated image"));
         assert_eq!(refs.len(), 1);
         assert!(refs[0].starts_with("data:image/png;base64,"));
+    }
+
+    #[tokio::test]
+    async fn prepare_messages_keeps_native_tool_result_json_valid_when_over_the_image_cap() {
+        // Regression: partial trimming used to parse markers out of the whole
+        // serialized envelope and append the retained ones after the closing
+        // brace, so the tool result stopped being JSON and the provider
+        // serializers lost `tool_call_id`. Five images against the default cap
+        // of four is enough to force a partial trim.
+        let temp = tempfile::tempdir().unwrap();
+        let mut markers = Vec::new();
+        for index in 0..5 {
+            let image_path = temp.path().join(format!("shot-{index}.png"));
+            std::fs::write(
+                &image_path,
+                [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'],
+            )
+            .unwrap();
+            markers.push(format!("[IMAGE:{}]", image_path.display()));
+        }
+
+        let native_tool_content = serde_json::json!({
+            "tool_call_id": "tc-overflow",
+            "tool_name": "screenshot",
+            "content": format!("captured five {}", markers.join(" ")),
+        })
+        .to_string();
+
+        let config = MultimodalConfig::default();
+        let prepared =
+            prepare_messages_for_provider(&[ChatMessage::tool(native_tool_content)], &config)
+                .await
+                .expect("preparation should succeed for an over-cap native tool result");
+
+        assert_eq!(prepared.messages[0].role, "tool");
+        let value: serde_json::Value = serde_json::from_str(&prepared.messages[0].content)
+            .expect("an over-cap tool result must still be valid JSON");
+
+        assert_eq!(
+            value.get("tool_call_id").and_then(|v| v.as_str()),
+            Some("tc-overflow"),
+            "tool_call_id must survive trimming so the provider can emit a native tool result"
+        );
+        assert_eq!(
+            value.get("tool_name").and_then(|v| v.as_str()),
+            Some("screenshot"),
+            "other envelope metadata must survive trimming"
+        );
+
+        let inner = value
+            .get("content")
+            .and_then(|v| v.as_str())
+            .expect("content must remain a JSON string");
+        assert!(
+            inner.contains("captured five"),
+            "surrounding text must survive trimming"
+        );
+
+        let (_, refs) = parse_image_markers(inner);
+        assert_eq!(
+            refs.len(),
+            config.max_images,
+            "exactly the budgeted images are retained, and they live inside `content`"
+        );
+        assert!(
+            refs.iter()
+                .all(|reference| reference.starts_with("data:image/png;base64,")),
+            "retained images stay normalized data URIs"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -914,8 +914,12 @@ fn trim_images_by_age(messages: &[ChatMessage], max_turns: usize) -> Vec<ChatMes
         .collect()
 }
 
-/// Strip image markers from older messages (oldest first) until total image
+/// Strip image markers from older messages (oldest first) until the total image
 /// count is within `max_images`. Keeps the text content of each message.
+///
+/// Eviction is per image, not per message: exactly `total - max_images` images
+/// are dropped, so a message holding more images than the budget allows keeps
+/// its newest ones instead of losing all of them.
 fn trim_old_images(messages: &[ChatMessage], max_images: usize) -> Vec<ChatMessage> {
     let latest_tool_indices = latest_tool_result_indices(messages);
     // Find which messages (by index) contain images, oldest first.
@@ -935,33 +939,46 @@ fn trim_old_images(messages: &[ChatMessage], max_images: usize) -> Vec<ChatMessa
     let total: usize = image_positions.iter().map(|(_, c)| c).sum();
     let mut to_drop = total.saturating_sub(max_images);
 
-    // Collect indices of messages whose images should be stripped.
-    let mut strip_indices = std::collections::HashSet::new();
+    // Record how many images to drop per message, oldest first. A message is
+    // only partially trimmed when it holds more images than remain to drop:
+    // marking the whole message would evict images the budget still allows and
+    // leave the request under `max_images` (a single message holding more than
+    // `max_images` would otherwise lose all of them).
+    let mut drop_counts = std::collections::HashMap::new();
     for &(idx, count) in &image_positions {
         if to_drop == 0 {
             break;
         }
-        strip_indices.insert(idx);
-        to_drop = to_drop.saturating_sub(count);
+        let drop_here = to_drop.min(count);
+        drop_counts.insert(idx, drop_here);
+        to_drop -= drop_here;
     }
 
     messages
         .iter()
         .enumerate()
         .map(|(i, m)| {
-            if strip_indices.contains(&i) {
-                let (cleaned, _) = parse_image_markers(&m.content);
-                let text = if cleaned.trim().is_empty() {
+            let Some(&drop_here) = drop_counts.get(&i) else {
+                return replay_message_without_stale_tool_images(i, m, &latest_tool_indices);
+            };
+
+            let (cleaned, refs) = parse_image_markers(&m.content);
+            // Newest images within the message survive, matching the
+            // oldest-first eviction order across messages.
+            let retained = refs.get(drop_here..).unwrap_or(&[]);
+            let content = if retained.is_empty() {
+                if cleaned.trim().is_empty() {
                     "[image removed from history]".to_string()
                 } else {
                     cleaned
-                };
-                ChatMessage {
-                    role: m.role.clone(),
-                    content: text,
                 }
             } else {
-                replay_message_without_stale_tool_images(i, m, &latest_tool_indices)
+                compose_multimodal_message(&cleaned, retained)
+            };
+
+            ChatMessage {
+                role: m.role.clone(),
+                content,
             }
         })
         .collect()
@@ -2333,11 +2350,10 @@ mod tests {
     }
 
     #[test]
-    fn trim_old_images_multi_image_message_stripped_as_unit() {
-        // A single message has 3 images. We need to drop 2 to reach max=1.
-        // But trimming works at message granularity — the entire message gets
-        // stripped (all 3 images removed), which over-trims to 0. The newest
-        // message (text-only) is untouched.
+    fn trim_old_images_partially_trims_a_multi_image_message() {
+        // A single message has 3 images and the budget is 1, so exactly 2 must
+        // be dropped. Evicting the message as a unit would remove all three and
+        // leave zero images, spending none of the budget the operator allowed.
         let messages = vec![
             ChatMessage::user(
                 "[IMAGE:/tmp/a.png]\n[IMAGE:/tmp/b.png]\n[IMAGE:/tmp/c.png]\nThree pics"
@@ -2348,12 +2364,51 @@ mod tests {
 
         let trimmed = trim_old_images(&messages, 1);
         assert_eq!(trimmed.len(), 2);
-        // All images in the first message are gone, but text remains
+        // The newest image in the message survives; the two older ones go.
         let (_, refs0) = parse_image_markers(&trimmed[0].content);
-        assert!(refs0.is_empty());
+        assert_eq!(refs0, vec!["/tmp/c.png".to_string()]);
         assert!(trimmed[0].content.contains("Three pics"));
         // Second message unchanged
         assert_eq!(trimmed[1].content, "Just text, no images");
+    }
+
+    #[test]
+    fn trim_old_images_drops_exactly_the_overflow() {
+        // The invariant the cap exists to enforce: whatever the per-message
+        // distribution, the survivors equal the budget rather than undershoot.
+        let messages = vec![
+            ChatMessage::user("[IMAGE:/tmp/a.png]\n[IMAGE:/tmp/b.png]\nPair".to_string()),
+            ChatMessage::user("[IMAGE:/tmp/c.png]\nSingle".to_string()),
+            ChatMessage::user("[IMAGE:/tmp/d.png]\n[IMAGE:/tmp/e.png]\nAnother pair".to_string()),
+        ];
+
+        for max_images in 1..=5 {
+            let trimmed = trim_old_images(&messages, max_images);
+            assert_eq!(
+                count_image_markers(&trimmed),
+                max_images,
+                "max_images={max_images} must keep exactly that many images"
+            );
+        }
+    }
+
+    #[test]
+    fn trim_old_images_keeps_the_newest_images_across_messages() {
+        let messages = vec![
+            ChatMessage::user("[IMAGE:/tmp/a.png]\n[IMAGE:/tmp/b.png]\nOld".to_string()),
+            ChatMessage::user("[IMAGE:/tmp/c.png]\n[IMAGE:/tmp/d.png]\nNew".to_string()),
+        ];
+
+        let trimmed = trim_old_images(&messages, 3);
+
+        // Oldest single image evicted; everything newer survives.
+        let (_, refs0) = parse_image_markers(&trimmed[0].content);
+        assert_eq!(refs0, vec!["/tmp/b.png".to_string()]);
+        let (_, refs1) = parse_image_markers(&trimmed[1].content);
+        assert_eq!(
+            refs1,
+            vec!["/tmp/c.png".to_string(), "/tmp/d.png".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `trim_old_images` enforced the `max_images` cap at message granularity: it added a message to the strip set whenever images still had to be dropped, then removed *every* marker in that message.
  - A message holding more images than the remaining overflow therefore lost all of them, leaving the request **under** the cap instead of at it. With three images in one message and `max_images = 1`, all three were dropped and the request carried no images at all.
  - The function now tracks a per-message drop count and trims exactly that many, keeping the newest markers in a partially trimmed message. Cross-message eviction order is unchanged: oldest first.
  - Trimming unwraps a native `role = "tool"` JSON envelope and operates on its inner `content`, then re-serializes with the rest of the object untouched. Composing retained markers against the serialized form would append them after the closing brace and destroy the tool-call association.
- **Scope boundary:** This PR only changes eviction granularity inside `trim_old_images`, plus the envelope handling that granularity change requires. It does NOT change the cap value, when the cap is applied, `max_image_turns` age trimming, `should_normalize_message_images` role/staleness rules, or how markers are produced or normalized.
- **Blast radius:** `trim_old_images` runs in `prepare_messages_inner` for every provider request that exceeds the image cap. Requests at or below the cap never reach it and are unaffected. Requests above it now carry more images than before — up to the cap, never beyond — so payloads can grow relative to today's over-trimming, bounded by the same `max_images` that was already the intended ceiling.
- **Linked issue(s):** None
- **Labels:** `bug`, `provider`, `risk:medium`, `size:S`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `channel` (any turn whose history exceeds the multimodal image cap)
- **Setup / preconditions:** A provider request where a single message carries more images than `multimodal.max_images`.
- **Steps to run:** Send one message containing three image markers with `max_images = 1`, and inspect how many images reach the provider.
- **Expected on this branch (after):** one image survives — the newest — and the message text is preserved.
- **Prior behavior on `master` (before):** zero images survive; the cap silently over-trims and the model sees none of them.

### How I tested

```sh
cargo fmt --all -- --check
cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
cargo test -p zeroclaw-providers
cargo check -p zeroclaw-runtime -p zeroclaw-channels -p zeroclaw-tools --all-targets
cargo doc --no-deps --workspace --exclude zeroclaw-desktop
bash scripts/ci/comment_hygiene_gate.sh
```

- **CI checks relied on and why they cover this change:** the standard Rust fmt/clippy/test jobs cover the changed surface; the change is one private function in `zeroclaw-providers` with unit coverage directly around it. The rustdoc warnings gate and comment hygiene gate are reproduced locally above.
- **Known CI coverage gap, if any:** None. `cargo check --workspace` does not complete locally because `glib-sys` needs system GTK packages, but the `Lint` job excludes `zeroclaw-desktop` for that same reason, so the local runs match what CI gates on.
- **Commands run and tail output:**

  ```text
  test result: ok. 1483 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
  ```

  The `trim_old_images_*` group plus the native-envelope regression, including three new tests:

  ```text
  test multimodal::tests::prepare_messages_keeps_native_tool_result_json_valid_when_over_the_image_cap ... ok
  test multimodal::tests::trim_old_images_partially_trims_a_multi_image_message ... ok
  test multimodal::tests::trim_old_images_drops_exactly_the_overflow ... ok
  test multimodal::tests::trim_old_images_keeps_the_newest_images_across_messages ... ok
  test multimodal::tests::trim_old_images_strips_multiple_oldest_messages ... ok
  test multimodal::tests::trim_old_images_skips_assistant_messages ... ok
  test multimodal::tests::trim_old_images_counts_latest_tool_messages ... ok
  test multimodal::tests::trim_old_images_no_trimming_when_exactly_at_limit ... ok
  test multimodal::tests::trim_old_images_no_trimming_when_under_limit ... ok
  test multimodal::tests::trim_old_images_replaces_image_only_message ... ok
  test multimodal::tests::trim_old_images_interleaved_roles ... ok
  test multimodal::tests::trim_old_images_empty_messages ... ok
  ```

  `trim_old_images_drops_exactly_the_overflow` sweeps `max_images` from 1 to 5 over a fixture whose images are unevenly distributed (2, 1, 2) and asserts the survivor count equals the budget every time. I ran the same sweep against `master`'s implementation to confirm what it actually does:

  ```text
  MASTER max_images=1 survivors=0
  MASTER max_images=2 survivors=2
  MASTER max_images=3 survivors=3
  MASTER max_images=4 survivors=3
  MASTER max_images=5 survivors=5
  ```

  So `master` undershoots at `max_images = 1` and `4` — the budgets where an eviction lands mid-message — and happens to be correct at 2, 3 and 5 where every eviction falls on a message boundary. This branch returns the budget for all five.
- **Beyond CI, what did you manually verify?** I confirmed the eviction order claim directly: with images `a, b` in the older message and `c, d` in the newer, `max_images = 3` evicts only `a`.

  I also confirmed the native-envelope regression test genuinely fails without its fix rather than assuming it: disabling the envelope branch makes `prepare_messages_keeps_native_tool_result_json_valid_when_over_the_image_cap` panic at the JSON-parse assertion. Before the fix, a five-image tool result at the default cap produced:

  ```text
  "{\"content\":\"captured    \",\"tool_call_id\":\"call_1\"}\n\n[IMAGE:/tmp/b.png]\n[IMAGE:/tmp/c.png]..."
  VALID_JSON=false
  ```

  I did NOT run a live end-to-end request against a real provider.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

Note for reviewers weighing risk direction: this makes over-cap requests carry *more* image data than they do today, up to but never beyond `max_images`. That is the ceiling the cap was already meant to enforce, and the surviving images are ones the operator's own configuration admits.

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low risk: after merge, fetch `master`, obtain the landed commit with `gh pr view 10564 --repo zeroclaw-labs/zeroclaw --json mergeCommit --jq .mergeCommit.oid`, then run `git revert <landed-squash-sha>`.

## Changed test expectation (please review deliberately)

`trim_old_images_multi_image_message_stripped_as_unit` asserted the old outcome and is replaced by `trim_old_images_partially_trims_a_multi_image_message`.

I am not treating that as a spec change made lightly. The original test's own comment recorded the outcome as a defect rather than a decision:

> But trimming works at message granularity — the entire message gets stripped (all 3 images removed), **which over-trims to 0**.

So the prior behaviour was characterised, not chosen: the test pinned what the implementation did while noting it was wrong. This PR makes the implementation match the cap's stated contract ("strip image markers from older messages (oldest first) until total image count is within `max_images`") and updates the assertion accordingly. If maintainers intended message-atomic eviction as a real invariant — for example to avoid splitting a "compare these three photos" message — say so and I will close this; in that case the doc comment and the cap's semantics should be corrected instead, since silently dropping to zero images is not obviously better for coherence than keeping the newest one.

## Related

Third of three defects found while investigating a production turn that failed with `Your input exceeds the context window of this model`. Independent of the other two and safe to review in any order:

- #10552 — operator `[multimodal]` config never reached the provider adapters, so `max_images` was inert. That one makes this cap reachable by configuration at all; this one makes it arithmetically correct. No code overlap.
- #10555 — tool-result path listings promoted every local image path into an `[IMAGE:...]` marker.

