### PR TITLE
feat(runtime): log reported context usage and budget trims

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -148,6 +148,24 @@ async fn enforce_reported_budget(
     event_tx: Option<&tokio::sync::mpsc::Sender<TurnEvent>>,
     observer: &dyn crate::observability::Observer,
 ) {
+    // The provider's own count of what the last request cost. Nothing else
+    // records it, so an operator sizing `max_context_tokens` has to infer the
+    // real peak from prompt reconstruction — which silently answers a
+    // different question, because it cannot see the trimming this function
+    // already applied. Emitted on every response, over budget or not, so the
+    // distribution is observable and not just the overruns.
+    ::zeroclaw_log::record!(
+        DEBUG,
+        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+            .with_category(::zeroclaw_log::EventCategory::Agent)
+            .with_attrs(::serde_json::json!({
+                "reported_input_tokens": reported_input_tokens,
+                "context_token_budget": context_token_budget,
+                "over_budget": context_token_budget > 0
+                    && reported_input_tokens > context_token_budget,
+            })),
+        "context_usage"
+    );
     if context_token_budget == 0 || reported_input_tokens <= context_token_budget {
         return;
     }
@@ -158,6 +176,21 @@ async fn enforce_reported_budget(
         reported_input_tokens,
     );
     if result.trimmed {
+        // Trimming is lossy and had no log record of its own: the existing
+        // TurnEvent reaches the UI and the observer event reaches telemetry,
+        // but neither lands in the daemon log an operator greps after the fact.
+        ::zeroclaw_log::record!(
+            WARN,
+            ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                .with_category(::zeroclaw_log::EventCategory::Agent)
+                .with_attrs(::serde_json::json!({
+                    "reported_input_tokens": reported_input_tokens,
+                    "context_token_budget": context_token_budget,
+                    "dropped_messages": result.dropped_messages,
+                    "kept_turns": result.kept_turns,
+                })),
+            "context_budget_trim: dropped history to fit the reported budget"
+        );
         let mut trimmed = result.history;
         crate::agent::history_trim::insert_breadcrumb_deduped(&mut trimmed);
         *history = trimmed;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `enforce_reported_budget` receives the provider's own `reported_input_tokens` for every model response — the only authoritative measure of what a request actually cost — compares it against `max_context_tokens`, trims history if it is over, and then discards the number.
  - Adds a **DEBUG `context_usage`** record on every response with the reported tokens, the budget, and an `over_budget` flag. Emitted whether or not the budget is exceeded, so the distribution is observable rather than only the overruns.
  - Adds a **WARN `context_budget_trim`** record when history is actually dropped, with the reported tokens, the budget, and the dropped/kept counts.
  - Logging only. No control flow, config surface, or trimming behaviour changes.

### Why this is worth a patch

Without it, sizing `max_context_tokens` means reconstructing the prompt by hand — and that silently answers a different question. A reconstruction cannot see the trimming this function has already applied, so it reports what the prompt *would* have been rather than what was sent, and overstates usage against a budget that is in fact enforced. I made exactly that mistake on a live deployment: a hand-reconstructed prompt came out 12% over the configured budget and I concluded the budget was too small, when usage had been bounded correctly the whole time and the number I had was not a measurement.

Trimming also had no log record of its own. `TurnEvent::HistoryTrimmed` reaches the UI and `ObserverEvent::HistoryTrimmed` reaches telemetry, but neither lands in the daemon log an operator greps after the fact — so "did history get dropped during that session?" was unanswerable after the fact on a deployment without an observer backend.

- **Scope boundary:** does not change when trimming happens, what it drops, or any default. Does not add a config key or touch the existing `TurnEvent` / `ObserverEvent` payloads.
- **Blast radius:** one DEBUG record per model response (inert unless `RUST_LOG` enables it) and one WARN record per actual trim, which is already an exceptional event.
- **Linked issue(s):** None
- **Labels:** `type:feat`, `runtime`, `observability`

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes — one command shows the new record.
- **Interface(s) exercised:** `surface: cli` and `channel`; the function is on the shared turn path.
- **Setup / preconditions:** any agent with `max_context_tokens` set.
- **Steps to run:** `RUST_LOG=zeroclaw_runtime::agent::turn=debug zeroclaw daemon`, then send a turn.
- **Expected on this branch (after):** a `context_usage` record per model response carrying `reported_input_tokens`, `context_token_budget`, `over_budget`. Drive a session past the budget and a `context_budget_trim` WARN appears with the dropped/kept counts.
- **Prior behavior on `master` (before):** neither record exists; `reported_input_tokens` is read and discarded, and a trim leaves nothing in the daemon log.

### How I tested

- **CI checks relied on and why they cover this change:** the Rust build/lint/test jobs cover `zeroclaw-runtime`, the only crate touched.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```console
$ cargo fmt --all -- --check
$ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo test -p zeroclaw-runtime -p zeroclaw-channels --locked
11 suites, 5011 passed, 0 failed
```

- **Beyond CI, what did you manually verify?** That the added record sits before the early return so the under-budget case — the common one — is still reported; a record placed after it would only ever fire on overruns, which is the case an operator already knows about.
- **What I did NOT verify, and why no test was added:** there is no `mod tests` in this module and the change adds no branch of its own, so a test would mean standing up a log-capture harness to assert on a log line. The existing suites are the check that surrounding behaviour is unchanged: the early return, the trim path, and both existing events are untouched.
- **If any command was intentionally skipped, why:** full-workspace `cargo test` not run; the change is confined to one function in one crate.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — the records carry integer counts only, never message content.
- Prompt injection or untrusted model-visible text introduced/changed? **No** — nothing added reaches the model.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>`. The DEBUG record is inert without `RUST_LOG`; the WARN record only fires where a trim already occurred.
