### PR TITLE
fix(plugins): reject expired dial budgets

### DIFF
--- a/crates/zeroclaw-plugins/src/wasi_http.rs
+++ b/crates/zeroclaw-plugins/src/wasi_http.rs
@@ -726,6 +726,12 @@ async fn dial_pinned(addresses: &[SocketAddr], deadline: Instant) -> Result<TcpS
     let mut attempted = false;
     for address in addresses {
         attempted = true;
+        // A ready loopback connect can win timeout_at's first poll even after
+        // its deadline has elapsed. Do not let that fast path fund another
+        // attempt from the shared budget.
+        if deadline <= Instant::now() {
+            return Err(ErrorCode::ConnectionTimeout);
+        }
         match timeout_at(deadline, TcpStream::connect(*address)).await {
             Ok(Ok(stream)) => return Ok(stream),
             // Refused or unreachable: try the next validated address.

--- a/crates/zeroclaw-plugins/tests/reference_plugin_e2e.rs
+++ b/crates/zeroclaw-plugins/tests/reference_plugin_e2e.rs
@@ -53,6 +53,19 @@ type = "integer"
 type = "boolean"
 "#;
 
+fn toml_basic_string(value: &str) -> String {
+    toml::Value::String(value.to_owned()).to_string()
+}
+
+#[test]
+fn toml_basic_string_preserves_windows_path_separators() {
+    let plugins_dir = r"C:\Users\agent\plugins";
+    let config = format!("plugins_dir = {}", toml_basic_string(plugins_dir));
+    let parsed: toml::Value = toml::from_str(&config).expect("parse escaped plugin path");
+
+    assert_eq!(parsed["plugins_dir"].as_str(), Some(plugins_dir));
+}
+
 /// Build the in-tree tool fixture once per test binary and return its component.
 fn fixture() -> PathBuf {
     static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
@@ -141,6 +154,7 @@ fn seed_config_dir(dir: &std::path::Path) {
     )
     .unwrap();
     let instance_key = scope.id().config_entry_key().unwrap();
+    let plugins_dir_toml = toml_basic_string(&plugins_root.to_string_lossy());
 
     fs::write(
         dir.join("config.toml"),
@@ -149,14 +163,13 @@ fn seed_config_dir(dir: &std::path::Path) {
              [plugins]\n\
              enabled = true\n\
              auto_discover = true\n\
-             plugins_dir = \"{}\"\n\n\
+             plugins_dir = {plugins_dir_toml}\n\n\
              [[plugins.entries]]\n\
              name = \"{}\"\n\n\
              [plugins.entries.config]\n\
              label = \"masked\"\n\
              uppercase = \"true\"\n\
              max_len = \"5\"\n",
-            plugins_root.display(),
             instance_key
         ),
     )


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - #10657 has landed, so its independently reviewed TOML fixture-path serialization fix is already present in the base.
  - Check the shared deadline before each pinned-address connection attempt.
  - Prevent an immediately ready loopback connection from winning `timeout_at` after the budget has already expired.
  - Keep the existing pinned-address failover and empty-address classification unchanged.
- **Scope boundary:** The branch history includes #10657's fixture commit, but that patch is already present in `master`. The effective merge diff is only the six-line WASI HTTP pre-dial deadline guard. Authorization, DNS resolution, TLS, configuration, and retry policy are unchanged.
- **Blast radius:** Plugin WASI HTTP egress reliably returns `ConnectionTimeout` once its documented shared connect budget is exhausted, including on Windows.
- **Linked issue(s):** Related #7462. Prerequisite #10657 has landed.
- **Labels:** `bug`, `experienced contributor`, `risk:medium`, `size:XS`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the affected behavior is covered by deterministic library regressions and the Windows plugin-host CI path.

### How I tested

- **CI checks relied on and why they cover this change:** [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34033639452/job/101491816957) passed on `d572fd029af76d029817379c7174e0ab20a8cf3c`. The [Windows plugin-host job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34033639452/job/101489025080) passed all 185 plugin library tests, including the expired-deadline regression, and all 24 component tests, including the fixture-path coverage inherited from #10657. The advisory job failed only because its separate baseline invocation used an invalid package argument; the affected test suites passed.
- **Known CI coverage gap, if any:** Local validation ran on macOS. The full component E2E requires `wasm32-wasip2`, which this checkout does not have; the Windows job installed that target and passed the component suite.
- **Commands run and tail output:**
  ```sh
  cargo fmt --all -- --check
  cargo clippy -p zeroclaw-plugins --features plugins-wasm-cranelift --lib -- -D warnings
  cargo test -p zeroclaw-plugins --features plugins-wasm-cranelift --lib
  # 185 passed; 0 failed
  cargo test -p zeroclaw-plugins --features plugins-wasm-cranelift --test reference_plugin_e2e toml_basic_string_preserves_windows_path_separators
  # 1 passed; 0 failed
  git diff --check jstar0/fix/7462-escape-plugin-fixture-path...HEAD
  ```
- **Beyond CI, what did you manually verify?** Reviewed the shared-budget path: the guard executes before every address attempt while the existing `timeout_at` still bounds each connect with that same deadline.
- **Visual interface changed?** N/A — no user interface changes.
- **If any command was intentionally skipped, why:** The full component E2E could not compile its WASM fixture locally without `wasm32-wasip2`; the hosted Windows job supplied that target and passed the component suite.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback

After merge, retrieve and revert the landed squash commit:

```sh
gh pr view 10658 --repo zeroclaw-labs/zeroclaw --json mergeCommit --jq '.mergeCommit.oid'
git revert <landed-squash-commit>
```
