### PR TITLE
feat(config): default multimodal.max_image_size_mb to the 20 MiB ceiling

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6530,6 +6530,18 @@ pub struct MultimodalConfig {
     #[serde(default = "default_multimodal_max_images")]
     pub max_images: usize,
     /// Maximum image payload size in MiB before base64 encoding.
+    ///
+    /// Measured on decoded bytes, so the encoded request payload is about a
+    /// third larger. Applies to every image entering the pipeline: channel
+    /// attachments, tool outputs that surface local image paths, and the web
+    /// dashboard upload. Defaults to the 20 MiB ceiling that
+    /// [`MultimodalConfig::effective_limits`] clamps to, so an ordinary photo
+    /// is accepted without configuration; lower it to bound per-turn upload
+    /// cost or gateway buffering.
+    ///
+    /// Providers apply their own limits on top of this one. Anthropic refuses a
+    /// single image over 10 MB base64-encoded (about 7.5 MiB decoded), enforced
+    /// by its provider client independently of this setting.
     #[serde(default = "default_multimodal_max_image_size_mb")]
     pub max_image_size_mb: usize,
     /// Maximum age of images in conversation turns.
@@ -6564,11 +6576,18 @@ fn default_multimodal_max_images() -> usize {
 }
 
 fn default_multimodal_max_image_size_mb() -> usize {
-    5
+    20
 }
 
 impl MultimodalConfig {
     /// Clamp configured values to safe runtime bounds.
+    ///
+    /// The 20 MiB image ceiling is the lowest common per-image or per-request
+    /// bound across the supported vision APIs (OpenAI accepts about 20 MB per
+    /// image, Gemini 20 MB for an inline request, Anthropic 32 MB per request
+    /// with a tighter per-image limit its own client enforces). Images are
+    /// buffered whole and grow by about a third under base64, so the ceiling
+    /// also bounds gateway memory per upload.
     pub fn effective_limits(&self) -> (usize, usize) {
         let max_images = self.max_images.clamp(1, 16);
         let max_image_size_mb = self.max_image_size_mb.clamp(1, 20);

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -26355,6 +26355,33 @@ untrusted_outbound_redact = false
     }
 
     #[test]
+    async fn multimodal_defaults_sit_at_the_effective_ceiling() {
+        // The default is deliberately the clamp ceiling: an operator who never
+        // configures `[multimodal]` should be able to send an ordinary photo.
+        // If either number moves, move it here too rather than incidentally.
+        let cfg = MultimodalConfig::default();
+        assert_eq!(cfg.max_image_size_mb, 20);
+        assert_eq!(cfg.effective_limits(), (4, 20));
+    }
+
+    #[test]
+    async fn multimodal_effective_limits_clamp_out_of_range_values() {
+        let cfg = MultimodalConfig {
+            max_images: 99,
+            max_image_size_mb: 512,
+            ..MultimodalConfig::default()
+        };
+        assert_eq!(cfg.effective_limits(), (16, 20));
+
+        let cfg = MultimodalConfig {
+            max_images: 0,
+            max_image_size_mb: 0,
+            ..MultimodalConfig::default()
+        };
+        assert_eq!(cfg.effective_limits(), (1, 1));
+    }
+
+    #[test]
     async fn http_request_config_default_has_correct_values() {
         let cfg = HttpRequestConfig::default();
         assert_eq!(cfg.timeout_secs, 30);

--- a/docs/book/src/providers/configuration.md
+++ b/docs/book/src/providers/configuration.md
@@ -138,6 +138,30 @@ The setting requires an Anthropic account enrolled in the
 request. Set `display = "off"` (or remove the field) to return to the
 previous wire behavior.
 
+## Image input limits
+
+`[multimodal]` bounds every image that enters the request pipeline, whatever its
+source: channel attachments, tool outputs that surface a local image path, and
+the web dashboard upload.
+
+```toml
+[multimodal]
+max_image_size_mb = 20   # per image, decoded bytes (default: 20, clamped to 1-20)
+max_images        = 4    # images kept per request (default: 4, clamped to 1-16)
+```
+
+`max_image_size_mb` is measured before base64 encoding, so the encoded payload
+reaching the provider is about a third larger. The 20 MiB ceiling is the lowest
+common per-image or per-request bound across the supported vision APIs, and
+images are buffered whole, so it also bounds gateway memory per upload. Lower
+the value to cap per-turn upload cost.
+
+Providers apply their own limits on top of this setting. Anthropic refuses a
+single image over 10 MB base64-encoded, about 7.5 MiB decoded, and its client
+enforces that regardless of what `max_image_size_mb` allows. Model context cost
+does not track bytes: providers rasterize images and bill by pixel dimensions,
+so a large file and a small one at the same resolution cost roughly the same.
+
 ## Per-family knobs: worked examples
 
 ### Ollama


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `multimodal.max_image_size_mb` defaulted to 5 MiB, below what every
    supported vision API accepts and below what an ordinary phone photo
    weighs, so images between 5 and 20 MiB were dropped before any provider
    saw them. Default to 20, the value `effective_limits` already clamps to.
  - Record why the numbers are what they are. The doc comment now states that
    the limit measures decoded bytes (base64 adds about a third), that it
    covers every image entering the pipeline, and that Anthropic enforces its
    own tighter per-image limit regardless of this setting. The
    `effective_limits` comment explains the 20 MiB ceiling: it is the lowest
    common per-image or per-request bound across the supported vision APIs,
    and images are buffered whole, so it also bounds gateway memory.
  - Document the keys. `max_image_size_mb` and `max_images` were not described
    anywhere in the book; provider configuration now has an "Image input
    limits" section, including the note that providers bill images by pixel
    dimensions rather than bytes, so a bigger file is not a bigger context
    cost.
  - Pin both numbers with tests, so a future change to the default or the
    clamp is deliberate rather than incidental.
- **Scope boundary:** The clamp ceiling stays at 20. No per-provider or
  per-agent defaults, no client-side downscaling before upload, no change to
  Anthropic's own per-image check, and no API, wire, or CLI surface change.
  Explicitly configured values are untouched.
- **Blast radius:** Any operator running on the default. That is the whole
  multimodal path, so channel image attachments and tool results that surface a
  local image path today, plus the web dashboard upload in #10544 once it
  lands, since it resolves its limit from this same setting at request time.
- **Linked issue(s):** Closes #10588. Related #10544 (the dashboard upload that
  made the low default visible).
- **Labels:** `enhancement`, `config`, `docs`, `risk:low`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `channel` (any channel that accepts image
  attachments), or a tool result that surfaces a local image path
- **Setup / preconditions:** An agent on a vision-capable provider and a config
  with no `[multimodal] max_image_size_mb` set, so the default applies. Have an
  image between 5 and 20 MiB on hand.
- **Steps to run:** Send that image to the agent through a configured channel,
  or run a tool whose output contains an `[IMAGE:/path/to/big.png]` marker, and
  ask the model to describe it.
- **Expected on this branch (after):** The image reaches the model and is
  described.
- **Prior behavior on `master` (before):** The same image is skipped before the
  request is built, with `multimodal image size limit exceeded for '<input>':
  <n> bytes > 5242880 bytes`, and the model answers as though no image was
  attached.

### How I tested

Config, docs, and tests only; no runtime code path changed, so the evidence is
the config crate suite, the multimodal consumer suite, and the docs gates.

```sh
$ cargo fmt --all -- --check
# clean

$ cargo test -p zeroclaw-config
test result: ok. 1494 passed; 0 failed; 0 ignored
test result: ok. 8 passed; 0 failed; 0 ignored
test result: ok. 92 passed; 0 failed; 0 ignored
test result: ok. 5 passed; 0 failed; 0 ignored
test result: ok. 9 passed; 0 failed; 0 ignored
test result: ok. 1 passed; 0 failed; 0 ignored
test result: ok. 1 passed; 0 failed; 0 ignored

$ cargo test -p zeroclaw-config multimodal
test schema::tests::multimodal_effective_limits_clamp_out_of_range_values ... ok
test schema::tests::multimodal_defaults_sit_at_the_effective_ceiling ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 1492 filtered out

$ cargo test -p zeroclaw-providers multimodal
test result: ok. 63 passed; 0 failed; 0 ignored; 1424 filtered out

$ BASE_SHA=$(git merge-base upstream/master HEAD) bash scripts/ci/docs_quality_gate.sh
Linting docs files: docs/book/src/providers/configuration.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Summary: 0 error(s)
OK

$ BASE_SHA=$(git merge-base upstream/master HEAD) bash scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.
```

- **CI checks relied on and why they cover this change:** The Rust workspace
  build, test, clippy, and format jobs cover the one changed crate and every
  consumer of `effective_limits`; `Docs Style` covers the changed Markdown.
- **Known CI coverage gap, if any:** None. No new runtime behavior is
  introduced; the changed value flows through call sites that already have
  coverage, and the multimodal consumer suite was run locally against the new
  default (63 tests).
- **Commands run and tail output:** See the block above.
- **Beyond CI, what did you manually verify?** I checked every reference to
  `max_image_size_mb` and `effective_limits` in the workspace to confirm nothing
  asserts the old default: the fixtures in `zeroclaw-providers/src/multimodal.rs`
  and `zeroclaw-runtime/src/agent/loop_.rs` construct explicit values, and
  `crates/zeroclaw-config/fixtures/v1.toml` sets the key explicitly for a
  migration fixture, so none of them depend on the default. I also confirmed
  the Anthropic client's per-image ceiling is a separate constant that this
  change does not touch. Not verified: a live oversized image through a real
  vision provider, since that needs provider credentials and a large fixture.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** Full-workspace
  `cargo test --locked` was not rerun; the diff is one crate's default plus a
  docs page, and the consumer suites above cover the call sites.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A. Note without a `Yes`:
  operators on the default now accept larger images, so request bodies and the
  gateway's per-upload buffering grow. Both stay bounded by the unchanged
  20 MiB ceiling that `effective_limits` enforces, and an operator who wants
  the old bound can set the key explicitly.

## Compatibility (required)

- Backward compatible? `Yes` — no key is added, removed, or renamed, and an
  explicitly configured value keeps its meaning.
- Config / env / CLI surface changed? `Yes` — the default value of the existing
  `multimodal.max_image_size_mb` key changes from 5 to 20. Operators who relied
  on the implicit 5 MiB bound restore it with:

  ```toml
  [multimodal]
  max_image_size_mb = 5
  ```

- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge sha>`; the change is a
  default and two doc blocks, with no persisted state or migration.
- **Feature flags or config toggles:** Setting `[multimodal]
  max_image_size_mb = 5` restores the previous bound without a revert.
- **Observable failure symptoms:** Growth in gateway memory during image
  uploads, or provider-side rejections of large images that previously never
  left ZeroClaw (for example Anthropic refusing an image above its own
  per-image limit, which is reported by its client rather than by the
  multimodal pipeline).
