### PR TITLE
fix(plugins): reject expired pinned dial attempts

### DIFF
--- a/crates/zeroclaw-plugins/src/wasi_http.rs
+++ b/crates/zeroclaw-plugins/src/wasi_http.rs
@@ -725,6 +725,9 @@ async fn send(
 async fn dial_pinned(addresses: &[SocketAddr], deadline: Instant) -> Result<TcpStream, ErrorCode> {
     let mut attempted = false;
     for address in addresses {
+        if Instant::now() >= deadline {
+            return Err(ErrorCode::ConnectionTimeout);
+        }
         attempted = true;
         match timeout_at(deadline, TcpStream::connect(*address)).await {
             Ok(Ok(stream)) => return Ok(stream),


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Reject an already-spent shared connection deadline before starting each pinned-address TCP attempt. Tokio polls an immediately-ready connection before its elapsed timer, which let a Windows loopback connection occasionally succeed after the budget had expired and made the advisory regression flaky across unrelated PRs.
- **Scope boundary:** This does not change the configured timeout, address authorization, DNS resolution, TLS or HTTP handshake deadlines, error types, or retry order.
- **Blast radius:** The plugin `wasi:http` host connection path only. Non-expired attempts and existing address failover retain their current behavior.
- **Linked issue(s):** Related #7462
- **Labels:** `bug`, `risk:medium`, `size:XS`

### What this does, simply

ZeroClaw resolves and checks the addresses a plugin may contact, then tries those approved addresses under one shared time budget. The timeout wrapper can still accept a connection that becomes ready immediately, even when that budget was already gone before the attempt began. This PR checks the budget before each attempt, so an expired request stops instead of opening another connection. It leaves the timeout length and every other connection stage unchanged.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the focused regression directly exercises the repaired internal boundary.

### How I tested

- **CI checks relied on and why they cover this change:** Fresh required CI and the Advisory Windows plugin test phase are pending on the published head. The Windows phase runs the affected `zeroclaw-plugins` test with the plugin host enabled and is the platform-specific confirmation for the original failure.
- **Known CI coverage gap, if any:** Hosted Windows evidence is pending until CI runs on this head.
- **Commands run and tail output:**

```text
$ cargo test --locked -p zeroclaw-plugins --features plugins-wasm-cranelift wasi_http::tests::an_expired_deadline_stops_the_dial_before_it_tries_an_address -- --exact
running 1 test
test wasi_http::tests::an_expired_deadline_stops_the_dial_before_it_tries_an_address ... ok
test result: ok. 1 passed; 0 failed; 184 filtered out

$ cargo fmt --all -- --check
(clean; no output)

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.
```

- **Beyond CI, what did you manually verify?** Source and control-flow inspection confirmed that empty address sets still return the existing DNS failure, non-expired refused addresses still advance in order, and expiry returns the existing `ConnectionTimeout`. I did not reproduce the original race on a local Windows host; hosted Windows CI remains the platform proof.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Broader local suites were skipped because this is a three-line single-owner repair with one exact regression; fresh required CI supplies aggregate coverage.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — this prevents a connection attempt after its budget is already spent.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 4de346e50cc9db2dbfa8e8b25d6039f0d39e5f14`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `an_expired_deadline_stops_the_dial_before_it_tries_an_address` intermittently fails on Windows with `a spent budget must not fund another attempt`, or an already-expired plugin connection unexpectedly reaches a listening address.
