### PR TITLE
docs(channels): add Twitch setup guide

### DIFF
--- a/docs/book/src/channels/overview.md
+++ b/docs/book/src/channels/overview.md
@@ -36,7 +36,7 @@ Real-time messaging where the agent can hold a conversation, get notified of new
 | LINE | `channel-line` | [LINE](./line.md) |
 | Nextcloud Talk | `channel-nextcloud` | [Nextcloud Talk](./nextcloud-talk.md) |
 | Signal | `channel-signal` | [Signal](./signal.md) |
-| Twitch | `channel-twitch` | No dedicated guide |
+| Twitch | `channel-twitch` | [Twitch](./social.md#twitch) |
 | WhatsApp Cloud API | `channel-whatsapp-cloud` | [WhatsApp](./whatsapp.md) |
 | WhatsApp Web | `whatsapp-web` | [WhatsApp](./whatsapp.md) |
 | iMessage, WeChat personal iLink Bot, DingTalk, Lark, QQ, IRC, Mochat, Notion | per channel | [Other chat platforms](./chat-others.md) |

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -8,9 +8,7 @@ Broadcast / social-feed integrations. These differ from chat channels in two way
 
 Twitch chat is a thin adapter over IRC. Build it with `--features channel-twitch` or include it through `--features channels-full`; the lean default build does not include it.
 
-{{#config-fields channels.twitch}}
-
-A minimal instance looks like this:
+Configure `enabled`, `bot_username`, `oauth_token`, and the channels to join under a Twitch alias. `mention_only` is optional and defaults to `false`. A minimal instance looks like this:
 
 ```toml
 [channels.twitch.default]

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -4,6 +4,33 @@ Broadcast / social-feed integrations. These differ from chat channels in two way
 
 > **Build note:** Social channels are **not included** in the lean default build. To use them, build with `--features channels-full` (all channels) or the specific feature flag (e.g. `--features channel-twitter`). Prebuilt binaries do not include these channels by default. See [Channels → Overview](./overview.md) for the full build-options table.
 
+## Twitch
+
+Twitch chat is a thin adapter over IRC. Build it with `--features channel-twitch` or include it through `--features channels-full`; the lean default build does not include it.
+
+{{#config-fields channels.twitch}}
+
+A minimal instance looks like this:
+
+```toml
+[channels.twitch.default]
+enabled = true
+bot_username = "zeroclaw_bot"
+oauth_token = "replace-with-twitch-token"
+channels = ["zeroclaw_channel"]
+mention_only = true
+
+[peer_groups.twitch_default]
+channel = "twitch.default"
+external_peers = ["zeroclaw_user"]
+```
+
+- **Auth:** use a Twitch user access token for the bot account. Create one with the [TMI token generator](https://twitchapps.com/tmi/) or the Twitch CLI, then store it through a protected config surface. ZeroClaw trims the value and adds the required `oauth:` prefix when it is omitted.
+- **Channels:** entries in `channels` may include the leading `#`; ZeroClaw adds it when missing and normalizes channel names to lowercase.
+- **Inbound and outbound:** channel messages are answered in the same channel. `mention_only = true` ignores channel messages that do not mention `bot_username`. If Twitch delivers a non-channel IRC `PRIVMSG` to the bot login, ZeroClaw replies to that sender; the adapter does not configure a separate whisper transport.
+- **Formatting:** Twitch replies use plain text and are split to fit IRC frames. Markdown formatting is not preserved.
+- **Rate limits:** the adapter writes IRC `PRIVMSG` frames directly and has no Twitch-specific rate limiter or HTTP `429` backoff. Keep the agent's posting cadence within Twitch Chat limits and throttle bursty workflows at their source.
+
 ## Bluesky (AT Protocol)
 
 - **Auth:** Bluesky app-password (not your real password). Create one in settings.
@@ -45,4 +72,4 @@ Bots on public social networks attract adversarial input. Two precautions:
 
 ## Rate limits and backoff
 
-All social channels are subject to aggressive rate limits. ZeroClaw's outbound queue uses exponential backoff on 429 responses. If you hit persistent rate-limiting, throttle the agent's posting cadence at the source rather than relying on per-channel streaming knobs (none of these channels expose draft-update intervals; their schema is intentionally minimal).
+All social channels are subject to aggressive rate limits. HTTP-backed social adapters use exponential backoff on `429` responses. Twitch is the IRC-backed exception described above and has no adapter-specific limiter. If you hit persistent rate-limiting, throttle the agent's posting cadence at the source rather than relying on per-channel streaming knobs (none of these channels expose draft-update intervals; their schema is intentionally minimal).

--- a/docs/book/src/channels/social.md
+++ b/docs/book/src/channels/social.md
@@ -23,7 +23,7 @@ channel = "twitch.default"
 external_peers = ["zeroclaw_user"]
 ```
 
-- **Auth:** use a Twitch user access token for the bot account. Create one with the [TMI token generator](https://twitchapps.com/tmi/) or the Twitch CLI, then store it through a protected config surface. ZeroClaw trims the value and adds the required `oauth:` prefix when it is omitted.
+- **Auth:** use a Twitch user access token for the bot account with [`chat:read` and `chat:edit`](https://dev.twitch.tv/docs/chat/irc/#authenticating-with-the-twitch-irc-server). After configuring the [Twitch CLI](https://dev.twitch.tv/docs/cli/token-command/), generate it while signed in as that account with `twitch token -u -s 'chat:read chat:edit'`, then store it through a protected config surface. ZeroClaw trims the value and adds the required `oauth:` prefix when it is omitted.
 - **Channels:** entries in `channels` may include the leading `#`; ZeroClaw adds it when missing and normalizes channel names to lowercase.
 - **Inbound and outbound:** channel messages are answered in the same channel. `mention_only = true` ignores channel messages that do not mention `bot_username`. If Twitch delivers a non-channel IRC `PRIVMSG` to the bot login, ZeroClaw replies to that sender; the adapter does not configure a separate whisper transport.
 - **Formatting:** Twitch replies use plain text and are split to fit IRC frames. Markdown formatting is not preserved.
@@ -68,6 +68,6 @@ Bots on public social networks attract adversarial input. Two precautions:
 1. **Restrict who the agent will respond to.** Gate inbound senders with a peer group (per channel, above): an empty peer set denies everyone, `["*"]` accepts anyone. Bluesky has no peer-group sender field; gate at the autonomy / tool layer instead.
 2. **Keep autonomy level at `Supervised` or lower.** A public-facing agent in `Full` autonomy is effectively a public shell. For public-facing channels, restrict the tool surface in the global tool-policy config rather than expecting per-channel `tools_allow` (no such per-channel field exists).
 
-## Rate limits and backoff
+## Rate limits
 
-All social channels are subject to aggressive rate limits. HTTP-backed social adapters use exponential backoff on `429` responses. Twitch is the IRC-backed exception described above and has no adapter-specific limiter. If you hit persistent rate-limiting, throttle the agent's posting cadence at the source rather than relying on per-channel streaming knobs (none of these channels expose draft-update intervals; their schema is intentionally minimal).
+Rate-limit handling differs by channel. Twitch writes IRC `PRIVMSG` frames directly and has no adapter-specific limiter. If you hit persistent rate-limiting, throttle the agent's posting cadence at the source rather than relying on per-channel streaming knobs (none of these channels expose draft-update intervals; their schema is intentionally minimal).


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add a Twitch section to the social-channel guide so the existing IRC-backed integration has a discoverable setup path.
  - Document the current feature flag, schema-owned config fields, OAuth normalization, channel and direct-message routing, plain-text output, and rate-limit boundary.
  - Replace the discontinued TMI token-generator guidance with the official Twitch CLI user-token flow and the IRC-required `chat:read` / `chat:edit` scopes.
  - Remove the inaccurate cross-adapter exponential-backoff claim while preserving the Twitch no-limiter warning.
  - Link the Twitch row in the channel overview to the new section.
- **Scope boundary:** Documentation only. This does not change the Twitch adapter, configuration schema, authentication behavior, message routing, or rate limiting.
- **Blast radius:** Readers of the channel overview and social-channel guide. No runtime, build, release, or compatibility surface changes.
- **Linked issue(s):** Closes #10571
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a docs-only change covered by the repository's docs gates and full mdBook build.

### How I tested

- **CI checks relied on and why they cover this change:** The current docs-only head completed all 37 current checks, including the required `CI Required Gate`; local docs quality, links, generated-prose, and full mdBook gates also cover the changed Markdown directly.
- **Known CI coverage gap, if any:** The links gate found the added HTTP links but could not run optional `lychee`; direct requests to both official Twitch documentation URLs returned HTTP 200.
- **Commands run and tail output:**

```sh
scripts/ci/docs_quality_gate.sh
# Linting: 2 file(s)
# Summary: 0 error(s)

scripts/ci/docs_links_gate.sh
# Ran 6 tests ... OK
# Collected 2 added link(s) from 2 docs file(s).
# Checked 1 local docs link target(s).

cargo +1.97.1 test -p xtask cmd::mdbook::peer_groups::generated_prose_gate::directives_emit_no_prose_em_dashes -- --exact
# 1 passed; 0 failed

cargo +1.97.1 mdbook build
# HTML books written for en, fr, ja, es, and zh-CN
# Internal link check passed

git diff origin/master...HEAD --check
# no output
```

- **Beyond CI, what did you manually verify?** Verified the token type, CLI command, and `chat:read` / `chat:edit` requirements against the current official Twitch CLI and IRC authentication documentation. Rechecked Twitch's direct IRC writes, Twitter's fixed 60-second polling wait, and the Reddit/Bluesky HTTP error paths before removing the cross-adapter backoff claim. I did not connect a live Twitch account or use a real token.
- **Visual interface changed?** N/A; authored Markdown and navigation link only.
- **If any command was intentionally skipped, why:** Routine English docs changes may omit generated translation catalogue churn. Optional `lychee` was unavailable, so the two official Twitch HTTP links were checked directly instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**; the guide documents the existing secret config field and required scopes without including a credential.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk documentation change: `git revert 65f1b2f68d61a498698367d9cbe5b0233e9de63f b3a4b9388cedfbfaf191f597690463724ab847ac 359b98fd6a08911f9a7d8cab1550151199c5ee3a`.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another contribution.
