### PR TITLE
fix(runtime): bound RPC dispatch stack usage

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -791,7 +791,18 @@ impl RpcDispatcher {
             return;
         }
 
-        // Exhaustive match — compiler enforces every Method has a handler.
+        Box::pin(self.dispatch_method(method, &req, req_id, is_notification)).await;
+    }
+
+    async fn dispatch_method(
+        &mut self,
+        method: Method,
+        req: &zeroclaw_api::jsonrpc::JsonRpcRequest,
+        req_id: Value,
+        is_notification: bool,
+    ) {
+        // Keep the exhaustive handler future behind one fixed-size pointer so
+        // adding a handler cannot enlarge every RPC transport worker's stack.
         let result = match method {
             // Core
             Method::Initialize => self.handle_initialize(&req.params).await,
@@ -12380,6 +12391,21 @@ mod tests {
             .expect("stack regression thread should spawn")
             .join()
             .expect("session/new should not exhaust a two-megabyte stack");
+    }
+
+    #[test]
+    fn process_line_future_keeps_handler_dispatch_off_the_transport_stack() {
+        let (mut dispatcher, _rx) = make_bidi_test_dispatcher();
+        let future = dispatcher
+            .process_line_for_test(r#"{"jsonrpc":"2.0","id":1,"method":"status","params":{}}"#);
+        let future_size = std::mem::size_of_val(&future);
+        drop(future);
+
+        assert!(
+            future_size < 64 * 1024,
+            "process_line future is {future_size} bytes; keep the exhaustive handler dispatch \
+             behind a fixed-size pointer"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Keep the exhaustive RPC handler future behind one heap pointer so adding a large handler does not inflate every local or WebSocket transport worker's outer future. Add a structural regression that failed at 100,704 bytes on unmodified `master` and requires the repaired outer future to remain below 64 KiB.
- **Scope boundary:** This does not change any RPC method, request or response, handler behavior, Tokio stack setting, Quickstart lookup, agent lifecycle rule, or ZeroCode interface.
- **Blast radius:** Local and WebSocket RPC dispatch gain one allocation per accepted method. Parsing, authentication, notification handling, detached prompts, and result or error conversion are unchanged.
- **Linked issue(s):** Related #10230, #10197 and #10621.
- **Labels:** `bug`, `daemon`, `runtime`, `distinguished contributor`, `risk:medium`, `size:XS`

### What this does, simply

ZeroClaw routes every daemon RPC request through one large method table. Rust reserves space in the surrounding async task for the largest method in that table, so adding an unrelated large handler can make ordinary requests exhaust a Tokio worker stack.

This PR puts that method table behind one fixed-size heap pointer. Individual RPC behavior stays the same, but future handler growth no longer enlarges the transport worker's outer request future. A regression measures that boundary directly.

The captured crash was reproduced on the #10636 branch rather than unmodified current `master`. The same binary passed the identical isolated request sequence after applying this boundary, while current `master` independently failed the new structural size check before the repair. This PR does not include #10636, #10197, or #10621 behavior.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The structural regression and isolated credential-free daemon A/B exercise the failure boundary directly without requiring a real provider or user configuration.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI is pending publication. It will cover formatting, lint, workspace tests, feature combinations, MSRV, and supported platform compilation for the exact PR head.
- **Known CI coverage gap, if any:** Hosted CI does not recreate the exact #10636 aggregate dispatcher shape that triggered the worker-stack abort. The isolated matched A/B covers that failure boundary.
- **Commands run and tail output:**

```text
cargo test --locked -p zeroclaw-runtime --lib process_line_future_keeps_handler_dispatch_off_the_transport_stack -- --nocapture
# Before repair: FAILED; process_line future is 100704 bytes.
# After repair: 1 passed; 0 failed.

cargo test --locked -p zeroclaw-runtime --lib process_line_session_new_creates_session_on_two_megabyte_stack
# 1 passed; 0 failed.

cargo build --locked -p zeroclaw --bin zeroclaw
# Finished successfully.
```

- **Beyond CI, what did you manually verify?** A synthetic local-IPC probe with no credentials or model prompt sent `initialize`, `config/sections`, `logs/subscribe`, ACP `session/new`, and `session/close`. The #10636 baseline aborted at `session/new` with a Tokio worker-stack overflow. The matched boundary comparison and this current-master candidate answered every request and exited cleanly.
- **Visual interface changed?** N/A. No rendered interface changes.
- **If any command was intentionally skipped, why:** No broad local workspace suite was run; required CI provides that integration coverage after publication.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Identify this PR's landed squash commit from the merged PR and run `git revert <landed-squash-sha>`.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Tokio worker-stack overflow, daemon abort, RPC EOF, or a request that never returns after the exhaustive dispatcher grows.
