### PR TITLE
fix(providers): warm compatible connections through models endpoint

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -954,6 +954,10 @@ impl OpenAiCompatibleModelProvider {
         })
     }
 
+    fn models_url(&self) -> String {
+        format!("{}/models", self.base_url)
+    }
+
     /// Build the full URL for chat completions, detecting if base_url already includes the path.
     /// This allows custom model_providers with non-standard endpoints (e.g., VolcEngine ARK uses
     /// `/api/coding/v3/chat/completions` instead of `/v1/chat/completions`).
@@ -2834,7 +2838,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         // servers with a public catalog use the same path without an Authorization header.
         let list_credential = self.resolve_credential().await?;
         if list_credential.is_some() || self.public_model_listing {
-            let url = format!("{}/models", self.base_url);
+            let url = self.models_url();
             let response = self
                 .apply_auth_header(self.http_client().get(&url), list_credential.as_deref())
                 .send()
@@ -2925,7 +2929,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         // endpoint — this returns pricing data that we can capture.
         let list_credential = self.resolve_credential().await?;
         if list_credential.is_some() || self.public_model_listing {
-            let url = format!("{}/models", self.base_url);
+            let url = self.models_url();
             let response = self
                 .apply_auth_header(self.http_client().get(&url), list_credential.as_deref())
                 .send()
@@ -3936,14 +3940,16 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
     }
 
     async fn warmup(&self) -> anyhow::Result<()> {
-        // Hit the appropriate URL with a GET to prime the connection pool.
-        // The server will likely return 405 Method Not Allowed, which is fine.
-        let url = self.chat_completions_url();
+        // Probe the catalog without invoking inference. Unsupported endpoints are
+        // still useful for connection warmup, so do not reject HTTP error statuses.
+        let url = self.models_url();
         let credential = self.resolve_credential().await?;
-        let _ = self
+        let mut response = self
             .apply_auth_header(self.http_client().get(&url), credential.as_deref())
             .send()
             .await?;
+        // Drain without retaining the catalog so HTTP/1 connections can be reused.
+        while response.chunk().await?.is_some() {}
         Ok(())
     }
 }
