### PR TITLE
test(plugins): escape fixture config paths

### DIFF
--- a/crates/zeroclaw-plugins/tests/reference_plugin_e2e.rs
+++ b/crates/zeroclaw-plugins/tests/reference_plugin_e2e.rs
@@ -53,6 +53,19 @@ type = "integer"
 type = "boolean"
 "#;
 
+fn toml_basic_string(value: &str) -> String {
+    toml::Value::String(value.to_owned()).to_string()
+}
+
+#[test]
+fn toml_basic_string_preserves_windows_path_separators() {
+    let plugins_dir = r"C:\Users\agent\plugins";
+    let config = format!("plugins_dir = {}", toml_basic_string(plugins_dir));
+    let parsed: toml::Value = toml::from_str(&config).expect("parse escaped plugin path");
+
+    assert_eq!(parsed["plugins_dir"].as_str(), Some(plugins_dir));
+}
+
 /// Build the in-tree tool fixture once per test binary and return its component.
 fn fixture() -> PathBuf {
     static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
@@ -141,6 +154,7 @@ fn seed_config_dir(dir: &std::path::Path) {
     )
     .unwrap();
     let instance_key = scope.id().config_entry_key().unwrap();
+    let plugins_dir_toml = toml_basic_string(&plugins_root.to_string_lossy());
 
     fs::write(
         dir.join("config.toml"),
@@ -149,14 +163,13 @@ fn seed_config_dir(dir: &std::path::Path) {
              [plugins]\n\
              enabled = true\n\
              auto_discover = true\n\
-             plugins_dir = \"{}\"\n\n\
+             plugins_dir = {plugins_dir_toml}\n\n\
              [[plugins.entries]]\n\
              name = \"{}\"\n\n\
              [plugins.entries.config]\n\
              label = \"masked\"\n\
              uppercase = \"true\"\n\
              max_len = \"5\"\n",
-            plugins_root.display(),
             instance_key
         ),
     )


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Serialize the fixture `plugins_dir` with TOML string serialization rather than interpolating a native path into a basic string.
  - Preserve Windows backslashes so config loading receives the original plugin directory.
  - Add a focused round-trip regression for a Windows-style path.
- **Scope boundary:** Only test-fixture config construction changes; runtime config parsing, plugin discovery, permissions, and workflow configuration are unchanged.
- **Blast radius:** Test-only plugin E2E fixture setup; this prevents a Windows CI false failure.
- **Linked issue(s):** Related #7462
- **Labels:** `experienced contributor`, `risk:low`, `size:XS`, `type:test`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — this is test-only serialization coverage; the normal plugin-host CI executes the E2E fixture.

### How I tested

- **CI checks relied on and why they cover this change:** [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34029888689/job/101480771013) passed on `2cd61e2c588dbfa594294cbc396a7451f74fb42b`. The [Windows plugin-host run](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34029888689/job/101477601285) passed the TOML round-trip regression, the full reference-plugin fixture E2E, and all 24 component tests. Its separate expired-deadline failure is outside this diff and addressed by #10658; its separate baseline invocation also failed with an invalid package argument. The advisory aggregate is not green.
- **Known CI coverage gap, if any:** The local full E2E cannot compile its WASM fixture because this checkout lacks `wasm32-wasip2`; the focused serializer regression executes locally without that target.
- **Commands run and tail output:**
  ```sh
  cargo fmt --all -- --check
  cargo clippy -p zeroclaw-plugins --features plugins-wasm-cranelift --test reference_plugin_e2e -- -D warnings
  cargo test -p zeroclaw-plugins --features plugins-wasm-cranelift --test reference_plugin_e2e toml_basic_string_preserves_windows_path_separators
  # 1 passed; 0 failed
  git diff --check
  ```
- **Beyond CI, what did you manually verify?** The regression parses generated TOML and asserts that `C:\\Users\\agent\\plugins` round-trips exactly.
- **Visual interface changed?** N/A — no user interface changes.
- **If any command was intentionally skipped, why:** None. The full E2E was attempted and stopped before fixture execution because `wasm32-wasip2` is unavailable locally.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

Low-risk test-only change. After merge, retrieve the landed squash commit and revert that commit rather than the source-branch commit:

```sh
gh pr view 10657 --repo zeroclaw-labs/zeroclaw --json mergeCommit --jq '.mergeCommit.oid'
git revert <landed-squash-commit>
```
