### PR TITLE
feat(vi): align constraint tags, cnf.jwk.kid, and the L3 header with the spec

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/verifiable_intent.rs
+++ b/crates/zeroclaw-runtime/src/tools/verifiable_intent.rs
@@ -330,8 +330,8 @@ mod tests {
         let args = json!({
             "operation": "evaluate_constraints",
             "constraints": [{
-                "type": "mandate.checkout.allowed_merchant",
-                "allowed_merchants": [
+                "type": "mandate.checkout.allowed_merchants",
+                "allowed": [
                     { "name": "Store A", "website": "https://store-a.example.com" }
                 ]
             }],
@@ -355,7 +355,7 @@ mod tests {
         let entry = &output["results"][0];
         assert_eq!(
             entry["constraint_type"],
-            "mandate.checkout.allowed_merchant"
+            "mandate.checkout.allowed_merchants"
         );
         assert_eq!(entry["satisfied"], false);
         let violation = entry["violations"][0]
@@ -374,8 +374,8 @@ mod tests {
         let args = json!({
             "operation": "evaluate_constraints",
             "constraints": [{
-                "type": "payment.allowed_payee",
-                "allowed_payees": [
+                "type": "mandate.payment.allowed_payees",
+                "allowed": [
                     { "name": "Payee A", "website": "https://payee-a.example.com" }
                 ]
             }],
@@ -397,7 +397,7 @@ mod tests {
             serde_json::from_str(result.output.as_str()).expect("tool output is JSON");
         assert_eq!(output["all_satisfied"], false);
         let entry = &output["results"][0];
-        assert_eq!(entry["constraint_type"], "payment.allowed_payee");
+        assert_eq!(entry["constraint_type"], "mandate.payment.allowed_payees");
         assert_eq!(entry["satisfied"], false);
         let violation = entry["violations"][0]
             .as_str()
@@ -417,8 +417,8 @@ mod tests {
         let args = json!({
             "operation": "evaluate_constraints",
             "constraints": [{
-                "type": "mandate.checkout.allowed_merchant",
-                "allowed_merchants": [
+                "type": "mandate.checkout.allowed_merchants",
+                "allowed": [
                     { "name": "Store A", "website": "https://store-a.example.com" }
                 ]
             }],
@@ -454,8 +454,8 @@ mod tests {
             "operation": "evaluate_constraints",
             "constraints": [
                 {
-                    "type": "mandate.checkout.allowed_merchant",
-                    "allowed_merchants": [
+                    "type": "mandate.checkout.allowed_merchants",
+                    "allowed": [
                         { "name": "Store A", "website": "https://store-a.example.com" }
                     ]
                 },
@@ -479,7 +479,7 @@ mod tests {
         let merchant = &output["results"][0];
         assert_eq!(
             merchant["constraint_type"],
-            "mandate.checkout.allowed_merchant"
+            "mandate.checkout.allowed_merchants"
         );
         assert_eq!(merchant["satisfied"], true);
         assert_eq!(merchant["skipped"], false);

--- a/crates/zeroclaw-runtime/src/verifiable_intent/crypto.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/crypto.rs
@@ -240,6 +240,10 @@ pub fn ec_public_bytes_to_jwk(pub_bytes: &[u8]) -> Result<Jwk, ViError> {
         crv: "P-256".into(),
         x: b64u_encode(&pub_bytes[1..33]),
         y: b64u_encode(&pub_bytes[33..65]),
+        // Raw key bytes carry no identifier. A caller that binds this key into a
+        // mandate sets `kid` there, where it is a naming decision rather than a
+        // property of the curve point.
+        kid: None,
         d: None,
     })
 }
@@ -903,6 +907,7 @@ mod tests {
             crv: field("crv"),
             x: field("x"),
             y: field("y"),
+            kid: None,
             d: None,
         })
         .expect("reference JWK must convert")

--- a/crates/zeroclaw-runtime/src/verifiable_intent/issuance.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/issuance.rs
@@ -118,6 +118,36 @@ pub fn create_layer2_autonomous(
         ));
     }
 
+    // An autonomous mandate must name the key it delegates to. §4.6 requires
+    // `cnf.jwk` to carry a `kid`, and §5.7 rule 1 is what makes it load-bearing:
+    // an L3 verifier resolves the agent's key by matching the L3 header's `kid`
+    // against this one, so an L2 without it delegates to a key nothing can
+    // resolve.
+    //
+    // `Jwk.kid` stays optional, because a bare public key and an L1 credential
+    // both have legitimate use for one without an identifier. The requirement
+    // belongs to this construction boundary, which is where the delegation is
+    // actually declared.
+    //
+    // Checking the checkout side alone is sufficient because the parity check
+    // above has already established that the two `cnf` values are equal. An
+    // all-whitespace identifier is refused on the same reasoning as an empty
+    // constraint currency in `verify_fulfillment_currency`: it is present
+    // without naming anything.
+    let names_a_key = checkout
+        .cnf
+        .jwk
+        .kid
+        .as_deref()
+        .is_some_and(|kid| !kid.trim().is_empty());
+    if !names_a_key {
+        return Err(ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            "an autonomous mandate must bind the agent key by identifier: \
+             cnf.jwk.kid is required and must not be blank",
+        ));
+    }
+
     let l1_hash = sd_hash(serialized_l1);
 
     let checkout_value = serde_json::to_value(checkout).map_err(|e| {
@@ -454,6 +484,79 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err.kind, ViErrorKind::ModeMismatch);
+    }
+
+    /// An autonomous L2 must not issue without `cnf.jwk.kid`.
+    ///
+    /// `credential-format.md` §4.6 requires every autonomous mandate to carry
+    /// `cnf.jwk` with a `kid` member, and §5.7 rule 1 is what makes it
+    /// load-bearing: an L3 verifier resolves the delegated key by matching the
+    /// L3 header's `kid` against this value. An L2 issued without one leaves the
+    /// L3 credentials no conformant key-binding path.
+    ///
+    /// Parity alone does not catch this. Two mandates whose nested JWK is
+    /// missing the identifier are equal to each other, so the pair check passes
+    /// and a structurally invalid credential gets signed. `generate_ec_p256`
+    /// returns `kid: None`, so that is the state a caller starts from.
+    #[test]
+    fn autonomous_issuance_requires_a_nested_kid() {
+        let (user_pkcs8, _user_jwk) = generate_ec_p256().unwrap();
+        let user_key = load_key_pair(&user_pkcs8).unwrap();
+        let (_agent_pkcs8, agent_jwk) = generate_ec_p256().unwrap();
+
+        let instrument = || PaymentInstrument {
+            instrument_type: "card".into(),
+            id: "tok-1".into(),
+            description: None,
+        };
+        let issue = |cnf: Cnf| {
+            create_layer2_autonomous(
+                &test_issuer_l1(),
+                &OpenCheckoutMandate {
+                    vct: "mandate.checkout.open".into(),
+                    cnf: cnf.clone(),
+                    constraints: vec![],
+                    prompt_summary: None,
+                },
+                &OpenPaymentMandate {
+                    vct: "mandate.payment.open".into(),
+                    cnf,
+                    payment_instrument: instrument(),
+                    constraints: vec![],
+                },
+                "https://network.example.com",
+                "nonce-kid",
+                &user_key,
+                1_700_000_000,
+                1_700_086_400,
+            )
+        };
+
+        // The pair matches, and the shared JWK carries no identifier.
+        let err = issue(Cnf {
+            jwk: Jwk {
+                kid: None,
+                ..agent_jwk.clone()
+            },
+        })
+        .expect_err("an autonomous mandate pair without `cnf.jwk.kid` must be refused");
+        assert_eq!(err.kind, ViErrorKind::IssuanceInputInvalid);
+        assert!(
+            err.message.contains("kid"),
+            "the refusal must name the missing member: {}",
+            err.message
+        );
+
+        // Control: the same pair issues once the identifier is present, so the
+        // refusal above is attributable to the missing `kid` and not to the
+        // empty constraint lists or anything else in the fixture.
+        issue(Cnf {
+            jwk: Jwk {
+                kid: Some("agent-key-1".into()),
+                ..agent_jwk
+            },
+        })
+        .expect("a pair carrying `cnf.jwk.kid` must still issue");
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/verifiable_intent/issuance.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/issuance.rs
@@ -276,11 +276,12 @@ pub fn create_layer3_checkout(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::verifiable_intent::crypto::{generate_ec_p256, load_key_pair};
+    use crate::verifiable_intent::crypto::{decode_disclosure, generate_ec_p256, load_key_pair};
     use crate::verifiable_intent::types::{
-        Cnf, DisclosableEntry, Entity, FulfillmentLineItem, KnownConstraint, PaymentAmount,
-        PaymentInstrument,
+        Cnf, DisclosableEntry, Entity, FulfillmentLineItem, KnownConstraint, MandateMode,
+        PaymentAmount, PaymentInstrument,
     };
+    use crate::verifiable_intent::verification::infer_mode_from_vct;
 
     fn test_issuer_l1() -> String {
         // Minimal L1 SD-JWT for testing (not cryptographically valid, just structural)
@@ -499,5 +500,90 @@ mod tests {
         )
         .unwrap();
         assert!(!l3b.serialized.is_empty());
+    }
+
+    /// Issuance passes a mandate's `vct` through into the disclosure it signs,
+    /// and until now nothing read the emitted value back: every assertion in
+    /// this module checks that a serialized form exists, never what VCT it
+    /// carries. The registry could therefore move on the verification side
+    /// while issuance kept emitting the old string, with the whole suite still
+    /// green.
+    ///
+    /// Asserting both halves together is what stops that. The first assertion
+    /// pins what issuance emits; the second requires verification to recognize
+    /// that exact string, so the two cannot drift apart.
+    #[test]
+    fn issuance_emits_mandate_vcts_that_verification_recognizes() {
+        const CHECKOUT_VCT: &str = "mandate.checkout.open";
+        const PAYMENT_VCT: &str = "mandate.payment.open";
+
+        let (user_pkcs8, _user_jwk) = generate_ec_p256().unwrap();
+        let user_key = load_key_pair(&user_pkcs8).unwrap();
+        let (_agent_pkcs8, agent_jwk) = generate_ec_p256().unwrap();
+        let cnf = Cnf {
+            jwk: agent_jwk,
+            kid: Some("agent-key-1".into()),
+        };
+
+        let checkout = OpenCheckoutMandate {
+            vct: CHECKOUT_VCT.into(),
+            cnf: cnf.clone(),
+            constraints: vec![],
+            prompt_summary: None,
+        };
+        let payment = OpenPaymentMandate {
+            vct: PAYMENT_VCT.into(),
+            cnf,
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            constraints: vec![],
+        };
+
+        let result = create_layer2_autonomous(
+            &test_issuer_l1(),
+            &checkout,
+            &payment,
+            "https://network.example.com",
+            "nonce-vct",
+            &user_key,
+            1_700_000_000,
+            1_700_086_400,
+        )
+        .unwrap();
+
+        // Read the VCTs back out of the disclosures issuance actually produced.
+        // The segments are split by hand because the serialized L1 this helper
+        // supplies already ends in `~`, which `parse_sd_jwt` refuses. That
+        // defect is stage 3's to fix and is deliberately not worked around
+        // here beyond reaching the disclosures.
+        let emitted: Vec<String> = result
+            .serialized
+            .split('~')
+            .filter_map(|segment| decode_disclosure(segment).ok())
+            .filter_map(|disclosure| {
+                disclosure
+                    .claim_value()
+                    .get("vct")?
+                    .as_str()
+                    .map(str::to_owned)
+            })
+            .collect();
+
+        assert_eq!(
+            emitted,
+            vec![CHECKOUT_VCT.to_owned(), PAYMENT_VCT.to_owned()],
+            "issuance must emit the mandate VCTs it was given, in order"
+        );
+
+        for vct in &emitted {
+            assert_eq!(
+                infer_mode_from_vct(vct).expect("verification must recognize an emitted VCT"),
+                MandateMode::Autonomous,
+                "verification must read `{vct}` as an open mandate"
+            );
+        }
     }
 }

--- a/crates/zeroclaw-runtime/src/verifiable_intent/issuance.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/issuance.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use crate::verifiable_intent::crypto::{create_disclosure, jws_sign, sd_hash, serialize_sd_jwt};
 use crate::verifiable_intent::error::{ViError, ViErrorKind};
 use crate::verifiable_intent::types::{
-    CheckoutL3Mandate, FinalCheckoutMandate, FinalPaymentMandate, Jwk, OpenCheckoutMandate,
+    CheckoutL3Mandate, FinalCheckoutMandate, FinalPaymentMandate, OpenCheckoutMandate,
     OpenPaymentMandate, PaymentL3Mandate,
 };
 
@@ -95,7 +95,7 @@ pub struct AutonomousL2Result {
     pub serialized: String,
     /// The SD hash of the L1 that was bound.
     pub sd_hash: String,
-    /// Disclosure hash of the checkout mandate (needed for `payment.reference`).
+    /// Disclosure hash of the checkout mandate (needed for `mandate.payment.reference`).
     pub checkout_disclosure_hash: String,
 }
 
@@ -180,11 +180,17 @@ pub struct L3PaymentResult {
 }
 
 /// Create an L3a payment mandate signed by the agent's key.
+///
+/// `agent_kid` names the key in the L2 mandate's `cnf.jwk.kid`. It is a key
+/// identifier and not a key: `credential-format.md` §13.3 requires the header to
+/// carry `kid` and forbids a `jwk`, and §13.4 rule 7 gives the reason, which is
+/// that a verifier resolves the agent's key out of L2 and must never trust one
+/// the L3 asserts about itself.
 pub fn create_layer3_payment(
     serialized_l2: &str,
     mandate: &PaymentL3Mandate,
     agent_key: &EcdsaKeyPair,
-    agent_jwk: &Jwk,
+    agent_kid: &str,
     iat: i64,
     exp: i64,
 ) -> Result<L3PaymentResult, ViError> {
@@ -193,8 +199,7 @@ pub fn create_layer3_payment(
     let header = json!({
         "alg": "ES256",
         "typ": "kb-sd-jwt",
-        "jwk": agent_jwk,
-        "kid": agent_jwk.x
+        "kid": agent_kid
     });
 
     let mandate_value = serde_json::to_value(mandate).map_err(|e| {
@@ -231,11 +236,14 @@ pub struct L3CheckoutResult {
 }
 
 /// Create an L3b checkout mandate signed by the agent's key.
+///
+/// `agent_kid` names the key in the L2 mandate's `cnf.jwk.kid`, on the same
+/// rule as [`create_layer3_payment`].
 pub fn create_layer3_checkout(
     serialized_l2: &str,
     mandate: &CheckoutL3Mandate,
     agent_key: &EcdsaKeyPair,
-    agent_jwk: &Jwk,
+    agent_kid: &str,
     iat: i64,
     exp: i64,
 ) -> Result<L3CheckoutResult, ViError> {
@@ -244,8 +252,7 @@ pub fn create_layer3_checkout(
     let header = json!({
         "alg": "ES256",
         "typ": "kb-sd-jwt",
-        "jwk": agent_jwk,
-        "kid": agent_jwk.x
+        "kid": agent_kid
     });
 
     let mandate_value = serde_json::to_value(mandate).map_err(|e| {
@@ -276,9 +283,11 @@ pub fn create_layer3_checkout(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::verifiable_intent::crypto::{decode_disclosure, generate_ec_p256, load_key_pair};
+    use crate::verifiable_intent::crypto::{
+        decode_disclosure, generate_ec_p256, jws_decode_header, load_key_pair,
+    };
     use crate::verifiable_intent::types::{
-        Cnf, DisclosableEntry, Entity, FulfillmentLineItem, KnownConstraint, MandateMode,
+        Cnf, DisclosableEntry, Entity, FulfillmentLineItem, Jwk, KnownConstraint, MandateMode,
         PaymentAmount, PaymentInstrument,
     };
     use crate::verifiable_intent::verification::infer_mode_from_vct;
@@ -342,8 +351,10 @@ mod tests {
         let l1 = test_issuer_l1();
 
         let cnf = Cnf {
-            jwk: agent_jwk,
-            kid: Some("agent-key-1".into()),
+            jwk: Jwk {
+                kid: Some("agent-key-1".into()),
+                ..agent_jwk
+            },
         };
 
         let checkout = OpenCheckoutMandate {
@@ -406,8 +417,10 @@ mod tests {
         let checkout = OpenCheckoutMandate {
             vct: "mandate.checkout.open".into(),
             cnf: Cnf {
-                jwk: agent_jwk1,
-                kid: Some("key-1".into()),
+                jwk: Jwk {
+                    kid: Some("key-1".into()),
+                    ..agent_jwk1
+                },
             },
             constraints: vec![],
             prompt_summary: None,
@@ -415,8 +428,10 @@ mod tests {
         let payment = OpenPaymentMandate {
             vct: "mandate.payment.open".into(),
             cnf: Cnf {
-                jwk: agent_jwk2,
-                kid: Some("key-2".into()),
+                jwk: Jwk {
+                    kid: Some("key-2".into()),
+                    ..agent_jwk2
+                },
             },
             payment_instrument: PaymentInstrument {
                 instrument_type: "card".into(),
@@ -443,8 +458,9 @@ mod tests {
 
     #[test]
     fn create_l3_payment_and_checkout() {
-        let (agent_pkcs8, agent_jwk) = generate_ec_p256().unwrap();
+        let (agent_pkcs8, _agent_jwk) = generate_ec_p256().unwrap();
         let agent_key = load_key_pair(&agent_pkcs8).unwrap();
+        let agent_kid = "agent-key-1";
         let l2_serialized = "l2.serialized.form~disc1~disc2~kb.jwt";
 
         let checkout_jwt = "merchant.checkout.jwt";
@@ -483,7 +499,7 @@ mod tests {
             l2_serialized,
             &l3a_mandate,
             &agent_key,
-            &agent_jwk,
+            agent_kid,
             1_700_000_000,
             1_700_000_300,
         )
@@ -494,12 +510,97 @@ mod tests {
             l2_serialized,
             &l3b_mandate,
             &agent_key,
-            &agent_jwk,
+            agent_kid,
             1_700_000_000,
             1_700_000_300,
         )
         .unwrap();
         assert!(!l3b.serialized.is_empty());
+    }
+
+    /// An L3 header names the agent's key and never carries it.
+    ///
+    /// `credential-format.md` §13.3 rule 3 requires `kid` and forbids `jwk`, and
+    /// §13.4 rule 7 says why: a verifier resolves the agent's key from the L2
+    /// mandate's `cnf.jwk` by matching this `kid`, so a `jwk` in the header is a
+    /// key the credential asserts about itself. Emitting one invites a verifier
+    /// to trust it.
+    ///
+    /// Both L3 constructors are walked, because the header was built twice and
+    /// a fix applied to one of them would leave the other emitting the
+    /// forbidden parameter.
+    #[test]
+    fn an_l3_header_carries_the_kid_and_never_the_agent_jwk() {
+        let (agent_pkcs8, _agent_jwk) = generate_ec_p256().unwrap();
+        let agent_key = load_key_pair(&agent_pkcs8).unwrap();
+        let agent_kid = "agent-key-1";
+        let l2 = "l2.serialized.form~disc1~kb.jwt";
+        let checkout_jwt = "merchant.checkout.jwt";
+
+        let payment = create_layer3_payment(
+            l2,
+            &PaymentL3Mandate {
+                vct: "mandate.payment".into(),
+                payment_instrument: PaymentInstrument {
+                    instrument_type: "card".into(),
+                    id: "tok-1".into(),
+                    description: None,
+                },
+                payment_amount: PaymentAmount {
+                    currency: "USD".into(),
+                    amount: 27999,
+                },
+                payee: Entity {
+                    id: None,
+                    name: "Test Store".into(),
+                    website: "https://store.example.com".into(),
+                },
+                transaction_id: sd_hash(checkout_jwt),
+            },
+            &agent_key,
+            agent_kid,
+            1_700_000_000,
+            1_700_000_300,
+        )
+        .unwrap();
+
+        let checkout = create_layer3_checkout(
+            l2,
+            &CheckoutL3Mandate {
+                vct: "mandate.checkout".into(),
+                checkout_jwt: checkout_jwt.into(),
+                checkout_hash: sd_hash(checkout_jwt),
+                line_items: None,
+            },
+            &agent_key,
+            agent_kid,
+            1_700_000_000,
+            1_700_000_300,
+        )
+        .unwrap();
+
+        for (label, serialized) in [("L3a", &payment.serialized), ("L3b", &checkout.serialized)] {
+            let jwt = serialized
+                .split('~')
+                .next()
+                .expect("a serialized L3 starts with its JWT");
+            let header = jws_decode_header(jwt).expect("the L3 header must decode");
+
+            assert_eq!(
+                header.get("kid").and_then(serde_json::Value::as_str),
+                Some(agent_kid),
+                "{label} must name the L2-bound key"
+            );
+            assert!(
+                header.get("jwk").is_none(),
+                "{label} header carries a forbidden `jwk`: {header}"
+            );
+            assert_eq!(
+                header.get("typ").and_then(serde_json::Value::as_str),
+                Some("kb-sd-jwt"),
+                "{label} typ"
+            );
+        }
     }
 
     /// Issuance passes a mandate's `vct` through into the disclosure it signs,
@@ -521,8 +622,10 @@ mod tests {
         let user_key = load_key_pair(&user_pkcs8).unwrap();
         let (_agent_pkcs8, agent_jwk) = generate_ec_p256().unwrap();
         let cnf = Cnf {
-            jwk: agent_jwk,
-            kid: Some("agent-key-1".into()),
+            jwk: Jwk {
+                kid: Some("agent-key-1".into()),
+                ..agent_jwk
+            },
         };
 
         let checkout = OpenCheckoutMandate {

--- a/crates/zeroclaw-runtime/src/verifiable_intent/types.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/types.rs
@@ -717,7 +717,11 @@ mod tests {
         }
         .into();
         let json = serde_json::to_string(&c).unwrap();
-        assert!(json.contains("payment.amount"));
+        // Compared whole. A substring test passes for any tag that merely
+        // contains this one, so it would survive a rename while proving
+        // nothing about the tag actually emitted.
+        let emitted: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(emitted["type"], "payment.amount");
         let back: Constraint = serde_json::from_str(&json).unwrap();
         assert_eq!(c, back);
     }
@@ -733,7 +737,8 @@ mod tests {
         }
         .into();
         let json = serde_json::to_string(&c).unwrap();
-        assert!(json.contains("mandate.checkout.allowed_merchant"));
+        let emitted: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(emitted["type"], "mandate.checkout.allowed_merchant");
         let back: Constraint = serde_json::from_str(&json).unwrap();
         assert_eq!(c, back);
     }
@@ -842,6 +847,15 @@ mod tests {
     fn known_constraint_preserves_unrecognized_fields() {
         let json = r#"{"type":"payment.amount","currency":"USD","max":40000,"acme_tier":"gold"}"#;
         let parsed: Constraint = serde_json::from_str(json).unwrap();
+
+        // Pinned to the recognized arm. An unrecognized constraint round-trips
+        // just as faithfully, so the equality below would still hold if this
+        // tag ever stopped being recognized, and the case this test exists for
+        // would go unexercised.
+        let Constraint::Known { known, .. } = &parsed else {
+            panic!("`payment.amount` must parse as a recognized constraint, got {parsed:?}");
+        };
+        assert!(matches!(known, KnownConstraint::PaymentAmount { .. }));
 
         let before: serde_json::Value = serde_json::from_str(json).unwrap();
         let after: serde_json::Value =
@@ -1080,16 +1094,32 @@ mod tests {
     /// checker says no and the signed mandate says yes.
     #[test]
     fn a_hand_built_unknown_may_not_become_a_recognized_constraint() {
-        let mut fields = serde_json::Map::new();
-        fields.insert("currency".to_owned(), serde_json::json!("USD"));
-        let disguised = Constraint::Unknown {
-            constraint_type: "payment.amount".to_owned(),
-            fields,
-        };
-        assert!(
-            signed_form_matches_the_evaluated_value(&disguised),
-            "an unrecognized constraint must not be signed as a recognized one"
-        );
+        // The disguise needs a tag this build recognizes and the fields that
+        // make it parse back as that variant. Both are taken from the enum, so
+        // renaming a tag cannot turn the disguise into a genuinely
+        // unrecognized constraint and leave this case silently unexercised.
+        // Walking every variant also covers the seven the hand-written case
+        // never reached.
+        for variant in every_known_variant() {
+            let serde_json::Value::Object(mut object) = serde_json::to_value(&variant).unwrap()
+            else {
+                panic!("a recognized constraint must serialize to an object");
+            };
+            let constraint_type = object
+                .remove("type")
+                .and_then(|tag| tag.as_str().map(str::to_owned))
+                .expect("a recognized constraint must carry a string `type`");
+
+            let disguised = Constraint::Unknown {
+                constraint_type: constraint_type.clone(),
+                fields: object,
+            };
+            assert!(
+                signed_form_matches_the_evaluated_value(&disguised),
+                "an unrecognized constraint carrying the recognized tag \
+                 `{constraint_type}` must not be signed as a recognized one"
+            );
+        }
 
         // Control: a genuinely unrecognized tag round-trips as itself.
         let mut fields = serde_json::Map::new();

--- a/crates/zeroclaw-runtime/src/verifiable_intent/types.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/types.rs
@@ -14,6 +14,15 @@ pub struct Jwk {
     pub x: String,
     /// Base64url-encoded y coordinate.
     pub y: String,
+    /// Key identifier, carried inside the JWK.
+    ///
+    /// `credential-format.md` §4.6 requires an Autonomous mandate's `cnf.jwk` to
+    /// "include a `kid` member as its key identifier", and §11.2's worked
+    /// mandates show it nested there. An L3 header's `kid` is resolved against
+    /// this value (§5.7 rule 1), so a `kid` sitting beside `jwk` rather than
+    /// inside it is not the claim a verifier looks up.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
     /// Base64url-encoded private key (only present for signing keys, never serialized to verifiers).
     #[serde(skip_serializing)]
     pub d: Option<String>,
@@ -27,17 +36,21 @@ impl fmt::Debug for Jwk {
             .field("crv", &self.crv)
             .field("x", &self.x)
             .field("y", &self.y)
+            .field("kid", &self.kid)
             .field("d", &private_scalar)
             .finish()
     }
 }
 
 /// Confirmation claim (`cnf`) binding a credential to a public key.
+///
+/// Carries the JWK alone. The key identifier lives inside it, so a mandate pair
+/// comparing `cnf` values compares the embedded `kid` too, which is what §4.6
+/// requires of a pair: identical `cnf.jwk` values "including the embedded
+/// `kid`".
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Cnf {
     pub jwk: Jwk,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kid: Option<String>,
 }
 
 // ── Execution mode ───────────────────────────────────────────────────
@@ -204,8 +217,14 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for DisclosableEntry<T> {
 #[serde(tag = "type")]
 pub enum KnownConstraint {
     /// Merchant allowlist for checkout mandates.
-    #[serde(rename = "mandate.checkout.allowed_merchant")]
+    ///
+    /// The wire field is `allowed` for both allowlists (`constraints.md` §4.1
+    /// and §4.3). The Rust name stays specific because two variants would
+    /// otherwise both carry a field called `allowed`, and the same
+    /// rename-on-the-wire idiom already appears on `PaymentInstrument::type`.
+    #[serde(rename = "mandate.checkout.allowed_merchants")]
     AllowedMerchant {
+        #[serde(rename = "allowed")]
         allowed_merchants: Vec<DisclosableEntry<Entity>>,
     },
 
@@ -216,13 +235,14 @@ pub enum KnownConstraint {
     },
 
     /// Payee allowlist for payment mandates.
-    #[serde(rename = "payment.allowed_payee")]
+    #[serde(rename = "mandate.payment.allowed_payees")]
     AllowedPayee {
+        #[serde(rename = "allowed")]
         allowed_payees: Vec<DisclosableEntry<Entity>>,
     },
 
     /// Per-transaction amount range.
-    #[serde(rename = "payment.amount")]
+    #[serde(rename = "mandate.payment.amount_range")]
     PaymentAmount {
         currency: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -232,11 +252,21 @@ pub enum KnownConstraint {
     },
 
     /// Cumulative budget cap.
-    #[serde(rename = "payment.budget")]
-    PaymentBudget { currency: String, max: i64 },
+    ///
+    /// `min` is a per-transaction floor, distinct from `max`'s cumulative
+    /// ceiling (`constraints.md` §4.5). The specification requires it to be
+    /// positive when present; enforcing that belongs to the checker stage, and
+    /// carrying the field is what lets that stage see it at all.
+    #[serde(rename = "mandate.payment.budget")]
+    PaymentBudget {
+        currency: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        min: Option<i64>,
+        max: i64,
+    },
 
     /// Merchant-managed recurring payment.
-    #[serde(rename = "payment.recurrence")]
+    #[serde(rename = "mandate.payment.recurrence")]
     PaymentRecurrence {
         frequency: String,
         start_date: String,
@@ -247,18 +277,23 @@ pub enum KnownConstraint {
     },
 
     /// Agent-managed recurring purchase.
-    #[serde(rename = "payment.agent_recurrence")]
+    ///
+    /// `end_date` is REQUIRED here and RECOMMENDED on `PaymentRecurrence`
+    /// (`constraints.md` §4.7 against §4.6). §7.4 gives the reason: a required
+    /// end date is what stops an open-ended agent-managed authorization, so an
+    /// agent-recurrence constraint without one is malformed and must not parse
+    /// into this variant.
+    #[serde(rename = "mandate.payment.agent_recurrence")]
     AgentRecurrence {
         frequency: String,
         start_date: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        end_date: Option<String>,
+        end_date: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         max_occurrences: Option<u32>,
     },
 
     /// Cross-reference between checkout and payment mandates.
-    #[serde(rename = "payment.reference")]
+    #[serde(rename = "mandate.payment.reference")]
     PaymentReference { conditional_transaction_id: String },
 }
 
@@ -271,14 +306,14 @@ pub enum KnownConstraint {
 /// malformed input is silently ignored. `known_constraint_tags_are_complete`
 /// pins the list to the enum.
 const KNOWN_CONSTRAINT_TYPES: &[&str] = &[
-    "mandate.checkout.allowed_merchant",
+    "mandate.checkout.allowed_merchants",
     "mandate.checkout.line_items",
-    "payment.allowed_payee",
-    "payment.amount",
-    "payment.budget",
-    "payment.recurrence",
-    "payment.agent_recurrence",
-    "payment.reference",
+    "mandate.payment.allowed_payees",
+    "mandate.payment.amount_range",
+    "mandate.payment.budget",
+    "mandate.payment.recurrence",
+    "mandate.payment.agent_recurrence",
+    "mandate.payment.reference",
 ];
 
 /// A constraint carried by an L2 open mandate.
@@ -721,7 +756,7 @@ mod tests {
         // contains this one, so it would survive a rename while proving
         // nothing about the tag actually emitted.
         let emitted: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(emitted["type"], "payment.amount");
+        assert_eq!(emitted["type"], "mandate.payment.amount_range");
         let back: Constraint = serde_json::from_str(&json).unwrap();
         assert_eq!(c, back);
     }
@@ -738,7 +773,7 @@ mod tests {
         .into();
         let json = serde_json::to_string(&c).unwrap();
         let emitted: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(emitted["type"], "mandate.checkout.allowed_merchant");
+        assert_eq!(emitted["type"], "mandate.checkout.allowed_merchants");
         let back: Constraint = serde_json::from_str(&json).unwrap();
         assert_eq!(c, back);
     }
@@ -750,8 +785,8 @@ mod tests {
     #[test]
     fn constraint_entries_keep_disclosed_and_withheld_forms() {
         let json = r#"{
-            "type": "mandate.checkout.allowed_merchant",
-            "allowed_merchants": [
+            "type": "mandate.checkout.allowed_merchants",
+            "allowed": [
                 {"id": "m-1", "name": "Audioshop", "website": "https://audioshop.example"},
                 {"...": "hrPPJ7L3t5KDOjA04PIL08z0_6UyW8finU53nPf-sCU"}
             ]
@@ -791,8 +826,8 @@ mod tests {
     #[test]
     fn a_reference_entry_must_carry_nothing_but_the_hash() {
         let hybrid = r#"{
-            "type": "mandate.checkout.allowed_merchant",
-            "allowed_merchants": [{"...": "abc", "id": "m-1"}]
+            "type": "mandate.checkout.allowed_merchants",
+            "allowed": [{"...": "abc", "id": "m-1"}]
         }"#;
         assert!(
             serde_json::from_str::<Constraint>(hybrid).is_err(),
@@ -800,8 +835,8 @@ mod tests {
         );
 
         let non_string_hash = r#"{
-            "type": "mandate.checkout.allowed_merchant",
-            "allowed_merchants": [{"...": 7}]
+            "type": "mandate.checkout.allowed_merchants",
+            "allowed": [{"...": 7}]
         }"#;
         assert!(
             serde_json::from_str::<Constraint>(non_string_hash).is_err(),
@@ -817,8 +852,8 @@ mod tests {
     #[test]
     fn a_complete_hybrid_entry_is_rejected_rather_than_silently_disclosed() {
         let merchant = r#"{
-            "type": "mandate.checkout.allowed_merchant",
-            "allowed_merchants": [
+            "type": "mandate.checkout.allowed_merchants",
+            "allowed": [
                 {"...": "HASH", "name": "Store X", "website": "https://store-x.example"}
             ]
         }"#;
@@ -845,7 +880,7 @@ mod tests {
     /// field erases data no later stage can recover.
     #[test]
     fn known_constraint_preserves_unrecognized_fields() {
-        let json = r#"{"type":"payment.amount","currency":"USD","max":40000,"acme_tier":"gold"}"#;
+        let json = r#"{"type":"mandate.payment.amount_range","currency":"USD","max":40000,"acme_tier":"gold"}"#;
         let parsed: Constraint = serde_json::from_str(json).unwrap();
 
         // Pinned to the recognized arm. An unrecognized constraint round-trips
@@ -905,7 +940,7 @@ mod tests {
     /// that it arrives through `extra` rather than through the variant.
     #[test]
     fn an_explicit_null_for_an_optional_field_is_preserved() {
-        let json = r#"{"type":"payment.amount","currency":"USD","min":null}"#;
+        let json = r#"{"type":"mandate.payment.amount_range","currency":"USD","min":null}"#;
         let parsed: Constraint = serde_json::from_str(json).unwrap();
 
         let Constraint::Known {
@@ -1159,7 +1194,7 @@ mod tests {
         };
 
         let serialized = serde_json::to_value(&hand_built).unwrap();
-        assert_eq!(serialized["type"], "payment.amount");
+        assert_eq!(serialized["type"], "mandate.payment.amount_range");
 
         let reparsed: Constraint = serde_json::from_value(serialized).unwrap();
         let Constraint::Known { known, extra } = &reparsed else {
@@ -1210,6 +1245,97 @@ mod tests {
             emitted, declared,
             "KNOWN_CONSTRAINT_TYPES has drifted from the KnownConstraint variants"
         );
+    }
+
+    /// `end_date` is REQUIRED on an agent-managed recurrence and RECOMMENDED on
+    /// a merchant-managed one (`constraints.md` §4.7 against §4.6). §7.4 gives
+    /// the reason: the required end date is the thing that stops an open-ended
+    /// agent-managed authorization.
+    ///
+    /// The consequence is a parse outcome, not a checker outcome. An
+    /// agent-recurrence constraint with no `end_date` must not become the
+    /// recognized variant, and because its tag is registered it must surface as
+    /// an error and not degrade into `Unknown`, where a permissive policy would
+    /// skip it.
+    #[test]
+    fn an_agent_recurrence_without_an_end_date_is_refused() {
+        let missing = r#"{
+            "type": "mandate.payment.agent_recurrence",
+            "frequency": "ON_DEMAND",
+            "start_date": "2026-03-01"
+        }"#;
+        let err = serde_json::from_str::<Constraint>(missing).unwrap_err();
+        assert!(
+            err.to_string().contains("end_date"),
+            "expected a missing-field error naming end_date, got: {err}"
+        );
+
+        // Control: the same constraint parses once the required field is there,
+        // so the refusal above is attributable to `end_date` and not to the tag.
+        let complete = r#"{
+            "type": "mandate.payment.agent_recurrence",
+            "frequency": "ON_DEMAND",
+            "start_date": "2026-03-01",
+            "end_date": "2026-03-31",
+            "max_occurrences": 10
+        }"#;
+        let parsed: Constraint = serde_json::from_str(complete).expect("the complete form parses");
+        let Constraint::Known {
+            known: KnownConstraint::AgentRecurrence { end_date, .. },
+            ..
+        } = &parsed
+        else {
+            panic!("expected an agent recurrence, got {parsed:?}");
+        };
+        assert_eq!(end_date, "2026-03-31");
+
+        // The sibling type keeps `end_date` optional, so the two must not have
+        // been changed together.
+        let merchant_managed = r#"{
+            "type": "mandate.payment.recurrence",
+            "frequency": "MNTH",
+            "start_date": "2026-03-01"
+        }"#;
+        assert!(
+            serde_json::from_str::<Constraint>(merchant_managed).is_ok(),
+            "a merchant-managed recurrence may omit end_date"
+        );
+    }
+
+    /// `mandate.payment.budget` carries a per-transaction floor beside its
+    /// cumulative ceiling (`constraints.md` §4.5). Nothing evaluates it yet, so
+    /// what matters at this stage is that it survives a round trip rather than
+    /// being dropped into `extra` or discarded.
+    #[test]
+    fn a_budget_minimum_round_trips_as_a_recognized_field() {
+        let json = r#"{"type":"mandate.payment.budget","currency":"USD","min":1000,"max":50000}"#;
+        let parsed: Constraint = serde_json::from_str(json).unwrap();
+
+        let Constraint::Known {
+            known: KnownConstraint::PaymentBudget { min, max, .. },
+            extra,
+        } = &parsed
+        else {
+            panic!("expected a payment budget, got {parsed:?}");
+        };
+        assert_eq!(*min, Some(1000));
+        assert_eq!(*max, 50000);
+        assert!(
+            extra.is_empty(),
+            "`min` must be a recognized field, not preserved as an extra: {extra:?}"
+        );
+
+        let before: serde_json::Value = serde_json::from_str(json).unwrap();
+        let after: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&parsed).unwrap()).unwrap();
+        assert_eq!(before, after);
+
+        // Absent stays absent: the field is skipped when unset, so a budget
+        // without a floor does not gain a null one.
+        let without = r#"{"type":"mandate.payment.budget","currency":"USD","max":50000}"#;
+        let parsed: Constraint = serde_json::from_str(without).unwrap();
+        let emitted = serde_json::to_value(&parsed).unwrap();
+        assert!(emitted.get("min").is_none(), "emitted: {emitted}");
     }
 
     #[test]
@@ -1271,8 +1397,9 @@ mod tests {
     /// malformed recognized constraint would pass unreported.
     #[test]
     fn malformed_known_constraint_errors_rather_than_becoming_unknown() {
-        // `payment.amount` requires `currency`.
-        let err = serde_json::from_str::<Constraint>(r#"{"type":"payment.amount"}"#).unwrap_err();
+        // `mandate.payment.amount_range` requires `currency`.
+        let err = serde_json::from_str::<Constraint>(r#"{"type":"mandate.payment.amount_range"}"#)
+            .unwrap_err();
         assert!(
             err.to_string().contains("currency"),
             "expected a missing-field error, got: {err}"
@@ -1290,7 +1417,8 @@ mod tests {
     /// Recognized types are unaffected by the open representation.
     #[test]
     fn known_constraint_still_parses_into_its_variant() {
-        let json = r#"{"type":"payment.amount","currency":"USD","min":10000,"max":40000}"#;
+        let json =
+            r#"{"type":"mandate.payment.amount_range","currency":"USD","min":10000,"max":40000}"#;
         let parsed: Constraint = serde_json::from_str(json).unwrap();
         assert!(matches!(
             parsed,
@@ -1305,7 +1433,7 @@ mod tests {
     #[test]
     fn mixed_constraint_list_parses_both_arms() {
         let json = r#"[
-            {"type":"payment.amount","currency":"USD","max":40000},
+            {"type":"mandate.payment.amount_range","currency":"USD","max":40000},
             {"type":"urn:example:experimental","scope":"wide"}
         ]"#;
         let parsed: Vec<Constraint> = serde_json::from_str(json).unwrap();

--- a/crates/zeroclaw-runtime/src/verifiable_intent/verification.rs
+++ b/crates/zeroclaw-runtime/src/verifiable_intent/verification.rs
@@ -289,22 +289,31 @@ fn check_single_constraint(
         KnownConstraint::PaymentAmount { currency, min, max } => {
             check_payment_amount(currency, *min, *max, fulfillment)
         }
-        KnownConstraint::PaymentBudget { currency, max } => {
-            check_payment_budget(currency, *max, fulfillment)
+        // `min` is bound and deliberately unevaluated. It is a per-transaction
+        // floor the specification requires to be positive when present, and
+        // enforcing it is the checker-parity stage's work. Naming it rather than
+        // eliding it with `..` keeps that omission visible here.
+        KnownConstraint::PaymentBudget {
+            currency,
+            min: _,
+            max,
+        } => check_payment_budget(currency, *max, fulfillment),
+        KnownConstraint::PaymentReference { .. } => {
+            // Reference binding is verified structurally, not against
+            // fulfillment. The reported type is the registered tag alone: a
+            // caller matches this value against the constraint it sent, and
+            // embedding a transaction identifier in it made that impossible.
+            ConstraintCheckResult::ok("mandate.payment.reference")
         }
-        KnownConstraint::PaymentReference {
-            conditional_transaction_id,
-        } => {
-            // Reference binding is verified structurally, not against fulfillment.
-            ConstraintCheckResult::ok(&format!(
-                "payment.reference({})",
-                &conditional_transaction_id[..8.min(conditional_transaction_id.len())]
-            ))
+        // Recurrence constraints are informational for the payment network to
+        // enforce statefulness. Pass-through at the agent level. The two are
+        // reported separately because they are separate registered types, and a
+        // shared label left a caller unable to tell which one it sent.
+        KnownConstraint::PaymentRecurrence { .. } => {
+            ConstraintCheckResult::ok("mandate.payment.recurrence")
         }
-        KnownConstraint::PaymentRecurrence { .. } | KnownConstraint::AgentRecurrence { .. } => {
-            // Recurrence constraints are informational for the payment network
-            // to enforce statefulness. Pass-through at the agent level.
-            ConstraintCheckResult::ok("recurrence")
+        KnownConstraint::AgentRecurrence { .. } => {
+            ConstraintCheckResult::ok("mandate.payment.agent_recurrence")
         }
     }
 }
@@ -341,7 +350,7 @@ fn check_allowed_merchant(
     allowed_merchants: &[DisclosableEntry<Entity>],
     fulfillment: &Fulfillment,
 ) -> ConstraintCheckResult {
-    let ct = "mandate.checkout.allowed_merchant";
+    let ct = "mandate.checkout.allowed_merchants";
     if allowed_merchants.is_empty() {
         return ConstraintCheckResult::violation(
             ct,
@@ -401,7 +410,7 @@ fn check_allowed_payee(
     allowed_payees: &[DisclosableEntry<Entity>],
     fulfillment: &Fulfillment,
 ) -> ConstraintCheckResult {
-    let ct = "payment.allowed_payee";
+    let ct = "mandate.payment.allowed_payees";
     if allowed_payees.is_empty() {
         return ConstraintCheckResult::violation(
             ct,
@@ -457,7 +466,7 @@ fn check_payment_amount(
     max: Option<i64>,
     fulfillment: &Fulfillment,
 ) -> ConstraintCheckResult {
-    let ct = "payment.amount";
+    let ct = "mandate.payment.amount_range";
     let Some(actual_amount) = fulfillment.amount else {
         return ConstraintCheckResult::violation(
             ct,
@@ -500,7 +509,7 @@ fn check_payment_budget(
     max: i64,
     fulfillment: &Fulfillment,
 ) -> ConstraintCheckResult {
-    let ct = "payment.budget";
+    let ct = "mandate.payment.budget";
     let Some(actual_amount) = fulfillment.amount else {
         return ConstraintCheckResult::violation(
             ct,
@@ -1151,6 +1160,7 @@ mod tests {
                 .into(),
                 KnownConstraint::PaymentBudget {
                     currency: expected.into(),
+                    min: None,
                     max: 50000,
                 }
                 .into(),
@@ -1168,8 +1178,8 @@ mod tests {
             );
 
             assert_eq!(results.len(), 2);
-            assert_eq!(results[0].constraint_type, "payment.amount");
-            assert_eq!(results[1].constraint_type, "payment.budget");
+            assert_eq!(results[0].constraint_type, "mandate.payment.amount_range");
+            assert_eq!(results[1].constraint_type, "mandate.payment.budget");
             for result in results {
                 assert!(!result.satisfied);
                 assert_eq!(result.violations.len(), 1);
@@ -1282,7 +1292,7 @@ mod tests {
     fn unknown_constraint_does_not_prevent_evaluating_the_rest() {
         let constraints: Vec<Constraint> = serde_json::from_str(
             r#"[
-                {"type":"payment.amount","currency":"USD","max":40000},
+                {"type":"mandate.payment.amount_range","currency":"USD","max":40000},
                 {"type":"urn:example:experimental","scope":"wide"}
             ]"#,
         )
@@ -1302,11 +1312,52 @@ mod tests {
 
         assert_eq!(results.len(), 2);
         assert!(results[0].satisfied);
-        assert_eq!(results[0].constraint_type, "payment.amount");
+        assert_eq!(results[0].constraint_type, "mandate.payment.amount_range");
         assert!(!results[1].satisfied);
         assert_eq!(
             results[1].violations[0].kind,
             ViErrorKind::UnknownConstraintType
         );
+    }
+
+    /// The tag a checker reports and the tag that variant serializes must be the
+    /// same string.
+    ///
+    /// `constraint_type` is built from literals inside each checker, entirely
+    /// separately from the `#[serde(rename)]` that decides the wire tag. Nothing
+    /// ties the two together, so a rename applied to one and not the other
+    /// compiles, passes every existing test, and produces a checker that
+    /// evaluates one constraint while reporting another. That reported value is
+    /// not internal: `constraint_result_json` publishes it to the caller of the
+    /// `vi_verify` tool.
+    ///
+    /// Deriving the walk from the enum rather than from a list is what stops a
+    /// ninth variant being added without a tag to match.
+    #[test]
+    fn every_checker_reports_the_tag_its_variant_serializes() {
+        use strum::IntoEnumIterator as _;
+
+        for variant in KnownConstraint::iter() {
+            let serialized = serde_json::to_value(&variant).expect("a variant must serialize");
+            let expected = serialized["type"]
+                .as_str()
+                .expect("a recognized constraint must carry a string `type`");
+
+            // Default-constructed fields, so most of these are violations. The
+            // reported type is set on every result whatever the outcome, which
+            // is the only field under test here.
+            let results = check_constraints(
+                std::slice::from_ref(&Constraint::from(variant.clone())),
+                &Fulfillment::default(),
+                StrictnessMode::Strict,
+                MandateMode::Autonomous,
+            );
+
+            assert_eq!(
+                results[0].constraint_type, expected,
+                "the checker for {variant:?} reports `{}` while the wire tag is `{expected}`",
+                results[0].constraint_type
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - **Seven of the eight constraint `type` tags now match the pinned specification.** The `payment.*`
    family gains the `mandate.` prefix, the two allowlists become plural, and their payload field
    becomes `allowed` on the wire. `mandate.checkout.line_items` was already correct.
    `spec/constraints.md` states every target name twice, in the §4.1-§4.8 schema tables and again in
    the §6.2 registry, and the two agree row for row.
  - **`kid` moves inside `cnf.jwk`, and autonomous issuance now requires one.** `credential-format.md`
    §4.6 requires an Autonomous mandate's `cnf.jwk` to "include a `kid` member as its key identifier",
    and §5.7 rule 1 resolves an L3 header's `kid` against it. The lookup reads the identifier from
    inside the JWK, so `Jwk` gains the field and `Cnf` carries the JWK alone. §11.2's worked mandates
    show the nested shape. `create_layer2_autonomous` refuses a mandate pair whose nested JWK has no
    identifier: parity alone accepted that pair, because two absent identifiers are equal to each
    other, and an L2 without one leaves the L3 credentials no conformant key-binding path. `Jwk.kid`
    stays optional for generic and Layer 1 key use, where an identifier is not required.
  - **Both L3 headers stop emitting a `jwk`.** §13.3 rule 3 requires `kid` in each L3 header and
    forbids `jwk`; §13.4 rule 7 gives the reason, which is that a verifier resolves the agent's key
    from L2 and must never trust one the L3 asserts about itself. The two constructors now take a key
    identifier, and the previous code set `kid` to the JWK's `x` coordinate.
  - **`mandate.payment.budget` gains `min`, and `agent_recurrence.end_date` becomes required.** §4.5
    defines the per-transaction floor; §4.7 marks the end date REQUIRED where §4.6 leaves the
    merchant-managed sibling at RECOMMENDED, and §7.4 explains that the required end date is what
    prevents an open-ended agent-managed authorization.
  - **The checker's own `constraint_type` literals are repaired in the same change, all seven of
    them.** They are built independently of the serde tags, so a rename applied to one and not the
    other compiles and passes, leaving a checker that evaluates one constraint while reporting another
    through the `vi_verify` tool's output. Two were already wrong before this PR: `payment.reference`
    was reported with a truncated transaction id formatted into it, and both recurrence variants
    reported a shared `recurrence` label matching no registered type.

- **Scope boundary:** This PR changes representation, plus one well-formedness requirement at the
  issuance boundary: an autonomous mandate pair must carry `cnf.jwk.kid`, which §4.6 makes structural
  for that credential class. **No checker semantics change.** Nothing about how a constraint is
  evaluated against a fulfillment moves here, so `budget.min` is parsed and carried for the checker
  stage to read, §4.5's requirement that it be positive is unenforced, and §4.7's companion-constraint
  requirements are untouched. Mandate VCT values keep their current unversioned stems, so the §10
  registry's `.1` suffixes are not applied here. `match_mode` from §4.2 remains absent. The L3 payload
  claims (`nonce`, `aud`, `delegate_payload`, selective `sd_hash`), nested `acceptable_items`
  disclosures, ASCII-escaped issuance, and the doubled-separator issuance defect all stay for later
  stages. No chain verifier is added, and `vi_verify` remains unregistered.

- **Blast radius:** The VI module and its one in-tree consumer. `crates/zeroclaw-runtime/src/tools/verifiable_intent.rs`
  publishes `constraint_type` to its caller through `constraint_result_json`, so the strings that
  surface there change. That tool is not registered for the model and reaches nothing else. Two
  public function signatures change, `create_layer3_payment` and `create_layer3_checkout`, and every
  caller is inside the VI module. No configuration, CLI, gateway, or channel surface is touched, and
  no documentation page names a constraint tag.

- **Linked issue(s):** Related #9328

- **Labels:** `enhancement`, `runtime`, `trusted contributor`, `domain:security`, `domain:architecture`, `tool:security`, `risk:high`, `size:L`. Two of those come from the path labeler and `.github/labeler.yml` explains which:
  `runtime` covers everything under `crates/zeroclaw-runtime/src/**`, and `tool:security` names
  `crates/zeroclaw-runtime/src/tools/verifiable_intent.rs` explicitly. The broader `tool` rule does
  not fire, because it covers `src/tools/**` in the root crate and `crates/zeroclaw-tools/src/**`,
  neither of which this diff touches.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A`. There is no operator-reachable surface: `vi_verify` is
  withheld from the model-visible registry, `verifiable_intent.enabled` defaults to false, and the
  change is confined to library types and their unit coverage.

### How I tested

- **CI checks relied on and why they cover this change:** `Test` executes the whole VI suite and the
  four added regressions; `Lint` compiles the module with `--features ci-all --all-targets` under
  `-D warnings`, which is where an unused binding or a stale pattern would surface; `Check (default
  features, all targets)` and `Check (no default features)` cover the same code on the narrower
  feature surfaces; `MSRV (declared floor)` compiles it at the 1.96.0 support floor; `Format` and the
  comment-hygiene step in `Lint` cover the prose in the diff.

- **Known CI coverage gap, if any:** No known material gap for this stage's scope. The commands below record local validation on Rust 1.98.0 and the separate Rust 1.96.0 MSRV check. `Check (32-bit)` and `Security` passed in hosted CI but were not run locally. Full-chain and reference-interoperability limits are described below.

- **Commands run and tail output:** all from `zeroclaw/`, `umask 0022`, `CARGO_INCREMENTAL=0`.

  ```sh
  $ rustup run 1.98.0 cargo fmt --all -- --check
  # exit 0

  $ RUSTFLAGS="-D warnings" rustup run 1.98.0 cargo check --locked --workspace \
      --exclude zeroclaw-desktop --no-default-features
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.63s   # exit 0

  $ RUSTFLAGS="-D warnings" rustup run 1.98.0 cargo check --locked --workspace \
      --exclude zeroclaw-desktop --all-targets
  # exit 0

  $ rustup run 1.98.0 cargo clippy --locked --workspace --exclude zeroclaw-desktop \
      --all-targets --features ci-all -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 21s   # exit 0, no diagnostics

  $ rustup run 1.98.0 cargo test --locked -p zeroclaw-runtime --lib verifiable_intent
  test result: ok. 109 passed; 0 failed; 0 ignored; 0 measured; 4047 filtered out

  $ rustup run 1.98.0 cargo nextest run --locked --workspace --exclude zeroclaw-desktop
  Summary [52.749s] 15254 tests run: 15254 passed (2 leaky), 22 skipped

  $ rustup run 1.98.0 cargo doc --no-deps --workspace --exclude zeroclaw-desktop
  # exit 0

  $ bash scripts/ci/comment_hygiene_gate.sh
  Comment hygiene gate passed.

  $ ZEROCLAW_PARALLEL_TEST_SCOPE=all rustup run 1.98.0 bash ./scripts/ci/parallel_runtime_test_gate.sh
  test result: ok. 1540 passed; 0 failed; 2 ignored   # exit 0, first attempt

  $ rustup run 1.96.0 cargo check --locked --workspace --exclude zeroclaw-desktop \
      --no-default-features --features "$(cargo generate features --selection all)"
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 53s   # exit 0
  ```

- **Beyond CI, what did you manually verify?**

  **Four assertions would have gone silent under the rename, and the first commit hardens them.** Two
  compared the emitted tag by substring, where the new tag contains the old one; one rested on a tag
  being unrecognized, which a rename makes trivially true; and one walked a hand-written variant list
  that a rename could desynchronize. Applying the renames afterwards failed **17 tests across three
  files, with none passing silently**.

  **The L3 header guard was broken on purpose:** put a `jwk` back into the L3a header and the new
  header test fails, printing the offending header. The `end_date` requirement bites earlier still,
  since reverting the field to `Option<String>` will not compile against a test that asserts on its
  type.

  Before the `cnf.jwk.kid` guard existed, a matching pair whose shared JWK carried no identifier
  issued successfully, emitting a signed L2 whose mandate disclosures decode to a `cnf.jwk` holding
  `crv`, `kty`, `x` and `y` and nothing else. `autonomous_issuance_requires_a_nested_kid` asserts the
  error kind and that the message names the member, with a positive control issuing the same pair once
  the identifier is present.

  **The checker-tag regression was red before any rename landed.** It walks every `KnownConstraint`
  variant and compares the `constraint_type` the checker reports against the tag that variant
  serializes. On master it fails on `PaymentRecurrence`, which reports `recurrence` against a wire tag
  of `payment.recurrence`, so it is a regression test for a defect that predates this PR.

  **What I did not verify:** A full credential chain was never exercised end to end, because no chain
  verifier exists yet. Interoperability against the Python reference implementation is untested for
  the renamed tags; the pinned fixture at
  `crates/zeroclaw-runtime/tests/fixtures/vi-reference-vectors.json` covers SD-JWT disclosure
  mechanics alone and carries no constraint tags, which leaves it silent on this change and unmodified
  here.

  §13.3 rule 3 has two halves, and this PR enforces one of them. An L3 header carrying a `kid` and no
  `jwk` is enforced and tested. That the `kid` MUST match L2 `cnf.jwk.kid` goes unchecked, because
  `create_layer3_payment` and `create_layer3_checkout` take a key identifier and never receive the L2
  to compare it against, which puts the comparison on the verification side. §4.5's positive-`min`
  rule and §4.7's required companion constraints are unenforced on the same basis, both being checker
  semantics for stage 5. Two CI legs went unrun locally, `Check (32-bit)` and `Security`, the first needing
  the `i686-unknown-linux-gnu` target and the second `cargo-deny` and `cargo-audit`; this diff changes
  no dependency and no architecture-sensitive code. My local runs also lack the `clang` linker and
  mold link argument CI sets on the build and test legs.

- **Visual interface changed?** `N/A`

- **If any command was intentionally skipped, why:** The two legs named above were left to hosted CI
  for the stated reasons. Nothing else was skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- **If any `Yes`, describe the risk and mitigation:** The L3 JWT header no longer carries the agent's
  public key. Previously each L3 header embedded a `jwk` and set `kid` to that key's `x` coordinate,
  which invites a verifier to read the key out of the credential presenting itself. `credential-format.md`
  §13.4 rule 7 requires the opposite: resolve the agent key from the L2 mandate's `cnf.jwk` by
  matching the header `kid`. Emitting only `kid` removes the self-asserted key from the wire. No key
  material handling, storage, or generation changes, and no private component was ever placed in a
  header (`Jwk::d` is `skip_serializing`).

## Compatibility (required)

- Backward compatible? **`No`**
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- **Exact upgrade steps for existing users:**

  This is a wire-format change with three independent breaks. None has a live consumer today, because
  `verifiable_intent.enabled` defaults to false, `vi_verify` is not registered, and no chain verifier
  exists.

  **1. Constraint documents.** A constraint carrying an old tag no longer parses as a recognized
  type. It becomes `Constraint::Unknown`, which an open mandate rejects, so the failure is closed and
  visible. Re-issue any stored constraint with the new tags:

  | Old | New |
  |---|---|
  | `mandate.checkout.allowed_merchant`, field `allowed_merchants` | `mandate.checkout.allowed_merchants`, field `allowed` |
  | `payment.allowed_payee`, field `allowed_payees` | `mandate.payment.allowed_payees`, field `allowed` |
  | `payment.amount` | `mandate.payment.amount_range` |
  | `payment.budget` | `mandate.payment.budget` |
  | `payment.recurrence` | `mandate.payment.recurrence` |
  | `payment.agent_recurrence` | `mandate.payment.agent_recurrence` |
  | `payment.reference` | `mandate.payment.reference` |

  An `mandate.payment.agent_recurrence` constraint must now carry `end_date`; one without it fails to
  parse with a missing-field error naming the field. A `cnf` object must move its `kid` inside `jwk`.

  **2. Embedder API, caught by the compiler.** `create_layer3_payment` and `create_layer3_checkout`
  take `agent_kid: &str` where they took `agent_jwk: &Jwk`. Pass the same identifier bound in the L2
  mandate's `cnf.jwk.kid`. `Cnf` no longer has a `kid` field; construct
  `Cnf { jwk: Jwk { kid: Some(..), ..key } }`.

  **3. Autonomous issuance rejects a mandate pair with no `cnf.jwk.kid`, and the compiler cannot warn
  about this one.** `Jwk.kid` stays `Option<String>`, so an embedder passing `kid: None` still
  compiles and now receives `Err(IssuanceInputInvalid)` where it previously received a signed
  credential. Callers that build a `Cnf` from `generate_ec_p256` output are affected by default,
  because that helper returns `kid: None`. Set an identifier on the JWK before constructing the
  mandate pair. This break surfaces at runtime, so a rebuild will not find it; search the call sites.
  `Jwk` gains a `kid` field, so struct literals need it and `Jwk` equality now includes it, which
  strengthens the existing `cnf` parity check between paired mandates as §4.6 requires.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge sha>`. The diff is confined to
  `crates/zeroclaw-runtime/src/verifiable_intent/` and its one consumer, touches no persisted state,
  no migration, and no configuration, so a revert restores the previous behaviour completely.
- **Feature flags or config toggles:** `None` specific to this change. The subsystem sits behind
  `verifiable_intent.enabled`, which defaults to false, and `vi_verify` stays unregistered either way.
- **Observable failure symptoms:** Watch for a `VI/UnknownConstraintType` violation raised against a
  constraint that should be recognized, which surfaces through the tool as one of the eight registered
  strings alongside `"satisfied": false`. Divergence between the checker and the wire tag shows up as
  a reported `constraint_type` matching none of the eight. Losing the issuance half of this change
  puts a `jwk` parameter back into an L3 header. The new issuance guard reports itself as
  `VI/IssuanceInputInvalid` naming `cnf.jwk.kid`, and an embedder seeing that on a call which used to
  succeed is hitting break 3 above and needs an identifier on the JWK. A silent regression in the
  other direction looks like an autonomous L2 whose decoded mandate disclosures carry a `cnf.jwk` with
  no `kid` member.

## Open questions for the maintainer

Three items sit inside the wire-schema subject this stage covers and are excluded from its diff.

1. **VCT alignment has no stage.** `credential-format.md` §10 registers `mandate.checkout.open.1`,
   `mandate.checkout.1`, `mandate.payment.open.1` and `mandate.payment.1`, and this build still emits
   the unversioned stems. It appears in neither the 3a nor the 3b list. It reads as 3a on subject
   matter, and two things argue for treating it separately: §10.1 states that constraint `type`
   strings "are NOT VCTs and are not versioned", so the two live in different registries; and the VCT
   change touches `infer_mode_from_vct`, the mandate structs, and the VCT strings inside the pinned
   reference-vector fixture, none of which the tag rename touches. Changing the fixture's VCTs would
   churn every disclosure blob and hash in it and require a regeneration run against the pinned
   checkout. Which stage should own it?
2. **`match_mode`** on `mandate.checkout.line_items` (§4.2) is absent from this build entirely. It
   carries checker semantics, so it reads as stage 5 alongside the other line-item rules. Confirming.
3. **The `constraint_type` repair** is included here because a rename that leaves it produces a
   checker reporting a tag it did not evaluate. It also fixes two cases that were already wrong. If
   you would rather see that as its own change, I will split it out.

