### PR TITLE
feat(memory): stamp recalled entries with their storage date

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10769,6 +10769,11 @@ pub struct MemoryConfig {
     /// operations; recall is a single hybrid call today, so this has no effect.
     #[serde(default = "default_fts_early_return_score")]
     pub fts_early_return_score: f64,
+    /// Prefix injected memory entries with their storage date
+    /// (`[from YYYY-MM-DD]`), so the model can tell recalled text from the
+    /// live turn it is prepended to.
+    #[serde(default = "default_true")]
+    pub recall_date_stamp: bool,
 
     // ── Namespace Isolation ─────────────────────────────────────
     /// Default namespace for memory entries.
@@ -11266,6 +11271,7 @@ impl Default for MemoryConfig {
             importance_weight: default_importance_weight(),
             recency_weight: default_recency_weight(),
             fts_early_return_score: default_fts_early_return_score(),
+            recall_date_stamp: true,
             default_namespace: default_namespace(),
             conflict_threshold: default_conflict_threshold(),
             conflict_supersede_enabled: default_conflict_supersede_enabled(),

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -5991,7 +5991,7 @@ mod tests {
         )
         .await;
         assert!(msg.starts_with(zeroclaw_memory::MEMORY_CONTEXT_OPEN));
-        assert!(msg.contains("- remembered: the server is prod-3"));
+        assert!(msg.contains("remembered: the server is prod-3"));
         assert!(msg.ends_with("what server?"));
         assert_eq!(recalls.len(), 1);
         assert!(recalls[0].1, "recall event must report success");

--- a/crates/zeroclaw-runtime/src/agent/memory_inject.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_inject.rs
@@ -72,6 +72,8 @@ pub struct MemoryInjectConfig {
     /// Rerank stage parameters (strategy, threshold, blend weights, floor,
     /// final trim). Only consulted when `rerank_enabled` is set.
     pub rerank: rerank::RerankConfig,
+    /// Prefix each entry with its storage date (`[from YYYY-MM-DD]`).
+    pub date_stamp: bool,
 }
 
 impl Default for MemoryInjectConfig {
@@ -85,6 +87,7 @@ impl Default for MemoryInjectConfig {
             rerank_enabled: false,
             candidate_multiplier: 1,
             rerank: rerank::RerankConfig::disabled(DEFAULT_RECALL_LIMIT, 0.0),
+            date_stamp: true,
         }
     }
 }
@@ -109,6 +112,7 @@ impl MemoryInjectConfig {
             rerank_enabled: memory.rerank_enabled,
             candidate_multiplier: memory.candidate_multiplier.max(1),
             rerank: build_rerank_config(memory, limit),
+            date_stamp: memory.recall_date_stamp,
             ..Default::default()
         }
     }
@@ -249,6 +253,19 @@ fn should_skip_entry(key: &str, content: &str) -> bool {
     false
 }
 
