### PR TITLE
fix(tts): surface providers dropped for a missing api_key

### DIFF
--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -1060,14 +1060,15 @@ impl TtsManager {
                     }
                 }
                 Err(e) => {
+                    let config_path = format!("[providers.tts.{dotted}]");
                     ::zeroclaw_log::record!(
                         WARN,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
                             .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
                             .with_attrs(
-                                ::serde_json::json!({"error": format!("{}", e), "dotted": dotted})
+                                ::serde_json::json!({"error": e.to_string(), "config_path": config_path})
                             ),
-                        "Skipping TTS provider"
+                        "typed TTS provider skipped (config error)"
                     );
                 }
             }
@@ -1818,6 +1819,53 @@ mod tests {
         let provider = OpenAiTtsProvider::new("test", &cfg).unwrap();
         assert_eq!(provider.base_url, "https://api.openai.com/v1/audio/speech");
         assert_eq!(provider.response_format, "opus");
+    }
+
+    #[test]
+    fn typed_registration_logs_config_path_for_keyless_uri_only_provider() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        // The exact real-world failure mode this diagnostic exists for: a
+        // local, keyless endpoint (e.g. Kokoro) configured via `uri` alone,
+        // with no `api_key`. `OpenAiTtsProvider::new` bails before it ever
+        // reads `uri`, so the provider never registers.
+        let mut cfg = Config::default();
+        cfg.providers.tts.openai.insert(
+            "stoa".to_string(),
+            zeroclaw_config::schema::OpenAITtsProviderConfig {
+                base: TtsProviderConfig {
+                    uri: Some("http://localhost:8880/v1/audio/speech".to_string()),
+                    ..TtsProviderConfig::default()
+                },
+            },
+        );
+
+        let manager = TtsManager::from_config(&cfg).unwrap();
+        assert!(
+            manager.available_providers().is_empty(),
+            "keyless openai provider must not register: {:?}",
+            manager.available_providers()
+        );
+
+        let events: Vec<serde_json::Value> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let event = events
+            .iter()
+            .find(|value| value["attributes"]["config_path"] == "[providers.tts.openai.stoa]")
+            .unwrap_or_else(|| panic!("expected a skip record for openai.stoa: {events:?}"));
+        assert_eq!(
+            event["message"], "typed TTS provider skipped (config error)",
+            "event: {event:?}"
+        );
+        assert!(
+            event["attributes"]["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("api_key")),
+            "error should name the missing api_key: {event:?}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/zeroclaw-runtime/src/doctor/mod.rs
+++ b/crates/zeroclaw-runtime/src/doctor/mod.rs
@@ -1258,6 +1258,70 @@ fn check_config_semantics(config: &Config, items: &mut Vec<DiagItem>) {
         }
     }
 
+    // TTS provider api_key presence. Unlike the model_provider check above,
+    // a missing key on `openai`, `elevenlabs`, or `google` is not "may rely
+    // on env vars or model_provider defaults" — `OpenAiTtsProvider::new` and
+    // its siblings (`crates/zeroclaw-channels/src/tts.rs`) bail on a
+    // missing/blank `api_key` before the entry is ever registered, so the
+    // provider silently drops out of `[providers.tts.*]` entirely.
+    // `edge` and `piper` have no key gate and are never checked here.
+    {
+        const TTS_KEY_GATED_FAMILIES: &[&str] = &["openai", "elevenlabs", "google"];
+        for (family, alias, entry) in config.providers.tts.iter_entries() {
+            if !TTS_KEY_GATED_FAMILIES.contains(&family) {
+                continue;
+            }
+            let label = format!("providers.tts.{family}.{alias}");
+            if entry
+                .api_key
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|k| !k.is_empty())
+            {
+                items.push(DiagItem::ok(cat, format!("{label}: API key configured")));
+            } else {
+                items.push(DiagItem::warn(
+                    cat,
+                    format!(
+                        "{label}: no api_key set — this provider will NOT register (not a soft fallback); set `[{label}].api_key` or remove the entry"
+                    ),
+                ));
+            }
+        }
+    }
+
+    // Transcription provider api_key presence — same shape as the TTS check
+    // above. `groq`, `openai`, `deepgram`, `assemblyai`, and `google` all
+    // gate registration on `api_key` in
+    // `crates/zeroclaw-channels/src/transcription.rs`. `local_whisper` has
+    // no api_key concept (its optional `bearer_token` is a different field)
+    // and is never checked here.
+    {
+        use zeroclaw_config::providers::TranscriptionProviderEntry;
+
+        for (family, alias, entry) in config.providers.transcription.iter_entries() {
+            let api_key = match entry {
+                TranscriptionProviderEntry::Groq(c) => c.base.api_key.as_deref(),
+                TranscriptionProviderEntry::OpenAi(c) => c.base.api_key.as_deref(),
+                TranscriptionProviderEntry::Deepgram(c) => c.base.api_key.as_deref(),
+                TranscriptionProviderEntry::AssemblyAi(c) => c.base.api_key.as_deref(),
+                TranscriptionProviderEntry::Google(c) => c.base.api_key.as_deref(),
+                TranscriptionProviderEntry::LocalWhisper(_) => continue,
+            };
+            let label = format!("providers.transcription.{family}.{alias}");
+            if api_key.map(str::trim).is_some_and(|k| !k.is_empty()) {
+                items.push(DiagItem::ok(cat, format!("{label}: API key configured")));
+            } else {
+                items.push(DiagItem::warn(
+                    cat,
+                    format!(
+                        "{label}: no api_key set — this provider will NOT register (not a soft fallback); set `[{label}].api_key` or remove the entry"
+                    ),
+                ));
+            }
+        }
+    }
+
     // Gateway port range
     let port = config.gateway.port;
     if port > 0 {
@@ -2048,6 +2112,142 @@ mod tests {
         let temp_item = items.iter().find(|i| i.message.contains("temperature"));
         assert!(temp_item.is_some());
         assert_eq!(temp_item.unwrap().severity, Severity::Ok);
+    }
+
+    #[test]
+    fn tts_doctor_warns_for_keyless_gated_provider() {
+        let mut config = Config::default();
+        config.providers.tts.openai.insert(
+            "stoa".to_string(),
+            zeroclaw_config::schema::OpenAITtsProviderConfig {
+                base: zeroclaw_config::schema::TtsProviderConfig {
+                    uri: Some("http://localhost:8880/v1/audio/speech".to_string()),
+                    ..Default::default()
+                },
+            },
+        );
+        let mut items = Vec::new();
+        check_config_semantics(&config, &mut items);
+        let item = items
+            .iter()
+            .find(|i| i.message.contains("providers.tts.openai.stoa"))
+            .expect("keyless openai TTS provider must produce a doctor item");
+        assert_eq!(item.severity, Severity::Warn);
+        assert!(
+            item.message.contains("will NOT register"),
+            "message: {}",
+            item.message
+        );
+    }
+
+    #[test]
+    fn tts_doctor_ok_for_keyed_provider() {
+        let mut config = Config::default();
+        config.providers.tts.openai.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::OpenAITtsProviderConfig {
+                base: zeroclaw_config::schema::TtsProviderConfig {
+                    api_key: Some("sk-test".to_string()),
+                    ..Default::default()
+                },
+            },
+        );
+        let mut items = Vec::new();
+        check_config_semantics(&config, &mut items);
+        let item = items
+            .iter()
+            .find(|i| i.message.contains("providers.tts.openai.default"))
+            .expect("keyed openai TTS provider must produce a doctor item");
+        assert_eq!(item.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn tts_doctor_no_warning_for_keyless_families() {
+        let mut config = Config::default();
+        config.providers.tts.edge.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::EdgeTtsProviderConfig::default(),
+        );
+        config.providers.tts.piper.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::PiperTtsProviderConfig::default(),
+        );
+        let mut items = Vec::new();
+        check_config_semantics(&config, &mut items);
+        let messages: Vec<&str> = items.iter().map(|i| i.message.as_str()).collect();
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.contains("providers.tts.edge") || m.contains("providers.tts.piper")),
+            "edge/piper have no api_key gate and must not produce an api_key item: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn transcription_doctor_warns_for_keyless_gated_provider() {
+        let mut config = Config::default();
+        config.providers.transcription.groq.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::GroqTranscriptionProviderConfig::default(),
+        );
+        let mut items = Vec::new();
+        check_config_semantics(&config, &mut items);
+        let item = items
+            .iter()
+            .find(|i| i.message.contains("providers.transcription.groq.default"))
+            .expect("keyless groq transcription provider must produce a doctor item");
+        assert_eq!(item.severity, Severity::Warn);
+        assert!(
+            item.message.contains("will NOT register"),
+            "message: {}",
+            item.message
+        );
+    }
+
+    #[test]
+    fn transcription_doctor_ok_for_keyed_provider() {
+        let mut config = Config::default();
+        config.providers.transcription.groq.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::GroqTranscriptionProviderConfig {
+                base: zeroclaw_config::schema::TranscriptionProviderConfig {
+                    api_key: Some("gsk-test".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let mut items = Vec::new();
+        check_config_semantics(&config, &mut items);
+        let item = items
+            .iter()
+            .find(|i| i.message.contains("providers.transcription.groq.default"))
+            .expect("keyed groq transcription provider must produce a doctor item");
+        assert_eq!(item.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn transcription_doctor_no_warning_for_local_whisper() {
+        let mut config = Config::default();
+        config.providers.transcription.local_whisper.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::LocalWhisperTranscriptionProviderConfig {
+                uri: "http://localhost:8001/inference".to_string(),
+                bearer_token: None,
+                language: None,
+                max_audio_bytes: 25 * 1024 * 1024,
+                timeout_secs: 30,
+            },
+        );
+        let mut items = Vec::new();
+        check_config_semantics(&config, &mut items);
+        let messages: Vec<&str> = items.iter().map(|i| i.message.as_str()).collect();
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.contains("providers.transcription.local_whisper")),
+            "local_whisper has no api_key concept and must not produce an api_key item: {messages:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - A TTS provider configured with a `uri` but no `api_key` — a local Kokoro endpoint that never reads a key, for instance — does not register, and an operator has no practical way to find out. TTS simply reports as unconfigured. This cost a full debugging round on a real deployment.
  - **The drop is not silent in code**, which is worth stating plainly because my note on #10489 implied otherwise. `OpenAiTtsProvider::new` bails before it reads `config.uri`, and the registration loop already emits a WARN naming the field. Three things can make that record harder to find: it fires inside the per-message TTS factory closure rather than at startup; its attrs carry `dotted` (`openai.local`) instead of the greppable `config_path` form its transcription twin uses; and the WARN is not persisted under `observability.log_persistence = "none"`, though it can still reach verbose stderr and live subscribers.
  - So this changes the diagnostics, in the two places an operator actually looks: align the skip record with `transcription.rs`'s (`config_path` as `[providers.tts.<family>.<alias>]`, message `"typed TTS provider skipped (config error)"`), and give `doctor` coverage it did not have — `doctor` had **zero** hits for TTS or transcription providers before this.
  - The doctor check is deliberately worded to say the provider "will NOT register (not a soft fallback)", because the existing model-provider check says a missing key "may rely on env vars", and that is exactly the wrong expectation to carry over here.
  - Transcription gets the same doctor coverage, since it has the identical structural gate and is merely better instrumented.
- **Scope boundary:** Diagnostics only. Key-gated families are checked (`openai`/`elevenlabs`/`google` for TTS; `groq`/`openai`/`deepgram`/`assemblyai`/`google` for transcription); keyless ones are skipped entirely (`edge`, `piper`, and `local_whisper`, whose optional `bearer_token` is a different field).
- **Blast radius:** One log record's attrs and message, plus new read-only `doctor` items. No provider registration behaviour changes; a config that worked before works identically after.
- **Linked issue(s):** Follow-up from #10489 review — "local TTS `api_key` ergonomics" was one of the items you asked to track separately.
- **Labels:** `bug`, `channel`, `config`, `doctor`, `observability`, `runtime`, `risk:medium`, `size:M`.

## The question I asked, deliberately left open

On #10489 I asked whether requiring `api_key` for a local endpoint that ignores it is intended. You did not answer, and **I have not assumed either way**: this PR does not change whether `api_key` is required for any provider. Making it optional is a provider-schema design call that is yours, not mine, and it would be a behaviour change rather than a diagnostic one.

If the requirement *is* intended, this PR is the whole fix and the ergonomics complaint reduces to "the operator could not see it". If it is not, this is still worth having, and the schema change is a separate PR I am happy to write.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Optional. Configure a TTS provider with a `uri` and no `api_key`, run `zeroclaw doctor`, and confirm you get a warning naming the exact config path instead of silence.

### How I tested

- **CI checks relied on and why they cover this change:** the Rust build/test/clippy jobs cover both changed crates. The doctor tests are in `zeroclaw-runtime` and run by default; the TTS registration test needs `--features channel-matrix`, which the commands below name explicitly.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```sh
cargo fmt --all -- --check
# (no output)

bash scripts/ci/rust_quality_gate.sh
# ==> rust quality: provider dispatch gate clean

cargo clippy -p zeroclaw-channels -p zeroclaw-runtime --all-targets --features channel-matrix -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 17s

cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib tts::
# Summary [3.020s] 35 tests run: 34 passed, 1 failed, 1732 skipped
#   FAIL zeroclaw-channels tts::tests::edge_tts_removes_temp_output_when_read_fails

cargo nextest run --locked -p zeroclaw-runtime --lib doctor::
# Summary [0.193s] 64 tests run: 64 passed, 4115 skipped
```

  **On that one failure:** `edge_tts_removes_temp_output_when_read_fails` asserts a permission error, and my local build container runs as root, so the error never occurs. It is pre-existing on an unmodified `master`, unrelated to this change, and green in CI — please read CI rather than my tail for it.

- **Beyond CI, what did you manually verify?** The new tests deliberately build the case every existing fixture avoids: `config_with_tts` and the `tts.rs` helpers all set `api_key: Some("test-key")`, which is precisely why nothing caught this. `typed_registration_logs_config_path_for_keyless_uri_only_provider` asserts the provider list is empty *and* that the record carries the right `config_path` and names `api_key` in its error. Doctor coverage is `tts_doctor_{warns_for_keyless_gated_provider,ok_for_keyed_provider,no_warning_for_keyless_families}` and the three matching `transcription_doctor_*` tests, including `no_warning_for_local_whisper`.

  The original diagnosis came from a live deployment where a Kokoro endpoint silently failed to register; the repair is verified by tests rather than by re-running that deployment.
- **Visual interface changed?** `N/A` — `doctor` gains output lines.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — the checks test only whether a key is present and non-empty after trimming. **No key value is ever logged or printed**, by the record or by `doctor`; both emit the config path only.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes` — no registration behaviour changes.
- Config / env / CLI surface changed? `No` — `doctor` prints more, but no flag or config key is added.
- Rust/MSRV/toolchain floor changed? `No`

## Rollback

Low risk: `git revert <sha>`. This removes the new doctor diagnostics and restores the previous TTS warning format.
