### PR TITLE
fix(providers): send x-opencode-session on OpenCode requests

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -5,6 +5,7 @@
 use crate::auth::AuthService;
 use crate::multimodal;
 use crate::openai::{NativeToolFunctionSpec, NativeToolSpec};
+use crate::opencode_session::OPENCODE_SESSION_HEADER;
 use crate::stream_guard::AbortOnDrop;
 use crate::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
@@ -2171,6 +2172,39 @@ impl OpenAiCompatibleModelProvider {
         apply_auth_to_request(req, &self.auth_header, credential)
     }
 
+    /// OpenCode affinity header value for the calling conversation, or `None`
+    /// when this provider does not target OpenCode.
+    ///
+    /// Returns `None` when the operator has already pinned the header through
+    /// `extra_headers`: those are baked into the client's default headers, so
+    /// adding a second value here would put the header on the wire twice.
+    fn opencode_session_value(&self) -> Option<String> {
+        if self
+            .extra_headers
+            .keys()
+            .any(|key| key.eq_ignore_ascii_case(OPENCODE_SESSION_HEADER))
+        {
+            return None;
+        }
+        crate::opencode_session::session_token(&self.base_url)
+    }
+
+    /// Attach the OpenCode affinity header, for request paths that build in the
+    /// caller's task.
+    ///
+    /// Streaming paths must not use this: they build inside
+    /// `zeroclaw_spawn::spawn!`, where the conversation task-local is no longer
+    /// readable. Those resolve `opencode_session_value` before the spawn.
+    fn apply_opencode_session_header(
+        &self,
+        req: reqwest::RequestBuilder,
+    ) -> reqwest::RequestBuilder {
+        match self.opencode_session_value() {
+            Some(session) => req.header(OPENCODE_SESSION_HEADER, session),
+            None => req,
+        }
+    }
+
     fn convert_tool_specs(
         &self,
         tools: Option<&[zeroclaw_api::tool::ToolSpec]>,
@@ -3081,10 +3115,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let url = self.chat_completions_url();
 
         let response = match self
-            .apply_auth_header(
+            .apply_opencode_session_header(self.apply_auth_header(
                 self.http_client().post(&url).json(&request),
                 credential.as_deref(),
-            )
+            ))
             .send()
             .await
         {
@@ -3170,10 +3204,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
         let url = self.chat_completions_url();
         let response = match self
-            .apply_auth_header(
+            .apply_opencode_session_header(self.apply_auth_header(
                 self.http_client().post(&url).json(&request),
                 credential.as_deref(),
-            )
+            ))
             .send()
             .await
         {
@@ -3250,10 +3284,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let url = self.chat_completions_url();
         let response = loop {
             let response = match self
-                .apply_auth_header(
+                .apply_opencode_session_header(self.apply_auth_header(
                     self.http_client().post(&url).json(&payload),
                     credential.as_deref(),
-                )
+                ))
                 .send()
                 .await
             {
@@ -3389,10 +3423,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         let url = self.chat_completions_url();
         let response = loop {
             let response = match self
-                .apply_auth_header(
+                .apply_opencode_session_header(self.apply_auth_header(
                     self.http_client().post(&url).json(&payload),
                     credential.as_deref(),
-                )
+                ))
                 .send()
                 .await
             {
@@ -3498,6 +3532,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         }
 
         let provider = self.clone();
+        // Resolved here, not in the spawned task: `spawn!` propagates the
+        // tracing span but not task-locals, so the conversation scope is
+        // unreadable past this point.
+        let opencode_session = self.opencode_session_value();
         let messages_owned: Vec<ChatMessage> = request.messages.to_vec();
         let tools_owned: Option<Vec<zeroclaw_api::tool::ToolSpec>> =
             request.tools.map(<[zeroclaw_api::tool::ToolSpec]>::to_vec);
@@ -3623,6 +3661,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 req_builder =
                     apply_auth_to_request(req_builder, &auth_header, credential.as_deref());
                 req_builder = req_builder.header("Accept", "text/event-stream");
+                if let Some(session) = opencode_session.as_deref() {
+                    req_builder = req_builder.header(OPENCODE_SESSION_HEADER, session);
+                }
 
                 let response = match req_builder.send().await {
                     Ok(r) => r,
@@ -3699,6 +3740,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
         let provider = self.clone();
+        // Resolved here, not in the spawned task: `spawn!` propagates the
+        // tracing span but not task-locals, so the conversation scope is
+        // unreadable past this point.
+        let opencode_session = self.opencode_session_value();
         let system_prompt_owned: Option<String> = system_prompt.map(str::to_string);
         let message_owned = message.to_string();
         let model = model.to_string();
@@ -3791,6 +3836,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
             // Set accept header for streaming
             req_builder = req_builder.header("Accept", "text/event-stream");
+            if let Some(session) = opencode_session.as_deref() {
+                req_builder = req_builder.header(OPENCODE_SESSION_HEADER, session);
+            }
 
             // Send request
             let response = match req_builder.send().await {
@@ -3839,6 +3887,10 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
         let provider = self.clone();
+        // Resolved here, not in the spawned task: `spawn!` propagates the
+        // tracing span but not task-locals, so the conversation scope is
+        // unreadable past this point.
+        let opencode_session = self.opencode_session_value();
         let messages_owned: Vec<ChatMessage> = messages.to_vec();
         let model = model.to_string();
         let count_tokens = options.count_tokens;
@@ -3903,6 +3955,9 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             let mut req_builder = client.post(&url).json(&request);
             req_builder = apply_auth_to_request(req_builder, &auth_header, credential.as_deref());
             req_builder = req_builder.header("Accept", "text/event-stream");
+            if let Some(session) = opencode_session.as_deref() {
+                req_builder = req_builder.header(OPENCODE_SESSION_HEADER, session);
+            }
 
             let response = match req_builder.send().await {
                 Ok(r) => r,
@@ -5793,6 +5848,71 @@ mod tests {
         assert!(zhipu_jwt_bearer("").is_err());
         assert!(zhipu_jwt_bearer(".secret").is_err());
         assert!(zhipu_jwt_bearer("id.").is_err());
+    }
+
+    fn opencode_provider(base_url: &str) -> OpenAiCompatibleModelProvider {
+        OpenAiCompatibleModelProvider::builder("opencode")
+            .display_name("OpenCode Zen")
+            .base_url(base_url)
+            .credential(Some("test-key"))
+            .auth_style(AuthStyle::Bearer)
+            .build()
+    }
+
+    /// Header value as it would go on the wire, without sending anything.
+    fn built_session_header(provider: &OpenAiCompatibleModelProvider) -> Option<String> {
+        let request = provider
+            .apply_opencode_session_header(reqwest::Client::new().post(provider.base_url.clone()))
+            .build()
+            .expect("request must build");
+        request
+            .headers()
+            .get(OPENCODE_SESSION_HEADER)
+            .map(|value| value.to_str().expect("header must be ASCII").to_string())
+    }
+
+    #[test]
+    fn opencode_requests_carry_the_session_header() {
+        for base_url in [
+            "https://opencode.ai/zen/v1",
+            "https://opencode.ai/zen/go/v1",
+        ] {
+            let header = built_session_header(&opencode_provider(base_url))
+                .unwrap_or_else(|| panic!("{base_url} must carry the affinity header"));
+            assert_eq!(header.len(), 32, "expected a 128-bit hex token");
+            assert!(header.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn non_opencode_requests_do_not_carry_the_session_header() {
+        assert!(
+            built_session_header(&opencode_provider("https://api.openai.com/v1")).is_none(),
+            "the header must not leak to unrelated providers"
+        );
+    }
+
+    #[test]
+    fn operator_pinned_session_header_is_not_overridden() {
+        // `extra_headers` become client default headers, so emitting our own
+        // value too would put the header on the wire twice.
+        let mut headers = std::collections::HashMap::new();
+        headers.insert(
+            "X-Opencode-Session".to_string(),
+            "pinned-by-operator".to_string(),
+        );
+        let provider = OpenAiCompatibleModelProvider::builder("opencode")
+            .display_name("OpenCode Zen")
+            .base_url("https://opencode.ai/zen/v1")
+            .credential(Some("test-key"))
+            .auth_style(AuthStyle::Bearer)
+            .extra_headers(headers)
+            .build();
+
+        assert!(
+            provider.opencode_session_value().is_none(),
+            "an operator-pinned header must win over the derived value"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -21,6 +21,7 @@ pub mod multimodal;
 pub mod ollama;
 pub mod openai;
 pub mod openai_codex;
+pub mod opencode_session;
 pub mod openrouter;
 pub mod openrouter_catalog;
 pub mod pricing;

--- a/crates/zeroclaw-providers/src/openai.rs
+++ b/crates/zeroclaw-providers/src/openai.rs
@@ -2,6 +2,7 @@ use crate::openai_codex::{
     ResponsesStreamApiError, ResponsesStreamState, ResponsesToolSpec, append_utf8_stream_chunk,
     build_responses_input, convert_tools, first_nonempty, parse_responses_usage, process_sse_chunk,
 };
+use crate::opencode_session::OPENCODE_SESSION_HEADER;
 use crate::stream_guard::AbortOnDrop;
 use crate::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
@@ -1156,6 +1157,37 @@ impl OpenAiResponsesModelProvider {
         headers
     }
 
+    /// OpenCode affinity header value for the calling conversation, or `None`
+    /// when this provider does not target OpenCode.
+    ///
+    /// `responses_url` is the full endpoint rather than a base URL; the target
+    /// test parses its host, so it matches either shape. Returns `None` when
+    /// the operator already pinned the header through `extra_headers`, which
+    /// `build_default_headers` puts on every request — a second value here
+    /// would send the header twice.
+    fn opencode_session_value(&self) -> Option<String> {
+        if self
+            .extra_headers
+            .keys()
+            .any(|key| key.eq_ignore_ascii_case(OPENCODE_SESSION_HEADER))
+        {
+            return None;
+        }
+        crate::opencode_session::session_token(&self.responses_url)
+    }
+
+    /// Attach the OpenCode affinity header, for request paths that build in the
+    /// caller's task. The streaming path resolves the value before its spawn.
+    fn apply_opencode_session_header(
+        &self,
+        req: reqwest::RequestBuilder,
+    ) -> reqwest::RequestBuilder {
+        match self.opencode_session_value() {
+            Some(session) => req.header(OPENCODE_SESSION_HEADER, session),
+            None => req,
+        }
+    }
+
     fn http_client(&self) -> Client {
         let default_headers = self.build_default_headers();
         let mut builder = Client::builder()
@@ -1244,9 +1276,11 @@ impl ModelProvider for OpenAiResponsesModelProvider {
         };
         let req = self.build_request(instructions, input, None, model, temperature, false);
         let response = self
-            .http_client()
-            .post(&self.responses_url)
-            .header("Authorization", format!("Bearer {credential}"))
+            .apply_opencode_session_header(
+                self.http_client()
+                    .post(&self.responses_url)
+                    .header("Authorization", format!("Bearer {credential}")),
+            )
             .json(&req)
             .send()
             .await?;
@@ -1294,9 +1328,11 @@ impl ModelProvider for OpenAiResponsesModelProvider {
             );
         }
         let response = self
-            .http_client()
-            .post(&self.responses_url)
-            .header("Authorization", format!("Bearer {credential}"))
+            .apply_opencode_session_header(
+                self.http_client()
+                    .post(&self.responses_url)
+                    .header("Authorization", format!("Bearer {credential}")),
+            )
             .json(&req)
             .send()
             .await?;
@@ -1335,6 +1371,9 @@ impl ModelProvider for OpenAiResponsesModelProvider {
         let tools_owned = request.tools.map(<[ToolSpec]>::to_vec);
         let model = model.to_string();
         let responses_url = self.responses_url.clone();
+        // Resolved before the spawn: `spawn!` propagates the tracing span but
+        // not task-locals, so the conversation scope is unreadable inside.
+        let opencode_session = self.opencode_session_value();
         let count_tokens = options.count_tokens;
         let reasoning_effort = self.reasoning_effort.clone();
         let max_tokens = self.max_tokens;
@@ -1387,11 +1426,14 @@ impl ModelProvider for OpenAiResponsesModelProvider {
                 );
             }
 
-            let request_builder = client
+            let mut request_builder = client
                 .post(&responses_url)
                 .header("Authorization", format!("Bearer {credential}"))
-                .header("Accept", "text/event-stream")
-                .json(&req);
+                .header("Accept", "text/event-stream");
+            if let Some(session) = opencode_session.as_deref() {
+                request_builder = request_builder.header(OPENCODE_SESSION_HEADER, session);
+            }
+            let request_builder = request_builder.json(&req);
 
             run_responses_sse(request_builder, &tx, count_tokens).await;
         });

--- a/crates/zeroclaw-providers/src/opencode_session.rs
+++ b/crates/zeroclaw-providers/src/opencode_session.rs
@@ -1,0 +1,318 @@
+//! `x-opencode-session` — OpenCode relay session-affinity header.
+//!
+//! The OpenCode relay (`opencode.ai`, serving both the Zen and Go endpoints)
+//! uses `x-opencode-session` to pin the requests of one conversation to the
+//! same upstream backend, which is what keeps that backend's prompt cache warm
+//! across the turns of a conversation. Upstream documents the header under its
+//! guidance for keeping an account from being flagged, and at least one Go
+//! model (`deepseek-v4-flash`) rejects header-less requests outright with
+//! HTTP 400 `Model is unavailable`.
+//!
+//! Every OpenCode request — both wires, streaming and non-streaming — resolves
+//! its value through [`session_token`] so the header cannot drift per code
+//! path.
+//!
+//! # Value derivation
+//!
+//! Upstream specifies no format, length, or lifetime for the value; its only
+//! normative statement is that a tool "includes the `x-opencode-session`
+//! header so we can optimize prompt caching". The one datum on accepted values
+//! is that a random UUID is sufficient to turn the 400 above into a 200. This
+//! module therefore emits a 128-bit lowercase hex digest: opaque, fixed-length,
+//! unambiguously safe as an HTTP header value, and non-reversible.
+//!
+//! The digest is taken over the ambient conversation scope
+//! ([`zeroclaw_api::TOOL_LOOP_SESSION_KEY`]) rather than over a cached random
+//! token, so the value is resolved from the canonical source at use time and
+//! this module holds no per-session lookup table.
+//!
+//! # Why the scope is hashed rather than sent
+//!
+//! Session keys embed channel and user identifiers — `sanitize_session_key`
+//! covers inputs shaped like `whatsapp_123@g.us_alice` and
+//! `slack_C123_1.2_user one`. Forwarding one verbatim would hand a third-party
+//! relay a cross-service-linkable per-user identifier, which the privacy
+//! contract in `docs/book/src/contributing/privacy.md` forbids. Hashing keeps
+//! the affinity behavior while sending nothing but an opaque token.
+//!
+//! The digest is domain-separated but unsalted, so it is deterministic across
+//! restarts — which is what preserves cache affinity for a conversation that
+//! spans a daemon restart. The tradeoff is explicit: this prevents plaintext
+//! exposure of channel and user identifiers, but it is not a defense against a
+//! party who knows ZeroClaw's session-key format brute-forcing a low-entropy
+//! key space. Defeating that would require a per-install salt, which would cost
+//! the cross-restart affinity this is for; it is deliberately out of scope here.
+
+use sha2::{Digest, Sha256};
+use std::sync::OnceLock;
+
+/// The affinity header OpenCode reads to pin a conversation to one backend.
+pub const OPENCODE_SESSION_HEADER: &str = "x-opencode-session";
+
+/// Registrable domain of the OpenCode relay.
+const OPENCODE_HOST: &str = "opencode.ai";
+
+/// Domain-separation tag mixed into every digest, so a value emitted here can
+/// never collide with a digest this codebase derives for another purpose.
+const AFFINITY_DOMAIN: &str = "zeroclaw.opencode.session.v1";
+
+/// Bytes of SHA-256 output kept. 128 bits is far beyond what backend selection
+/// needs and keeps the header short.
+const TOKEN_BYTES: usize = 16;
+
+/// Extract the host from `base_url`, tolerating a missing scheme, userinfo, a
+/// port, and an IPv6 literal.
+///
+/// Hand-rolled rather than pulled from a URL crate because this is the only
+/// parsing this crate needs and the accepted shapes are covered by tests.
+fn host_of(base_url: &str) -> Option<&str> {
+    let after_scheme = base_url
+        .split_once("://")
+        .map_or(base_url, |(_scheme, rest)| rest);
+    // The authority ends at the first path, query, or fragment delimiter.
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .filter(|authority| !authority.is_empty())?;
+    // `user:pass@host` — the last '@' separates userinfo from the host, so a
+    // password containing '@' cannot smuggle a host past this.
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_userinfo, host)| host);
+
+    let host = if let Some(after_bracket) = host_port.strip_prefix('[') {
+        // IPv6 literal. Never the OpenCode relay, but must not be mis-split on
+        // the colons inside the address.
+        after_bracket.split_once(']').map(|(host, _port)| host)?
+    } else {
+        host_port
+            .split_once(':')
+            .map_or(host_port, |(host, _port)| host)
+    };
+
+    // A fully-qualified name may carry a trailing dot; `opencode.ai.` is the
+    // same host as `opencode.ai`.
+    let host = host.trim_end_matches('.');
+    (!host.is_empty()).then_some(host)
+}
+
+/// True when `base_url` addresses the OpenCode relay.
+///
+/// Matches `opencode.ai` and any subdomain of it, so the built-in Zen and Go
+/// endpoints and an operator's `uri` override all resolve alike. Matching is
+/// on the parsed host, so a lookalike such as `opencode.ai.example.com` or
+/// `notopencode.ai` is correctly rejected.
+#[must_use]
+pub fn is_opencode_target(base_url: &str) -> bool {
+    host_of(base_url).is_some_and(|host| {
+        let host = host.to_ascii_lowercase();
+        host == OPENCODE_HOST || host.ends_with(&format!(".{OPENCODE_HOST}"))
+    })
+}
+
+/// Domain-separated, truncated SHA-256 of one affinity scope.
+fn digest_scope(scope: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(AFFINITY_DOMAIN.as_bytes());
+    // A length-free separator would let a crafted scope reproduce another
+    // domain's preimage; a NUL cannot appear in the tag, so it terminates it
+    // unambiguously.
+    hasher.update([0u8]);
+    hasher.update(scope.as_bytes());
+    hex::encode(&hasher.finalize()[..TOKEN_BYTES])
+}
+
+/// Affinity token for requests made outside any conversation scope.
+///
+/// Warmup probes and other calls that never enter the agent loop still have to
+/// carry a header, or the Go models that reject header-less requests would fail
+/// on exactly those paths. One process-stable random token keeps them pinned
+/// together without inventing a conversation identity for them.
+fn process_token() -> &'static str {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| digest_scope(&uuid::Uuid::new_v4().to_string()))
+}
+
+/// Affinity token for the calling conversation, or `None` when `base_url` is
+/// not an OpenCode target.
+///
+/// # Call site placement
+///
+/// This reads a `tokio` task-local, which **does not** cross `tokio::spawn`.
+/// The streaming provider paths build their requests inside
+/// `zeroclaw_spawn::spawn!`, whose macro propagates only the tracing span, so
+/// calling this from inside a spawned task would silently fall back to
+/// the process-stable fallback and lose per-conversation affinity. Resolve the
+/// value before the spawn and move it in.
+#[must_use]
+pub fn session_token(base_url: &str) -> Option<String> {
+    if !is_opencode_target(base_url) {
+        return None;
+    }
+    let scope = zeroclaw_api::TOOL_LOOP_SESSION_KEY
+        .try_with(Clone::clone)
+        .ok()
+        .flatten()
+        .filter(|key| !key.trim().is_empty());
+    Some(match scope {
+        Some(key) => digest_scope(&key),
+        None => process_token().to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_builtin_zen_and_go_endpoints() {
+        assert!(is_opencode_target("https://opencode.ai/zen/v1"));
+        assert!(is_opencode_target("https://opencode.ai/zen/go/v1"));
+        assert!(is_opencode_target("https://opencode.ai/zen/v1/responses"));
+    }
+
+    #[test]
+    fn matches_subdomains_and_ignores_case_port_and_trailing_dot() {
+        assert!(is_opencode_target("https://api.opencode.ai/v1"));
+        assert!(is_opencode_target("https://OpenCode.AI/zen/v1"));
+        assert!(is_opencode_target("https://opencode.ai:443/zen/v1"));
+        assert!(is_opencode_target("https://opencode.ai./zen/v1"));
+        assert!(is_opencode_target("opencode.ai/zen/v1"));
+    }
+
+    #[test]
+    fn rejects_lookalike_hosts() {
+        // The registrable domain appears only as a path or a prefix here.
+        assert!(!is_opencode_target(
+            "https://opencode.ai.example.com/zen/v1"
+        ));
+        assert!(!is_opencode_target("https://notopencode.ai/zen/v1"));
+        assert!(!is_opencode_target(
+            "https://example.com/opencode.ai/zen/v1"
+        ));
+        // Userinfo must not be mistaken for the host.
+        assert!(!is_opencode_target("https://opencode.ai@example.com/v1"));
+        assert!(!is_opencode_target("https://api.openai.com/v1"));
+        assert!(!is_opencode_target(""));
+    }
+
+    #[test]
+    fn ipv6_literal_is_not_a_target_and_does_not_panic() {
+        assert!(!is_opencode_target("http://[::1]:8080/v1"));
+        assert_eq!(host_of("http://[::1]:8080/v1"), Some("::1"));
+        // Unterminated bracket must yield no host rather than panicking.
+        assert_eq!(host_of("http://[::1"), None);
+    }
+
+    #[test]
+    fn non_opencode_target_yields_no_header() {
+        assert!(session_token("https://api.openai.com/v1").is_none());
+    }
+
+    #[test]
+    fn opencode_target_always_yields_a_token() {
+        // Outside any conversation scope the process token still applies, so
+        // warmup-style calls are never header-less.
+        let token = session_token("https://opencode.ai/zen/go/v1")
+            .expect("OpenCode target must always carry an affinity token");
+        assert_eq!(token.len(), TOKEN_BYTES * 2);
+        assert!(
+            token
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase())
+        );
+    }
+
+    #[tokio::test]
+    async fn token_is_stable_per_scope_and_distinct_across_scopes() {
+        async fn token_for(session_key: &str) -> String {
+            zeroclaw_api::TOOL_LOOP_SESSION_KEY
+                .scope(Some(session_key.to_string()), async {
+                    session_token("https://opencode.ai/zen/v1").expect("token")
+                })
+                .await
+        }
+
+        let first = token_for("telegram_1001_alice").await;
+        let again = token_for("telegram_1001_alice").await;
+        let other = token_for("telegram_1002_bob").await;
+
+        assert_eq!(first, again, "one conversation must pin to one backend");
+        assert_ne!(
+            first, other,
+            "distinct conversations must not share a scope"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_never_contains_the_session_key() {
+        // The identifiers inside a session key must not leave the process.
+        let session_key = "whatsapp_123@g.us_alice";
+        let token = zeroclaw_api::TOOL_LOOP_SESSION_KEY
+            .scope(Some(session_key.to_string()), async {
+                session_token("https://opencode.ai/zen/v1").expect("token")
+            })
+            .await;
+        assert!(!token.contains("alice"));
+        assert!(!token.contains("123"));
+        assert!(!token.contains(session_key));
+    }
+
+    #[tokio::test]
+    async fn blank_scope_falls_back_to_the_process_token() {
+        let blank = zeroclaw_api::TOOL_LOOP_SESSION_KEY
+            .scope(Some("   ".to_string()), async {
+                session_token("https://opencode.ai/zen/v1").expect("token")
+            })
+            .await;
+        assert_eq!(blank, process_token());
+    }
+
+    #[tokio::test]
+    async fn conversation_scope_does_not_survive_a_spawn() {
+        // Guards the call-site contract in `session_token`'s docs. If a change
+        // ever moves resolution inside `zeroclaw_spawn::spawn!`, the streaming
+        // paths silently stop distinguishing conversations rather than
+        // failing, so assert the mechanism that makes that happen.
+        async fn token_in_scope<F, Fut>(f: F) -> String
+        where
+            F: FnOnce() -> Fut,
+            Fut: std::future::Future<Output = String>,
+        {
+            zeroclaw_api::TOOL_LOOP_SESSION_KEY
+                .scope(Some("telegram_1001_alice".to_string()), f())
+                .await
+        }
+
+        let before_spawn = token_in_scope(|| async {
+            session_token("https://opencode.ai/zen/v1").expect("token")
+        })
+        .await;
+        let inside_spawn = token_in_scope(|| async {
+            // The production streaming paths spawn through this same macro, so
+            // assert against it rather than a bare `tokio::spawn`.
+            ::zeroclaw_spawn::spawn!(async {
+                session_token("https://opencode.ai/zen/v1").expect("token")
+            })
+            .await
+            .expect("join")
+        })
+        .await;
+
+        assert_ne!(
+            before_spawn, inside_spawn,
+            "task-local scope must not appear to cross a spawn"
+        );
+        assert_eq!(
+            inside_spawn,
+            process_token(),
+            "a spawned read falls back to the process token"
+        );
+    }
+
+    #[test]
+    fn digest_is_domain_separated() {
+        // A scope that reproduces the tag's bytes must not collide with it.
+        assert_ne!(digest_scope(""), digest_scope(AFFINITY_DOMAIN));
+    }
+}

--- a/docs/book/src/providers/custom.md
+++ b/docs/book/src/providers/custom.md
@@ -99,6 +99,24 @@ wire_api = "responses"
 
 The setting governs both the primary agent path and delegate targets, so a delegate whose target alias declares `wire_api = "responses"` reaches the endpoint over the responses wire.
 
+### OpenCode session affinity
+
+Every request to an `opencode.ai` host carries an `x-opencode-session` header on both wires, streaming and non-streaming. OpenCode uses it to pin one conversation's turns to the same upstream backend, which keeps that backend's prompt cache warm across turns; upstream also lists it under the guidance for keeping an account from being flagged, and some OpenCode Go models reject header-less requests outright.
+
+The value is an opaque 128-bit hex token derived from the active conversation scope, so each conversation pins to its own backend and the same conversation keeps its backend across a daemon restart. The conversation's session key is **hashed, never sent**: session keys embed channel and user identifiers, and forwarding one verbatim would hand a third-party relay a per-user identifier. Requests made outside any conversation, such as warmup probes, share one process-stable token instead.
+
+Nothing needs configuring. To pin the value yourself, for instance to share one affinity scope across replicas, set it explicitly and ZeroClaw leaves it alone:
+
+```toml
+[providers.models.opencode.default]
+model = "big-pickle"
+
+[providers.models.opencode.default.extra_headers]
+x-opencode-session = "my-fixed-scope"
+```
+
+Hosts other than `opencode.ai` and its subdomains never receive the header.
+
 ## Validation
 
 Regardless of approach:


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - OpenCode uses `x-opencode-session` to pin one conversation's turns to the same upstream backend, which keeps that backend's prompt cache warm across turns. ZeroClaw sent it on no path, so every turn could land on a cold backend and re-pay full prompt cost.
  - Upstream's OpenCode Go page lists the header in its guidance for keeping an account from being flagged. ZeroClaw satisfied none of that guidance.
  - At least one Go model (`deepseek-v4-flash`) rejects header-less requests outright with HTTP 400 `Model is unavailable`, so the provider was unusable for it. The surfaced error names the model rather than the missing header, which misdirects diagnosis.
  - The value is derived from the ambient conversation scope (`TOOL_LOOP_SESSION_KEY`) and attached at all ten OpenCode request sites: seven on the chat-completions wire in `compatible.rs`, three on the responses wire in `openai.rs`.
  - The session key is hashed rather than forwarded. Keys embed channel and user identifiers, so sending one verbatim would hand a third-party relay a cross-service-linkable per-user identifier.
- **Scope boundary:** this does not plumb a session or conversation id through the `ModelProvider` trait; it reads the task-local that already exists. It adds no config key, changes no default, and touches no provider other than those resolving to an `opencode.ai` host. It does not alter the native `openai` family's own chat-completions sites, which are not an OpenCode route.
- **Blast radius:** `zeroclaw-providers` only. `OpenAiCompatibleModelProvider` and `OpenAiResponsesModelProvider` gain one request header when, and only when, the parsed host is `opencode.ai` or a subdomain. Every other provider and endpoint builds byte-identical requests to before, which `non_opencode_requests_do_not_carry_the_session_header` asserts. No public API changed; the new module is additive.
- **Linked issue(s):** Closes #10603
- **Labels:** `bug`, `docs`, `provider`, `provider:openai`, `provider:compatible`, `domain:security`, `risk:high`, `size:L`, `distinguished contributor`, `needs-author-action`

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** not surface-specific; this is the provider layer beneath every surface. Reachable from `cli` for a manual run.
- **Setup / preconditions:** for the credential-free path, none. For the live A/B, an OpenCode Go key and a config entry:

  ```toml
  [providers.models.opencode.default]
  uri   = "https://opencode.ai/zen/go/v1"
  model = "deepseek-v4-flash"
  ```

- **Steps to run:**

  ```sh
  # Credential-free: the header decision and the derived value.
  cargo test -p zeroclaw-providers opencode
  cargo test -p zeroclaw-providers operator_pinned

  # Live A/B, needs an OpenCode Go key.
  zeroclaw run "hello"
  ```

- **Expected on this branch (after):** the unit tests pass, including `opencode_requests_carry_the_session_header`. With a key, the turn completes; the request carries one `x-opencode-session` header holding 32 lowercase hex characters.
- **Prior behavior on `master` (before):** `git grep x-opencode-session -- 'crates/**/*.rs'` returns nothing, so no request carries the header. With a key, `zeroclaw run` fails with `Error from provider (Console Go): Upstream request failed: Model is unavailable.`

### How I tested

- **CI checks relied on and why they cover this change:** the Rust quality gate (`cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test`) covers the whole changed surface, which is Rust in one crate plus one Markdown page. `Docs Style` covers the changed Markdown lines. Rustdoc lint covers the new module's public docs.
- **Known CI coverage gap, if any:** no test exercises a live `opencode.ai` host, which would need a credential and real DNS. The header's presence is therefore asserted against a built `reqwest::Request` rather than a captured server-side request: `opencode_requests_carry_the_session_header` builds the request and reads back `HeaderMap`. Wiring at the ten call sites is covered by the compiler and by diff review, not by an end-to-end test. Flagging this explicitly so a reviewer can weigh it.
- **Commands run and tail output:**

  ```
  $ cargo fmt --all -- --check                                  # exit 0, no output
  $ cargo clippy --all-targets -- -D warnings                   # exit 0, 0 warnings
  $ cargo test -p zeroclaw-providers
  test result: ok. 1497 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out

  $ cargo check --workspace --all-targets --exclude zeroclaw-desktop   # exit 0
  $ cargo doc --no-deps -p zeroclaw-providers                          # exit 0
  $ bash scripts/ci/docs_quality_gate.sh
  No prose em-dashes in changed docs files.
  Summary: 0 error(s)
  $ bash scripts/ci/docs_links_gate.sh                          # exit 0
  $ bash scripts/ci/comment_hygiene_gate.sh
  Comment hygiene gate passed.
  ```

  The 17 new tests, all passing:

  ```
  compatible::tests::opencode_requests_carry_the_session_header
  compatible::tests::non_opencode_requests_do_not_carry_the_session_header
  compatible::tests::operator_pinned_session_header_is_not_overridden
  compatible::tests::opencode_session_header_follows_the_built_request_destination
  openai::tests::opencode_session_header_follows_the_built_request_destination
  opencode_session::tests::matches_builtin_zen_and_go_endpoints
  opencode_session::tests::matches_subdomains_and_ignores_case_port_and_trailing_dot
  opencode_session::tests::rejects_lookalike_hosts
  opencode_session::tests::classifies_the_host_the_request_reaches
  opencode_session::tests::ipv6_literal_is_not_a_target_and_does_not_panic
  opencode_session::tests::non_opencode_target_yields_no_header
  opencode_session::tests::opencode_target_always_yields_a_token
  opencode_session::tests::token_is_stable_per_scope_and_distinct_across_scopes
  opencode_session::tests::token_never_contains_the_session_key
  opencode_session::tests::blank_scope_falls_back_to_the_process_token
  opencode_session::tests::conversation_scope_does_not_survive_a_spawn
  opencode_session::tests::digest_is_domain_separated
  ```

  Review follow-up at `421671df18` and `875b791f21`. The first moves host classification to `reqwest::Url`; the second makes the chat provider classify its finished endpoint (`chat_completions_url()`) rather than `base_url`. These runs are on `875b791f21`, scoped to the changed crate; the full-suite run above predates both commits:

  ```
  $ rustfmt --edition 2024 --check <the 3 changed files>        # exit 0
  $ cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings   # exit 0
  $ cargo test --locked -p zeroclaw-providers opencode
  test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 1525 filtered out
  $ cargo test --locked -p zeroclaw-providers session_header
  test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1540 filtered out
  ```

  Both `*_follows_the_built_request_destination` regressions fail against the previous `host_of` (2 failed, at the header-presence assertion), so they catch the reviewed bug instead of restating the new implementation. The chat test's `api_path` case (`https:` plus `//opencode.ai/...`) likewise fails against the previous `base_url` classification.

- **One test failure I hit and chased down:** `grok_cli::tests::unix_fake_child::timeout_kills_leader_and_descendant` failed on my first full-suite run with `timed out waiting for ".../leader.pid"`. It is a pre-existing intermittent flake, not caused by this change. Evidence: it fails the same way on unmodified `master` at `e5d556a17` (1 of 3 full-suite runs there), passes on the other two, and passes 3 of 3 in isolation on this branch. This diff touches no process-spawning code. The clean branch run quoted above is the current head.
- **Beyond CI, what did you manually verify?** That the derived value never contains the session key, including the `@` and digit runs from a WhatsApp-shaped key, asserted by `token_never_contains_the_session_key`. That host matching rejects the lookalikes worth worrying about: `opencode.ai.example.com`, `notopencode.ai`, and `https://opencode.ai@example.com/v1`, where the registrable domain sits in userinfo. That the documented `extra_headers` TOML shape parses and reaches both builders (`factory.rs:241` and `factory.rs:331`).

  **What I did not verify:** any request against a live `opencode.ai` endpoint. I hold no OpenCode credential, so the HTTP 400 that motivates this fix is upstream's reported evidence rather than something I reproduced. I also did not measure the prompt-cache saving, only restored the header that enables it.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** `./dev/ci.sh all` was not run; the targeted gates above cover the changed surface, which is one crate plus one docs page.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — no new endpoint or request is introduced; existing OpenCode requests carry one additional header.
- Secrets / tokens / credentials handling changed? `Yes` — a token derived from the conversation's session key is sent to the OpenCode relay. Credential resolution and auth headers are untouched.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — test scopes are synthetic (`telegram_1001_alice`, `whatsapp_123@g.us_alice`) and mirror the shapes already in `crates/zeroclaw-api/src/session_keys.rs`.
- Prompt injection or untrusted model-visible text introduced/changed? `No` — the header is request metadata and never enters a prompt.
- If any `Yes`, describe the risk and mitigation:

This PR causes a value *derived from* the conversation's session key to leave the process for a third-party relay. That is inherent to session affinity: the recipient must be able to correlate a conversation's turns, which is the entire feature. What is avoidable is sending the identifiers themselves, so the key is hashed with a domain-separated SHA-256 truncated to 128 bits, and only the digest goes on the wire.

The limit of that, stated plainly: the digest is unsalted, which is deliberate so a conversation keeps its backend across a daemon restart. Unsalted means it is not a defense against a party who knows ZeroClaw's session-key format and brute-forces a low-entropy key space. Defeating that needs a per-install salt, which would cost the cross-restart affinity this exists for. If a maintainer prefers the stronger guarantee over restart-stable affinity, that trade is a one-line change in `digest_scope` and I am happy to make it.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — `extra_headers` already existed on both providers and is only newly documented. An operator who has already pinned `x-opencode-session` there keeps their value, asserted by `operator_pinned_session_header_is_not_overridden`.
- Rust/MSRV/toolchain floor changed? `No` — `sha2`, `hex`, and `uuid` were already direct dependencies of `zeroclaw-providers`.
- If backward compatibility is `No` or either surface/floor question is `Yes`: not applicable.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`. The change is additive and confined to one crate.
- **Feature flags or config toggles:** `None`. An operator can pin their own value through `extra_headers`, which suppresses the derived one, but there is no switch that turns the header off entirely.
- **Observable failure symptoms:** OpenCode requests failing where they previously succeeded, or a duplicated `x-opencode-session` on the wire. Grep provider error logs for `opencode` alongside a 4xx status. Prompt-cache regressions would show as a rising cost per turn on OpenCode aliases in cost tracking, with no change in token counts.



