### PR TITLE
ci(channels/matrix): execute every Matrix lib test, not one module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,9 +697,9 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # `channel-matrix` is outside `default-channels`, so the workspace run
       # above does not execute Matrix's feature-gated library regressions. This
-      # step covers transcription-provider resolution for the Matrix channel.
-      - name: Run Matrix transcription provider resolution tests
-        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib matrix::tests::transcription_provider_resolution"
+      # step is what actually executes them.
+      - name: Run Matrix channel lib unit tests
+        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib matrix::"
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `channel-matrix` sits outside `default-channels`, so the workspace test run compiles Matrix's library tests but never executes them. One dedicated step in the `test` job does, and its filter named a single module: `matrix::tests::transcription_provider_resolution`. Every other Matrix test module was compiled and skipped.
  - Among the skipped modules is `matrix::tests::inbound_route`, which holds the configured-route transcription regression added in #10624 — that test has never executed in CI, including on its own PR. The reviewer flagged the gap in that approval, and again while reviewing #10627.
  - The filter had to be edited by hand for coverage to follow a new test module, and nothing failed when it was not. That is the failure mode this fixes: silent exclusion rather than a visible error.
  - Widened to `matrix::`, matching the WeChat step three blocks above (`--lib wechat::`). Coverage now tracks the module instead of a hand-maintained list.
  - Step name and comment updated to describe what the step actually runs.
- **Scope boundary:** No test is added, removed, or changed; no Rust source is touched. The step's package, feature flags, `env`, and position are unchanged, as are the WeChat and Lark steps and the workspace run. This does not add `channel-matrix` to any feature bundle.
- **Blast radius:** One step of the `test` job. It can now fail on a Matrix library test that was previously compiled but not run — that is the point, and the run below shows all 221 currently pass. No other job, crate, or consumer is affected.
- **Linked issue(s):** Related #10624
- **Labels:** `ci`, `domain:ci`, `risk:low`, `size:XS`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes` — this PR *is* a CI coverage claim, and it is cheap to verify directly.
- **Interface(s) exercised:** `channel` (`matrix`) — no `surface` change; this is CI configuration only.
- **Setup / preconditions:** A checkout and `cargo-nextest`. No Matrix credentials, no network services.
- **Steps to run:**
  ```sh
  cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib matrix::tests::inbound_route
  cargo nextest run --locked -p zeroclaw-channels --features channel-matrix --lib matrix::
  ```
- **Expected on this branch (after):** The second command is exactly what the step now runs: 221 tests, all passing. `configured_route_transcribes_via_the_agents_provider` appears in the list.
- **Prior behavior on `master` (before):** The step's command on `master` is `... --lib matrix::tests::transcription_provider_resolution` — run it and it reports **4 tests run, 1771 skipped**. `matrix::tests::inbound_route` is absent from the output, which is the gap. The first command above shows those 8 tests exist and pass; nothing in CI was running them.

### How I tested

Ran all three selectors against `upstream/master` in a pinned container, after one warm build so the timings measure execution rather than compilation.

Baseline — the filter on `master`:

```
    Starting 4 tests across 1 binary (1771 tests skipped)
     Summary [   0.011s] 4 tests run: 4 passed, 1771 skipped
```

This branch — `matrix::`:

```
        PASS [   0.179s] (213/221) zeroclaw-channels matrix::tests::inbound_route::configured_route_transcribes_via_the_agents_provider
        PASS [   0.351s] (220/221) zeroclaw-channels matrix::tests::inbound_route::sync_ingress_suppresses_rejected_approval_replies_and_delivers_authorized_one
        PASS [   0.639s] (221/221) zeroclaw-channels matrix::tests::inbound_route::mention_only_drops_unmentioned_reply_to_non_bot_parent
     Summary [   0.664s] 221 tests run: 221 passed, 1554 skipped
```

Execution goes from 4 tests in 0.011s to 221 in 0.664s. The compile is unchanged — the step already builds this binary with its own `--features channel-matrix`, and the added cost is under a second inside a job budgeted at `timeout-minutes: 30`.

I also checked the one hazard in widening a filter, which is picking up tests that need credentials or a network. Three Matrix tests are `#[ignore]`d and nextest does not run them by default:

```
$ cargo nextest list --locked -p zeroclaw-channels --features channel-matrix --lib matrix:: --run-ignored=only
zeroclaw-channels matrix::tests::live_smoke::idle_sync_does_not_error_at_30s_cadence
zeroclaw-channels matrix::tests::live_smoke::same_room_partial_draft_lifecycle_uses_real_draft_ids
zeroclaw-channels matrix::tests::live_smoke::same_room_single_message_draft_edits_one_real_event
```

They stay skipped under the new filter, so this adds no credential or network requirement to CI.

- **CI checks relied on and why they cover this change:** The `test` job on this PR is the change — it runs the edited step against this branch, so a green `Test` check is direct evidence the widened selector passes. `CI Required Gate` confirms all required checks passed.
- **Known CI coverage gap, if any:** None for this change; closing one is the point of it. Note the change is self-verifying only from this PR onward — CI on `master` before this merge does not exercise it.
- **Commands run and tail output:** above.
- **Beyond CI, what did you manually verify?** That the file still parses as valid workflow YAML and the edited step resolves to the intended command; that `matrix::tests::inbound_route` is excluded by the old filter and included by the new one; and the ignored-test list above. **What I did not verify:** anything about runtime on GitHub-hosted or Blacksmith runners specifically — my timings are local, in a container, and the argument rests on the added work being under a second rather than on matching runner performance. I also did not audit the other 209 newly-executed tests for flakiness beyond this single green run; if any of them is flaky under load, this step is where it will now show up.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** `cargo fmt` / `clippy` / `cargo test` are not run for a workflow-YAML-only diff; the required `CI Required Gate` confirms the required workflow passed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — and verified above that the newly-executed tests include no live-smoke test.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Revert this PR's landed squash commit to restore the previous selector. The change is one line of filter plus its comment and step name; reverting restores the previous selector with no other effect.
