### PR TITLE
feat(ci): execute hardware feature tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
 
       - name: Test CLI and hardware path-label ownership
         run: bash scripts/ci/path_labeler_matrix.test.sh
+      - name: Test hardware feature test-lane contract
+        run: bash scripts/ci/hardware_feature_test_lane.test.sh
 
   relay-container-smoke-changes:
     name: Detect Relay Container Smoke changes
@@ -678,6 +680,14 @@ jobs:
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      # The crate's default feature set excludes the host-side hardware
+      # modules. Compile-only `ci-all` coverage cannot exercise their process,
+      # timeout, cleanup, and validation regressions.
+      - name: Run hardware feature lib unit tests
+        run: cargo nextest run --locked --no-fail-fast -p zeroclaw-hardware --features hardware --lib
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # `channel-wechat` is outside `default-channels` and `channels-full`, so
       # the workspace run above compiles neither the module nor its unit tests.
       # Adding it to `ci-all` gives Lint and Check compile coverage; this step
@@ -830,6 +840,7 @@ jobs:
           plugin_gateway_log="$RUNNER_TEMP/windows-plugin-gateway-nextest.log"
           plugin_cli_log="$RUNNER_TEMP/windows-plugin-cli-nextest.log"
           plugin_root_log="$RUNNER_TEMP/windows-plugin-root-nextest.log"
+          hardware_log="$RUNNER_TEMP/windows-hardware-nextest.log"
           case "$MODE" in
             scoped)
               package_args_file="$RUNNER_TEMP/windows-package-args"
@@ -862,6 +873,12 @@ jobs:
           esac
 
           baseline_duration=$((SECONDS - started_at))
+          hardware_started_at=$SECONDS
+          set +e
+          cargo nextest run --locked --no-fail-fast -p zeroclaw-hardware --features hardware --lib 2>&1 | tee "$hardware_log"
+          hardware_status=${PIPESTATUS[0]}
+          set -e
+          hardware_duration=$((SECONDS - hardware_started_at))
           plugin_host_status=0
           plugin_host_duration=0
           plugin_components_status=not-run
@@ -927,12 +944,18 @@ jobs:
           fi
 
           overall_status=$baseline_status
+          if (( hardware_status != 0 )); then
+            overall_status=1
+          fi
           if (( plugin_host_status != 0 )); then
             overall_status=1
           fi
           failure_inventory=""
           if (( baseline_status != 0 )); then
             failure_inventory="baseline"
+          fi
+          if (( hardware_status != 0 )); then
+            failure_inventory="${failure_inventory:+$failure_inventory,}hardware"
           fi
           if [[ "$plugin_components_status" != "not-run" && "$plugin_components_status" != "0" ]]; then
             failure_inventory="${failure_inventory:+$failure_inventory,}plugin-components"
@@ -969,6 +992,7 @@ jobs:
             printf "| Reason | %s |\n" "$REASON"
             printf "| Plugin host required | %s |\n" "$NEEDS_PLUGIN_HOST"
             printf "| Baseline status | %s |\n" "$baseline_status"
+            printf "| Hardware feature status | %s |\n" "$hardware_status"
             printf "| Plugin-host component status | %s |\n" "$plugin_components_status"
             printf "| Plugin-host library status | %s |\n" "$plugin_lib_status"
             printf "| Plugin-host runtime config status | %s |\n" "$plugin_runtime_config_status"
@@ -978,6 +1002,7 @@ jobs:
             printf "| Plugin-host root status | %s |\n" "$plugin_root_status"
             printf "| Failure inventory | %s |\n" "$failure_inventory"
             printf "| Baseline duration | %ss |\n" "$baseline_duration"
+            printf "| Hardware feature duration | %ss |\n" "$hardware_duration"
             printf "| Plugin-host duration | %ss |\n" "$plugin_host_duration"
             printf "| Total duration | %ss |\n" "$total_duration"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/master-branch-flow.md
