### PR TITLE
fix(docs): snap reader scale to an explicit step ladder

### DIFF
--- a/docs/book/theme/pc-enhance.js
+++ b/docs/book/theme/pc-enhance.js
@@ -9,9 +9,13 @@
   'use strict';
 
   const READER_SCALE_KEY = 'pc-reader-font-scale';
-  const READER_SCALE_MIN = 0.85;
-  const READER_SCALE_MAX = 1.4;
-  const READER_SCALE_STEP = 0.1;
+  // Explicit ladder: the minimum must be a real rung, so the stored value, the
+  // displayed percentage, and the bounds all describe the same endpoints. An
+  // arithmetic step grid cannot express 0.85 and rounded it away (#10547).
+  const READER_SCALES = [0.85, 0.9, 1, 1.1, 1.2, 1.3, 1.4];
+  const READER_SCALE_MIN = READER_SCALES[0];
+  const READER_SCALE_MAX = READER_SCALES[READER_SCALES.length - 1];
+  const READER_SCALE_DEFAULT = 1;
 
   const LOCALE_TEXT = {
     en: {
@@ -117,15 +121,26 @@
     return Math.min(max, Math.max(min, value));
   }
 
-  function readReaderScale() {
-    let value = 1;
+  // Maps any stored value — including off-ladder ones written by earlier
+  // versions — to the index of the nearest rung.
+  function snapReaderScale(value) {
+    const target = clamp(value, READER_SCALE_MIN, READER_SCALE_MAX);
+    let best = 0;
+    for (let i = 1; i < READER_SCALES.length; i++) {
+      if (Math.abs(READER_SCALES[i] - target) < Math.abs(READER_SCALES[best] - target)) best = i;
+    }
+    return best;
+  }
+
+  function readReaderScaleIndex() {
+    let value = READER_SCALE_DEFAULT;
     try {
       value = Number.parseFloat(localStorage.getItem(READER_SCALE_KEY));
     } catch (e) {
       // Storage can be unavailable in private or embedded browser contexts.
     }
-    if (!Number.isFinite(value)) value = 1;
-    return clamp(Math.round(value * 10) / 10, READER_SCALE_MIN, READER_SCALE_MAX);
+    if (!Number.isFinite(value)) value = READER_SCALE_DEFAULT;
+    return snapReaderScale(value);
   }
 
   function saveReaderScale(value) {
@@ -145,7 +160,7 @@
     const buttons = document.querySelector('#mdbook-menu-bar .left-buttons');
     if (!buttons || document.getElementById('pc-reader-controls')) return;
 
-    let scale = readReaderScale();
+    let scaleIndex = readReaderScaleIndex();
     const wrapper = document.createElement('div');
     wrapper.id = 'pc-reader-controls';
     wrapper.className = 'pc-reader-controls';
@@ -203,12 +218,15 @@
     reset.textContent = localeText('resetText', 'Reset text size');
     reset.title = reset.textContent;
 
-    function applyScale(next) {
-      scale = clamp(Math.round(next * 10) / 10, READER_SCALE_MIN, READER_SCALE_MAX);
+    function applyScale(nextIndex) {
+      scaleIndex = clamp(nextIndex, 0, READER_SCALES.length - 1);
+      const scale = READER_SCALES[scaleIndex];
       document.documentElement.style.setProperty('--pc-reader-scale', String(scale));
       value.textContent = formatPercent(scale);
-      decrease.disabled = scale <= READER_SCALE_MIN;
-      increase.disabled = scale >= READER_SCALE_MAX;
+      decrease.disabled = scaleIndex === 0;
+      increase.disabled = scaleIndex === READER_SCALES.length - 1;
+      // Persist the scale, not the index, so the stored format stays readable
+      // by older builds of this theme.
       saveReaderScale(scale);
     }
 
@@ -219,13 +237,13 @@
     }
 
     decrease.addEventListener('click', function () {
-      applyScale(scale - READER_SCALE_STEP);
+      applyScale(scaleIndex - 1);
     });
     increase.addEventListener('click', function () {
-      applyScale(scale + READER_SCALE_STEP);
+      applyScale(scaleIndex + 1);
     });
     reset.addEventListener('click', function () {
-      applyScale(1);
+      applyScale(snapReaderScale(READER_SCALE_DEFAULT));
     });
     toggle.addEventListener('click', function (e) {
       e.stopPropagation();
@@ -248,7 +266,7 @@
     popup.append(title, label, row, reset);
     wrapper.append(toggle, popup);
     buttons.appendChild(wrapper);
-    applyScale(scale);
+    applyScale(scaleIndex);
   }
 
   // ── Reading progress bar ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The reader-size control stepped on a `0.1` grid anchored at `1.0`, but #10515 introduced an `0.85` minimum that does not sit on that grid. `readReaderScale` rounded before clamping, so a stored `0.85` came back as `0.9`.
  - Boot calls `applyScale(readReaderScale())` and `applyScale` ends in `saveReaderScale`, so the promoted value was written back. The stored preference was destroyed on the first reload, not merely mis-displayed. The issue reports the display symptom; the persistence corruption is the same root cause.
  - The same grid made `A+` from 85% land on 100%, silently skipping 90%.
  - Replaced the arithmetic grid with an explicit `READER_SCALES` ladder stepped by index, so the minimum is a real rung and the stored value, displayed percentage, step sequence, and bounds all describe the same endpoints.
  - `snapReaderScale` maps any stored value, including off-ladder ones written by earlier builds, to the nearest rung.
- **Scope boundary:** Does not change `custom.css`, the `--pc-reader-scale` consumption, the popup markup or its localized strings, the `localStorage` key or value format, or any other installer in `pc-enhance.js`. The chosen rungs match the bounds already shipped by #10515; no new minimum or maximum is introduced.
- **Blast radius:** Docs-site presentation only. One file, `docs/book/theme/pc-enhance.js`. No Rust, no build, no runtime surface. `saveReaderScale` still persists the scale value rather than the ladder index, so the stored format stays readable by older builds of this theme and no migration is required.
- **Linked issue(s):** Closes #10547
- **Labels:** `bug`, `type:docs`, `docs`, `risk:low`, `size:XS`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `surface: web` (mdBook docs site reader-size control)
- **Setup / preconditions:** `cargo mdbook build`, then serve the generated book over a local HTTP server. `file://` will not work, because `localStorage` is origin-scoped.
- **Steps to run:** Open any docs page, click `Aa`, press `A−` until the control reads 85%. Reload the page and reopen `Aa`. Then press `A+` repeatedly and watch the sequence.
- **Expected on this branch (after):** The control still reads 85% after reload, and `localStorage['pc-reader-font-scale']` is still `0.85`. Pressing `A+` from 85% walks 90 → 100 → 110 → 120 → 130 → 140%.
- **Prior behavior on `master` (before):** The same steps show 90% after reload, and the stored value has been rewritten to `0.9`. Pressing `A+` from 85% jumps straight to 100%, skipping 90%.

### How I tested

The docs theme has no JS test runner in-repo, so this was verified by driving the actual module in a browser rather than by asserting on a copy of its logic.

I built a temporary harness (not committed) that serves the real `docs/book/theme/pc-enhance.js` over `http://localhost`, loads it with `<script src>` into a minimal mdBook-shaped DOM, stubs `localStorage` so the persistence path is observable and can be made to throw, and simulates a reload by re-injecting the script against the surviving store.

23 assertions pass on this branch. The same harness run against `master`'s `pc-enhance.js` fails 7, reproducing the reported symptom exactly:

```
FAIL  RELOAD keeps 85% display        got="90%"                     want="85%"
FAIL  RELOAD keeps 0.85 stored        got="0.9"                     want="0.85"
FAIL  RELOAD keeps css var            got="0.9"                     want="0.85"
FAIL  RELOAD decrease still disabled  got=false                     want=true
FAIL  upward ladder                   got="100%,110%,120%,130%,..." want="90%,100%,110%,120%,..."
FAIL  off-ladder 1.05 snaps           got="110%"                    want="100%"
FAIL  off-ladder 0.87 snaps           got="90%"                     want="85%"

7 failing / 23 total
```

- **CI checks relied on and why they cover this change:** `Docs Links` covers added-link integrity for the docs tree. Note that `Docs Style` / `scripts/ci/docs_quality_gate.sh` does **not** cover this change: it scans `docs/book/src/**/*.md(x)` only, so it reports "No docs files detected" for a theme JS edit.
- **Known CI coverage gap, if any:** Yes. No CI job lints or executes `docs/book/theme/*.js`; there is no JS test runner for the theme. The behavior here is guarded only by the manual steps above and the throwaway harness described. Standing up a JS test runner for the theme is deliberately out of scope for this PR.
- **Commands run and tail output:**

```
$ bash scripts/ci/docs_quality_gate.sh
No docs files detected; skipping docs quality gate.
exit=0        # markdown-only gate; correctly not applicable to theme JS

$ bash scripts/ci/docs_links_gate.sh
Python was not found; ...
exit=49       # NOT RUN locally: python3 is unavailable on this machine, not a
              # failure of this change. Needs to run in CI.
```

- **Beyond CI, what did you manually verify?** Endpoint disabling at both ends, `Reset text size` returning to 100% and persisting `1`, migration of off-ladder stored values (`1.05` → 100%, `0.87` → 85%), the already-corrupted legacy `0.9` staying valid at 90%, out-of-range (`99` → 140%) and unparseable (`junk` → 100%) input, and the storage-denied path still installing and stepping within the session.
- **What I did NOT verify:** I did not run `cargo mdbook build` or exercise the control on the real rendered docs page, so the evidence below is from the real module in a stub DOM rather than the shipped site. No screenshots were captured.
- **Visual interface changed?** Yes
- **Tested revision, interface, and terminal or viewport dimensions:** *(pending — see below)*
- **Screenshot evidence:** *(pending — not yet captured)*
- **Action or changed state and observed result:** *(pending)*
- **If any command was intentionally skipped, why:** `scripts/ci/docs_links_gate.sh` could not run locally for lack of `python3`; deferred to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

The `localStorage` key and value format are unchanged. Values written by #10515, including the corrupted `0.9`, remain valid and snap to the nearest rung on read.

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>` on the single file.
