### PR TITLE
fix(config): bind degraded remediation to running executable

### DIFF
--- a/crates/zeroclaw-config/src/migration.rs
+++ b/crates/zeroclaw-config/src/migration.rs
@@ -375,8 +375,9 @@ fn deserialize_resilient(value: toml::Value) -> ResilientLoad {
                 "SECURITY-CRITICAL config section `{path}` is invalid and was reset to \
                  its default so the daemon can boot; the running posture may be WEAKER \
                  than intended — repair `{path}` and reload before trusting this instance. \
-                 Run `zeroclaw config migrate` to see the precise parse error, or fix it \
-                 via the gateway config editor at `/api/config`"
+                 Use the same executable that started this process with `config migrate` \
+                 to see the precise parse error, or fix it via the gateway config editor \
+                 at `/api/config`"
             )
         );
     }

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -830,7 +830,7 @@ cli-plugin-installed-name-version = Installed plugin {$name} v{$version}
 cli-plugin-config-entry-seeded = Seeded [[plugins.entries]] for '{$name}'. Set plugin config values with `zeroclaw config set plugins.entries.{$name}.config.<key>`.
 cli-plugin-config-entry-key = Config entry key ({$capability}): {$key}
 cli-plugin-config-entry-seed-skipped = warning: skipped seeding the config entry for '{$name}': the [plugins] section on disk is malformed. Repair it, add a [[plugins.entries]] block with `name = "{$name}"`, then set values with `zeroclaw config set plugins.entries.{$name}.config.<key>`.
-cli-config-section-degraded = warning: config section `{$section}` in {$path} is malformed and was reset to defaults for this run. Values in that section are NOT in effect. Run `zeroclaw config migrate` to see the parse error, then repair the file.
+cli-config-section-degraded = warning: config section `{$section}` in {$path} is malformed and was reset to defaults for this run. Values in that section are NOT in effect. Use the running executable at `{$executable}` with `config migrate` to see the parse error, then repair the file.
 cli-config-section-retired-wati = warning: retired WATI channel config section `{$section}` is ignored because WATI support was removed. Migrate to `[channels.whatsapp.<alias>]` using the Cloud API or WhatsApp Web, then revoke the unused WATI API token.
 cli-config-section-retired-node-transport = warning: retired `[node_transport]` config is ignored because the legacy HMAC node transport was removed. Delete the section from config.toml.
 cli-plugin-removed = Plugin '{$name}' removed.

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -831,6 +831,7 @@ cli-plugin-config-entry-seeded = Seeded [[plugins.entries]] for '{$name}'. Set p
 cli-plugin-config-entry-key = Config entry key ({$capability}): {$key}
 cli-plugin-config-entry-seed-skipped = warning: skipped seeding the config entry for '{$name}': the [plugins] section on disk is malformed. Repair it, add a [[plugins.entries]] block with `name = "{$name}"`, then set values with `zeroclaw config set plugins.entries.{$name}.config.<key>`.
 cli-config-section-degraded = warning: config section `{$section}` in {$path} is malformed and was reset to defaults for this run. Values in that section are NOT in effect. Use the running executable at `{$executable}` with `config migrate` to see the parse error, then repair the file.
+cli-config-section-degraded-executable = warning: config section `{$section}` in {$path} is malformed and was reset to defaults for this run. Values in that section are NOT in effect. Use the running executable at `{$executable}` with `config migrate` to see the parse error, then repair the file.
 cli-config-section-retired-wati = warning: retired WATI channel config section `{$section}` is ignored because WATI support was removed. Migrate to `[channels.whatsapp.<alias>]` using the Cloud API or WhatsApp Web, then revoke the unused WATI API token.
 cli-config-section-retired-node-transport = warning: retired `[node_transport]` config is ignored because the legacy HMAC node transport was removed. Delete the section from config.toml.
 cli-plugin-removed = Plugin '{$name}' removed.

--- a/crates/zeroclaw-runtime/src/i18n.rs
+++ b/crates/zeroclaw-runtime/src/i18n.rs
@@ -400,6 +400,28 @@ mod tests {
     }
 
     #[test]