+++ b/.github/workflows/master-branch-flow.md
@@ -26,7 +26,7 @@ Maintainers with merge authority: `JordanTheJet`, `Audacity88`, `WareWolf-MoonWa
 
 | File | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | `pull_request` → `master`; `push` → `master`; `merge_group` (dormant) | Lint + test + build on PRs and trusted post-merge cache-warming runs, plus advisory affected-scope Windows nextest and conditional plugin-host fixture coverage on PRs only. The `merge_group` trigger stays wired but never fires while the merge queue is disabled. |
+| `ci.yml` | `pull_request` → `master`; `push` → `master`; `merge_group` (dormant) | Lint + test + build on PRs and trusted post-merge cache-warming runs, feature-enabled hardware library tests on required Linux and advisory Windows lanes, plus advisory affected-scope Windows nextest and conditional plugin-host fixture coverage on PRs only. The `merge_group` trigger stays wired but never fires while the merge queue is disabled. |
 | `platform-tests.yml` | changes to this workflow in a `pull_request` → `master`; `workflow_dispatch`; nightly schedule | Advisory macOS/Windows workspace tests, outside the required PR gate and merge queue. |
 | `release-stable-manual.yml` | `workflow_dispatch`, tag push `v*` | Stable release (manual, version-gated) |
 | `docker-publish.yml` | `workflow_call`, `workflow_dispatch`, tag push `v*` | Build, sign, and scan the generated Docker variant matrix |
@@ -71,8 +71,8 @@ tag push.
    - `check`: matrix: all features + no default features.
    - `check-32bit`: `i686-unknown-linux-gnu`, no default features.
    - `bench`: benchmarks compile check.
-   - `test`: `cargo nextest run --locked --workspace --exclude zeroclaw-desktop` on `ubuntu-latest`.
-   - `windows-test-scope` and `windows-test`: advisory-only Windows measurement. The selector compares base SHA..`HEAD` and chooses baseline `skip`, `scoped`, or `full` plus the orthogonal `needs_plugin_host` flag; the Windows job records both outputs, passes explicit `-p` arguments for `scoped`, uses the full workspace command for `full`, and when the flag is true installs `wasm32-wasip2` and runs the feature-enabled plugin component, library, runtime config, runtime admission, gateway, CLI, and root host tests. Baseline and appended invocations use `--no-fail-fast`, retain separate failure statuses, and report baseline, plugin-host, and total durations.
+   - `test`: the default-feature workspace suite and the `zeroclaw-hardware` library suite with `hardware` enabled on `ubuntu-latest`. Physical-device tests remain ignored unless explicitly selected outside ordinary CI.
+   - `windows-test-scope` and `windows-test`: advisory-only Windows measurement. The selector compares base SHA..`HEAD` and chooses baseline `skip`, `scoped`, or `full` plus the orthogonal `needs_plugin_host` flag; the Windows job records both outputs, passes explicit `-p` arguments for `scoped`, uses the full workspace command for `full`, always runs the feature-enabled `zeroclaw-hardware` library suite when the advisory job is selected, and when the plugin flag is true installs `wasm32-wasip2` and runs the feature-enabled plugin component, library, runtime config, runtime admission, gateway, CLI, and root host tests. Baseline and appended invocations use `--no-fail-fast`, retain separate failure statuses, and report baseline, hardware, plugin-host, and total durations.
    - `security`: `cargo deny check`.
    - `CI Required Gate`: composite job; branch protection requires this.
 3. The advisory Windows job is outside `CI Required Gate`, uses restore-only cache behavior on PRs, and is visibly non-blocking. Direct changes to the root, gateway, or provider packages, plus changes to plugin, runtime, plugin config, WIT, root plugin activation, plugin backend filter, dependency, selector, selector-contract, or `ci.yml` paths, set `needs_plugin_host=true`; malformed or unavailable paths select baseline `full` and true. Missing or malformed Cargo metadata also selects baseline `full` with `needs_plugin_host=true` because the dependency closure cannot be established safely. The controlling-file cases make workflow revisions exercise the plugin-host path they own. Ordinary `scoped` and `full` selections do not install the plugin target or run the feature-enabled host tests. When the PR changes `platform-tests.yml`, that workflow checks formatting, then runs the same full workspace nextest selection on `macos-14` and `windows-latest` as non-blocking checks. The nightly schedule is the full-platform backstop, and maintainers can manually dispatch the workflow against other platform-sensitive branches. `--no-fail-fast` inventories all platform failures.
@@ -140,7 +140,7 @@ flowchart TD
   A --> W["windows-test-scope\nskip · scoped · full"]
   W --> WT["windows-test\nadvisory nextest"]
   B --> L["lint\nfmt · clippy"]
-  L --> T["test\ncargo nextest --workspace"]
+  L --> T["test\nworkspace + hardware feature"]
   P --> PF["fmt"]
   PF --> PT["macOS · Windows\nscheduled nextest"]
   L --> BLD["build\nLinux · macOS · Windows"]

--- a/scripts/ci/hardware_feature_test_lane.test.sh
+++ b/scripts/ci/hardware_feature_test_lane.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+python3 - "$repo_root/.github/workflows/ci.yml" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text()
+command = (
+    "cargo nextest run --locked --no-fail-fast "
+    "-p zeroclaw-hardware --features hardware --lib"
+)
+
+
+def job(name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(?P<body>.*?)(?=^  [a-z0-9][a-z0-9-]*:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"missing workflow job: {name}")
+    return match.group("body")
+
+
+linux = job("test")
+windows = job("windows-test")
+
+assert linux.count(command) == 1, "required Linux Test job must execute hardware lib tests"
+assert windows.count(command) == 1, "advisory Windows job must execute hardware lib tests"
+assert "hardware_status=${PIPESTATUS[0]}" in windows
+assert "if (( hardware_status != 0 ))" in windows
+assert 'failure_inventory="${failure_inventory:+$failure_inventory,}hardware"' in windows
+assert "| Hardware feature status | %s |" in windows
+
+for lane in (linux, windows):
+    assert "--run-ignored" not in lane
+    assert "--ignored" not in lane
+
+print("hardware feature test lanes preserve required Linux and advisory Windows coverage")
+PY


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Run `zeroclaw-hardware` library tests with the non-default `hardware` feature in the required Linux Test job.
  - Run the same feature-enabled suite in every selected advisory Windows test job, retain its independent status, and include failures in the job result and summary.
  - Add a CI contract test that prevents either lane from silently dropping the command or opting into ignored physical-device tests.
  - Document the required Linux and advisory Windows coverage in the delivery-flow source of truth.
- **Scope boundary:** This does not enable physical-device tests, change runtime hardware behavior, or make the existing Windows advisory job required.
- **Blast radius:** Pull-request and post-merge CI duration for the required Linux Test job; selected pull-request Windows jobs also compile and execute the hardware-feature library suite.
- **Linked issue(s):** Closes #10104
- **Labels:** `bug`, `ci`, `docs`, `scripts`, `domain:ci`, `follow-up`, `risk:high`, `size:XS`, `type:ci`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; the PR workflow change itself selects the full advisory Windows job, while the contract test verifies both commands and ignored-test boundary statically.

### How I tested

- **Current hosted evidence:** Required Linux Test and CI Required Gate passed on `e3e0ddf38f39da68577dc3e554b8376b8eb7bc55` in [run 34936062762](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34936062762). Advisory Windows remains in progress at this snapshot, not passed. The detailed results below describe the earlier named head and local runs, not new executions on this head.

- **CI checks relied on and why they cover this change:** Hosted CI for head `84e90aaf6a484b8cadee133f3cb9a8f01c5fa098` ran both lanes. The required Linux [Test job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34050905396/job/101536926650) and [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34050905396/job/101549083355) passed. The [Advisory Windows nextest (full, plugin-host=true) job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34050905396/job/101540352750) failed. Its baseline full-workspace run had the unrelated failure `publish_contract::published_crates_never_include_files_outside_their_own_directory`. Its hardware-feature run executed 166 tests: 164 passed, 2 failed, and 2 additional tests were skipped. The hardware failures were `peripherals::arduino_upload::tests::failed_preflight_does_not_compile_or_upload` and `peripherals::arduino_upload::tests::fake_cli_success_runs_all_stages_and_cleans_workspace`. These test fixtures and the publish-contract test are unchanged by this PR; the Windows lane remains advisory and reports the failures rather than hiding them. Local nextest covers the host-side feature inventory on macOS; the contract test checks both workflow commands and failure propagation.
- **Known CI coverage gap, if any:** The Windows-specific PowerShell fixtures were not executed locally on macOS. Hosted Windows execution provides platform evidence, but it is not a passing result: the unchanged preflight fixture compares LF with CRLF, and the success fixture cannot find the expected `upload -p ` log entry. The two ignored physical-device cases remain skipped; no physical-device testing is claimed. Required Linux success does not imply Windows success.
- **Commands run and tail output:**

```text
$ bash scripts/ci/hardware_feature_test_lane.test.sh  # before workflow change
AssertionError: required Linux Test job must execute hardware lib tests

