### PR TITLE
docs(mcp): add Parallel Search configuration example

### DIFF
--- a/docs/book/src/tools/mcp.md
+++ b/docs/book/src/tools/mcp.md
@@ -50,6 +50,39 @@ A server is reached over one of three transports (the `transport` field):
 
 Add a server through the gateway, zerocode, or `zeroclaw config set` (for example `zeroclaw config set mcp.servers.filesystem.command npx`). A stdio server needs `command` plus optional `args`/`env`; an http/sse server needs `url` plus optional `headers`. The per-field commands are in the field table below.
 
+### Example: Parallel Search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)
+provides public web search and page extraction without a Parallel account or API
+key. Free access is rate limited. Its Streamable HTTP endpoint uses ZeroClaw's
+`http` transport:
+
+```toml
+[[mcp.servers]]
+name = "parallel"
+transport = "http"
+url = "https://search.parallel.ai/mcp"
+
+[mcp_bundles.web]
+servers = ["parallel"]
+
+[agents.assistant]
+mcp_bundles = ["web"]
+```
+
+Merge these entries into your existing `config.toml`, using the alias of the
+agent you want to grant access. Add `"web"` to that agent's existing
+`mcp_bundles` list rather than replacing its other grants. If the `web` bundle
+already exists, add `"parallel"` to its `servers` list. Keep `mcp.enabled = true`
+and restart the affected session after changing grants.
+
+The agent can then use `parallel__web_search` and `parallel__web_fetch`, subject
+to its normal tool authorization and approval policy. Calls send queries,
+requested URLs, and any supplied objective or context to Parallel. Once granted
+access, the agent may choose these tools during its work. To revoke access,
+remove `"parallel"` from every bundle granted to that agent, or add it to a
+granted bundle's `exclude` list, then restart the session.
+
 ## Editing servers
 
 Three surfaces edit the same `[[mcp.servers]]` table:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds a Parallel Search example to the MCP reference so users can configure public web search and page extraction without a Parallel account or API key.
  - Shows the HTTP transport and per-agent bundle grant together, including how to preserve existing grants and revoke access.
  - Explains what calls send to Parallel and that free access is rate limited.
- **Scope boundary:** Documentation only. No runtime, provider routing, dependency, credential, or permission-policy changes.
- **Blast radius:** Readers configuring MCP servers from the English reference.
- **Linked issue(s):** None.
- **Labels:** `docs`, `tool`, `domain:web-fetch`, `tool:mcp`, `risk:medium`, `size:XS`, `type:docs`.

ZeroClaw already [enables DuckDuckGo by default](https://github.com/zeroclaw-labs/zeroclaw/blob/fd6efbd65924ea7d373a1e6d677c18be895fbcb3/crates/zeroclaw-config/src/schema.rs#L8276-L8300). This gives users a simple way to try Parallel alongside it, with no account or API key.

The reason I think it's worth trying: [Artificial Analysis](https://artificialanalysis.ai/agents/search-api) reports **81/100 on DeepSearchQA and 77/100 on BrowseComp** for Parallel Search (advanced), in its August 31, 2026 leaderboard. Those are Search API results; DuckDuckGo and this free MCP setup weren't evaluated. I'd test Parallel against the current DuckDuckGo path on ZeroClaw's own agent tasks. If it gives better answers there, I'd consider making it the default in a follow-up.

I work at Parallel, which operates this service.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. This adds an example for existing behavior, with native-client evidence below.

### How I tested

- **CI checks relied on and why they cover this change:** [Docs Style](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33933122866/job/101215989582) and [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/33933122866/job/101219950736) pass on `6b8cda5611616b073cc19ddd67002bd0cf7b4cec`. Docs Style checks the changed documentation; the local documentation-gate results are recorded below. These checks do not exercise the external MCP endpoint.
- **Known CI coverage gap, if any:** Documentation gates do not exercise a live external MCP server.
- **Commands run and tail output:**

```text
git diff HEAD^ HEAD --check
# exit 0

BASE_SHA=full-file-check DOCS_FILES=docs/book/src/tools/mcp.md scripts/ci/docs_quality_gate.sh
# BASE_SHA is missing or invalid; falling back to full-file markdown lint.
# No prose em-dashes in changed docs files.
# markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
# Linting: 1 file(s)
# Summary: 0 error(s)

BASE_SHA=fd6efbd65924ea7d373a1e6d677c18be895fbcb3 DOCS_FILES=docs/book/src/tools/mcp.md scripts/ci/docs_links_gate.sh
# Ran 6 tests
# OK
# Collected 2 added link(s) from 1 docs file(s).
# Added HTTP(S) links detected, but lychee is not installed; skipping optional HTTP(S) validation.
```

- **Beyond CI, what did you manually verify?** Parsed the exact TOML example and loaded its server, bundle, and agent fields with the official prebuilt ZeroClaw 0.8.4 binary. A bounded native agent session with isolated configuration and a deterministic local provider fixture discovered `parallel__web_search` and `parallel__web_fetch`, then called both against the live anonymous endpoint with no Parallel credentials. Search returned 10 results; fetch returned the public setup page with no URL errors. The session exited successfully. The public documentation link separately returned HTTP 200. An earlier fixture repeated searches and hit the loop detector; the corrected fixture made one search and one fetch. This verifies the native client path, not a real model's tool choices.
- **Visual interface changed?** N/A. Adds Markdown reference content without changing UI or theme code.
- **If any command was intentionally skipped, why:** No local repository build or Rust suite was run for this docs-only change. The native check used the prebuilt 0.8.4 release, not a branch build. Full docs generation requires compiling the repository's tooling and was not run. Routine English docs changes defer generated `.po` updates to a translation-cache follow-up.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No runtime change. Users following the example grant an existing MCP capability to their chosen agent.
- New external network calls? Yes when the example is enabled: the existing MCP client sends queries, requested URLs, and supplied objective/context to Parallel. The example documents this and how to revoke the grant.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No runtime change. Retrieved content continues through existing MCP handling and tool policy.
- If any `Yes`, describe the risk and mitigation: Hosted search receives the request data described above. The server requires an explicit per-agent bundle grant and remains subject to normal authorization and approval rules.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- Upgrade steps: None.

## Rollback

Revert the documentation commit. Users who adopted the example can revoke its bundle grant and restart the affected session as documented.

## Supersede Attribution

N/A. This does not supersede another contribution.
