### PR TITLE
fix(sop): surface the global concurrency ceiling to operators

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -37079,7 +37079,7 @@ stream_tool_arguments = [
 
     #[test]
     async fn set_prop_sop_max_concurrent_total() {
-        // #9902 reported `config set sop.max_concurrent_total` as "Unknown
+        // `config set sop.max_concurrent_total` was reported as returning "Unknown
         // property". It resolves today, but only through the derive's nested
         // delegation (`Config` -> `SopConfig`), and no named test covers it:
         // the bulk scalar sweep swallows unsettable keys into a counter, so a

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -24681,7 +24681,10 @@ pub struct SopConfig {
     #[serde(default = "default_sop_execution_mode")]
     pub default_execution_mode: String,
 
-    /// Maximum total concurrent SOP runs across all SOPs.
+    /// Maximum SOP runs executing at once across ALL SOPs: one shared pool, not a per-SOP allowance; a SOP's own `max_concurrent` bounds only its own runs, so an individual SOP never exceeds the smaller of the two and reaches this ceiling only when no other SOP holds a slot; runs parked at a HITL approval or a deterministic checkpoint release their slot and count against neither cap; a trigger that cannot admit is deferred and a resume that cannot re-claim reports `deferred_at_capacity`, staying parked and re-resolvable rather than oversubscribing.
+    ///
+    /// Raising this raises the ceiling for every SOP at once. To bound one SOP
+    /// alone, set that SOP's `max_concurrent` in its `SOP.toml`.
     #[serde(default = "default_sop_max_concurrent_total")]
     pub max_concurrent_total: usize,
 
@@ -37072,6 +37075,21 @@ stream_tool_arguments = [
             mx.set_prop("channels.matrix.draft_update_interval_ms", "abc")
                 .is_err()
         );
+    }
+
+    #[test]
+    async fn set_prop_sop_max_concurrent_total() {
+        // #9902 reported `config set sop.max_concurrent_total` as "Unknown
+        // property". It resolves today, but only through the derive's nested
+        // delegation (`Config` -> `SopConfig`), and no named test covers it:
+        // the bulk scalar sweep swallows unsettable keys into a counter, so a
+        // regression here would not fail CI. Drive it off the whole `Config`,
+        // which is the path the CLI, gateway and RPC writers all take.
+        let mut config = Config::default();
+        config.set_prop("sop.max_concurrent_total", "8").unwrap();
+        assert_eq!(config.sop.max_concurrent_total, 8);
+        assert_eq!(config.get_prop("sop.max_concurrent_total").unwrap(), "8");
+        assert!(config.set_prop("sop.max_concurrent_total", "abc").is_err());
     }
 
     #[test]

--- a/crates/zeroclaw-config/src/schema_markdown.rs
+++ b/crates/zeroclaw-config/src/schema_markdown.rs
@@ -831,7 +831,7 @@ mod tests {
     #[test]
     fn sop_global_pool_contract_appears_in_generated_reference() {
         // `max_concurrent_total` is a POOL shared by every SOP, not a per-SOP
-        // allowance. In #9902 an operator raised one SOP's `max_concurrent`
+        // allowance. An operator raised one SOP's `max_concurrent`
         // twice and measured no change, because the binding ceiling was this
         // global key. `first_line` truncates a field description to its FIRST
         // line, so reflowing that doc comment onto a second line would silently

--- a/crates/zeroclaw-config/src/schema_markdown.rs
+++ b/crates/zeroclaw-config/src/schema_markdown.rs
@@ -829,6 +829,27 @@ mod tests {
     }
 
     #[test]
+    fn sop_global_pool_contract_appears_in_generated_reference() {
+        // `max_concurrent_total` is a POOL shared by every SOP, not a per-SOP
+        // allowance. In #9902 an operator raised one SOP's `max_concurrent`
+        // twice and measured no change, because the binding ceiling was this
+        // global key. `first_line` truncates a field description to its FIRST
+        // line, so reflowing that doc comment onto a second line would silently
+        // gut the reference again; this pins the whole contract to line one.
+        let schema = schemars::schema_for!(crate::schema::Config);
+        let md = generate(&schema.to_value());
+        let row = md
+            .lines()
+            .find(|line| line.contains("`max_concurrent_total`"))
+            .expect("generated config reference should include the global SOP concurrency pool");
+
+        assert!(row.contains("across ALL SOPs"));
+        assert!(row.contains("one shared pool, not a per-SOP allowance"));
+        assert!(row.contains("smaller of the two"));
+        assert!(row.contains("deferred_at_capacity"));
+    }
+
+    #[test]
     fn cron_section_exposes_uses_memory_field() {
         // Regression test: the generated config reference must expose
         // per-cron-job fields (including `uses_memory`) instead of only the

--- a/crates/zeroclaw-gateway/src/api_sop_author.rs
+++ b/crates/zeroclaw-gateway/src/api_sop_author.rs
@@ -47,7 +47,12 @@ pub async fn handle_sops_list(State(state): State<AppState>, headers: HeaderMap)
     }
     let (dir, mode) = sops_dir_and_mode(&state);
     let sops = zeroclaw_runtime::sop::load_sops_from_directory(&dir, mode);
-    Json(serde_json::json!({ "sops": sops })).into_response()
+    // The global ceiling binds in addition to each SOP's own `max_concurrent`,
+    // so a client rendering only the per-SOP number shows a cap that may never
+    // be reachable. Resolved from live config per request, never snapshotted.
+    let max_concurrent_total = state.config.read().sop.max_concurrent_total;
+    Json(serde_json::json!({ "sops": sops, "max_concurrent_total": max_concurrent_total }))
+        .into_response()
 }
 
 pub async fn handle_sop_trigger_sources(
@@ -1618,5 +1623,36 @@ mod tests {
         assert_eq!(json["status"], "cancelled");
         assert_eq!(json["already_terminal"], false);
         assert_eq!(run_status(&state, &run_id), Some(SopRunStatus::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn sops_list_carries_the_global_concurrency_ceiling() {
+        // #9902: the listing returned each SOP's declared `max_concurrent` but
+        // not the shared `sop.max_concurrent_total` pool that actually binds,
+        // so a client could render only a cap that may never be reachable.
+        let tmp = tempfile::tempdir().unwrap();
+        let sops_dir = tmp.path().join("sops");
+        zeroclaw_runtime::sop::save_sop(&sops_dir, &authoring_policy_sop()).unwrap();
+
+        let mut config = zeroclaw_config::schema::Config {
+            config_path: tmp.path().join("config.toml"),
+            ..zeroclaw_config::schema::Config::default()
+        };
+        config.sop.sops_dir = Some(sops_dir.to_string_lossy().into_owned());
+        config.sop.max_concurrent_total = 7;
+        let state = crate::api::test_state(config);
+
+        let resp = handle_sops_list(State(state), HeaderMap::new()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            json["max_concurrent_total"], 7,
+            "the listing must carry the shared pool that actually binds"
+        );
+        // Additive guarantee: `sops` keeps its shape for existing clients.
+        assert!(json["sops"].is_array(), "sops must stay an array");
+        assert_eq!(json["sops"][0]["max_concurrent"], 1);
     }
 }

--- a/crates/zeroclaw-gateway/src/api_sop_author.rs
+++ b/crates/zeroclaw-gateway/src/api_sop_author.rs
@@ -1627,7 +1627,7 @@ mod tests {
 
     #[tokio::test]
     async fn sops_list_carries_the_global_concurrency_ceiling() {
-        // #9902: the listing returned each SOP's declared `max_concurrent` but
+        // The listing returned each SOP's declared `max_concurrent` but
         // not the shared `sop.max_concurrent_total` pool that actually binds,
         // so a client could render only a cap that may never be reachable.
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -526,6 +526,7 @@ cli-sop-execution-mode = {"  "}Execution mode: {$value}
 cli-sop-deterministic = {"  "}Deterministic:  {$value}
 cli-sop-cooldown = {"  "}Cooldown:       {$value}s
 cli-sop-max-concurrent = {"  "}Max concurrent: {$value}
+cli-sop-global-ceiling = {"  "}Global ceiling: {$value} (shared across all SOPs)
 cli-sop-admission-policy = {"  "}Admission:      {$value}
 cli-sop-max-pending-approvals = {"  "}Max pending:    {$value}
 cli-sop-location = {"  "}Location:       {$value}

--- a/crates/zeroclaw-runtime/locales/es/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/es/cli.ftl
@@ -449,6 +449,7 @@ cli-sop-execution-mode = {"  "}Modo de ejecución: {$value}
 cli-sop-deterministic = {"  "}Determinista:  {$value}
 cli-sop-cooldown = {"  "}Tiempo de espera: {$value}s
 cli-sop-max-concurrent = {"  "}Máx. concurrentes: {$value}
+cli-sop-global-ceiling = {"  "}Límite global: {$value} (compartido entre todos los SOP)
 cli-sop-admission-policy = {"  "}Admisión:        {$value}
 cli-sop-max-pending-approvals = {"  "}Máx. pendientes: {$value}
 cli-sop-location = {"  "}Ubicación:       {$value}

--- a/crates/zeroclaw-runtime/locales/fr/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/fr/cli.ftl
@@ -452,6 +452,7 @@ cli-sop-execution-mode = {"  "}Mode d'exécution : {$value}
 cli-sop-deterministic = {"  "}Déterministe :  {$value}
 cli-sop-cooldown = {"  "}Délai :         {$value}s
 cli-sop-max-concurrent = {"  "}Max simultanés : {$value}
+cli-sop-global-ceiling = {"  "}Plafond global : {$value} (partagé entre tous les SOP)
 cli-sop-admission-policy = {"  "}Admission :     {$value}
 cli-sop-max-pending-approvals = {"  "}Max en attente : {$value}
 cli-sop-location = {"  "}Emplacement :   {$value}

--- a/crates/zeroclaw-runtime/locales/ja/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/ja/cli.ftl
@@ -449,6 +449,7 @@ cli-sop-execution-mode = {"  "}実行モード: {$value}
 cli-sop-deterministic = {"  "}決定論的:  {$value}
 cli-sop-cooldown = {"  "}クールダウン:       {$value}秒
 cli-sop-max-concurrent = {"  "}最大同時実行数: {$value}
+cli-sop-global-ceiling = {"  "}全体上限: {$value} (全 SOP で共有)
 cli-sop-admission-policy = {"  "}許可ポリシー:   {$value}
 cli-sop-max-pending-approvals = {"  "}最大保留承認数: {$value}
 cli-sop-location = {"  "}場所:       {$value}

--- a/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/zh-CN/cli.ftl
@@ -448,6 +448,7 @@ cli-sop-execution-mode = {"  "}执行模式: {$value}
 cli-sop-deterministic = {"  "}确定性:  {$value}
 cli-sop-cooldown = {"  "}冷却时间:       {$value}s
 cli-sop-max-concurrent = {"  "}最大并发数: {$value}
+cli-sop-global-ceiling = {"  "}全局上限: {$value}（所有 SOP 共享）
 cli-sop-admission-policy = {"  "}准入策略:   {$value}
 cli-sop-max-pending-approvals = {"  "}最大待批数: {$value}
 cli-sop-location = {"  "}位置:       {$value}

--- a/crates/zeroclaw-runtime/src/i18n.rs
+++ b/crates/zeroclaw-runtime/src/i18n.rs
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn sop_show_concurrency_strings_format_in_all_locales() {
-        // #9902: `sop show` printed only the SOP's declared `max_concurrent`
+        // `sop show` printed only the SOP's declared `max_concurrent`
         // while the shared `sop.max_concurrent_total` pool was what actually
         // bound. Both lines must render, with the value substituted, in every
         // locale a user can select.

--- a/crates/zeroclaw-runtime/src/i18n.rs
+++ b/crates/zeroclaw-runtime/src/i18n.rs
@@ -824,6 +824,30 @@ mod tests {
     }
 
     #[test]
+    fn sop_show_concurrency_strings_format_in_all_locales() {
+        // #9902: `sop show` printed only the SOP's declared `max_concurrent`
+        // while the shared `sop.max_concurrent_total` pool was what actually
+        // bound. Both lines must render, with the value substituted, in every
+        // locale a user can select.
+        for (source, locale) in [
+            (include_str!("../locales/en/cli.ftl"), "en"),
+            (include_str!("../locales/es/cli.ftl"), "es"),
+            (include_str!("../locales/fr/cli.ftl"), "fr"),
+            (include_str!("../locales/ja/cli.ftl"), "ja"),
+            (include_str!("../locales/zh-CN/cli.ftl"), "zh-CN"),
+        ] {
+            for key in ["cli-sop-max-concurrent", "cli-sop-global-ceiling"] {
+                let value = format_ftl_message(source, locale, key, &[("value", "4")])
+                    .unwrap_or_else(|| panic!("{key} should format in {locale}"));
+                assert!(
+                    value.contains('4'),
+                    "{key} in {locale} should substitute the value; got: {value:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn cli_approval_prompt_strings_format_in_all_locales() {
         let tool = "shell";
         let cases = [

--- a/docs/book/src/sop/syntax.md
+++ b/docs/book/src/sop/syntax.md
@@ -30,7 +30,7 @@ happens when a trigger arrives while this SOP's execution slots are full:
 
 | Field | Default | Effect |
 |---|---:|---|
-| `max_concurrent` | `1` | Maximum runs of this SOP *executing* at once. A run parked at a HITL approval or a deterministic checkpoint releases its slot, so it does not count against this. |
+| `max_concurrent` | `1` | Maximum runs of this SOP *executing* at once. A run parked at a HITL approval or a deterministic checkpoint releases its slot, so it does not count against this. The global `max_concurrent_total` pool applies on top of it; see [Global Concurrency Ceiling](#global-concurrency-ceiling). |
 | `admission_policy` | `parallel` | How a trigger that cannot admit right now is handled (see below). |
 | `max_pending_approvals` | `0` (unlimited) | Upper bound on runs of this SOP parked at a HITL approval simultaneously. Past the bound, further triggers are deferred (backpressure), never silently dropped (except under `drop`). |
 
@@ -73,6 +73,28 @@ max_pending_approvals = 8
 [[triggers]]
 type = "manual"
 ```
+
+### Global Concurrency Ceiling
+
+The `[sop]` config caps how many runs may execute across *all* SOPs at once:
+
+| Field | Default | Effect |
+|---|---:|---|
+| `max_concurrent_total` | `4` | Maximum runs *executing* at once across every loaded SOP. Applies on top of each SOP's own `max_concurrent`; a run parked at a HITL approval or a deterministic checkpoint releases its slot and does not count against either. |
+
+This is a shared pool, not a per-SOP clamp. Two SOPs that each declare
+`max_concurrent = 8` contend for the same budget of 4, so raising one SOP's
+`max_concurrent` above `max_concurrent_total` cannot widen it: an individual SOP
+never observes more than the smaller of the two.
+
+The ceiling is enforced on a fresh start and again on resume, so a burst of
+simultaneous approvals cannot push the executing set past it. Exhaustion is
+backpressure, not loss: a trigger that cannot admit is deferred per its
+`admission_policy`, and an approval that cannot resume reports
+`deferred_at_capacity`, leaving the gate waiting and re-resolvable once a slot
+frees.
+
+Set it with `zeroclaw config set sop.max_concurrent_total <n>`.
 
 Approval broker groups and policies live in the main ZeroClaw config, not in
 per-SOP `SOP.toml` files. A step can reference a configured policy by name with

--- a/src/sop/mod.rs
+++ b/src/sop/mod.rs
@@ -151,6 +151,13 @@ pub fn handle_command(command: crate::SopCommands, config: &crate::config::Confi
             println!(
                 "{}",
                 get_required_cli_string_with_args(
+                    "cli-sop-global-ceiling",
+                    &[("value", &config.sop.max_concurrent_total.to_string())]
+                )
+            );
+            println!(
+                "{}",
+                get_required_cli_string_with_args(
                     "cli-sop-admission-policy",
                     &[("value", &sop.admission_policy.to_string())]
                 )


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `sop.max_concurrent_total` is a pool shared by every SOP, but it appeared on no surface an operator would consult. The reporter raised one SOP's `max_concurrent` from 8 to 16 twice, measured no change, and read the resulting `deferred_at_capacity` as per-SOP backpressure. It was the global key all along.
  - The schema doc comment is the canonical input to the generated config reference, and `write_section_fields` renders only `first_line(...)` of it (`schema_markdown.rs:521`, helper at `:702`). The old comment was one terse line, so that was also the entire published contract. Expanded so the full contract lives on line one, following the `docker.allowed_workspace_roots` precedent (`schema.rs:13261`), and pinned by a generated-reference test so a future reflow onto a second line cannot silently gut it again.
  - `sop/syntax.md` documented only the per-SOP `max_concurrent`. Added a `### Global Concurrency Ceiling` section and cross-referenced it from the per-SOP table row, which is where the reporter looked first.
  - `sop show` printed only the declared value. It now also prints `Global ceiling:`, resolved from live config at use time rather than snapshotted, in all five locales.
  - `/api/sops` returned each SOP's declared `max_concurrent` but not the pool that binds. It now carries `max_concurrent_total` as a sibling key.
- **Scope boundary:** This PR does **not** change any admission or concurrency behavior. No cap is computed, clamped, or enforced differently; every edit is prose, one CLI line, one additive JSON key, and tests. It also does not touch the `deferred_at_capacity` refusal, which is the remaining item on the issue (see Follow-up).
- **Blast radius:** `/api/sops` gains a key; `sops` keeps its shape, and the new test asserts that explicitly, so existing clients are unaffected. `web/src/lib/sops.ts:65` hand-writes `SopSummary` with only `name`/`description`/`version`, and `Sops.tsx` renders no concurrency input, so the dashboard needs no change. `sop show` gains an output line, which could affect anyone scraping that command; the existing `Max concurrent:` line is deliberately untouched. The generated `docs/book/src/reference/config.md` is gitignored and rebuilt by `cargo mdbook`.
- **Linked issue(s):** Related #9902
- **Labels:** I do not have label permission on this repo. Suggested: `bug`, `docs`, `config`, `gateway`, `runtime`, `tool:sop`, `cli`, `risk:low`, `size:S`.

### Two findings from the issue worth recording

Both are stated in #9902 and neither holds against `master`. A maintainer may want to trim the issue rather than have the next reader re-derive them.

1. **`config set sop.max_concurrent_total` does not return `Unknown property`.** `#[derive(Configurable)]` auto-registers every non-`#[nested]`, non-`skip`, non-map field; `usize` maps to `PropKind::Integer` (`traits.rs:120`); `Config.sop` is `#[nested]` (`schema.rs:664`) and `SopConfig` carries `#[prefix = "sop"]` (`schema.rs:24664`). There is no allowlist on the path. The reported error was most likely a stale binary, or `sop.max_concurrent`, which is a per-SOP manifest field and genuinely unknown to config. No production change was needed, so this PR adds only the missing named regression test: the sole existing coverage is a bulk sweep that swallows unsettable keys into a counter, so a real regression here would not fail CI.
2. **The dashboard does not display the non-binding number.** The issue says `/api/sops` "does return per-SOP `max_concurrent`, so the dashboard shows the number that is not binding". The API does return it, but the hand-written client type drops it before render. The API change here is still correct for API consumers; no dashboard fix is required.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes`
- **Interface(s) exercised:** `cli` (`zeroclaw sop show`) and the gateway HTTP API (`GET /api/sops`)
- **Setup / preconditions:** A workspace with at least one SOP under `<install>/shared/sops/<name>/SOP.toml`, and `[sop] sops_dir` set so the CLI resolves it. Set `max_concurrent = 16` on that SOP and leave `[sop] max_concurrent_total` unset, so it defaults to 4. That is the reporter's exact configuration.
- **Steps to run:**

```sh
zeroclaw sop show <name>
curl -s localhost:<port>/api/sops | jq '{ceiling: .max_concurrent_total, declared: .sops[0].max_concurrent}'
zeroclaw config set sop.max_concurrent_total 8
```

- **Expected on this branch (after):** `sop show` prints `Max concurrent: 16` followed by `Global ceiling: 4 (shared across all SOPs)`. The `/api/sops` payload carries `max_concurrent_total: 4` beside the declared 16. `config set` succeeds.
- **Prior behavior on `master` (before):** `sop show` prints only `Max concurrent: 16`, with nothing indicating that 4 is the real ceiling. `/api/sops` has no `max_concurrent_total`. The third command is expected to succeed on `master` too; if it does not for you, please say so, because that would mean finding 1 above is wrong.

### How I tested

Local validation was not possible: there is no Rust toolchain on the machine this was written on (no `cargo`, `rustc`, or `rustup` on any drive), and no Node or Python either, so `cargo fmt`, `cargo clippy`, `cargo test`, `cargo fluent check`, `scripts/ci/docs_quality_gate.sh` and `scripts/ci/docs_links_gate.sh` were unrunnable rather than skipped by choice. **Required CI is therefore the entirety of the machine-checked evidence here.** It is green on `90ba5a1a`: 33 passed, 4 skipped, 0 failed.

- **CI checks relied on and why they cover this change:**
  - `Test` and `Test (Landlock)` exercise the four added tests: `sop_global_pool_contract_appears_in_generated_reference`, `set_prop_sop_max_concurrent_total`, `sop_show_concurrency_strings_format_in_all_locales`, `sops_list_carries_the_global_concurrency_ceiling`. The generated-reference test is the one that proves the doc comment actually reaches the published config reference.
  - `Lint` covers clippy and the comment hygiene gate.
  - `Format` covers rustfmt, including the deliberately long doc-comment line, which survives because `wrap_comments` is unset in `rustfmt.toml`.
  - `Docs Style` covers the changed Markdown lines and the em-dash policy in `sop/syntax.md`.
  - The `Check` matrix (all features, no default features, 32-bit, all three plugin backends, `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, MSRV floor) covers compilation of the gateway and CLI edits.
- **Known CI coverage gap, if any:** The `sop show` rendered output has no automated assertion anywhere. The new line is covered only indirectly, by the locale-parity test proving the Fluent key formats with its value substituted in all five catalogues. That print block is untested on `master` today and this PR does not change that.
- **Commands run and tail output:** None locally, for the reason above. The CI tail:

```text
CI Required Gate  pass   3s
Docs Style        pass   5m32s
Format            pass   26s
Lint              pass   8m11s
Test              pass   24m40s
Test (Landlock)   pass   4m18s
```

  The first run failed `Lint` on the comment hygiene gate, detector "issue/PR refs in comments", because four new comments opened with a bare issue number. Commit `90ba5a1a` rewords them to keep the rationale and drop the reference.

- **Beyond CI, what did you manually verify?** Inspection only: no U+2014 em-dash on any added prose line (byte-scanned; the 7 pre-existing ones in `syntax.md` sit inside fenced blocks and are exempt); the added comments checked by hand against all ten comment-hygiene detectors, not just the one that failed; the committed diff is 136 insertions with no CRLF normalisation noise. What I did **not** verify by hand, and am taking from CI instead: that it compiles, that the tests pass, and that the generated reference renders the expected row.
- **Visual interface changed?** `Yes`, in the narrow sense that `zeroclaw sop show` gains one rendered line.
- **Tested revision, interface, and terminal or viewport dimensions:** None. I could not build the binary, so there is no actual-interface evidence for the new CLI line, and CI does not supply it either. Flagging that as a real gap against the template's requirement rather than offering the string assertions in its place, which the template correctly says do not substitute for it. The A/B steps above close it in about a minute for anyone with a toolchain.
- **Screenshot evidence:** Not provided, for the reason above.
- **Action or changed state and observed result:** Not observed.
- **If any command was intentionally skipped, why:** None were skipped by choice; the local toolchain is absent, and CI covers every surface it can reach.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

`GET /api/sops` already requires auth via `require_auth` and this PR does not touch that path; the added field is a configured limit, not user data.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`, additively. No config key is added, renamed, or given a new default, but `zeroclaw sop show` gains an output line and `GET /api/sops` gains a response field. Nothing is removed or renamed, so there are no upgrade steps.
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low risk: `git revert <sha>` is the plan.

## Follow-up

The remaining item on #9902 is naming the binding limit in the `deferred_at_capacity` refusal, which today emits only that token and leaves the operator to guess which of the two caps bound. It is deliberately not in this PR: it gives `ResolveOutcome::DeferredAtCapacity` a payload, which ripples through roughly eight match sites across four crates, and it should not be reviewed alongside a docs table. Two things surfaced while mapping it that are worth recording now:

- `rpc/dispatch.rs:4686` collapses `DeferredAtCapacity` with `NotWaiting` into `sop-rpc-decision-invalid-state`, so an operator whose run was accepted and is simply waiting for a slot is told it "is not waiting". That is a defect in its own right, not just a missing detail.
- `crates/zeroclaw-channels/src/orchestrator/mod.rs:8449` swallows the outcome in a `_ => None` catch-all, so a channel gate button produces no user-visible message at all. The surrounding comment suggests the catch-all is deliberate for retryability, so this likely wants its own issue rather than a fix folded into the above.

Two existing test gaps want closing there as well: `outcome_response_maps_status_codes` (`api_sop.rs:267`) omits `DeferredAtCapacity` entirely, and `outcome_labels_and_is_resumed` (`decision.rs:104`) never asserts the `deferred_at_capacity` label, which is the exact string a 503 body hands to API clients.
