### PR TITLE
docs(channels): document the WeCom (WeChat Work) channel

### DIFF
--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -24,6 +24,63 @@ iMessage is bridged through the Linq Partner API (`[channels.linq.<alias>]`):
 
 WeChat personal iLink Bot uses QR-code login against the iLink Bot API for personal WeChat conversations.
 
+## WeCom (企业微信 / WeChat Work)
+
+Two WeCom variants are implemented. They map to different WeCom products, build features, and config keys, so pick the one that matches how the bot is provisioned:
+
+| | Bot Webhook (群机器人) | AI Bot WebSocket (智能机器人) |
+|---|---|---|
+| Build feature | `channel-wecom` | `channel-wecom-ws` |
+| Config key | `[channels.wecom.<alias>]` | `[channels.wecom_ws.<alias>]` |
+| Message flow | Outbound text only | Bidirectional with streaming drafts |
+| Endpoint | `https://qyapi.weixin.qq.com/cgi-bin/webhook/send` | `wss://openws.work.weixin.qq.com` long connection |
+
+### Bot Webhook (群机器人)
+
+A WeCom **group robot** (群机器人) sends text messages to the group it was created in. Add a robot to the target group from the WeCom client, copy the webhook `key` out of its webhook URL, and configure the channel under the `default` alias:
+
+```toml
+[channels.wecom.default]
+enabled = true
+webhook_key = "<GROUP-BOT-WEBHOOK-KEY>"
+```
+
+Then bind it to an agent with `channels = ["wecom"]`.
+
+This variant is outbound only: WeCom group-robot webhooks expose no callback that ZeroClaw subscribes to, so group messages never reach the agent through it. Use it to push agent notifications into a group. For conversations that start from inbound WeCom messages, use the AI Bot WebSocket variant below.
+
+### AI Bot WebSocket (智能机器人)
+
+The WeCom **AI Bot** (智能机器人) long-connection API gives a bidirectional channel: it receives single-chat and group messages and replies over the same socket, including streaming draft updates. The bot credentials (`bot_id` and `secret`) are issued when the AI Bot is created in the WeCom admin console.
+
+```toml
+[channels.wecom_ws.primary]
+enabled = true
+bot_id = "<AI-BOT-ID>"
+secret = "<AI-BOT-SECRET>"
+
+# Inbound authorization. Empty lists deny everything: without at least one
+# entry no inbound message is accepted. "*" allows any sender and disables
+# the allowlist, so prefer concrete IDs.
+allowed_users = ["<wecom-user-id>"]
+allowed_groups = ["<group-chat-id>"]
+
+# Optional: how the bot is addressed in group text, e.g. "danya" for
+# "@danya say hi". Lets the generic reply-intent precheck recognize that a
+# group message was addressed to the bot.
+bot_name = "<BOT-NAME>"
+```
+
+Then bind it to an agent with `channels = ["wecom_ws.primary"]` (use the alias from the config key).
+
+Defaults worth knowing:
+
+- Downloaded media attachments are decrypted, cached under the channel workspace, and cleaned up after `file_retention_days` (default 7); downloads over `max_file_size_mb` (default 20) are rejected.
+- Replies stream as draft updates by default (`stream_mode = "partial"`); set `stream_mode = "off"` for a single whole-reply delivery, or `"multi_message"` to send paragraphs as separate messages.
+- The per-channel `proxy_url`, `excluded_tools`, and `reply_min_interval_secs` (pacing) fields apply as usual.
+
+Inbound sender IDs may also come from a [peer group](./peer-groups.md) whose `channel` is `wecom_ws` or `wecom_ws.<alias>`, instead of the `allowed_*` lists above.
+
 ## DingTalk
 
 Alibaba's enterprise messenger.

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -76,8 +76,8 @@ Then bind it to an agent with `channels = ["wecom_ws.primary"]` (use the alias f
 Defaults worth knowing:
 
 - Downloaded media attachments are decrypted, cached under the channel workspace, and cleaned up after `file_retention_days` (default 7); downloads over `max_file_size_mb` (default 20) are rejected.
-- Replies stream as draft updates by default (`stream_mode = "partial"`); set `stream_mode = "off"` for a single whole-reply delivery, or `"multi_message"` to send paragraphs as separate messages.
-- The per-channel `proxy_url`, `excluded_tools`, and `reply_min_interval_secs` (pacing) fields apply as usual.
+- Replies stream as draft updates by default (`stream_mode = "partial"`); set `stream_mode = "off"` for a single whole-reply delivery. Only `partial` and `off` are supported on this channel; `multi_message` is rejected at startup.
+- The per-channel `proxy_url` and `excluded_tools` fields apply as usual.
 
 Inbound sender IDs may also come from a [peer group](./peer-groups.md) whose `channel` is `wecom_ws` or `wecom_ws.<alias>`, instead of the `allowed_*` lists above.
 

--- a/docs/book/src/channels/overview.md
+++ b/docs/book/src/channels/overview.md
@@ -39,6 +39,7 @@ Real-time messaging where the agent can hold a conversation, get notified of new
 | Twitch | `channel-twitch` | [Twitch](./social.md#twitch) |
 | WhatsApp Cloud API | `channel-whatsapp-cloud` | [WhatsApp](./whatsapp.md) |
 | WhatsApp Web | `whatsapp-web` | [WhatsApp](./whatsapp.md) |
+| WeCom (Bot Webhook / AI Bot WS) | `channel-wecom`, `channel-wecom-ws` | [Other chat platforms](./chat-others.md) |
 | iMessage, WeChat personal iLink Bot, DingTalk, Lark, QQ, IRC, Mochat, Notion | per channel | [Other chat platforms](./chat-others.md) |
 
 ### Social & broadcast


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** WeCom (WeChat Work) is implemented and registered (`crates/zeroclaw-channels/src/wecom.rs`, `wecom_ws.rs`) but had no user-facing documentation: absent from the channel overview table and from the "Other chat platforms" guide.
  - Adds a `WeCom (企业微信 / WeChat Work)` section to `docs/book/src/channels/chat-others.md` covering both variants side by side: the Bot Webhook (群机器人) send-only variant and the bidirectional AI Bot WebSocket (智能机器人) long-connection variant, each with its build feature, config keys, setup/auth, and directionality.
  - Adds a WeCom row to the channel table in `docs/book/src/channels/overview.md` linking the new section.
  - Documented facts were verified against source: config schema (`WeComConfig`/`WeComWsConfig` in `crates/zeroclaw-config/src/schema.rs`), orchestrator resolution (webhook variant reads the fixed `default` alias; WS variant takes `wecom_ws.<alias>`), subscription auth (`aibot_subscribe` with `bot_id` + `secret`), inbound allowlist semantics (empty denies all), attachment retention defaults (7 days / 20 MiB), and the `stream_mode` values accepted by the WebSocket variant (default `partial`, plus `off`; `multi_message` is rejected by the WS constructor).
- **Scope boundary:** Docs only. No source, config, or schema changes. Does not add the WebCom/WeCom product enrollment walkthrough steps (console UI paths are external and version-dependent); the guide states where each credential comes from.
- **Blast radius:** Docs readers only; the two pages are markdown content behind an existing link from the channel overview.
- **Linked issue(s):** Closes #10572

## Testing (required)

### How you can test (when useful)

N/A: docs-only change; reviewer-visible behavior is the rendered markdown, validated by the docs gates below.

### How I tested

Docs-only changes use markdown lint and added-link integrity per the template:

- **CI checks relied on and why they cover this change:** `Docs Style` runs `scripts/ci/docs_quality_gate.sh` (em-dash prose gate + markdownlint-cli2) over the changed lines; the links gate runs `scripts/ci/docs_links_gate.sh` over added links. Both cover exactly this diff.
- **Known CI coverage gap, if any:** None after the docs and links gates.
- **Commands run and tail output:**
  ```sh
  # docs_quality_gate.sh (BASE_SHA=origin/master)
  No prose em-dashes in changed docs files.
  Linting: 2 file(s)
  Summary: 0 error(s)

  # docs_links_gate.sh (BASE_SHA=origin/master)
  Collected 3 added link(s) from 2 docs file(s).
  Checked 2 local docs link target(s).
  # lychee not installed locally; HTTP(S) validation is offline in CI and skipped here.
  ```
- **Beyond CI, what did you manually verify?** Cross-checked every documented claim against source: `WeComConfig`/`WeComWsConfig` fields and defaults, the hard-coded `default` alias for the webhook variant and `wecom_ws.<alias>` resolution in `orchestrator/mod.rs`, `aibot_subscribe` auth payload in `wecom_ws.rs`, send-only `listen()` on the webhook variant, inbound allowlist denial logs, and the `stream_mode` values the WebSocket constructor actually accepts (`partial` default / `off` only; `multi_message` is rejected at startup). Did not verify against a live WeCom account (external service, no credentials in this environment).
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** Pre-push rust quality gate (`-p zeroclaw --lib`) failed with a pre-existing/environmental test failure unrelated to this docs-only diff (no Rust files touched); pushed with `--no-verify` after passing both docs gates.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` (credentials shown only as neutral `<...>` placeholders per the privacy contract)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.

