### PR TITLE
fix(ci): allow PR size label updates

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: pr-size-labeler-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 concurrency:

--- a/scripts/github/pr_size_label_test.py
+++ b/scripts/github/pr_size_label_test.py
@@ -383,7 +383,7 @@ class PrSizeLabelTest(unittest.TestCase):
             workflow.index("- name: Apply size label from PR metadata"),
         )
         self.assertIn("issues: write", workflow)
-        self.assertIn("pull-requests: read", workflow)
+        self.assertIn("pull-requests: write", workflow)
 
     def test_workflow_fetch_step_fails_closed(self) -> None:
         fetch_step = workflow_step_run("Fetch trusted workflow classifier")

--- a/scripts/github/pr_size_label_test.py
+++ b/scripts/github/pr_size_label_test.py
@@ -382,7 +382,7 @@ class PrSizeLabelTest(unittest.TestCase):
             workflow.index("- name: Fetch trusted workflow classifier"),
             workflow.index("- name: Apply size label from PR metadata"),
         )
-        self.assertIn("issues: write", workflow)
+        self.assertNotIn("issues: write", workflow)
         self.assertIn("pull-requests: write", workflow)
 
     def test_workflow_fetch_step_fails_closed(self) -> None:


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Grant the trusted PR Size Labeler workflow `pull-requests: write` so its existing add/remove label requests can succeed, and drop the now-redundant `issues: write` scope (label add/remove on a pull request is covered by `pull-requests: write` alone, as `pr-path-labeler.yml` already relies on). Update the existing workflow contract assertion to require the one permission and reject the other.
- **Scope boundary:** Does not change size thresholds, label policy, classifier behavior, retries, tokens, triggers, or workflow execution provenance.
- **Blast radius:** Only the `pull_request_target` size-label workflow token scope changes. The workflow still fetches its classifier from the trusted base revision, performs no checkout, and executes no pull-request code.
- **Linked issue(s):** Related #9345
- **Labels:** `ci`, `scripts`, `distinguished contributor`, `risk:high`, `size:XS`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the meaningful behavioral proof is a trusted post-merge workflow run that needs to add or replace a size label.

### How I tested

- **CI checks relied on and why they cover this change:** CI Required Gate is green at the reviewed head; the `Security` job's `Validate GitHub helper scripts` step runs `pr_size_label_test.py`, which pins the permissions block. The repository's Python workflow tests cover trusted classifier provenance, no checkout, permission text, mutation ordering, and fail-closed behavior.
- **Known CI coverage gap, if any:** Static tests cannot prove GitHub will accept a real label mutation with the changed `GITHUB_TOKEN` permission. The first post-merge PR event requiring a size-label change is the live proof.
- **Commands run and tail output:**

```text
$ python3 -m unittest discover -s scripts/github -p '*_test.py'
Ran 64 tests in 1.235s
OK

$ python3 -m compileall -q scripts/github/pr_size_label.py scripts/github/pr_size_label_test.py
[no output; exit 0]

$ python3 - <<'PY'
... yaml.safe_load for .github/workflows/pr-size-labeler.yml and .github/workflows/ci.yml ...
PY
YAML OK: .github/workflows/pr-size-labeler.yml
YAML OK: .github/workflows/ci.yml

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check
[no output; exit 0]
```

- **Beyond CI, what did you manually verify?** Confirmed the workflow still uses `pull_request_target`, fetches the executable classifier from `github.sha`, performs no checkout, executes no PR-head code, and retains `contents: read`. I did not claim a successful live label mutation.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Cargo is unrelated to this workflow/Python-only repair.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes.** The workflow token changes from `issues: write` + `pull-requests: read` to `pull-requests: write` only, which is the scope the existing PR-label mutation path actually requires; net token reach stays at one write scope. Risk remains bounded by trusted base-revision execution, no checkout, no PR-head execution, metadata-only inputs, and the unchanged five-minute job timeout.
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR to restore `issues: write` + `pull-requests: read`; size-label mutations will again fail closed when the workflow needs to add or remove a label.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** The PR Size Labeler workflow fails its label `POST` or `DELETE` with HTTP 403, leaving the previous or missing `size:*` label unchanged.

