### PR TITLE
fix(gateway): sanitize public health errors

### DIFF
--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -2192,13 +2192,39 @@ fn paircode_recovery_curl_host(host: &str) -> &str {
 // AXUM HANDLERS
 // ══════════════════════════════════════════════════════════════════════════════
 
+fn public_health_snapshot() -> serde_json::Value {
+    let snapshot = zeroclaw_runtime::health::snapshot();
+    let components = snapshot
+        .components
+        .into_iter()
+        .map(|(name, component)| {
+            (
+                name,
+                serde_json::json!({
+                    "status": component.status,
+                    "updated_at": component.updated_at,
+                    "last_ok": component.last_ok,
+                    "restart_count": component.restart_count,
+                }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+
+    serde_json::json!({
+        "pid": snapshot.pid,
+        "updated_at": snapshot.updated_at,
+        "uptime_seconds": snapshot.uptime_seconds,
+        "components": components,
+    })
+}
+
 /// GET /health — always public (no secrets leaked)
 async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
     let body = serde_json::json!({
         "status": "ok",
         "paired": state.pairing.is_paired(),
         "require_pairing": state.pairing.require_pairing(),
-        "runtime": zeroclaw_runtime::health::snapshot_json(),
+        "runtime": public_health_snapshot(),
     });
     Json(body)
 }
@@ -4309,6 +4335,37 @@ mod tests {
         assert_eq!(
             format_paircode_recovery_curl("127.0.0.1", 42617, "/gw"),
             "curl -s -X POST http://127.0.0.1:42617/gw/admin/paircode/new"
+        );
+    }
+
+    #[tokio::test]
+    async fn public_health_omits_component_error_details() {
+        let component = format!("health-public-{}", uuid::Uuid::new_v4());
+        let sensitive_error = "provider failed: token=not-for-public-health";
+        zeroclaw_runtime::health::mark_component_ok(&component);
+        zeroclaw_runtime::health::mark_component_error(&component, sensitive_error);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let response = handle_health(State(admin_paircode_state(&tmp, false, false)))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let public_component = &json["runtime"]["components"][&component];
+
+        assert_eq!(public_component["status"], "error");
+        assert!(public_component["updated_at"].is_string());
+        assert!(public_component["last_ok"].is_string());
+        assert_eq!(public_component["restart_count"], 0);
+        assert!(public_component.get("last_error").is_none());
+        assert!(!json.to_string().contains(sensitive_error));
+        assert_eq!(
+            zeroclaw_runtime::health::snapshot().components[&component]
+                .last_error
+                .as_deref(),
+            Some(sensitive_error)
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `GET /health` now builds an explicit public projection of runtime health instead of serializing the shared diagnostic snapshot.
  - Component status, timestamps, successful-check time, and restart count remain available for liveness checks; producer-supplied `last_error` text is omitted.
  - Authenticated `/api/status` and `/api/health` continue to use the complete shared diagnostic snapshot.
  - The operator guide now documents the public liveness fields and directs detailed-error consumers to authenticated diagnostics.
- **Scope boundary:** This does not change component health collection, supervisor error capture, retry behavior, pairing, or authenticated API access.
- **Blast radius:** Unauthenticated `GET /health` is the only changed response. Existing consumers that use liveness fields keep their fields; consumers that read `last_error` must use an authenticated diagnostic route.
- **Linked issue(s):** Fixes #10606
- **Labels:** `bug`, `docs`, `gateway`, `domain:security`, `risk:high`, `size:XS`.

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The focused gateway-handler regression injects a component error and reads the exact unauthenticated response without external setup.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passes on `51d8939110c1634336786cd49783d281f7f20666`, including Test, Lint, and Docs Style: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34934436539. These cover the gateway regression and documentation. Advisory Windows remains in progress at this readiness snapshot; no passing result is claimed for it.
- **Known CI coverage gap, if any:** No external service or visual interface is involved.
- **Commands run and tail output:** Historical contributor results from the original implementation, not a new run on the current head:

  ```sh
  cargo fmt --all -- --check
  cargo clippy -p zeroclaw-gateway --all-targets -- -D warnings
  cargo test -p zeroclaw-gateway
  # 477 library tests passed; 9 integration tests passed
  ```

- **Beyond CI, what I verified:** Before the projection, the injected `provider failed: token=not-for-public-health` value appeared in `/health`; the same route-level regression now confirms the public response omits it while retaining `status`, `updated_at`, `last_ok`, and `restart_count`. The shared runtime snapshot still retains the full error for authenticated diagnostics.
- **Visual interface changed?** N/A; this changes a JSON response contract, not presentation. Tested revision and evidence: current-head hosted CI linked above; no screenshot or live-server test is claimed.
- **If any command was intentionally skipped, why:** No relevant package-scoped check was skipped.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? Yes. Arbitrary component error text is no longer exposed by the unauthenticated health response; internal and authenticated diagnostics retain it.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: The public projection uses an explicit allowlist of liveness fields, so future diagnostic fields are not exposed by default.

## Compatibility

- Backward compatible? Liveness fields are preserved, but the formerly documented unauthenticated `last_error` field is removed to prevent disclosure. Consumers of that field must use authenticated diagnostics.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback

- **Fast rollback command/path:** Revert the merge commit to restore the previous public health payload.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** An unauthenticated health client that depends on `runtime.components.*.last_error` no longer receives that field; liveness status, timestamps, and restart count remain present.