+/// The `YYYY-MM-DD` prefix of an RFC3339 timestamp, or `None` when the value
+/// is not shaped like one. A prefix check, not a full parse: a backend that
+/// stores something else renders the untagged line rather than a half-parsed
+/// date.
+fn stored_on(timestamp: &str) -> Option<&str> {
+    let date = timestamp.get(..10)?;
+    let ok = date.as_bytes().iter().enumerate().all(|(i, b)| match i {
+        4 | 7 => *b == b'-',
+        _ => b.is_ascii_digit(),
+    });
+    ok.then_some(date)
+}
+
 pub async fn render_memory_context(
     mem: &dyn Memory,
     observer: &dyn Observer,
@@ -359,7 +376,14 @@ pub async fn render_memory_context(
         };
 
         let mut line = String::new();
-        let _ = writeln!(line, "- {}: {}", entry.key, content);
+        // Without the stamp a days-old sentence renders identically to the
+        // live user turn it is prepended to — an observed cause of stale
+        // values being copied into fresh tool calls.
+        let stamp = cfg.date_stamp.then(|| stored_on(&entry.timestamp)).flatten();
+        let _ = match stamp {
+            Some(date) => writeln!(line, "- [from {date}] {}: {}", entry.key, content),
+            None => writeln!(line, "- {}: {}", entry.key, content),
+        };
         let line_chars = line.chars().count();
         if used_chars + line_chars > cfg.max_total_chars {
             break;
@@ -654,6 +678,103 @@ mod tests {
 
     // ── renderer ──────────────────────────────────────────────────────────
 
+    #[test]
+    fn stored_on_takes_the_date_from_an_rfc3339_timestamp() {
+        assert_eq!(
+            stored_on("2026-09-01T16:35:55.123456789-04:00"),
+            Some("2026-09-01")
+        );
+        assert_eq!(stored_on("2026-09-01T00:00:00Z"), Some("2026-09-01"));
+    }
+
+    // A backend that stores something else renders the untagged line rather
+    // than a half-parsed date.
+    #[test]
+    fn stored_on_rejects_anything_not_shaped_like_a_date() {
+        assert_eq!(stored_on(""), None);
+        assert_eq!(stored_on("2026-09-0"), None);
+        assert_eq!(stored_on("yesterday!!"), None);
+        assert_eq!(stored_on("2026/09/01T00:00:00Z"), None);
+        assert_eq!(stored_on("20260901T00:00:00Z"), None);
+    }
+
+    // Multi-byte content must not panic the 10-byte prefix slice.
+    #[test]
+    fn stored_on_is_safe_on_a_non_ascii_timestamp() {
+        assert_eq!(stored_on("20261日01T00:00:00Z"), None);
+    }
+
+    #[tokio::test]
+    async fn an_entry_without_a_usable_timestamp_renders_untagged() {
+        let mut e = entry(
+            "user_preference",
+            "prefers concise answers",
+            MemoryCategory::Core,
+            Some(0.9),
+        );
+        e.timestamp = "not-a-timestamp".into();
+        let mem = FixtureMemory::with(vec![e]);
+        let observer = RecordingObserver::default();
+
+        let context = render_memory_context(
+            &mem,
+            &observer,
+            "how should I answer",
+            &[],
+            &MemoryInjectConfig::default(),
+            false,
+            TurnMeta {
+                parent_agent_alias: None,
+                agent_alias: None,
+                turn_id: "t",
+                channel_name: "test",
+            },
+        )
+        .await;
+
+        assert!(
+            context.contains("- user_preference: prefers concise answers"),
+            "unparseable timestamp must fall back to the untagged line, got: {context}"
+        );
+        assert!(!context.contains("[from"), "got: {context}");
+    }
+
+    #[tokio::test]
+    async fn the_date_stamp_gate_off_renders_untagged() {
+        let mem = FixtureMemory::with(vec![entry(
+            "user_preference",
+            "prefers concise answers",
+            MemoryCategory::Core,
+            Some(0.9),
+        )]);
+        let observer = RecordingObserver::default();
+
+        let context = render_memory_context(
+            &mem,
+            &observer,
+            "how should I answer",
+            &[],
+            &MemoryInjectConfig {
+                date_stamp: false,
+                ..Default::default()
+            },
+            false,
+            TurnMeta {
+                parent_agent_alias: None,
+                agent_alias: None,
+                turn_id: "t",
+                channel_name: "test",
+            },
+        )
+        .await;
+
+        assert!(
+            context.contains("- user_preference: prefers concise answers"),
+            "got: {context}"
+        );
+        assert!(!context.contains("[from"), "got: {context}");
+    }
+
     #[tokio::test]
     async fn renders_wrapped_block_and_emits_one_recall_event() {
         let mem = FixtureMemory::with(vec![entry(
@@ -681,7 +802,7 @@ mod tests {
         .await;
 
         assert!(context.starts_with(MEMORY_CONTEXT_OPEN));
-        assert!(context.contains("- user_preference: prefers concise answers"));
+        assert!(context.contains("user_preference: prefers concise answers"));
         assert!(context.ends_with(&format!("{MEMORY_CONTEXT_CLOSE}\n\n")));
         assert_eq!(observer.recalls.lock().as_slice(), &[(1, true)]);
     }
@@ -820,7 +941,7 @@ mod tests {
         .await;
 
         assert!(!context.contains("said hi earlier"));
-        assert!(context.contains("- fact: server is prod-3"));
+        assert!(context.contains("fact: server is prod-3"));
     }
 
     #[tokio::test]
@@ -862,7 +983,7 @@ mod tests {
         assert!(!context.contains("transcript blob"));
         assert!(!context.contains("[IMAGE:"));
         assert!(!context.contains("<tool_result"));
-        assert!(context.contains("- keeper: real knowledge"));
+        assert!(context.contains("keeper: real knowledge"));
     }
 
     #[tokio::test]
@@ -895,8 +1016,8 @@ mod tests {
         .await;
 
         assert!(!context.contains("barely related"));
-        assert!(context.contains("- high: very related"));
-        assert!(context.contains("- unscored: keyword backend"));
+        assert!(context.contains("high: very related"));
+        assert!(context.contains("unscored: keyword backend"));
     }
 
     #[tokio::test]
@@ -928,8 +1049,8 @@ mod tests {
         .await;
 
         // Entry cap: 4 of the 5 render.
-        assert!(context.contains("- d: four"));
-        assert!(!context.contains("- e: five"));
+        assert!(context.contains("d: four"));
+        assert!(!context.contains("e: five"));
         // Per-entry cap: the 900-char content is ellipsis-truncated.
         assert!(context.contains("..."));
         assert!(!context.contains(&long));
@@ -965,9 +1086,9 @@ mod tests {
         )
         .await;
 
-        assert!(context.contains("- a: "));
-        assert!(context.contains("- b: "));
-        assert!(!context.contains("- c: "));
+        assert!(context.contains("] a: "));
+        assert!(context.contains("] b: "));
+        assert!(!context.contains("] c: "));
     }
 
     #[tokio::test]
@@ -1007,10 +1128,10 @@ mod tests {
         .await;
 
         // First scope wins the duplicate key; both uniques render; one event.
-        assert!(context.contains("- shared: from history scope"));
+        assert!(context.contains("shared: from history scope"));
         assert!(!context.contains("from sender scope"));
-        assert!(context.contains("- only_first: h"));
-        assert!(context.contains("- only_sender: s"));
+        assert!(context.contains("only_first: h"));
+        assert!(context.contains("only_sender: s"));
         assert_eq!(observer.recalls.lock().as_slice(), &[(3, true)]);
     }
 
@@ -1063,7 +1184,7 @@ mod tests {
         )
         .await;
 
-        assert!(first.contains("- fact: server is prod-3"));
+        assert!(first.contains("fact: server is prod-3"));
         assert_eq!(
             first, second,
             "direct backend recall must render identically"
@@ -1101,8 +1222,7 @@ mod tests {
     /// cannot distinguish the rerank arm), a Conversation entry, a stale
     /// scored entry old enough for time decay to drop it, and an autosave
     /// key the skip set filters on every arm. Recall order is fixture order.
-    fn golden_corpus() -> Vec<MemoryEntry> {
-        let now = chrono::Utc::now();
+    fn golden_corpus(now: chrono::DateTime<chrono::Utc>) -> Vec<MemoryEntry> {
         vec![
             scored_entry(
                 "alpha",
@@ -1193,38 +1313,45 @@ mod tests {
     // near-duplicate pair renders twice, recall order is preserved). Later
     // pipeline stages re-prove against these.
     const GOLDEN_FULL: &str = "[Memory context]\n\
-        - alpha: deploy target is prod-cluster-3\n\
-        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
-        - beta: team standup moved to 0930\n\
-        - chat: user said hello\n\
+        - [from {today}] alpha: deploy target is prod-cluster-3\n\
+        - [from {today}] alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - [from {today}] beta: team standup moved to 0930\n\
+        - [from {today}] chat: user said hello\n\
         [/Memory context]\n\n";
     const GOLDEN_NO_CONVERSATION: &str = "[Memory context]\n\
-        - alpha: deploy target is prod-cluster-3\n\
-        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
-        - beta: team standup moved to 0930\n\
+        - [from {today}] alpha: deploy target is prod-cluster-3\n\
+        - [from {today}] alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - [from {today}] beta: team standup moved to 0930\n\
         [/Memory context]\n\n";
-    const GOLDEN_TIGHT_BUDGET: &str = "[Memory context]\n\
-        - alpha: deploy target is prod-cluster-3\n\
-        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+    // Entry-count cap: unaffected by the date stamp.
+    const GOLDEN_TIGHT_ENTRY_BUDGET: &str = "[Memory context]\n\
+        - [from {today}] alpha: deploy target is prod-cluster-3\n\
+        - [from {today}] alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        [/Memory context]\n\n";
+    // Character cap: the date stamp is charged to `max_total_chars` like any
+    // other part of the line, so the 100-char budget fits one entry where it
+    // fitted two; this golden pins that cost.
+    const GOLDEN_TIGHT_CHAR_BUDGET: &str = "[Memory context]\n\
+        - [from {today}] alpha: deploy target is prod-cluster-3\n\
         [/Memory context]\n\n";
     // Rerank arm on the same corpus: the blend re-sorts, MMR demotes the
     // near-duplicate to the tail, the trim drops the unscored Conversation
     // entry, and `stale` survives (the blend's recency factor replaces the
     // decay drop). Divergence from the flags-off goldens is the point.
     const GOLDEN_RERANK: &str = "[Memory context]\n\
-        - alpha: deploy target is prod-cluster-3\n\
-        - beta: team standup moved to 0930\n\
-        - stale: quarterly report workflow uses legacy tool\n\
-        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - [from {today}] alpha: deploy target is prod-cluster-3\n\
+        - [from {today}] beta: team standup moved to 0930\n\
+        - [from {stale}] stale: quarterly report workflow uses legacy tool\n\
+        - [from {today}] alpha_dup: deploy target is prod-cluster-3 for staging\n\
         [/Memory context]\n\n";
     // Conversation exclusion is an eligibility boundary, so it runs before
     // duplicate collapse and MMR. Once the ineligible rows are removed, this
     // fixture is below the advanced-strategy threshold and keeps blend order.
     const GOLDEN_RERANK_NO_CONVERSATION: &str = "[Memory context]\n\
-        - alpha: deploy target is prod-cluster-3\n\
-        - alpha_dup: deploy target is prod-cluster-3 for staging\n\
-        - beta: team standup moved to 0930\n\
-        - stale: quarterly report workflow uses legacy tool\n\
+        - [from {today}] alpha: deploy target is prod-cluster-3\n\
+        - [from {today}] alpha_dup: deploy target is prod-cluster-3 for staging\n\
+        - [from {today}] beta: team standup moved to 0930\n\
+        - [from {stale}] stale: quarterly report workflow uses legacy tool\n\
         [/Memory context]\n\n";
 
     #[tokio::test]
@@ -1302,7 +1429,7 @@ mod tests {
                     max_entries: 2,
                     ..flags_off
                 },
-                GOLDEN_TIGHT_BUDGET,
+                GOLDEN_TIGHT_ENTRY_BUDGET,
             ),
             (
                 "tight_total_char_budget",
@@ -1313,7 +1440,7 @@ mod tests {
                     max_total_chars: 100,
                     ..flags_off
                 },
-                GOLDEN_TIGHT_BUDGET,
+                GOLDEN_TIGHT_CHAR_BUDGET,
             ),
             (
                 "rerank_on_interactive",
@@ -1333,8 +1460,17 @@ mod tests {
             ),
         ];
 
+        // One clock for the fixture and the expectations, so the recall
+        // stamps cannot straddle a UTC midnight mid-test.
+        let now = chrono::Utc::now();
+        let today = now.format("%Y-%m-%d").to_string();
+        let stale = (now - chrono::Duration::days(60))
+            .format("%Y-%m-%d")
+            .to_string();
+
         for (name, origin, has_session, suppress, cfg, want) in cases {
-            let mem = FixtureMemory::with(golden_corpus());
+            let mem = FixtureMemory::with(golden_corpus(now));
+            let want = want.replace("{today}", &today).replace("{stale}", &stale);
             let got = render_for_origin(origin, has_session, suppress, &mem, &cfg).await;
             assert_eq!(got, want, "golden mismatch for case {name}");
         }
@@ -1391,9 +1527,9 @@ mod tests {
             },
         )
         .await;
-        assert!(context.contains("- a: "));
-        assert!(context.contains("- b: "));
-        assert!(context.contains("- c: "));
+        assert!(context.contains("] a: "));
+        assert!(context.contains("] b: "));
+        assert!(context.contains("] c: "));
 
         // Rerank on with a 2-slot trim: MMR demotes the near-duplicate below
         // the unrelated entry and the trim drops it.
@@ -1429,11 +1565,11 @@ mod tests {
             },
         )
         .await;
-        let a_pos = context.find("- a: ").expect("top entry renders");
-        let c_pos = context.find("- c: ").expect("diverse entry renders");
+        let a_pos = context.find("] a: ").expect("top entry renders");
+        let c_pos = context.find("] c: ").expect("diverse entry renders");
         assert!(a_pos < c_pos, "relevance leader stays first");
         assert!(
-            !context.contains("- b: "),
+            !context.contains("] b: "),
             "near-duplicate must be demoted out of the trimmed set"
         );
     }
@@ -1740,7 +1876,7 @@ mod tests {
             !context.contains("channel_history"),
             "ineligible row dropped"
         );
-        assert!(context.contains("- fact_e: epsilon elderberry"));
+        assert!(context.contains("fact_e: epsilon elderberry"));
     }
 
     /// Composed score-domain regression: current SQLite recall owns BM25
@@ -1818,10 +1954,10 @@ mod tests {
         .await;
 
         let best = context
-            .find("- best_match: ")
+            .find("best_match: ")
             .expect("the relevance leader survives the configured floor");
         let supporting = context
-            .find("- supporting_match: ")
+            .find("supporting_match: ")
             .expect("the weaker relevant entry survives the configured floor");
         assert!(best < supporting, "BM25 relevance order survives blending");
     }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `render_memory_context` renders each recalled entry as `- {key}: {content}`. The key is an opaque store id and there is **no date**, so an entry recalled from days ago is textually indistinguishable from the live user message it is prepended to.
  - Renders the entry's storage date, which `MemoryEntry.timestamp` already carries and the renderer ignored: `- [from 2026-09-01] {key}: {content}`. (`[from]`, not `[recalled]`: the timestamp is when the entry was stored, and the recall happens now — labelling it the recall date would itself be the class of ambiguity this PR removes.)
  - Gated by a new `memory.recall_date_stamp` key, **default on**. An entry the model mistakes for live input is wrong on every deployment and the change is additive text on a line that already exists — but a deployment that needs byte-stable injection output can switch it off.
  - `stored_on` takes the `YYYY-MM-DD` prefix only when the value is shaped like an RFC3339 date, so a backend storing anything else keeps the untagged line rather than surfacing a half-parsed one. Prefix check, not a parse: no new dependency, and it cannot panic on a multi-byte timestamp.

### The failure this fixes

On a tool-using agent that writes structured records, a numeric value from a message recalled from **two days earlier** was copied into a tool call made for the live message, which supplied no such value. The record written was wrong in a way nothing downstream could detect, because the value was well-formed and plausible.

The model's own reasoning named the memory block as its source. In other turns on the same agent it described that block as "confusing", "weird", and "probably other users" — it can tell something is off in the input and has no field that would let it say what. Fourteen turns in one session cited the block; three complained about it.

This is not a retrieval-quality problem. The right entries were recalled. They were rendered without the one attribute that makes them safe to read.

### Trade-offs

- **The stamp is charged to `max_total_chars`**, like the rest of the line — about 17 characters per entry. A tight character budget therefore fits one fewer entry. That is deliberate: an unlabelled entry the model mistakes for live input is worse than one entry fewer, and the tight-budget golden pins the cost so it cannot regress silently. The entry-count cap is unaffected; the two cases now have separate goldens.
- **Golden tests gained a clock dependency** once dates entered the output, and the corpus deliberately holds one entry aged 60 days, so expectations need two different dates. `golden_corpus` now takes the clock as a parameter and the goldens are templated on `{today}` / `{stale}`, so an expectation cannot straddle a UTC midnight mid-test.

- **Scope boundary:** Does not change what is recalled, ranked, filtered, decayed, or budgeted — only how a surviving entry is rendered. Does not touch the `[Memory context]` wrapper, the skip set, the rerank stage, or `MemoryEntry`.
- **Blast radius:** With the gate on (default), every agent that injects memory sees ~17 more characters per rendered entry, and a deployment sitting exactly on `max_total_chars` renders one fewer entry; `recall_date_stamp = false` restores the previous output byte-for-byte. Contains-style assertions that pinned the old `- {key}:` line prefix now anchor on `{key}: {content}` alone, so they keep proving the pipeline behaviour they were written for without pinning the line shape; the goldens pin the exact shape.
- **Linked issue(s):** None
- **Labels:** `type:feat`, `memory`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes — the render change is visible in one turn with any memory backend that returns a hit.
- **Interface(s) exercised:** `surface: cli` and `channel` — injection is shared by both.
- **Setup / preconditions:** any agent with a memory backend that recalls at least one entry (`[agent.memory]`, backend `sqlite`).
- **Steps to run:** store a memory, then send a turn whose text recalls it, with `RUST_LOG=zeroclaw_runtime::agent=debug`.
- **Expected on this branch (after):** the injected block reads `- [from YYYY-MM-DD] {key}: {content}`.
- **Prior behavior on `master` (before):** the same line without the date — identical in shape to the live user turn beneath it.
- **Gate off (`recall_date_stamp = false`):** identical to `master`.
