### PR TITLE
fix(providers): retry replay-safe empty streams once

### DIFF
--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -71,6 +71,7 @@ pub(crate) struct ReliableCallAccounting {
     accepted_route: Option<AcceptedRoute>,
     stream_resume_after: Option<ReliableEntryId>,
     stream_recovery_semantic_empty: bool,
+    stream_recovery_semantic_empty_permission: bool,
     stream_recovery_failure: Option<ProviderErrorDiagnostic>,
 }
 
@@ -116,16 +117,6 @@ async fn scope_reliable_call_accounting<F: std::future::Future>(
 
 fn accounted_rejected_attempt_usage() -> Option<TokenUsage> {
     current_dispatch_billable_usage()
-}
-
-fn is_stream_recovery_skip(model_slot: usize, entry_index: usize) -> bool {
-    RELIABLE_CALL_ACCOUNTING
-        .try_with(|accounting| {
-            accounting.lock().stream_resume_after.is_some_and(|failed| {
-                model_slot == failed.model_slot && entry_index == failed.entry_index
-            })
-        })
-        .unwrap_or(false)
 }
 
 /// Preserve Reliable's exact-entry recovery policy, but only once the selected
@@ -186,12 +177,14 @@ fn has_reliable_call_accounting() -> bool {
 
 pub(crate) fn mark_stream_recovery_semantic_empty() {
     let _ = RELIABLE_CALL_ACCOUNTING.try_with(|accounting| {
-        accounting.lock().stream_recovery_semantic_empty = true;
+        let mut accounting = accounting.lock();
+        accounting.stream_recovery_semantic_empty = true;
+        accounting.stream_recovery_semantic_empty_permission = true;
     });
 }
 
-/// Preserve the classified stream failure while runtime recovers through the
-/// remaining candidates without replaying the failed stream entry.
+/// Preserve the classified stream failure while runtime attempts eligible
+/// non-streaming recovery candidates.
 pub(crate) fn record_stream_recovery_failure(error: &anyhow::Error) {
     let _ = RELIABLE_CALL_ACCOUNTING.try_with(|accounting| {
         accounting.lock().stream_recovery_failure = Some(provider_error_diagnostic(error));
@@ -1769,6 +1762,29 @@ impl ReliableModelProvider {
         self.model_providers.len() > 1 && self.provider_cooldown_active(&entry.cooldown_key)
     }
 
+    /// Admit an entry with its configured retry budget, except for the exact
+    /// semantic-empty stream entry, which receives one atomic non-stream
+    /// recovery attempt when the configured budget permits it.
+    fn effective_retry_limit(&self, model_slot: usize, entry_index: usize) -> Option<u32> {
+        let max_retries = self.max_retries;
+        RELIABLE_CALL_ACCOUNTING
+            .try_with(|accounting| {
+                let mut accounting = accounting.lock();
+                let exact_failed_entry = accounting.stream_resume_after.is_some_and(|failed| {
+                    model_slot == failed.model_slot && entry_index == failed.entry_index
+                });
+                if !exact_failed_entry {
+                    return Some(max_retries);
+                }
+                if max_retries == 0 || !accounting.stream_recovery_semantic_empty_permission {
+                    return None;
+                }
+                accounting.stream_recovery_semantic_empty_permission = false;
+                Some(0)
+            })
+            .unwrap_or(Some(max_retries))
+    }
+
     fn record_cooldown_skip_failure(failures: &mut FailureEvents, max_attempts: u32) {
         let diagnostic = ProviderErrorDiagnostic {
             kind: "rate_limited",
@@ -2610,10 +2626,10 @@ impl ModelProvider for ReliableModelProvider {
 
         for (model_slot, current_model) in models.iter().enumerate() {
             for (entry_index, entry) in self.model_providers.iter().enumerate() {
-                if is_stream_recovery_skip(model_slot, entry_index) {
+                let Some(retry_limit) = self.effective_retry_limit(model_slot, entry_index) else {
                     final_cause_provider = Some(entry.candidate_name().to_string());
                     continue;
-                }
+                };
                 let provider_name = entry.display_name.as_str();
                 let served_model = entry.served_model(current_model);
                 if self.provider_should_skip_for_cooldown(entry) {
@@ -2626,7 +2642,7 @@ impl ModelProvider for ReliableModelProvider {
                 let mut last_error_detail: Option<String> = None;
                 let mut last_diagnostic: Option<ProviderErrorDiagnostic> = None;
 
-                for attempt in 0..=self.max_retries {
+                for attempt in 0..=retry_limit {
                     match with_exact_dispatch_route(
                         entry.cooldown_key.clone(),
                         entry.served_model(current_model).to_string(),
@@ -2646,7 +2662,7 @@ impl ModelProvider for ReliableModelProvider {
                                 {
                                     accumulate_usage(&mut rejected_attempt_usage, Some(&usage));
                                 }
-                                if attempt < self.max_retries {
+                                if attempt < retry_limit {
                                     self.backoff_after_empty_completion(
                                         &mut failures,
                                         provider_name,
@@ -2719,7 +2735,7 @@ impl ModelProvider for ReliableModelProvider {
                         }
                         Err(e) => {
                             if is_semantic_empty_completion_error(&e) {
-                                if attempt < self.max_retries {
+                                if attempt < retry_limit {
                                     self.backoff_after_empty_completion(
                                         &mut failures,
                                         provider_name,
@@ -2836,7 +2852,7 @@ impl ModelProvider for ReliableModelProvider {
                                 break;
                             }
 
-                            if attempt < self.max_retries {
+                            if attempt < retry_limit {
                                 let wait = self.compute_backoff(backoff_ms, &e);
                                 ::zeroclaw_log::record!(
                                     WARN,
@@ -2911,10 +2927,10 @@ impl ModelProvider for ReliableModelProvider {
 
         for (model_slot, current_model) in models.iter().enumerate() {
             for (entry_index, entry) in self.model_providers.iter().enumerate() {
-                if is_stream_recovery_skip(model_slot, entry_index) {
+                let Some(retry_limit) = self.effective_retry_limit(model_slot, entry_index) else {
                     final_cause_provider = Some(entry.candidate_name().to_string());
                     continue;
-                }
+                };
                 let provider_name = entry.display_name.as_str();
                 let served_model = entry.served_model(current_model);
                 if self.provider_should_skip_for_cooldown(entry) {
@@ -2927,7 +2943,7 @@ impl ModelProvider for ReliableModelProvider {
                 let mut last_error_detail: Option<String> = None;
                 let mut last_diagnostic: Option<ProviderErrorDiagnostic> = None;
 
-                for attempt in 0..=self.max_retries {
+                for attempt in 0..=retry_limit {
                     let req = ChatRequest {
                         messages: &effective_messages,
                         tools: request.tools,
@@ -2951,7 +2967,7 @@ impl ModelProvider for ReliableModelProvider {
                                 {
                                     accumulate_usage(&mut rejected_attempt_usage, Some(&usage));
                                 }
-                                if attempt < self.max_retries {
+                                if attempt < retry_limit {
                                     self.backoff_after_empty_completion(
                                         &mut failures,
                                         provider_name,
@@ -3024,7 +3040,7 @@ impl ModelProvider for ReliableModelProvider {
                         }
                         Err(e) => {
                             if is_semantic_empty_completion_error(&e) {
-                                if attempt < self.max_retries {
+                                if attempt < retry_limit {
                                     self.backoff_after_empty_completion(
                                         &mut failures,
                                         provider_name,
@@ -3141,7 +3157,7 @@ impl ModelProvider for ReliableModelProvider {
                                 break;
                             }
 
-                            if attempt < self.max_retries {
+                            if attempt < retry_limit {
                                 let wait = self.compute_backoff(backoff_ms, &e);
                                 ::zeroclaw_log::record!(
                                     WARN,
@@ -8814,6 +8830,19 @@ mod tests {
         chat_calls: Arc<AtomicUsize>,
     }
 
+    #[derive(Clone, Copy)]
+    enum SemanticRecoveryChatResult {
+        Success,
+        Empty,
+        Error,
+    }
+
+    struct SemanticEmptyNoChatReplayMock {
+        stream_calls: Arc<AtomicUsize>,
+        chat_calls: Arc<AtomicUsize>,
+        chat_result: SemanticRecoveryChatResult,
+    }
+
     struct StreamThenChatErrorMock;
 
     impl ::zeroclaw_api::attribution::Attributable for StreamThenChatErrorMock {
@@ -8915,6 +8944,20 @@ mod tests {
 
         fn alias(&self) -> &str {
             "StreamErrorNoChatReplayMock"
+        }
+    }
+
+    impl ::zeroclaw_api::attribution::Attributable for SemanticEmptyNoChatReplayMock {
+        fn role(&self) -> ::zeroclaw_api::attribution::Role {
+            ::zeroclaw_api::attribution::Role::Provider(
+                ::zeroclaw_api::attribution::ProviderKind::Model(
+                    ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+                ),
+            )
+        }
+
+        fn alias(&self) -> &str {
+            "SemanticEmptyNoChatReplayMock"
         }
     }
 
@@ -9053,6 +9096,64 @@ mod tests {
         ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
             self.stream_calls.fetch_add(1, Ordering::SeqCst);
             stream::iter(vec![Err(StreamingRecordMock::stream_error())]).boxed()
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for SemanticEmptyNoChatReplayMock {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok("must not replay".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            self.chat_calls.fetch_add(1, Ordering::SeqCst);
+            match self.chat_result {
+                SemanticRecoveryChatResult::Success => Ok(ChatResponse {
+                    text: Some("recovered".to_string()),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                    reasoning_content: None,
+                }),
+                SemanticRecoveryChatResult::Empty => Ok(ChatResponse {
+                    text: None,
+                    tool_calls: Vec::new(),
+                    usage: None,
+                    reasoning_content: None,
+                }),
+                SemanticRecoveryChatResult::Error => anyhow::bail!("recovery failed"),
+            }
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn stream_chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+            _options: StreamOptions,
+        ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            stream::iter(vec![
+                Ok(StreamEvent::TextDelta(StreamChunk::reasoning(
+                    "reasoning only",
+                ))),
+                Ok(StreamEvent::Final),
+            ])
+            .boxed()
         }
     }
     impl ::zeroclaw_api::attribution::Attributable for StreamingRecordMock {
@@ -9630,6 +9731,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn semantic_stream_recovery_permission_is_one_shot_and_exact() {
+        let provider = ReliableModelProvider::new("test", Vec::new(), 2, 1);
+        let zero_budget = ReliableModelProvider::new("test", Vec::new(), 0, 1);
+
+        scope_reliable_call_accounting(async {
+            activate_stream_recovery_after_first_poll(3, 4);
+            mark_stream_recovery_semantic_empty();
+
+            assert_eq!(provider.effective_retry_limit(3, 3), Some(2));
+            assert_eq!(provider.effective_retry_limit(2, 4), Some(2));
+            assert_eq!(provider.effective_retry_limit(3, 4), Some(0));
+            assert_eq!(provider.effective_retry_limit(3, 4), None);
+
+            activate_stream_recovery_after_first_poll(5, 6);
+            mark_stream_recovery_semantic_empty();
+            assert_eq!(zero_budget.effective_retry_limit(5, 6), None);
+            assert!(stream_recovery_was_semantic_empty());
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn semantic_stream_recovery_skips_only_failed_entry_and_uses_later_candidate() {
         let earlier_chat_calls = Arc::new(AtomicUsize::new(0));
         let failed_stream_calls = Arc::new(AtomicUsize::new(0));
@@ -9649,9 +9772,10 @@ mod tests {
                 ),
                 (
                     "duplicate-display".into(),
-                    Box::new(StreamErrorNoChatReplayMock {
+                    Box::new(SemanticEmptyNoChatReplayMock {
                         stream_calls: Arc::clone(&failed_stream_calls),
                         chat_calls: Arc::clone(&failed_chat_calls),
+                        chat_result: SemanticRecoveryChatResult::Success,
                     }) as Box<dyn ModelProvider>,
                 ),
                 (
@@ -9680,7 +9804,16 @@ mod tests {
                 Some(0.0),
                 StreamOptions::new(true),
             );
-            assert!(stream.next().await.unwrap().is_err());
+            assert!(matches!(
+                stream.next().await.unwrap().unwrap(),
+                StreamEvent::TextDelta(chunk)
+                    if chunk.delta.is_empty()
+                        && chunk.reasoning.as_deref() == Some("reasoning only")
+            ));
+            assert!(matches!(
+                stream.next().await.unwrap().unwrap(),
+                StreamEvent::Final
+            ));
             mark_stream_recovery_semantic_empty();
             model_provider
                 .chat(
@@ -9701,6 +9834,135 @@ mod tests {
         assert_eq!(failed_stream_calls.load(Ordering::SeqCst), 1);
         assert_eq!(failed_chat_calls.load(Ordering::SeqCst), 0);
         assert_eq!(later_chat_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn semantic_stream_recovery_is_bounded_for_empty_and_error_recovery() {
+        for chat_result in [
+            SemanticRecoveryChatResult::Empty,
+            SemanticRecoveryChatResult::Error,
+        ] {
+            let stream_calls = Arc::new(AtomicUsize::new(0));
+            let chat_calls = Arc::new(AtomicUsize::new(0));
+            let provider = ReliableModelProvider::new(
+                "test",
+                vec![(
+                    "primary".into(),
+                    Box::new(SemanticEmptyNoChatReplayMock {
+                        stream_calls: Arc::clone(&stream_calls),
+                        chat_calls: Arc::clone(&chat_calls),
+                        chat_result,
+                    }) as Box<dyn ModelProvider>,
+                )],
+                3,
+                1,
+            );
+            let messages = vec![ChatMessage::user("hello")];
+
+            let result = scope_reliable_call_accounting(async {
+                let mut stream = provider.stream_chat(
+                    ChatRequest {
+                        messages: &messages,
+                        tools: None,
+                        thinking: None,
+                    },
+                    "test",
+                    Some(0.0),
+                    StreamOptions::new(true),
+                );
+                assert!(stream.next().await.unwrap().is_ok());
+                assert!(matches!(
+                    stream.next().await.unwrap().unwrap(),
+                    StreamEvent::Final
+                ));
+                mark_stream_recovery_semantic_empty();
+                provider
+                    .chat(
+                        ChatRequest {
+                            messages: &messages,
+                            tools: None,
+                            thinking: None,
+                        },
+                        "test",
+                        Some(0.0),
+                    )
+                    .await
+            })
+            .await
+            .0;
+
+            assert!(result.is_err());
+            assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(chat_calls.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_semantic_stream_recovery_advances_to_fallback_budget() {
+        let failed_chat_calls = Arc::new(AtomicUsize::new(0));
+        let fallback_calls = Arc::new(AtomicUsize::new(0));
+        let provider = ReliableModelProvider::new(
+            "test",
+            vec![
+                (
+                    "failed".into(),
+                    Box::new(SemanticEmptyNoChatReplayMock {
+                        stream_calls: Arc::new(AtomicUsize::new(0)),
+                        chat_calls: Arc::clone(&failed_chat_calls),
+                        chat_result: SemanticRecoveryChatResult::Error,
+                    }) as Box<dyn ModelProvider>,
+                ),
+                (
+                    "fallback".into(),
+                    Box::new(MockModelProvider {
+                        calls: Arc::clone(&fallback_calls),
+                        fail_until_attempt: 1,
+                        response: "fallback response",
+                        error: "temporary fallback failure",
+                    }) as Box<dyn ModelProvider>,
+                ),
+            ],
+            3,
+            1,
+        );
+        let messages = vec![ChatMessage::user("hello")];
+
+        let response = scope_reliable_call_accounting(async {
+            let mut stream = provider.stream_chat(
+                ChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test",
+                Some(0.0),
+                StreamOptions::new(true),
+            );
+            assert!(stream.next().await.unwrap().is_ok());
+            assert!(matches!(
+                stream.next().await.unwrap().unwrap(),
+                StreamEvent::Final
+            ));
+            mark_stream_recovery_semantic_empty();
+            provider
+                .chat(
+                    ChatRequest {
+                        messages: &messages,
+                        tools: None,
+                        thinking: None,
+                    },
+                    "test",
+                    Some(0.0),
+                )
+                .await
+        })
+        .await
+        .0
+        .expect("fallback should recover after one failed semantic recovery");
+
+        assert_eq!(response.text.as_deref(), Some("fallback response"));
+        assert_eq!(failed_chat_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fallback_calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/agent/turn/provider_call.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/provider_call.rs
@@ -283,8 +283,8 @@ pub(crate) async fn call_provider(
                             let result = if let Some(token) = ctx.cancellation_token {
                                 tokio::select! {
                                     biased;
-                                    result = recovery => result,
                                     () = token.cancelled() => Err(ToolLoopCancelled.into()),
+                                    result = recovery => result,
                                 }
                             } else {
                                 recovery.await
@@ -625,6 +625,7 @@ mod streaming_fallback_tests {
     use crate::observability::NoopObserver;
     use async_trait::async_trait;
     use axum::{Router, http::StatusCode, routing::post};
+    use futures_util::StreamExt;
     use futures_util::stream::BoxStream;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -640,7 +641,9 @@ mod streaming_fallback_tests {
     };
 
     struct EmptyStreamThenTextProvider {
-        non_stream_calls: AtomicUsize,
+        stream_calls: Arc<AtomicUsize>,
+        non_stream_calls: Arc<AtomicUsize>,
+        cancel_on_final: Option<tokio_util::sync::CancellationToken>,
     }
 
     struct PreExecutedToolThenEmptyProvider {
@@ -731,7 +734,11 @@ mod streaming_fallback_tests {
             Ok(ChatResponse {
                 text: Some("fallback response".to_string()),
                 tool_calls: Vec::new(),
-                usage: None,
+                usage: Some(TokenUsage {
+                    input_tokens: Some(20),
+                    output_tokens: Some(7),
+                    cached_input_tokens: None,
+                }),
                 reasoning_content: None,
             })
         }
@@ -747,14 +754,28 @@ mod streaming_fallback_tests {
             _temperature: Option<f64>,
             _options: StreamOptions,
         ) -> BoxStream<'static, StreamResult<StreamEvent>> {
-            Box::pin(futures_util::stream::iter(vec![
-                Ok(StreamEvent::Usage(TokenUsage {
-                    input_tokens: Some(10),
-                    output_tokens: Some(5),
-                    cached_input_tokens: None,
-                })),
-                Ok(StreamEvent::Final),
-            ]))
+            self.stream_calls.fetch_add(1, Ordering::Relaxed);
+            let cancel_on_final = self.cancel_on_final.clone();
+            Box::pin(
+                futures_util::stream::iter(vec![
+                    Ok(StreamEvent::Usage(TokenUsage {
+                        input_tokens: Some(10),
+                        output_tokens: Some(5),
+                        cached_input_tokens: None,
+                    })),
+                    Ok(StreamEvent::TextDelta(
+                        zeroclaw_api::model_provider::StreamChunk::reasoning("private reasoning"),
+                    )),
+                    Ok(StreamEvent::Final),
+                ])
+                .inspect(move |event| {
+                    if matches!(event, Ok(StreamEvent::Final))
+                        && let Some(token) = &cancel_on_final
+                    {
+                        token.cancel();
+                    }
+                }),
+            )
         }
     }
 
@@ -943,13 +964,37 @@ mod streaming_fallback_tests {
 
     #[tokio::test]
     async fn completed_empty_stream_uses_one_non_streaming_fallback() {
+        check_empty_stream_recovery(false).await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_empty_stream_does_not_start_recovery() {
+        check_empty_stream_recovery(true).await;
+    }
+
+    async fn check_empty_stream_recovery(cancel_on_final: bool) {
+        let stream_calls = Arc::new(AtomicUsize::new(0));
+        let non_stream_calls = Arc::new(AtomicUsize::new(0));
+        let token = tokio_util::sync::CancellationToken::new();
         let provider = EmptyStreamThenTextProvider {
-            non_stream_calls: AtomicUsize::new(0),
+            stream_calls: Arc::clone(&stream_calls),
+            non_stream_calls: Arc::clone(&non_stream_calls),
+            cancel_on_final: cancel_on_final.then(|| token.clone()),
         };
+        let provider = ReliableModelProvider::new(
+            "test",
+            vec![(
+                "primary".to_string(),
+                Box::new(provider) as Box<dyn ModelProvider>,
+            )],
+            1,
+            1,
+        );
         let observer = NoopObserver;
         let pacing = PacingConfig::default();
         let cost_context = ToolLoopCostTrackingContext::usage_only();
         let turn_usage = std::sync::Arc::new(parking_lot::Mutex::new(TurnUsage::default()));
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(8);
         let ctx = TurnCtx {
             observer: &observer,
             provider_name: "test-provider",
@@ -958,9 +1003,9 @@ mod streaming_fallback_tests {
             approval: None,
             channel_name: "test",
             channel_reply_target: None,
-            cancellation_token: None,
+            cancellation_token: Some(&token),
             on_delta: None,
-            event_tx: None,
+            event_tx: Some(&event_tx),
             hooks: None,
             dedup_exempt_tools: &[],
             pacing: &pacing,
@@ -989,20 +1034,45 @@ mod streaming_fallback_tests {
                 ),
             )
             .await
-            .expect("stream failure is recovered by one non-streaming request");
-        let response = outcome.chat_result.expect("fallback response succeeds");
+            .expect("provider call returns its terminal outcome");
 
-        assert_eq!(response.text.as_deref(), Some("fallback response"));
-        assert_eq!(provider.non_stream_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(stream_calls.load(Ordering::Relaxed), 1);
+        assert!(matches!(
+            event_rx
+                .try_recv()
+                .expect("reasoning event must be forwarded once"),
+            zeroclaw_api::agent::TurnEvent::Thinking { delta }
+                if delta == "private reasoning"
+        ));
+        assert!(
+            event_rx.try_recv().is_err(),
+            "reasoning must be forwarded once"
+        );
         let recorded = *turn_usage.lock();
         assert_eq!(recorded.input_tokens, 0);
         assert_eq!(recorded.output_tokens, 0);
-        assert_eq!(outcome.attempts.len(), 2);
+        assert_eq!(outcome.attempts[0].provider_ref(), "primary");
         assert!(matches!(
             outcome.attempts[0].outcome(),
             zeroclaw_providers::dispatch::AttemptUsageOutcome::OutcomeUnknown {
                 observed: Some(usage),
             } if usage.input_tokens == Some(10) && usage.output_tokens == Some(5)
+        ));
+        if cancel_on_final {
+            assert!(outcome.chat_result.unwrap_err().is::<ToolLoopCancelled>());
+            assert_eq!(non_stream_calls.load(Ordering::Relaxed), 0);
+            assert_eq!(outcome.attempts.len(), 1);
+            return;
+        }
+        let response = outcome.chat_result.expect("fallback response succeeds");
+        assert_eq!(response.text.as_deref(), Some("fallback response"));
+        assert_eq!(non_stream_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(outcome.attempts.len(), 2);
+        assert_eq!(outcome.attempts[1].provider_ref(), "primary");
+        assert!(matches!(
+            outcome.attempts[1].outcome(),
+            zeroclaw_providers::dispatch::AttemptUsageOutcome::Complete(usage)
+                if usage.input_tokens == Some(20) && usage.output_tokens == Some(7)
         ));
     }
 

--- a/docs/book/src/architecture/provider-routing-lifecycle.md
+++ b/docs/book/src/architecture/provider-routing-lifecycle.md
@@ -66,6 +66,8 @@ Streaming deliberately has a narrower retry contract than non-streaming calls:
 
 Draft-update sinks are mutable. A pre-commit fallback may replace a draft without duplicating immutable output, while event sinks define the no-replay boundary.
 
+A stream that completes with no final text or tool calls is a semantic-empty response, not a successful answer. When runtime marks that result replay-safe and `provider_retries` is nonzero, Reliable allows one non-streaming recovery call to the exact provider/model that produced the empty stream. That allowance is consumed once; a failed recovery advances to the remaining configured candidates with their normal retry budgets. With zero retries, the failed stream entry remains skipped. Reasoning already shown stays visible once, but does not count as a final answer. This exception does not authorize replay after cancellation, interrupted visible output, or provider-executed tool work.
+
 This division keeps transport recovery in the runtime, provider-specific framing in the adapter, and retry/fallback policy in the reliability wrapper. A provider implementation should not invent a second turn-level replay policy.
 
 ## Attribution and known gaps


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:**
  - Allow one non-streaming recovery request to the exact provider/model whose stream was classified replay-safe but empty of final text and tool calls, when `reliability.provider_retries` is nonzero.
  - Consume that permission once while retaining the original failure classification. A failed recovery advances to configured fallback candidates with their existing retry budgets.
  - Give already-signalled cancellation priority before polling recovery. Preserve separate accounting for the rejected stream and the recovery request.
- **Scope boundary:** No provider parser, output-token limit, configuration schema, transcript, or rendering changes. Partial output and provider-executed tool activity retain their existing no-replay behavior. This does not diagnose why a particular upstream stream ended without an answer.
- **Blast radius:** Reliable's `chat` and `chat_with_tools` recovery walks, plus runtime cancellation at recovery admission. Ordinary non-streaming retry budgets are unchanged.
- **Linked issue(s):** Related #9421. This implements the bounded same-provider recovery slice, not the whole issue. Terminal classification in #9447 and #9999 remains separate; this PR does not depend on either branch.
- **Labels:** `bug`, `risk:medium`, `size:M`, `provider`, `provider:reliable`, `runtime`, `agent`, `docs`.

### What this does, simply

ZeroClaw already rejects a model response that contains reasoning but no answer or tool request. However, after a streamed response failed that check, its retry layer skipped the provider that had just been used. With no fallback provider configured, recovery could fail without making another request even though retries were enabled.

This change gives that same provider one chance to return a normal, non-streamed answer. A second empty response or error does not start another same-provider retry loop. Existing fallback providers remain available, and setting retries to zero keeps same-provider recovery disabled. Reasoning already delivered is not emitted again as an answer. Cancellation already signalled before recovery starts wins over the extra request.

### Scope and maintenance tradeoff

Runtime continues to decide whether replay is safe; Reliable continues to choose providers and bound attempts. One transient permission in the existing call-local state and one shared admission helper cover both chat paths. No new API or independent retry coordinator is added.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. Deterministic provider fixtures exercise the production call path; reproducing an intermittent paid-provider empty response adds no reliable acceptance signal.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed at `f189214229baa65e19beab95f5b4293d000ec72d`, including workspace tests, repeated parallel runtime tests, lint, builds, platform checks and documentation checks.
- **Known CI coverage gap, if any:** Synthetic fixtures do not prove a specific real provider's stop-reason parsing or output-cap behavior.
- **Commands run and tail output:**
  - `cargo test --locked -p zeroclaw-providers --lib -- stream_recovery same_candidate_reliable_recovery_skip`: 9 passed; 0 failed.
  - `cargo test --locked -p zeroclaw-runtime --lib streaming_fallback_tests`: 8 passed; 0 failed. Covers one successful recovery, cancellation before recovery admission, visible-output and provider-executed-tool no-replay, typed transport failures, and attempt accounting.
  - `cargo fmt --all -- --check` and `bash scripts/ci/comment_hygiene_gate.sh`: passed.
  - `npx --yes markdownlint-cli2 docs/book/src/architecture/provider-routing-lifecycle.md`: 0 issues.
- **Beyond CI, what did you manually verify?** Inspected the runtime replay classifier, both Reliable chat paths, exact-entry identity, and dispatch accounting ownership. No live provider requests were made for validation.
- **Visual interface changed?** N/A. No rendered presentation changes.
- **If any command was intentionally skipped, why:** Full local workspace tests are deferred to required CI; focused tests target the changed recovery and cancellation contract.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? Yes. A replay-safe empty stream can cause one additional request to the already-configured provider/model with the existing prompt. It can incur additional provider cost; retries must be enabled, the permission is one-shot, and existing replay-safety checks remain authoritative.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No. Fixtures are synthetic.
- Prompt injection or untrusted model-visible text introduced/changed? No.

## Compatibility (required)

- Backward compatible? Yes; this repairs recovery under the existing retry setting.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the landed squash commit with `git revert <landed-squash-sha>`, then rebuild and restart the affected runtime.
- **Feature flags or config toggles:** Set `reliability.provider_retries` to `0` to disable this same-provider recovery. This also disables ordinary same-provider retries; it is not an isolated feature switch.
- **Observable failure symptoms:** Repeated recovery requests after a semantic-empty stream, recovery beginning despite cancellation already being signalled, incorrect billed-attempt accounting, or a valid fallback response being rejected. Existing `llm_stream_fallback` logging identifies the recovery boundary.

## Supersede Attribution

N/A. No PR is superseded.
