### PR TITLE
feat(web): add /upload slash command to open the image picker

### DIFF
--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1441,6 +1441,7 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.start_conversation': 'Send a message to start the conversation',
     'agent.type_message': 'Type a message...',
     'agent.attach_image': 'Attach image',
+    'agent.cmd_help_upload': 'Attach an image via the file picker',
     'agent.drop_to_attach': 'Drop images to attach',
     'agent.upload_failed': 'Image upload failed: {error}',
     'agent.upload_not_image': '{name} is not an image — only PNG, JPEG, GIF, and WebP can be attached.',

--- a/web/src/lib/slashCommands.ts
+++ b/web/src/lib/slashCommands.ts
@@ -13,7 +13,7 @@ import { t } from '@/lib/i18n';
  */
 
 /** Canonical command name (without the leading slash). */
-export type CommandName = 'help' | 'clear' | 'new' | 'model';
+export type CommandName = 'help' | 'clear' | 'new' | 'model' | 'upload';
 
 export interface CommandSpec {
   /** Command name without the leading slash, e.g. `help`. */
@@ -33,6 +33,7 @@ export const COMMANDS: readonly CommandSpec[] = [
   { name: 'clear', usage: '/clear', descriptionKey: 'agent.cmd_help_clear' },
   { name: 'new', usage: '/new', descriptionKey: 'agent.cmd_help_new' },
   { name: 'model', usage: '/model [name]', descriptionKey: 'agent.cmd_help_model' },
+  { name: 'upload', usage: '/upload', descriptionKey: 'agent.cmd_help_upload' },
 ] as const;
 
 export interface ParsedCommand {

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -255,6 +255,13 @@ export function AgentChatInner({
         }
         return true;
 
+      case 'upload':
+        // Same picker as the attach button — the input click is allowed here
+        // because runCommand fires from the user's Enter keypress, keeping
+        // the browser's user-activation requirement satisfied.
+        fileInputRef.current?.click();
+        return true;
+
       case 'model': {
         const name = args.trim();
         if (!name) {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `/upload` joins the web composer's command registry (help/clear/new/model), opening the same OS file picker as the attach button introduced in #10544 — a keyboard-first route to attaching an image. The registry derives the autocomplete popover and `/help` output, so both pick it up with no extra wiring. The picker click fires synchronously from the user's Enter keypress, satisfying the browser's user-activation requirement.
- **Scope boundary:** No backend changes; no new upload semantics — this only adds a third gesture to the picker #10544 ships. No arbitrary-file support (tracked separately).
- **Blast radius:** `slashCommands.ts` registry, one `runCommand` case, one English i18n key (other locales fall back).
- **Linked issue(s):** Depends on #10544 (uses its hidden file input and upload endpoint). No issue closed.
- **Labels:** to be snapshotted after the labeler runs

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** surface `web`
- **Setup / preconditions:** #10544 checked out underneath (this branch stacks on it); gateway serving the dashboard
- **Steps to run:** in Agent Chat, type `/upl` — observe the autocomplete popover; complete to `/upload` and press Enter
- **Expected on this branch (after):** the OS file picker opens; picking an image uploads it and appends the `[IMAGE:…]` marker to the composer; `/help` lists `/upload`
- **Prior behavior on `master` (before):** `/upload` is an unknown command; the only picker routes are the attach button and drag-and-drop from #10544

### How I tested

- **CI checks relied on and why they cover this change:** none yet — will run on this PR; frontend-only diff
- **Known CI coverage gap, if any:** none expected
- **Commands run and tail output:** `npm run typecheck` → exit 0; `npm run build` → `✓ built in 730ms`
- **Beyond CI, what did you manually verify?** Command registry derivations (popover + /help) are code-driven from `COMMANDS`, verified by reading the derivation sites; the user-activation reasoning is documented at the call site. NOT verified: a live click-through on this head (the picker flow itself is exercised and screenshotted in #10544).
- **Visual interface changed?** N/A — no new rendered elements; the command popover renders registry entries as it already does
- **If any command was intentionally skipped, why:** Rust checks skipped — no Rust files touched

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.