### PR TITLE
fix(runtime): surface bootstrap-file truncation to the operator

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -1681,7 +1681,7 @@ pub async fn run(
         }
         retain_registered_tool_descriptions(&mut tool_descs, &tools_registry);
         let bootstrap_max_chars = if eff_compact_context {
-            Some(6000)
+            Some(crate::agent::system_prompt::COMPACT_BOOTSTRAP_MAX_CHARS)
         } else {
             None
         };
@@ -3190,7 +3190,7 @@ pub async fn process_message(
         tool_descs.retain(|(name, _)| effective_tool_names.contains(name));
 
         let bootstrap_max_chars = if eff_compact_context {
-            Some(6000)
+            Some(crate::agent::system_prompt::COMPACT_BOOTSTRAP_MAX_CHARS)
         } else {
             None
         };

--- a/crates/zeroclaw-runtime/src/agent/system_prompt.rs
+++ b/crates/zeroclaw-runtime/src/agent/system_prompt.rs
@@ -14,6 +14,17 @@ pub const NO_TOOLS_TASK_FRAMING: &str = "No tools are available for this turn";
 pub const NATIVE_TOOLS_TASK_FRAMING: &str = "Use tools when the request requires action";
 const TRUNCATION_MARKER: &str = "\n\n[System prompt truncated to fit context budget]\n";
 
+/// Per-file cap applied to every injected workspace bootstrap file while
+/// compact context is on. Shared by the turn paths and `zeroclaw doctor`
+/// so both report the same budget.
+pub(crate) const COMPACT_BOOTSTRAP_MAX_CHARS: usize = 6000;
+
+/// Workspace files injected into the system prompt, in order. `doctor`
+/// scans the same list (plus the conditional `BOOTSTRAP.md` /
+/// `MEMORY.md`) so its report matches what the prompt builder caps.
+pub(crate) const BOOTSTRAP_FILES: &[&str] =
+    &["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md"];
+
 fn load_openclaw_bootstrap_files(
     prompt: &mut String,
     workspace_dir: &std::path::Path,
@@ -24,9 +35,7 @@ fn load_openclaw_bootstrap_files(
         "The following workspace files define your identity, behavior, and context. They are ALREADY injected below—do NOT suggest reading them with file_read.\n\n",
     );
 
-    let bootstrap_files = ["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md"];
-
-    for filename in &bootstrap_files {
+    for filename in BOOTSTRAP_FILES {
         inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file);
     }
 
@@ -582,6 +591,52 @@ pub fn build_skills_prompt_with_effective_tools(
     )
 }
 
+/// Emit the operator-facing truncation WARN once per file per process.
+/// The turn paths inject bootstrap files on every turn; warning once
+/// keeps the signal discoverable in logs (`agent.bootstrap_file_truncated`)
+/// without spamming every turn. `zeroclaw doctor` re-checks offline.
+fn warn_bootstrap_truncation_once(
+    workspace_dir: &std::path::Path,
+    filename: &str,
+    max_chars: usize,
+    total_chars: usize,
+) -> bool {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::{LazyLock, Mutex};
+
+    static WARNED: LazyLock<Mutex<HashSet<(PathBuf, String)>>> =
+        LazyLock::new(|| Mutex::new(HashSet::new()));
+
+    let mut seen = WARNED
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !seen.insert((workspace_dir.to_path_buf(), filename.to_string())) {
+        return false;
+    }
+
+    let discarded = total_chars.saturating_sub(max_chars);
+    ::zeroclaw_log::record!(
+        WARN,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+            .with_attrs(::serde_json::json!({
+                "error_key": "agent.bootstrap_file_truncated",
+                "file": filename,
+                "workspace": workspace_dir.display().to_string(),
+                "injected": max_chars,
+                "total": total_chars,
+                "discarded": discarded,
+                "compact_context": true,
+            })),
+        &format!(
+            "{filename}: injected {max_chars} of {total_chars} chars \
+             ({discarded} discarded, compact_context=true)"
+        )
+    );
+    true
+}
+
 /// Inject a single workspace file into the prompt with truncation and missing-file markers.
 fn inject_workspace_file(
     prompt: &mut String,
@@ -609,6 +664,15 @@ fn inject_workspace_file(
                 trimmed
             };
             if truncated.len() < trimmed.len() {
+                // Operator-facing visibility for the cap (#10523): the
+                // marker below tells the model, this WARN tells the person
+                // who wrote the file.
+                let _ = warn_bootstrap_truncation_once(
+                    workspace_dir,
+                    filename,
+                    max_chars,
+                    trimmed.chars().count(),
+                );
                 prompt.push_str(truncated);
                 let _ = writeln!(
                     prompt,
@@ -630,6 +694,20 @@ fn inject_workspace_file(
 mod tests {
     use super::*;
     use zeroclaw_config::schema::SkillsPromptInjectionMode;
+
+    #[test]
+    fn bootstrap_truncation_warns_once_per_workspace_file() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let first = warn_bootstrap_truncation_once(dir.path(), "AGENTS.md", 6000, 13985);
+        assert!(first, "first truncation of a workspace file must warn");
+        let second = warn_bootstrap_truncation_once(dir.path(), "AGENTS.md", 6000, 13985);
+        assert!(
+            !second,
+            "same workspace+file must not warn twice per process"
+        );
+        let other_file = warn_bootstrap_truncation_once(dir.path(), "SOUL.md", 6000, 9000);
+        assert!(other_file, "a different file still warns");
+    }
 
     #[test]
     fn compact_skills_fall_back_to_full_when_loader_is_described_but_unavailable() {

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -94,6 +94,7 @@ pub fn diagnose(config: &Config) -> Vec<DiagResult> {
     check_degraded_sections(config, &mut items);
     check_config_semantics(config, &mut items);
     check_workspace(config, &mut items);
+    check_bootstrap_truncation(config, &mut items);
     check_daemon_state(config, &mut items);
     check_environment(&mut items);
     check_cli_tools(&mut items);
@@ -1508,6 +1509,45 @@ fn embedding_provider_validation_error(name: &str) -> Option<String> {
 
 // ── Workspace integrity ──────────────────────────────────────────
 
+/// Compact-context bootstrap cap visibility (#10523): while compact context
+/// is on, every injected workspace bootstrap file is capped at
+/// [`crate::agent::system_prompt::COMPACT_BOOTSTRAP_MAX_CHARS`] chars. A
+/// persona file that is fine on disk can reach the model truncated with no
+/// operator-visible signal, so report every over-cap file per agent with the
+/// same injected/total/discarded shape the runtime WARN uses.
+fn check_bootstrap_truncation(config: &Config, items: &mut Vec<DiagItem>) {
+    let cat = "agent.prompt";
+    let cap = crate::agent::system_prompt::COMPACT_BOOTSTRAP_MAX_CHARS;
+
+    let mut aliases: Vec<&str> = config.agents.keys().map(String::as_str).collect();
+    aliases.sort_unstable();
+    for alias in aliases {
+        if !config.effective_compact_context(alias) {
+            continue;
+        }
+        let workspace = config.agent_workspace_dir(alias);
+        let mut files: Vec<&str> = crate::agent::system_prompt::BOOTSTRAP_FILES.to_vec();
+        files.push("BOOTSTRAP.md");
+        files.push("MEMORY.md");
+        for filename in files {
+            let Ok(content) = std::fs::read_to_string(workspace.join(filename)) else {
+                continue;
+            };
+            let total = content.chars().count();
+            if total > cap {
+                items.push(DiagItem::warn(
+                    cat,
+                    format!(
+                        "{alias}/{filename}: injected {cap} of {total} chars \
+                         ({} discarded, compact_context=true)",
+                        total - cap
+                    ),
+                ));
+            }
+        }
+    }
+}
+
 fn check_workspace(config: &Config, items: &mut Vec<DiagItem>) {
     let cat = "workspace";
     let ws = &config.data_dir;
@@ -2278,6 +2318,31 @@ mod tests {
             data_dir: tmp.path().to_path_buf(),
             ..Config::default()
         }
+    }
+
+    #[test]
+    fn check_bootstrap_truncation_reports_over_cap_files_only() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = config_with_install_root(&tmp);
+        config.agents.insert(
+            "alpha".to_string(),
+            toml::from_str("").expect("empty agent config deserializes"),
+        );
+        let ws = config.agent_workspace_dir("alpha");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("AGENTS.md"), "a".repeat(7000)).unwrap();
+        std::fs::write(ws.join("SOUL.md"), "s".repeat(100)).unwrap();
+
+        let mut items = Vec::new();
+        check_bootstrap_truncation(&config, &mut items);
+
+        assert_eq!(items.len(), 1, "only the over-cap file is reported");
+        assert_eq!(items[0].severity, Severity::Warn);
+        assert_eq!(items[0].category, "agent.prompt");
+        assert_eq!(
+            items[0].message,
+            "alpha/AGENTS.md: injected 6000 of 7000 chars (1000 discarded, compact_context=true)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - With `compact_context` on (the default), every injected workspace bootstrap file is capped at 6000 chars before entering the system prompt. The model sees a truncation marker, but the operator had no signal at all — a persona file could look correct on disk while most of it never reached the model. This adds the operator-facing visibility the issue asks for.
  - WARN once per file per process at truncation time, naming the file with injected/total/discarded counts (`AGENTS.md: injected 6000 of 13985 chars (7985 discarded, compact_context=true)`) and a stable `error_key` (`agent.bootstrap_file_truncated`); once-per-process keeps the signal discoverable in logs without spamming every turn.
  - New `zeroclaw doctor` check (category `agent.prompt`) reporting every over-cap bootstrap file per agent with the same counts, for offline discovery without a turn. Agents with `compact_context` explicitly off are skipped.
  - `COMPACT_BOOTSTRAP_MAX_CHARS` and `BOOTSTRAP_FILES` now live in `system_prompt` and are shared by both turn paths and doctor, so the runtime warn and the doctor report can never drift apart.
- **Scope boundary:** no change to the truncation budget, the cap value, the agent-facing marker, or injection ordering — #10465 / #5287 own the budget work. `prompt_injection_mode` (skills injection) is untouched.
- **Blast radius:** every agent turn with compact context (one deduped WARN per file per process), `zeroclaw doctor` output (new check rows), and the two `loop_.rs` cap call sites now reference the shared constant.
- **Linked issue(s):** Closes #10523. Related #10465 (compact prompt budget), #5287 (accepted budget contract), #10068 (adjacent context ceiling).
- **Labels:** bug, agent, runtime, agent:prompt, daemon, doctor, priority:p1, risk:medium (carried from the issue).

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (`zeroclaw doctor`).
- **Setup / preconditions:** an agent whose `AGENTS.md` exceeds 6000 characters on a default runtime profile.
- **Steps to run:** `zeroclaw doctor` with such a workspace; or send the agent any message and grep the log for `agent.bootstrap_file_truncated`.
- **Expected on this branch (after):** doctor prints an `agent.prompt` Warn row `alpha/AGENTS.md: injected 6000 of <N> chars (<N-6000> discarded, compact_context=true)`; the daemon log carries the same line once after restart.
- **Prior behavior on `master` (before):** no doctor row and no log line anywhere — the truncation marker is only visible to the model.

### How I tested

- **CI checks relied on and why they cover this change:** workspace fmt / clippy (`--all-targets -D warnings`) / test gates cover `zeroclaw-runtime` including the new tests.
- **Known CI coverage gap, if any:** none for the changed surface.
- **Commands run and tail output:**

```sh
cargo +1.98.0-aarch64-apple-darwin fmt --all -- --check        # clean
cargo +1.98.0-aarch64-apple-darwin clippy -p zeroclaw-runtime --all-targets -- -D warnings
#     Finished `dev` profile ... (0 warnings)
cargo +1.98.0-aarch64-apple-darwin test -p zeroclaw-runtime --lib
#     test result: ok. 4112 passed; 0 failed; 3 ignored
```

New tests: `bootstrap_truncation_warns_once_per_workspace_file` (first truncation warns, same file does not warn twice, a different file still does) and `check_bootstrap_truncation_reports_over_cap_files_only` (exactly one Warn row with the exact message for a 7000-char file, none for an under-cap file).

- **Beyond CI, what did you manually verify?** The leader personally read the full diff. **Not-checked: cross-vendor adversarial review** — the designated external review seats were unreachable while this was prepared (network timeouts to the review backends); a review pass will follow on this PR as soon as a seat is reachable, before merge.
- **If any command was intentionally skipped, why:** full-workspace suite not run locally (pre-existing local MSRV gap on unrelated crates); CI covers the workspace on the pinned toolchain.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** (doctor already reads agent workspaces; the WARN only logs counts, never file content)
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No** (the agent-visible prompt text is unchanged; the new WARN goes to the operator log only)

## Compatibility (required)

- Backward compatible? **Yes** (additive logging and a doctor check; no API, config, or behavior change)
- Config / env / CLI surface changed? **No** (doctor gains a check row; no new keys)
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge sha>`
- **Feature flags or config toggles:** None (disable `compact_context` per agent to avoid the cap itself, as before)
- **Observable failure symptoms:** extra `agent.prompt` Warn rows in doctor output or one `agent.bootstrap_file_truncated` WARN per file per process in the daemon log; absence of either does not affect turns.
