### PR TITLE
test(channels/matrix): prove the configured route reaches the routed STT provider

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -5576,8 +5576,12 @@ mod tests {
             wav
         }
 
-        fn handler_ctx(
-            stt_url: &str,
+        /// The handler context every route test drives, with the
+        /// transcription resolver left to the caller so a test can supply the
+        /// one a *configured* channel installed instead of the legacy
+        /// single-endpoint resolver.
+        fn handler_ctx_with_resolver(
+            transcription: Option<super::super::TranscriptionResolver>,
             workspace: &std::path::Path,
             tx: mpsc::Sender<zeroclaw_api::channel::ChannelMessage>,
         ) -> HandlerCtx {
@@ -5585,7 +5589,27 @@ mod tests {
                 config: Arc::new(MatrixConfig::default()),
                 alias: "test".to_string(),
                 peer_resolver: Arc::new(|| vec!["*".to_string()]),
-                transcription: Some(super::super::legacy_transcription_resolver(
+                transcription,
+                workspace_dir: Some(Arc::new(workspace.to_path_buf())),
+                tx,
+                pending_approvals: Arc::new(TokioMutex::new(HashMap::new())),
+                threads_seen: Arc::new(TokioRwLock::new(HashSet::new())),
+                bot_user_id: user_id!("@bot:localhost").to_owned(),
+                bot_display_name: Arc::new(TokioRwLock::new(None)),
+                initial_sync_done: Arc::new(AtomicBool::new(true)),
+                undecryptable_seen: Arc::new(TokioMutex::new(HashSet::new())),
+            }
+        }
+
+        /// Legacy-resolver context: the single `[transcription]` endpoint at
+        /// `stt_url`, which is what most route tests want.
+        fn handler_ctx(
+            stt_url: &str,
+            workspace: &std::path::Path,
+            tx: mpsc::Sender<zeroclaw_api::channel::ChannelMessage>,
+        ) -> HandlerCtx {
+            handler_ctx_with_resolver(
+                Some(super::super::legacy_transcription_resolver(
                     TranscriptionConfig {
                         enabled: true,
                         local_whisper: Some(zeroclaw_config::schema::LocalWhisperConfig {
@@ -5597,15 +5621,9 @@ mod tests {
                         ..TranscriptionConfig::default()
                     },
                 )),
-                workspace_dir: Some(Arc::new(workspace.to_path_buf())),
+                workspace,
                 tx,
-                pending_approvals: Arc::new(TokioMutex::new(HashMap::new())),
-                threads_seen: Arc::new(TokioRwLock::new(HashSet::new())),
-                bot_user_id: user_id!("@bot:localhost").to_owned(),
-                bot_display_name: Arc::new(TokioRwLock::new(None)),
-                initial_sync_done: Arc::new(AtomicBool::new(true)),
-                undecryptable_seen: Arc::new(TokioMutex::new(HashSet::new())),
-            }
+            )
         }
 
         fn voice_event_json(event_id: &str) -> serde_json::Value {
@@ -5730,6 +5748,141 @@ mod tests {
             assert_eq!(std::fs::read(&saved_path).unwrap(), wav);
 
             assert_stt_received_the_wav(&stt.received_requests().await.unwrap(), &wav);
+        }
+
+        /// A voice note arriving on a *really configured* Matrix channel must
+        /// reach the STT server the owning agent's `transcription_provider`
+        /// names — not merely "some" registered provider.
+        ///
+        /// The channel is built by the production factory
+        /// [`crate::orchestrator::build_configured_matrix_channel`], and only
+        /// the resolver it installed is handed to the route, so nothing here
+        /// short-circuits provider selection.
+        ///
+        /// Two providers are registered on purpose:
+        /// [`super::super::build_transcription_manager`] binds a *sole*
+        /// registered provider when the agent states no preference, so a
+        /// one-provider fixture passes even with routing completely broken.
+        /// The decoy is what makes the assertion mean something.
+        #[tokio::test]
+        async fn configured_route_transcribes_via_the_agents_provider() {
+            use zeroclaw_config::schema::LocalWhisperTranscriptionProviderConfig;
+
+            let wav = build_wav();
+
+            let matrix = MatrixMockServer::new().await;
+            let client = matrix.client_builder().build().await;
+            matrix.sync_joined_room(&client, test_room()).await;
+            mount_media_download(&matrix, &wav).await;
+
+            let wanted = wiremock::MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/transcribe"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({ "text": TRANSCRIPT })),
+                )
+                .expect(1)
+                .mount(&wanted)
+                .await;
+
+            let decoy = wiremock::MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/transcribe"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({ "text": "decoy transcript" })),
+                )
+                .expect(0)
+                .mount(&decoy)
+                .await;
+
+            // Provider aliases share no name with the channel alias or the
+            // agent alias, so nothing can route correctly by coincidence.
+            let mut config = zeroclaw_config::schema::Config::default();
+            config.transcription.enabled = true;
+            config.channels.matrix.insert(
+                "home".to_string(),
+                MatrixConfig {
+                    enabled: true,
+                    homeserver: "https://matrix.invalid".to_string(),
+                    access_token: Some("test-token".to_string()),
+                    ..MatrixConfig::default()
+                },
+            );
+            config.agents.insert(
+                "listener".to_string(),
+                zeroclaw_config::schema::AliasedAgentConfig {
+                    enabled: true,
+                    channels: vec!["matrix.home".into()],
+                    transcription_provider: "local_whisper.wanted".into(),
+                    ..Default::default()
+                },
+            );
+            config.providers.transcription.local_whisper.insert(
+                "wanted".to_string(),
+                LocalWhisperTranscriptionProviderConfig {
+                    uri: format!("{}/v1/transcribe", wanted.uri()),
+                    ..Default::default()
+                },
+            );
+            config.providers.transcription.local_whisper.insert(
+                "decoy".to_string(),
+                LocalWhisperTranscriptionProviderConfig {
+                    uri: format!("{}/v1/transcribe", decoy.uri()),
+                    ..Default::default()
+                },
+            );
+
+            let config_arc = Arc::new(parking_lot::RwLock::new(config));
+            let channel = {
+                let config = config_arc.read();
+                crate::orchestrator::build_configured_matrix_channel(
+                    &config_arc,
+                    &config,
+                    "home",
+                    config
+                        .channels
+                        .matrix
+                        .get("home")
+                        .expect("configured Matrix alias"),
+                )
+                .expect("configured Matrix channel builds")
+            };
+
+            let workspace = tempfile::tempdir().unwrap();
+            let (tx, mut rx) = mpsc::channel(4);
+            let ctx =
+                handler_ctx_with_resolver(channel.transcription.clone(), workspace.path(), tx);
+            assert!(
+                ctx.transcription.is_some(),
+                "the configured channel must install a transcription resolver"
+            );
+
+            let _guards = register_event_handlers(&client, &ctx);
+            let json = voice_event_json("$configured1:localhost");
+            matrix
+                .sync_room(
+                    &client,
+                    JoinedRoomBuilder::new(test_room()).add_timeline_event(timeline_raw(&json)),
+                )
+                .await;
+
+            let msg = recv_forwarded(&mut rx).await;
+            assert!(
+                msg.content
+                    .contains(&format!("[voice transcript]: {TRANSCRIPT}")),
+                "transcript from the routed provider must land in the inbound content: {}",
+                msg.content
+            );
+
+            assert_stt_received_the_wav(&wanted.received_requests().await.unwrap(), &wav);
+            assert!(
+                decoy.received_requests().await.unwrap().is_empty(),
+                "the provider the agent did not name must never be called"
+            );
+            wanted.verify().await;
+            decoy.verify().await;
         }
 
         #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10321,6 +10321,50 @@ fn matrix_state_dir(config_path: &std::path::Path, alias: &str) -> std::path::Pa
         .unwrap_or_else(|| std::path::PathBuf::from(".zeroclaw/state/matrix").join(alias))
 }
 
+/// Build the Matrix channel for `[channels.matrix.<alias>]` with every
+/// live-config resolver installed, mirroring
+/// [`build_configured_discord_channel`].
+///
+/// Extracted from [`collect_configured_channels`] so the *configured*
+/// construction path stays reachable: the loop wraps the result in
+/// `PacedChannel` and type-erases it to `Arc<dyn Channel>` immediately, so a
+/// test can otherwise never observe the resolvers this function installs.
+///
+/// Fallible because [`MatrixChannel::new`] validates `homeserver` and the
+/// credential pair; the caller logs and skips the alias on `Err`.
+#[cfg(feature = "channel-matrix")]
+pub(crate) fn build_configured_matrix_channel(
+    config_arc: &Arc<RwLock<Config>>,
+    config: &Config,
+    alias: &str,
+    mx: &zeroclaw_config::schema::MatrixConfig,
+) -> Result<MatrixChannel> {
+    let state_dir = matrix_state_dir(&config.config_path, alias);
+    let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
+        let cfg_arc = config_arc.clone();
+        let alias = alias.to_string();
+        Arc::new(move || cfg_arc.read().channel_external_peers("matrix", &alias))
+    };
+    let ack = mx.ack_reactions.unwrap_or(config.channels.ack_reactions);
+    let transcription_config_arc = Arc::clone(config_arc);
+    let transcription_channel_key = format!("matrix.{alias}");
+    let channel = MatrixChannel::new(mx.clone(), alias.to_string(), peer_resolver, state_dir)?;
+    Ok(channel
+        .with_transcription_manager_factory(move || {
+            let config = transcription_config_arc.read();
+            if !config.transcription.enabled {
+                return None;
+            }
+            let provider =
+                resolve_agent_transcription_provider(&config, &transcription_channel_key);
+            Some(crate::matrix::build_transcription_manager(
+                &config, &provider,
+            ))
+        })
+        .with_workspace_dir(config.channel_workspace_dir(&format!("matrix.{alias}")))
+        .with_ack_reactions(ack))
+}
+
 fn collect_configured_channels(
     config_arc: &Arc<RwLock<Config>>,
     matrix_skip_context: &str,
@@ -10646,33 +10690,8 @@ fn collect_configured_channels(
         if !mx.enabled {
             continue;
         }
-        let state_dir = matrix_state_dir(&config.config_path, alias);
-        let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> = {
-            let cfg_arc = config_arc.clone();
-            let alias = alias.clone();
-            Arc::new(move || cfg_arc.read().channel_external_peers("matrix", &alias))
-        };
-        let ack = mx.ack_reactions.unwrap_or(config.channels.ack_reactions);
-        let transcription_config_arc = Arc::clone(config_arc);
-        let transcription_channel_key = format!("matrix.{alias}");
-        match MatrixChannel::new(mx.clone(), alias.clone(), peer_resolver, state_dir) {
+        match build_configured_matrix_channel(config_arc, &config, alias, mx) {
             Ok(channel) => {
-                let channel = channel
-                    .with_transcription_manager_factory(move || {
-                        let config = transcription_config_arc.read();
-                        if !config.transcription.enabled {
-                            return None;
-                        }
-                        let provider = resolve_agent_transcription_provider(
-                            &config,
-                            &transcription_channel_key,
-                        );
-                        Some(crate::matrix::build_transcription_manager(
-                            &config, &provider,
-                        ))
-                    })
-                    .with_workspace_dir(config.channel_workspace_dir(&format!("matrix.{alias}")))
-                    .with_ack_reactions(ack);
                 channels.push(ConfiguredChannel {
                     display_name: "Matrix",
                     alias: Some(alias.clone()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - #10487's four tests exercise the transcription manager builder directly, and the end-to-end inbound tests reach the pipeline through a `#[cfg(test)]` shortcut. Neither goes through the configured construction path, so neither can catch a routing regression where it actually matters. This adds the missing coverage @Audacity88 asked for.
  - Nothing could reach that path from a test: Matrix channel construction and resolver installation were inlined in the `for (alias, mx) in &config.channels.matrix` loop of `collect_configured_channels`, and the result was type-erased into `Arc<dyn Channel>` by `PacedChannel::wrap` before any concrete `MatrixChannel` could escape. `build_configured_matrix_channel` extracts that as a pure move, mirroring the existing `build_configured_discord_channel`.
  - The new test builds the channel through that production factory, takes the transcription resolver *the factory installed*, and drives a genuine decodable WAV voice note through real sync dispatch, real media download, and a real transcription call — then asserts which STT server received it.
  - Two STT servers and two registered providers are the point: `build_transcription_manager` binds a *sole* registered provider when the agent states no preference, so a one-provider fixture stays green even with routing completely broken.
- **Scope boundary:** No behaviour change. The extracted function moves the existing builder chain verbatim (state dir, peer resolver, transcription manager factory, workspace dir, ack reactions); the loop keeps only `PacedChannel::wrap`, the `ConfiguredChannel` push, and the same log-and-skip on `Err`. Existing `#[cfg(feature = "channel-matrix")]` gating is unchanged. No config, schema, or public API surface is touched, and no other channel is modified.
- **Blast radius:** `collect_configured_channels` for the Matrix arm only. If the extraction were wrong, Matrix channels would fail to construct at startup — loudly, and covered by the existing orchestrator suite (577 tests). Other channels share no code with the moved block.
- **Linked issue(s):** Related #10487
- **Labels:** `channel`, `channel:core`, `channel:matrix`, `risk:medium`, `size:S`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the production change is a pure extraction with no observable behaviour delta, and the coverage it enables is asserted by the new test rather than by anything a reviewer could see by hand.

### How I tested

- **CI checks relied on and why they cover this change:** the Rust build/check/lint jobs validate the changed production code. The Matrix test step selects only `matrix::tests::transcription_provider_resolution`; it does not execute the new inbound regression. The explicit local Matrix suite command below covers that test.
- **Known CI coverage gap, if any:** `matrix::tests::inbound_route::configured_route_transcribes_via_the_agents_provider` is outside the current CI selector. Its execution evidence is the local Matrix suite run reported below.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# (no output)

bash scripts/ci/rust_quality_gate.sh
# ==> rust quality: provider dispatch gate clean

cargo clippy -p zeroclaw-channels --all-targets --features channel-matrix -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 43.65s

cargo doc --no-deps -p zeroclaw-channels --features channel-matrix
# Generated /target/doc/zeroclaw_channels/index.html

cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib matrix::
# Summary [0.668s] 221 tests run: 221 passed, 1546 skipped

cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib orchestrator::
# Summary [5.296s] 577 tests run: 577 passed, 1190 skipped
```

- **Beyond CI, what did you manually verify?** That the new test is not vacuous, by breaking the wiring and confirming it fails:
  1. agent's `transcription_provider` repointed at the decoy → fails with `[voice transcript]: decoy transcript`;
  2. the route fed a legacy resolver aimed at the decoy instead of the factory's resolver → same failure.

  I also reproduced the blind spot deliberately: with the decoy provider registration removed and the agent's preference emptied, the test **passes** — which is the shape of coverage that let #10486 ship, and the reason this test registers two providers rather than one.

  Not verified: no live homeserver or live STT server was exercised; both are mocked (`MatrixMockServer` and `wiremock`). The extraction is covered only by the existing orchestrator suite, not by a running deployment.
- **Visual interface changed?** `N/A`

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

- **Fast rollback command/path:** `git revert <sha>` after squash merge; this removes the added regression and restores the inlined constructor.
- **Feature flags or config toggles:** None added by this PR.
- **Observable failure symptoms:** Matrix channel construction errors at startup or failure of the configured-route regression.

## An offer, not a change

While mirroring it, I noticed the Discord test `configured_discord_transcription_dispatches_to_routed_agent_provider` registers only one transcription provider, so it shares the sole-provider blind spot described above — `TranscriptionManager::from_config_with_provider` would still land on `local_whisper.routed` if the agent's preference were dropped, and the test would stay green.

I have deliberately **not** touched it. Happy to add a decoy provider there, in this PR or a follow-up, if you would like.