$ bash scripts/ci/hardware_feature_test_lane.test.sh  # after workflow change
hardware feature test lanes preserve required Linux and advisory Windows coverage

$ cargo nextest run --locked --no-fail-fast -p zeroclaw-hardware --features hardware --lib
Summary [2.272s] 166 tests run: 166 passed, 2 skipped

$ cargo clippy -p zeroclaw-hardware --features hardware --lib --tests --locked -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 43.69s

$ cargo fmt --all -- --check
# passed

$ DOCS_FILES=.github/workflows/master-branch-flow.md scripts/ci/docs_quality_gate.sh
Summary: 0 error(s)

$ DOCS_FILES=.github/workflows/master-branch-flow.md scripts/ci/docs_links_gate.sh
Ran 6 tests: OK; no added links detected

$ ruby -e 'require "yaml"; data=YAML.load_file(".github/workflows/ci.yml"); abort unless data["jobs"].is_a?(Hash)'
workflow YAML parsed: 29 jobs
```

- **Beyond CI, what did you manually verify?** Static workflow and test-inventory inspection only: the feature-enabled inventory includes process timeout, cleanup, validation, USB/serial, and firmware-isolation tests while the two physical-device cases remain skipped. Linux retains the existing mold linker environment, and Windows records the hardware status, duration, failure inventory, and overall failure result. This is not a claim of human runtime or physical-device verification; the Windows-only fixtures were not executed locally.
- **Visual interface changed?** N/A; CI configuration and maintainer documentation only.
- **If any command was intentionally skipped, why:** The full workspace suite was not repeated because no Rust source or dependency changed; the feature-enabled package suite and workflow contract directly cover the omitted surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**
- If any `Yes`, describe the risk and mitigation: N/A. Ordinary CI continues to omit ignored physical-device tests and does not flash attached hardware.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's squash merge commit; the previous CI test selection is restored.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Increased Test or advisory Windows duration, failures isolated to the `Run hardware feature lib unit tests` command, or a `hardware` entry in the Windows failure inventory.
