### PR TITLE
fix(release): stream crate metadata into publish ordering

### DIFF
--- a/scripts/release/publish-crates.sh
+++ b/scripts/release/publish-crates.sh
@@ -264,6 +264,49 @@ if [[ $EXECUTE -eq 1 && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
   exit 1
 fi
 
+# Topological order over the publishable set, so each crate's dependencies are
+# already on the registry when it uploads. Compute this during the dry run too:
+# the tokenless preflight must exercise every operation needed before the first
+# irreversible upload. Cargo metadata is too large for one argv entry on the
+# full workspace, so pass it on a dedicated file descriptor instead.
+ORDER="$(python3 - "$VERSION" 3<<<"$META" <<'PY'
+import json
+import os
+import sys
+
+with os.fdopen(3) as metadata:
+    meta = json.load(metadata)
+version = sys.argv[1]
+pkgs = {p["name"]: p for p in meta["packages"]}
+pub = {
+    n for n, p in pkgs.items()
+    if p["publish"] is None and p["version"] == version
+}
+deps = {
+    n: sorted({d["name"] for d in p["dependencies"]
+               if d["name"] in pub and d["kind"] in (None, "build")})
+    for n, p in pkgs.items()
+}
+order, state = [], {}
+def visit(n, trail=()):
+    if state.get(n) == "done":
+        return
+    if state.get(n) == "visiting":
+        sys.exit("dependency cycle: " + " -> ".join(trail + (n,)))
+    state[n] = "visiting"
+    for d in deps[n]:
+        visit(d, trail + (n,))
+    state[n] = "done"
+    order.append(n)
+for n in sorted(pub):
+    visit(n)
+print("\n".join(order))
+PY
+)" || {
+  echo "error: could not compute publish order." >&2
+  exit 1
+}
+
 if [[ $EXECUTE -eq 0 ]]; then
   echo "── Dry run: packaging and verifying every crate (no upload) ──"
   # Cargo builds an ephemeral local registry for a multi-package dry run, so
@@ -316,43 +359,6 @@ is_creation() {
     [[ "$c" == "$needle" ]] && return 0
   done
   return 1
-}
-
-# Topological order over the publishable set, so each crate's dependencies are
-# already on the registry when it uploads. Derived from cargo metadata, never
-# hand-maintained.
-ORDER="$(python3 - "$META" "$VERSION" <<'PY'
-import json, sys
-meta = json.loads(sys.argv[1])
-version = sys.argv[2]
-pkgs = {p["name"]: p for p in meta["packages"]}
-pub = {
-    n for n, p in pkgs.items()
-    if p["publish"] is None and p["version"] == version
-}
-deps = {
-    n: sorted({d["name"] for d in p["dependencies"]
-               if d["name"] in pub and d["kind"] in (None, "build")})
-    for n, p in pkgs.items()
-}
-order, state = [], {}
-def visit(n, trail=()):
-    if state.get(n) == "done":
-        return
-    if state.get(n) == "visiting":
-        sys.exit("dependency cycle: " + " -> ".join(trail + (n,)))
-    state[n] = "visiting"
-    for d in deps[n]:
-        visit(d, trail + (n,))
-    state[n] = "done"
-    order.append(n)
-for n in sorted(pub):
-    visit(n)
-print("\n".join(order))
-PY
-)" || {
-  echo "error: could not compute publish order." >&2
-  exit 1
 }
 
 published=0

--- a/tests/architecture/publish_contract.rs
+++ b/tests/architecture/publish_contract.rs
@@ -14,6 +14,9 @@
 //!   which packages fine and then fails to compile from the tarball. Feature
 //!   gated ones are the dangerous case: `cargo publish --dry-run` verifies
 //!   default features only, so they pass preflight and ship broken
+//! * publish-order calculation hidden behind the dry-run return and fed the
+//!   full workspace metadata through argv, which exceeded Linux `ARG_MAX`
+//!   only after the irreversible job was approved
 
 use proc_macro2::{TokenStream, TokenTree};
 use std::collections::{BTreeMap, BTreeSet};
@@ -377,6 +380,28 @@ fn root_package_is_the_installable_crate() {
         root.publishable,
         "the root package must remain publishable; `publish = false` here silently \
          removes ZeroClaw from crates.io"
+    );
+}
+
+#[test]
+fn publish_order_is_streamed_and_exercised_by_preflight() {
+    let script = fs::read_to_string(repo_root().join("scripts/release/publish-crates.sh"))
+        .expect("read crates.io publisher");
+
+    assert!(
+        !script.contains("python3 - \"$META\""),
+        "cargo metadata must not be passed as one argv entry; the full workspace exceeds ARG_MAX"
+    );
+
+    let order = script
+        .find("ORDER=\"$(python3 - \"$VERSION\" 3<<<\"$META\"")
+        .expect("publisher streams metadata into its order helper");
+    let dry_run = script
+        .find("if [[ $EXECUTE -eq 0 ]]")
+        .expect("publisher has a tokenless dry-run branch");
+    assert!(
+        order < dry_run,
+        "tokenless preflight must compute publish order before returning"
     );
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** master
- **What changed and why:**
  - Stream Cargo workspace metadata through file descriptor 3 instead of one argv entry, avoiding Linux `ARG_MAX`.
  - Compute publication order before the dry-run return so tokenless preflight exercises this release-critical step.
  - Add regression coverage for both requirements.
- **Scope boundary:** Does not change crate contents, manifests, dependencies, tags, or published artifacts.
- **Blast radius:** Limited to the crates.io release publisher and its architecture contract.
- **Linked issue(s):** Related #10048
- **Labels:** `type:ci`, `risk:high`, `size:S`, `release-gate`, `scripts`, `tests`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — executing the live path writes irreversibly to crates.io; the complete tokenless preflight exercises the safe boundary.

### How I tested

- **CI checks relied on and why they cover this change:** None yet; local checks ran on exact head `f114fc4096`.
- **Known CI coverage gap, if any:** The irreversible registry upload remains intentionally untested until this fix merges.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
exit 0

bash -n scripts/release/publish-crates.sh
exit 0

RUSTC_WRAPPER= cargo test --test architecture publish_contract -- --nocapture
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured

RUSTC_WRAPPER= ./scripts/release/publish-crates.sh 0.8.5
Dry run OK. Re-run with --execute to publish for real.
```

- **Beyond CI, what did you manually verify?** All 23 v0.8.5 tarballs packaged, compiled from the temporary registry, and reached dry-run upload. The three new crates—`zeroclaw-relay-proto`, `zeroclaw-tls`, and `zerorelay`—also passed. The original failed release job uploaded zero crates.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Live `--execute` was skipped because crates.io publication is irreversible.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- Exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merge-sha>` before another publisher run.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `could not compute publish order`, an unexpected crate order, or a dependency-not-found error during publication. Published crates cannot be withdrawn by reverting, so the publisher remains resumable after any partial upload.

## Supersede Attribution

N/A — this PR does not supersede another PR.
