### PR TITLE
fix(runtime): decide attachment image markers by the provider-loadable contract

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/attachments.rs
+++ b/crates/zeroclaw-runtime/src/rpc/attachments.rs
@@ -34,7 +34,7 @@ pub async fn process_file_entry(
     use sha2::{Digest, Sha256};
 
     // 1. Resolve bytes + filename + mime_type.
-    let (bytes, filename, mime_type) = if let Some(ref b64) = entry.data_b64 {
+    let (bytes, filename) = if let Some(ref b64) = entry.data_b64 {
         let decoded = STANDARD
             .decode(b64)
             .map_err(|e| rpc_err(INVALID_PARAMS, format!("Invalid base64: {e}")))?;
@@ -49,11 +49,7 @@ pub async fn process_file_entry(
             ));
         }
         let fname = entry.filename.as_deref().unwrap_or("upload").to_string();
-        let mime = entry
-            .mime_type
-            .clone()
-            .unwrap_or_else(|| mime_from_filename(&fname));
-        (decoded, fname, mime)
+        (decoded, fname)
     } else if let Some(ref path) = entry.path {
         if is_wss {
             return Err(rpc_err(
@@ -82,11 +78,7 @@ pub async fn process_file_entry(
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "upload".to_string());
-        let mime = entry
-            .mime_type
-            .clone()
-            .unwrap_or_else(|| mime_from_filename(&fname));
-        (bytes, fname, mime)
+        (bytes, fname)
     } else {
         return Err(rpc_err(
             INVALID_PARAMS,
@@ -130,8 +122,15 @@ pub async fn process_file_entry(
     .map_err(|e| rpc_err(INTERNAL_ERROR, e.to_string()))?;
     let workspace_path = strip_windows_verbatim_prefix(&dest.to_string_lossy()).into_owned();
 
-    let kind = attachment_kind(&mime_type);
-    let marker = if kind == "IMAGE" {
+    // IMAGE iff the multimodal loader will actually accept these bytes under
+    // this name — the canonical provider-loadable contract from
+    // `zeroclaw_api::media` — never a declared MIME. A MIME the loader
+    // rejects (image/svg+xml, image/bmp, image/heic) used to earn an
+    // [IMAGE:] marker whose payload the provider path then dropped in
+    // favour of a "could not be loaded" note, stranding the upload.
+    let is_image =
+        zeroclaw_api::media::provider_loadable_image_mime_for(&sanitized, &bytes).is_some();
+    let marker = if is_image {
         format!("[IMAGE:{workspace_path}]")
     } else {
         // Non-image: prose format with workspace path so the agent can
@@ -180,25 +179,6 @@ fn strip_windows_verbatim_prefix(path: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Borrowed(path)
 }
 
-/// Derive MIME type from filename extension via `mime_guess`.
-/// Falls back to `application/octet-stream` for unknown extensions.
-fn mime_from_filename(name: &str) -> String {
-    mime_guess::from_path(name)
-        .first_or_octet_stream()
-        .to_string()
-}
-
-/// Map MIME type to attachment kind for markers.
-fn attachment_kind(mime: &str) -> &'static str {
-    if mime.starts_with("image/") {
-        "IMAGE"
-    } else if mime == "application/pdf" {
-        "DOCUMENT"
-    } else {
-        "FILE"
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,27 +192,84 @@ mod tests {
             .any(|component| matches!(component, Component::Normal(name) if name == OsStr::new("uploads")))
     }
 
-    #[test]
-    fn mime_from_filename_common_types() {
-        assert_eq!(mime_from_filename("photo.png"), "image/png");
-        assert_eq!(mime_from_filename("photo.jpg"), "image/jpeg");
-        assert_eq!(mime_from_filename("doc.pdf"), "application/pdf");
-        assert_eq!(mime_from_filename("data.csv"), "text/csv");
-        assert_eq!(
-            mime_from_filename("unknown.zzzzz"),
-            "application/octet-stream"
+    #[tokio::test]
+    async fn svg_becomes_a_document_marker_not_an_image() {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().to_string_lossy().to_string();
+        let store = setup_store(&ws).await;
+
+        // Declared image MIME cannot earn an [IMAGE:] marker: the provider
+        // loader refuses SVG, so promising it to the model strands the file.
+        let entry = FileEntry {
+            path: None,
+            data_b64: Some(STANDARD.encode(b"<svg xmlns='http://www.w3.org/2000/svg'/>")),
+            filename: Some("logo.svg".into()),
+            mime_type: Some("image/svg+xml".into()),
+            source: FileSource::File,
+        };
+        let r = process_file_entry(&entry, "s1", &ws, false, &store)
+            .await
+            .unwrap();
+        assert!(
+            r.marker.starts_with("[Document: logo.svg]"),
+            "expected document marker, got {}",
+            r.marker
         );
-        assert_eq!(mime_from_filename("noext"), "application/octet-stream");
     }
 
-    #[test]
-    fn attachment_kind_maps_correctly() {
-        assert_eq!(attachment_kind("image/png"), "IMAGE");
-        assert_eq!(attachment_kind("image/jpeg"), "IMAGE");
-        assert_eq!(attachment_kind("image/svg+xml"), "IMAGE");
-        assert_eq!(attachment_kind("application/pdf"), "DOCUMENT");
-        assert_eq!(attachment_kind("application/zip"), "FILE");
-        assert_eq!(attachment_kind("text/plain"), "FILE");
+    #[tokio::test]
+    async fn extensionless_png_bytes_are_an_image_by_magic() {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().to_string_lossy().to_string();
+        let store = setup_store(&ws).await;
+
+        // No filename, no MIME: the payload's magic bytes alone decide.
+        let png = [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1A, b'\n', 0, 0];
+        let entry = FileEntry {
+            path: None,
+            data_b64: Some(STANDARD.encode(png)),
+            filename: None,
+            mime_type: None,
+            source: FileSource::File,
+        };
+        let r = process_file_entry(&entry, "s1", &ws, false, &store)
+            .await
+            .unwrap();
+        assert!(
+            r.marker.starts_with("[IMAGE:"),
+            "expected image marker, got {}",
+            r.marker
+        );
+    }
+
+    #[tokio::test]
+    async fn declared_image_mime_cannot_widen_acceptance() {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().to_string_lossy().to_string();
+        let store = setup_store(&ws).await;
+
+        // Text bytes under a text name: a lying image/png MIME changes nothing.
+        let entry = FileEntry {
+            path: None,
+            data_b64: Some(STANDARD.encode(b"plain text")),
+            filename: Some("note.txt".into()),
+            mime_type: Some("image/png".into()),
+            source: FileSource::File,
+        };
+        let r = process_file_entry(&entry, "s1", &ws, false, &store)
+            .await
+            .unwrap();
+        assert!(
+            r.marker.starts_with("[Document: note.txt]"),
+            "expected document marker, got {}",
+            r.marker
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/rpc/types.rs
+++ b/crates/zeroclaw-runtime/src/rpc/types.rs
@@ -1229,6 +1229,9 @@ rpc_type! {
         pub data_b64: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub filename: Option<String>,
+        /// Advisory only, retained for wire compatibility. The image/document
+        /// marker decision is made from the filename and payload bytes via the
+        /// canonical provider-loadable contract, never from this field.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mime_type: Option<String>,
         #[serde(default)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** RPC `file/attach` (and the inline `session/prompt.attachments` path that shares it) typed an attachment IMAGE from the client-declared MIME or an extension guess. A MIME the multimodal loader refuses — `image/svg+xml`, `image/bmp`, `image/heic` — therefore earned an `[IMAGE:]` marker whose payload the provider path then dropped with a "could not be loaded" note, stranding the upload: not visible to the model, and not reachable as a document either. The marker decision now defers to the canonical provider-loadable contract in `zeroclaw_api::media` (`provider_loadable_image_mime_for`: filename extension first, then magic bytes — the same precedence the loader itself uses); non-loadable files fall back to `[Document: name] path` markers the agent can read with its file tools. The now-dead MIME resolution (`mime_from_filename`, `attachment_kind`) is removed.
- **Scope boundary:** RPC attachment marker decision only. No wire-shape change: `FileEntry.mime_type` remains accepted (documented advisory). No change to storage, dedup, size caps, or the web upload endpoint.
- **Blast radius:** Any RPC client (zerocode, ACP bridges) attaching a file whose declared MIME said image but whose payload the loader rejects: it now gets a `[Document: …]` marker instead of a doomed `[IMAGE:]` one — a behavior change that is strictly an improvement in what the agent can actually do with the file. Channels are untouched (they already consult this contract).
- **Linked issue(s):** None. Standalone fix; independent of the web upload stack (#10544/#10578), which consults the same contract from the web side.
- **Labels:** to be snapshotted after the labeler runs

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the behavior boundary is fully covered by in-crate regressions below, and driving `file/attach` manually requires an RPC client session.

### How I tested

- **CI checks relied on and why they cover this change:** none yet — will run on this PR
- **Known CI coverage gap, if any:** none expected
- **Commands run and tail output:**
  - `cargo test -p zeroclaw-runtime rpc::attachments` → `test result: ok. 18 passed; 0 failed` (3 new: `svg_becomes_a_document_marker_not_an_image`, `extensionless_png_bytes_are_an_image_by_magic`, `declared_image_mime_cannot_widen_acceptance`)
  - `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings` → clean
  - `cargo fmt --all -- --check` → clean
  - `cargo test -p zeroclaw-runtime` (full) → 4125 passed, 3 failed — the 3 failures (`tools::delegate::tests::{background_task_result_persisted_to_disk, check_result_retrieves_persisted_background_result, list_results_includes_background_tasks}`) reproduce identically on clean master `00215f7a9` with this diff stashed, so they are pre-existing on master (possibly environment-specific to this macOS host, possibly related to #10030 which touched RPC session persistence) and unrelated to this change
- **Beyond CI, what did you manually verify?** The stash/unstash comparison above isolating the pre-existing failures. NOT verified: a live RPC client round-trip on this head.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** none

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No — the marker vocabulary is unchanged; this only corrects which of the two existing marker forms a file receives, and stops a client-declared MIME from influencing that choice

## Compatibility (required)

- Backward compatible? Yes — wire shapes unchanged; `FileEntry.mime_type` still accepted
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`. Observable symptom if misbehaving: RPC attachments that previously produced `[IMAGE:]` markers produce `[Document: …]` markers (or vice versa); grep transcripts for the marker forms.