@@ -7022,6 +7028,128 @@ mod tests {
         assert_eq!(
             model_provider.reasoning_effort_for_model("llama-3.3-70b"),
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn warmup_uses_models_endpoint_with_existing_auth() {
+        use axum::{
+            Router,
+            body::Body,
+            http::{Request, StatusCode},
+        };
+        use tokio::net::TcpListener;
+
+        for (base_path, status, auth_style, credential, header) in [
+            (
+                "",
+                200,
+                AuthStyle::Bearer,
+                Some("test-key"),
+                Some(("authorization", "Bearer test-key")),
+            ),
+            (
+                "/v1",
+                401,
+                AuthStyle::Bearer,
+                Some("test-key"),
+                Some(("authorization", "Bearer test-key")),
+            ),
+            (
+                "/v1/",
+                404,
+                AuthStyle::XApiKey,
+                Some("test-key"),
+                Some(("x-api-key", "test-key")),
+            ),
+            (
+                "/custom/api",
+                405,
+                AuthStyle::Custom("x-provider-key".into()),
+                Some("test-key"),
+                Some(("x-provider-key", "test-key")),
+            ),
+            ("/v1", 500, AuthStyle::Bearer, None, None),
+        ] {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+            let app = Router::new().fallback(move |request: Request<Body>| {
+                let tx = tx.clone();
+                async move {
+                    tx.send((
+                        request.method().clone(),
+                        request.uri().path().to_owned(),
+                        request.headers().clone(),
+                    ))
+                    .await
+                    .unwrap();
+                    (StatusCode::from_u16(status).unwrap(), "probe body")
+                }
+            });
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let server = ::zeroclaw_spawn::spawn!(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            let provider = OpenAiCompatibleModelProvider::builder("test")
+                .display_name("test")
+                .base_url(&format!("http://{addr}{base_path}"))
+                .credential(credential)
+                .auth_style(auth_style)
+                .extra_headers(std::collections::HashMap::from([(
+                    "x-probe-test".into(),
+                    "preserved".into(),
+                )]))
+                .api_path((status == 500).then(|| "/inference".to_string()))
+                .build();
+            let result = provider.warmup().await;
+            server.abort();
+            assert!(
+                result.is_ok(),
+                "HTTP {status} must not fail warmup: {result:?}"
+            );
+            let (method, path, headers) = rx.recv().await.unwrap();
+            assert_eq!(method, "GET");
+            assert_eq!(headers.get("x-probe-test").unwrap(), "preserved");
+            assert_eq!(path, format!("{}/models", base_path.trim_end_matches('/')));
+            if let Some((name, value)) = header {
+                assert_eq!(headers.get(name).unwrap(), value);
+            } else {
+                assert!(!headers.contains_key("authorization"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn warmup_drains_response_with_configured_timeout() {
+        use axum::{
+            Router,
+            body::{Body, Bytes},
+        };
+        let app = Router::new().fallback(|| async {
+            Body::from_stream(futures_util::stream::once(async {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                Ok::<_, std::io::Error>(Bytes::from_static(b"catalog"))
+            }))
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = ::zeroclaw_spawn::spawn!(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let provider = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("test")
+            .base_url(&format!("http://{addr}"))
+            .auth_style(AuthStyle::Bearer)
+            .timeout_secs(1)
+            .build();
+        let result = provider.warmup().await;
+        server.abort();
+        assert!(
+            result
+                .unwrap_err()
+                .downcast_ref::<reqwest::Error>()
+                .unwrap()
+                .is_timeout()
         );
     }
 

--- a/docs/book/src/providers/custom.md
+++ b/docs/book/src/providers/custom.md
@@ -21,6 +21,12 @@ model = "my-model"
 tool_result_image_policy = "omit"
 ```
 
+### Connection warmup
+
+OpenAI-compatible providers warm the connection with `GET {base_url}/models`, using the same authentication and HTTP client settings as model listing.
+The probe consumes the response body and accepts non-success HTTP status codes, so a service without a models endpoint can still start.
+Chat-completion requests continue to use POST; warmup does not invoke inference or require a model catalog.
+
 ## First-class local-inference servers
 
 ZeroClaw ships canonical slots for popular local-inference stacks. They're all OpenAI-compatible under the hood but with default `uri` values pre-applied so you can usually omit `uri` entirely.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Warm OpenAI-compatible connections with GET `/models` instead of an invalid GET to the chat-completions endpoint.
  - Share the URL resolver with both model-listing paths, retaining the configured base URL and existing authentication/client construction.
  - Drain response chunks without retaining the catalog so the connection can be reused; HTTP error statuses remain acceptable for warmup.
- **Scope boundary:** No inference POST, configuration, provider registration, or model-discovery requirement changes.
- **Blast radius:** Warmup for OpenAI-compatible provider instances; model-list URL construction is behavior-preserving.
- **Linked issue(s):** Fixes #9575.
- **Labels:** `enhancement`, `docs`, `provider`, `provider:compatible`, `risk:medium`, `size:S`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; local HTTP boundary tests capture the exact request and timeout behavior without requiring provider credentials.

### How I tested

- **CI checks relied on and why they cover this change:** The [hosted provider tests](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34001851127/job/101405696755) pass both new warmup regressions, and the [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34001851127/job/101413409024) passed at `668174a65a05e9e939ec77349ab5edf4f9a8ba9d`. The local provider tests, clippy and documentation checks below provide additional evidence.
- **Known CI coverage gap, if any:** Live provider-specific TLS/proxy environments were not exercised. The existing HTTP client and credential paths are unchanged.
- **Commands run and tail output:**
  - Before the fix, `cargo test -p zeroclaw-providers warmup_uses_models_endpoint_with_existing_auth --locked` failed: actual `/chat/completions`, expected `/models`.
  - `cargo test -p zeroclaw-providers warmup_ --locked`: `14 passed; 0 failed`.
  - `cargo test -p zeroclaw-providers --locked -- --test-threads=4`: `1508 passed; 0 failed; 4 ignored`, plus `1 passed` dispatch integration test. Both new regression names are present in the rebuilt test binary. The first run at default parallelism had one unrelated fake-child PID-file timeout; that test passed alone on the clean base, and the complete rebuilt current suite passed at four test threads.
  - `cargo clippy -p zeroclaw-providers --all-targets --locked -- -D warnings`: finished successfully.
  - `cargo fmt -p zeroclaw-providers -- --check`: exit 0.
  - Scoped `docs_quality_gate.sh`: `0 error(s)`; `docs_links_gate.sh`: no added links.
- **Beyond CI, what did you manually verify?** Inspected the reliable-provider wrapper's non-fatal warmup handling and preserved inference POST calls. HTTP fixtures cover root/versioned/custom base paths, trailing slashes, bearer/API-key/custom-header/no credentials, extra client headers, and 200/401/404/405/500 responses. A delayed response body verifies draining respects the configured timeout.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** Full workspace checks were not run; the changed provider crate and its tests were checked directly. Live external provider calls were not needed for these transport assertions.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? Yes: the existing warmup probe targets the models path on the same configured origin; no additional request or origin is introduced.
- Secrets / tokens / credentials handling changed? No; the existing credential resolver and authentication header helper are reused.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No; the response is discarded.
- Risk and mitigation: model-listing endpoints may return non-success statuses; warmup continues to accept these and uses the existing request timeout while draining the body.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- Upgrade steps: none.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's commit.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Warmup transport/timeouts can produce the existing `Warmup failed (non-fatal)` warning. Reverting restores the previous GET chat-completions probe.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; no existing PR is superseded.

English provider documentation is updated; generated translation catalogs are unchanged for this focused English-source change.