+    fn executable_degraded_guidance_falls_back_past_stale_translated_catalog() {
+        let stale_disk =
+            "cli-config-section-degraded = advertencia: Ejecuta `zeroclaw config migrate`.\n";
+        let executable = "/opt/zeroclaw/bin/zeroclaw";
+
+        let rendered = get_disk_override_cli_string_for_test(
+            "es",
+            stale_disk,
+            "cli-config-section-degraded-executable",
+            &[
+                ("section", "risk_profiles"),
+                ("path", "/tmp/config.toml"),
+                ("executable", executable),
+            ],
+        );
+
+        assert!(rendered.contains(executable));
+        assert!(rendered.contains("config migrate"));
+        assert!(!rendered.contains("`zeroclaw config migrate`"));
+    }
+
+    #[test]
     fn paircode_cli_strings_format_in_every_builtin_locale() {
         let endpoint = "gateway.example:49001";
         let cases = [

--- a/crates/zeroclaw-runtime/src/restart.rs
+++ b/crates/zeroclaw-runtime/src/restart.rs
@@ -38,6 +38,15 @@ pub fn record_launch() {
     });
 }
 
+/// Return the executable path captured for daemon self-respawn.
+///
+/// Once the daemon has recorded its launch command, this remains stable even
+/// after an in-app upgrade replaces the on-disk binary and `current_exe()`
+/// would resolve to an unspawnable "... (deleted)" path on Linux.
+pub fn recorded_launch_executable() -> Option<&'static std::path::Path> {
+    LAUNCH.get().map(|command| command.exe.as_path())
+}
+
 /// Request a self-respawn after the daemon shuts down. The caller is expected to
 /// also trigger the daemon's graceful shutdown so the loop tears down first.
 pub fn request_respawn() {

--- a/crates/zeroclaw-runtime/src/restart.rs
+++ b/crates/zeroclaw-runtime/src/restart.rs
@@ -197,7 +197,10 @@ mod tests {
         let command = launch_command_from_resolved_exe(Some(path.clone()), Vec::new());
 
         assert_eq!(command.exe, path);
-        assert_eq!(remediation_executable(&command), Some(command.exe.as_path()));
+        assert_eq!(
+            remediation_executable(&command),
+            Some(command.exe.as_path())
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/restart.rs
+++ b/crates/zeroclaw-runtime/src/restart.rs
@@ -26,25 +26,56 @@ static LAUNCH: OnceLock<LaunchCommand> = OnceLock::new();
 #[derive(Clone)]
 struct LaunchCommand {
     exe: PathBuf,
+    exe_resolved: bool,
     args: Vec<OsString>,
+}
+
+fn launch_command_from_resolved_exe(
+    resolved_exe: Option<PathBuf>,
+    args: Vec<OsString>,
+) -> LaunchCommand {
+    match resolved_exe {
+        Some(exe) => LaunchCommand {
+            exe,
+            exe_resolved: true,
+            args,
+        },
+        None => LaunchCommand {
+            exe: PathBuf::from("zeroclaw"),
+            exe_resolved: false,
+            args,
+        },
+    }
+}
+
+fn remediation_executable(command: &LaunchCommand) -> Option<&std::path::Path> {
+    command.exe_resolved.then_some(command.exe.as_path())
 }
 
 /// Capture the launch executable + args once, at startup (before any upgrade
 /// swaps the binary). Idempotent — later calls are ignored.
 pub fn record_launch() {
-    let _ = LAUNCH.set(LaunchCommand {
-        exe: std::env::current_exe().unwrap_or_else(|_| PathBuf::from("zeroclaw")),
-        args: std::env::args_os().skip(1).collect(),
-    });
+    let _ = LAUNCH.set(launch_command_from_resolved_exe(
+        std::env::current_exe().ok(),
+        std::env::args_os().skip(1).collect(),
+    ));
 }
 
-/// Return the executable path captured for daemon self-respawn.
+/// Return the resolved launch executable when it is safe to use for remediation.
 ///
-/// Once the daemon has recorded its launch command, this remains stable even
-/// after an in-app upgrade replaces the on-disk binary and `current_exe()`
-/// would resolve to an unspawnable "... (deleted)" path on Linux.
+/// The respawn command may retain a bare `zeroclaw` fallback when executable
+/// resolution failed, but that PATH-dependent fallback is intentionally excluded
+/// here. A successfully resolved path remains stable across an in-app binary swap.
 pub fn recorded_launch_executable() -> Option<&'static std::path::Path> {
-    LAUNCH.get().map(|command| command.exe.as_path())
+    LAUNCH.get().and_then(remediation_executable)
+}
+
+/// Whether the daemon launch command has already been captured.
+///
+/// This distinguishes startup before capture from a captured command whose
+/// executable could not be resolved.
+pub fn launch_command_recorded() -> bool {
+    LAUNCH.get().is_some()
 }
 
 /// Request a self-respawn after the daemon shuts down. The caller is expected to
@@ -148,6 +179,26 @@ pub fn respawn_if_requested() -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unresolved_launch_keeps_respawn_fallback_but_not_remediation_path() {
+        let command = launch_command_from_resolved_exe(None, Vec::new());
+
+        assert_eq!(command.exe, PathBuf::from("zeroclaw"));
+        assert!(
+            remediation_executable(&command).is_none(),
+            "bare PATH-dependent fallback must not be used for remediation"
+        );
+    }
+
+    #[test]
+    fn resolved_launch_is_available_for_remediation() {
+        let path = PathBuf::from("/resolved/zeroclaw");
+        let command = launch_command_from_resolved_exe(Some(path.clone()), Vec::new());
+
+        assert_eq!(command.exe, path);
+        assert_eq!(remediation_executable(&command), Some(command.exe.as_path()));
+    }
 
     #[test]
     fn respawn_flag_defaults_false_until_requested() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4700,17 +4700,20 @@ async fn async_main(command: clap::Command) -> Result<()> {
     {
         let path = config.config_path.display().to_string();
         let warning = if let Some(executable) = running_executable.as_deref() {
+            let fallback = format!(
+                "warning: config section `{section}` in {path} is malformed and was reset to \
+                 defaults for this run. Values in that section are NOT in effect. Use the \
+                 running executable at `{executable}` with `config migrate` to see the parse \
+                 error, then repair the file."
+            );
             ta(
-                "cli-config-section-degraded",
+                "cli-config-section-degraded-executable",
                 &[
                     ("section", section),
                     ("path", &path),
                     ("executable", executable),
                 ],
-                "warning: config section is malformed and was reset to defaults \
-                 for this run. Values in that section are NOT in effect. Use the \
-                 running executable with `config migrate` to see the parse error, \
-                 then repair the file.",
+                &fallback,
             )
         } else {
             format!(
@@ -9423,9 +9426,13 @@ fn warn_verifiable_intent_withheld(config: &Config) {
 fn running_executable_for_remediation() -> Option<std::path::PathBuf> {
     #[cfg(feature = "agent-runtime")]
     {
-        zeroclaw_runtime::restart::recorded_launch_executable()
-            .map(std::path::Path::to_path_buf)
-            .or_else(|| std::env::current_exe().ok())
+        if let Some(executable) = zeroclaw_runtime::restart::recorded_launch_executable() {
+            return Some(executable.to_path_buf());
+        }
+        if zeroclaw_runtime::restart::launch_command_recorded() {
+            return None;
+        }
+        std::env::current_exe().ok()
     }
 
     #[cfg(not(feature = "agent-runtime"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4704,11 +4704,15 @@ async fn async_main(command: clap::Command) -> Result<()> {
         let warning = if let Some(executable) = running_executable.as_deref() {
             ta(
                 "cli-config-section-degraded",
-                &[("section", section), ("path", &path), ("executable", executable)],
+                &[
+                    ("section", section),
+                    ("path", &path),
+                    ("executable", executable),
+                ],
                 "warning: config section is malformed and was reset to defaults \
                  for this run. Values in that section are NOT in effect. Use the \
                  running executable with `config migrate` to see the parse error, \
-                 then repair the file."
+                 then repair the file.",
             )
         } else {
             format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4691,10 +4691,8 @@ async fn async_main(command: clap::Command) -> Result<()> {
 
     // All other commands need config loaded first
     let mut config = Box::pin(Config::load_or_init()).await?;
-    let running_executable = zeroclaw_runtime::restart::recorded_launch_executable()
-        .map(std::path::Path::to_path_buf)
-        .or_else(|| std::env::current_exe().ok())
-        .map(|path| path.display().to_string());
+    let running_executable =
+        running_executable_for_remediation().map(|path| path.display().to_string());
     for section in config
         .degraded_sections
         .iter()
@@ -9422,6 +9420,20 @@ fn warn_verifiable_intent_withheld(config: &Config) {
     );
 }
 
+fn running_executable_for_remediation() -> Option<std::path::PathBuf> {
+    #[cfg(feature = "agent-runtime")]
+    {
+        zeroclaw_runtime::restart::recorded_launch_executable()
+            .map(std::path::Path::to_path_buf)
+            .or_else(|| std::env::current_exe().ok())
+    }
+
+    #[cfg(not(feature = "agent-runtime"))]
+    {
+        std::env::current_exe().ok()
+    }
+}
+
 fn gate_security_posture(
     config: &zeroclaw::config::Config,
     allow_degraded: bool,
@@ -9431,9 +9443,7 @@ fn gate_security_posture(
     }
     let sections = config.degraded_security.join(", ");
     if !allow_degraded {
-        let remediation_executable = zeroclaw_runtime::restart::recorded_launch_executable()
-            .map(std::path::Path::to_path_buf)
-            .or_else(|| std::env::current_exe().ok());
+        let remediation_executable = running_executable_for_remediation();
         let remediation = remediation_executable.map_or_else(
             || {
                 "The running executable path could not be resolved; use a daemon-owned repair \

--- a/src/main.rs
+++ b/src/main.rs
@@ -4691,25 +4691,34 @@ async fn async_main(command: clap::Command) -> Result<()> {
 
     // All other commands need config loaded first
     let mut config = Box::pin(Config::load_or_init()).await?;
+    let running_executable = zeroclaw_runtime::restart::recorded_launch_executable()
+        .map(std::path::Path::to_path_buf)
+        .or_else(|| std::env::current_exe().ok())
+        .map(|path| path.display().to_string());
     for section in config
         .degraded_sections
         .iter()
         .chain(config.degraded_security.iter())
     {
-        eprintln!(
-            "{}",
+        let path = config.config_path.display().to_string();
+        let warning = if let Some(executable) = running_executable.as_deref() {
             ta(
                 "cli-config-section-degraded",
-                &[
-                    ("section", section),
-                    ("path", &config.config_path.display().to_string()),
-                ],
+                &[("section", section), ("path", &path), ("executable", executable)],
                 "warning: config section is malformed and was reset to defaults \
-                 for this run. Values in that section are NOT in effect. Run \
-                 `zeroclaw config migrate` to see the parse error, then repair \
-                 the file."
+                 for this run. Values in that section are NOT in effect. Use the \
+                 running executable with `config migrate` to see the parse error, \
+                 then repair the file."
             )
-        );
+        } else {
+            format!(
+                "warning: config section `{section}` in {path} is malformed and was reset to \
+                 defaults for this run. Values in that section are NOT in effect. The running \
+                 executable path could not be resolved; repair the file through a daemon-owned \
+                 config surface instead of an unqualified PATH command."
+            )
+        };
+        eprintln!("{warning}");
     }
     for section in &config.retired_wati_config_sections {
         let fallback = format!(
@@ -9418,13 +9427,29 @@ fn gate_security_posture(
     }
     let sections = config.degraded_security.join(", ");
     if !allow_degraded {
+        let remediation_executable = zeroclaw_runtime::restart::recorded_launch_executable()
+            .map(std::path::Path::to_path_buf)
+            .or_else(|| std::env::current_exe().ok());
+        let remediation = remediation_executable.map_or_else(
+            || {
+                "The running executable path could not be resolved; use a daemon-owned repair \
+                 surface such as the gateway config editor instead of an unqualified PATH command."
+                    .to_string()
+            },
+            |exe| {
+                format!(
+                    "Running executable: {}. Use that executable with `config migrate` to see \
+                     the precise error.",
+                    exe.display()
+                )
+            },
+        );
         anyhow::bail!(
             "Config contains malformed security-critical sections ({sections}); \
              they were reset to defaults, so the running posture may be weaker \
              than intended. Refusing to serve with a degraded security posture. \
-             Repair these sections in {} and restart — run `zeroclaw config \
-             migrate` to see the precise error. To boot anyway (e.g. to reach \
-             the gateway config editor and repair from there), re-run with \
+             Repair these sections in {} and restart — {remediation} To boot anyway \
+             (e.g. to reach the gateway config editor and repair from there), re-run with \
              `--allow-degraded-security`.",
             config.config_path.display()
         );

--- a/tests/component/degraded_config_remediation.rs
+++ b/tests/component/degraded_config_remediation.rs
@@ -1,0 +1,124 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn path_with_fixture_first(dir: &Path) -> OsString {
+    let mut paths = vec![dir.to_path_buf()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    std::env::join_paths(paths).expect("test PATH must be joinable")
+}
+
+#[cfg(unix)]
+fn write_fake_zeroclaw(dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = dir.join("zeroclaw");
+    std::fs::write(
+        &path,
+        "#!/bin/sh\nprintf '%s\\n' '{\"error\":null,\"migrated\":false,\"schema_version\":3,\"valid\":true}'\n",
+    )
+    .expect("write fake zeroclaw");
+    let mut permissions = std::fs::metadata(&path)
+        .expect("stat fake zeroclaw")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).expect("make fake zeroclaw executable");
+    path
+}
+
+#[cfg(windows)]
+fn write_fake_zeroclaw(dir: &Path) -> PathBuf {
+    let path = dir.join("zeroclaw.cmd");
+    std::fs::write(
+        &path,
+        "@echo off\r\necho {\"error\":null,\"migrated\":false,\"schema_version\":3,\"valid\":true}\r\n",
+    )
+    .expect("write fake zeroclaw.cmd");
+    path
+}
+
+#[cfg(unix)]
+fn run_path_zeroclaw(path: &OsString, config_dir: &Path) -> Output {
+    Command::new("sh")
+        .args(["-c", "zeroclaw config migrate --json"])
+        .env("PATH", path)
+        .env("ZEROCLAW_CONFIG_DIR", config_dir)
+        .output()
+        .expect("run PATH zeroclaw fixture through sh")
+}
+
+#[cfg(windows)]
+fn run_path_zeroclaw(path: &OsString, config_dir: &Path) -> Output {
+    Command::new("cmd.exe")
+        .args(["/D", "/S", "/C", "zeroclaw config migrate --json"])
+        .env("PATH", path)
+        .env("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+        .env("ZEROCLAW_CONFIG_DIR", config_dir)
+        .output()
+        .expect("run PATH zeroclaw fixture through cmd.exe")
+}
+
+#[test]
+fn degraded_config_guidance_is_bound_to_running_executable_when_path_disagrees() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    std::fs::write(
+        config_dir.path().join("config.toml"),
+        r#"schema_version = 3
+
+[gateway]
+require_pairing = false
+
+[risk_profiles.example]
+level = "autonomous"
+"#,
+    )
+    .expect("write degraded config");
+
+    let fake_bin_dir = tempfile::tempdir().expect("temp fake-bin dir");
+    let fake_zeroclaw = write_fake_zeroclaw(fake_bin_dir.path());
+    assert!(fake_zeroclaw.exists(), "fake PATH zeroclaw must exist");
+
+    let test_path = path_with_fixture_first(fake_bin_dir.path());
+    let path_result = run_path_zeroclaw(&test_path, config_dir.path());
+    let path_stdout = String::from_utf8_lossy(&path_result.stdout);
+    let path_stderr = String::from_utf8_lossy(&path_result.stderr);
+    assert!(
+        path_result.status.success() && path_stdout.contains("\"valid\":true"),
+        "PATH zeroclaw must accept the fixture config\nstdout:\n{path_stdout}\nstderr:\n{path_stderr}"
+    );
+
+    let daemon_bin = Path::new(env!("CARGO_BIN_EXE_zeroclaw"));
+    let output = Command::new(daemon_bin)
+        .arg("--config-dir")
+        .arg(config_dir.path())
+        .arg("daemon")
+        .env("PATH", &test_path)
+        .env("LC_ALL", "C")
+        .env("TERM", "dumb")
+        .output()
+        .expect("run real zeroclaw daemon");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "daemon must reject the security-critical config without --allow-degraded-security\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("risk_profiles"),
+        "daemon rejection must identify the degraded security section: {stderr}"
+    );
+
+    let daemon_path = daemon_bin.display().to_string();
+    assert!(
+        stderr.contains(&daemon_path) && stderr.contains("config migrate"),
+        "remediation must bind config migration to the running executable {daemon_path}: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Run `zeroclaw config migrate`")
+            && !stderr.contains("run `zeroclaw config migrate`"),
+        "daemon startup must not direct the operator through PATH: {stderr}"
+    );
+}

--- a/tests/component/degraded_config_remediation.rs
+++ b/tests/component/degraded_config_remediation.rs
@@ -122,3 +122,40 @@ level = "autonomous"
         "daemon startup must not direct the operator through PATH: {stderr}"
     );
 }
+
+#[cfg(not(feature = "agent-runtime"))]
+#[test]
+fn degraded_config_guidance_keeps_executable_path_without_runtime_i18n() {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    std::fs::write(
+        config_dir.path().join("config.toml"),
+        r#"schema_version = 3
+
+[risk_profiles.example]
+level = "autonomous"
+"#,
+    )
+    .expect("write degraded config");
+
+    let zeroclaw = Path::new(env!("CARGO_BIN_EXE_zeroclaw"));
+    let output = Command::new(zeroclaw)
+        .arg("--config-dir")
+        .arg(config_dir.path())
+        .arg("daemon")
+        .env("LC_ALL", "C")
+        .env("TERM", "dumb")
+        .output()
+        .expect("run no-runtime zeroclaw");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let executable = zeroclaw.display().to_string();
+
+    assert!(
+        stderr.contains(&executable) && stderr.contains("config migrate"),
+        "no-runtime fallback must retain the actual executable path {executable}: {stderr}"
+    );
+    assert!(
+        !stderr.contains("`zeroclaw config migrate`"),
+        "no-runtime fallback must not direct remediation through PATH: {stderr}"
+    );
+}

--- a/tests/component/mod.rs
+++ b/tests/component/mod.rs
@@ -9,6 +9,7 @@ mod config_schema;
 mod cron_delivery_cli;
 mod cron_help_examples;
 mod daemon_startup_feedback;
+mod degraded_config_remediation;
 #[cfg(all(feature = "agent-runtime", target_os = "linux"))]
 mod desktop_cli_linux;
 mod direct_cli_terminal_completion;


### PR DESCRIPTION
## Summary

Fixes #10532.

Degraded-config warnings were telling users to run bare `zeroclaw config migrate`, which can hit a different binary from the daemon that actually rejected the config.

This changes the warning to use the running daemon executable instead. It also reuses ZeroClaw's recorded launch executable when available, so the remediation path stays valid after an in-app binary replacement.

A cross-platform regression test now covers the exact failure case: PATH resolves to a fake `zeroclaw` that accepts the config, while the real daemon rejects the same security-critical `risk_profiles` section.

The repair also bypasses stale translated warning keys, includes the executable in builds without runtime localization, and excludes unresolved launch paths from remediation. Scope is limited to diagnostics, launch-path access, and their tests; config parsing, security gating, and respawn behavior are unchanged. The affected consumers are startup warnings and degraded-security rejection messages. Base branch: `master`.

Labels: `bug`, `core`, `config`, `runtime`, `tests`, `risk:high`, `size:M`, `cli`.

## Testing (required)

### How you can test

Reviewer testing requested: N/A. The component regression runs the real CLI against a conflicting PATH fixture and checks the resulting diagnostic.

### How I tested

Previously reported local validation:

```sh
cargo test --test component degraded_config_guidance_is_bound_to_running_executable_when_path_disagrees -- --nocapture
# 1 passed, 0 failed
```

The same test failed before the fix because startup still pointed the operator to bare `zeroclaw config migrate`.

Current validation: [required CI](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33995644606) passed on cb89d2e56b5eb878b5ea03cfd297bf39670f2131. The Test job records passing results for the PATH-disagreement component test, stale-translated-catalog rendering test, and resolved/unresolved launch tests. Compile checks include no default features. Execution of the new no-runtime-specific component test has not been verified in this CI run.

The changed CLI diagnostic content is exercised through the real binary's stderr. No screenshot or interactive-test result is supplied; the checked acceptance criterion is executable identity rather than terminal layout. No additional local test execution is claimed by this update.

## Security & Privacy Impact (required)

No new permissions, network calls, credential handling, or personal data. The executable path is displayed in the local operator diagnostic; no new external sink is introduced. No model-visible text or prompt-injection surface changes.

## Compatibility (required)

Backward compatible. No config schema, environment variable, CLI syntax, or toolchain-floor changes. Missing translations use the updated English fallback.

## Rollback (required for medium/high-risk PRs)

Revert this PR. There is no new feature flag or data migration. A regression would appear as missing or incorrect executable guidance; reverting restores the earlier PATH-based diagnostic.
