### PR TITLE
feat(providers): place a third cache breakpoint on the previous turn's last message

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -911,6 +911,23 @@ pub struct ModelProviderConfig {
     #[tab(Advanced)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replay_assistant_reasoning: Option<bool>,
+    /// Forward Anthropic prompt caching through this OpenAI-compatible
+    /// provider. When true, request bodies gain an Anthropic-shaped
+    /// `cache_control` breakpoint on the system prompt and on the last
+    /// message once the conversation has more than one non-system message,
+    /// mirroring the native Anthropic provider's placement strategy, and
+    /// gateway-reported cache usage populates the cached-token counters.
+    /// Only gateways that translate between OpenAI Chat Completions and the
+    /// Anthropic Messages API forward these breakpoints (e.g. LiteLLM).
+    /// Default `false`: request bodies and response handling are unchanged.
+    ///
+    /// Before relying on it, verify the configured route serves cache reads:
+    /// an immediate repeat of a cache-creating request must report
+    /// `cache_read_input_tokens > 0`. Some gateway routes accept and bill
+    /// cache writes without ever serving reads.
+    #[tab(Advanced)]
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub cache_passthrough: bool,
     /// Pull live token prices for this provider's models from its own
     /// OpenAI-compatible `/models` listing (the gateway is the source of truth
     /// for its prices), filling cost-tracking rates for models the operator
@@ -25148,6 +25165,18 @@ impl HasPropKind for serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+
+    #[::core::prelude::v1::test]
+    fn cache_passthrough_deserializes_and_defaults_to_omitted() {
+        let enabled: ModelProviderConfig = toml::from_str("cache_passthrough = true").unwrap();
+        assert!(enabled.cache_passthrough);
+
+        let serialized = toml::to_string(&ModelProviderConfig::default()).unwrap();
+        assert!(
+            !serialized.contains("cache_passthrough"),
+            "default cache_passthrough must be omitted from serialized config"
+        );
+    }
 
     // ── Nextcloud Talk: one normalized bot secret for both directions ──
     //

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -912,11 +912,17 @@ pub struct ModelProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replay_assistant_reasoning: Option<bool>,
     /// Forward Anthropic prompt caching through this OpenAI-compatible
-    /// provider. When true, request bodies gain an Anthropic-shaped
+    /// provider. When true, request bodies on the structured paths (agent
+    /// turns, tool calls, structured streaming) gain an Anthropic-shaped
     /// `cache_control` breakpoint on the system prompt and on the last
     /// message once the conversation has more than one non-system message,
     /// mirroring the native Anthropic provider's placement strategy, and
     /// gateway-reported cache usage populates the cached-token counters.
+    /// With `merge_system_into_user`, the merged first user message carries
+    /// the system breakpoint instead. The text-only helpers (`chat_with_system`,
+    /// `chat_with_history`, the legacy chunk-stream APIs) deliberately emit
+    /// no breakpoints: their responses drop usage, so a premium cache write
+    /// they triggered could never be accounted for.
     /// Only gateways that translate between OpenAI Chat Completions and the
     /// Anthropic Messages API forward these breakpoints (e.g. LiteLLM).
     /// Default `false`: request bodies and response handling are unchanged.

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -432,13 +432,13 @@ struct NativeToolSpec {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct CacheControl {
+pub(crate) struct CacheControl {
     #[serde(rename = "type")]
     cache_type: String,
 }
 
 impl CacheControl {
-    fn ephemeral() -> Self {
+    pub(crate) fn ephemeral() -> Self {
         Self {
             cache_type: "ephemeral".to_string(),
         }

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -2550,6 +2550,9 @@ impl ModelProvider for AnthropicModelProvider {
         // Auto-cache last message if conversation is long
         if Self::should_cache_conversation(request.messages) {
             Self::apply_cache_to_last_message(&mut messages);
+            if let Some(index) = Self::prior_turn_breakpoint_index(&messages) {
+                Self::apply_cache_to_message_at(&mut messages, index);
+            }
         }
 
         // Check for tool_choice override from the agent loop (e.g. "any"
@@ -2752,6 +2755,9 @@ impl ModelProvider for AnthropicModelProvider {
         let (system_prompt, mut messages) = Self::convert_messages(request.messages);
         if Self::should_cache_conversation(request.messages) {
             Self::apply_cache_to_last_message(&mut messages);
+            if let Some(index) = Self::prior_turn_breakpoint_index(&messages) {
+                Self::apply_cache_to_message_at(&mut messages, index);
+            }
         }
 
         let tool_choice_override = zeroclaw_api::TOOL_CHOICE_OVERRIDE

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -4417,6 +4417,295 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert!(messages.is_empty());
     }
 
+    /// Native text message with one unmarked text block.
+    fn native_text_message(role: &str, text: &str) -> NativeMessage {
+        NativeMessage {
+            role: role.to_string(),
+            content: vec![NativeContentOut::Text {
+                text: text.to_string(),
+                cache_control: None,
+            }],
+        }
+    }
+
+    /// Native assistant message whose trailing block is a tool call, the
+    /// shape `parse_assistant_tool_call_message` always produces (text
+    /// precedes the calls).
+    fn native_tool_call_carrier() -> NativeMessage {
+        NativeMessage {
+            role: "assistant".to_string(),
+            content: vec![NativeContentOut::ToolUse {
+                id: "toolu_1".to_string(),
+                name: "get_weather".to_string(),
+                input: serde_json::json!({}),
+                cache_control: None,
+            }],
+        }
+    }
+
+    /// Native user message carrying one tool result, the wire shape of
+    /// `tool_result_message`.
+    fn native_tool_result_carrier() -> NativeMessage {
+        NativeMessage {
+            role: "user".to_string(),
+            content: vec![NativeContentOut::ToolResult {
+                tool_use_id: "toolu_1".to_string(),
+                content: ToolResultContent::Text("result".to_string()),
+                cache_control: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_index_lands_on_previous_assistant_text() {
+        let messages = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+            native_text_message("user", "q2"),
+        ];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&messages),
+            Some(1),
+            "the message before the last user message is the previous turn's last message"
+        );
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_index_is_none_without_a_previous_turn() {
+        let single_exchange = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+        ];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&single_exchange),
+            None,
+            "the only user message opens the turn, so nothing sits before it"
+        );
+        let single_message = vec![native_text_message("user", "q1")];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&single_message),
+            None
+        );
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&[]),
+            None,
+            "empty history has no placement"
+        );
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_index_lands_on_tool_result() {
+        // The previous turn was cut short after its tool result.
+        let messages = vec![
+            native_text_message("user", "q1"),
+            native_tool_call_carrier(),
+            native_tool_result_carrier(),
+            native_text_message("user", "q2"),
+        ];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&messages),
+            Some(2),
+            "a trailing tool_result block is cacheable, the same gate the rolling marker uses"
+        );
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_index_walks_back_over_tool_call_carrier() {
+        // Mid-loop: the last user-role message is the tool-result carrier, so
+        // the first candidate is the tool-call carrier; the rule steps back
+        // onto the turn's opening user message.
+        let messages = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+            native_text_message("user", "q2"),
+            native_tool_call_carrier(),
+            native_tool_result_carrier(),
+        ];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&messages),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_index_gives_up_after_two_walk_back_steps() {
+        let messages = vec![
+            native_text_message("user", "q1"),
+            native_tool_call_carrier(),
+            native_tool_call_carrier(),
+            native_tool_call_carrier(),
+            native_text_message("user", "q2"),
+        ];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&messages),
+            None,
+            "candidates three, two, and one are all carriers; the search stops after two \
+             walk-back steps instead of landing further back"
+        );
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_index_skips_trailing_image() {
+        let image_only = NativeMessage {
+            role: "assistant".to_string(),
+            content: vec![NativeContentOut::Image {
+                source: ImageSource {
+                    source_type: "base64".to_string(),
+                    media_type: "image/png".to_string(),
+                    data: "aGVsbG8=".to_string(),
+                },
+            }],
+        };
+        let messages = vec![
+            native_text_message("user", "q1"),
+            image_only,
+            native_text_message("user", "q2"),
+        ];
+        assert_eq!(
+            AnthropicModelProvider::prior_turn_breakpoint_index(&messages),
+            None,
+            "a message ending on an image block is breakpoint-transparent; walking back \
+             reaches index zero, which is out of bounds"
+        );
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_within_budget_places_marker_for_plain_keys() {
+        let system = Some(SystemPrompt::Blocks(vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: "be brief".to_string(),
+            cache_control: Some(CacheControl::ephemeral()),
+        }]));
+        let mut messages = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+            native_text_message("user", "q2"),
+        ];
+        AnthropicModelProvider::apply_prior_turn_breakpoint_within_budget(
+            system.as_ref(),
+            false,
+            true,
+            &mut messages,
+        );
+        assert!(matches!(
+            &messages[1].content[0],
+            NativeContentOut::Text {
+                cache_control: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_within_budget_skips_oauth_tool_requests() {
+        // OAuth prefix (1) + system text (1) + last tool definition (1) +
+        // rolling marker (1) = 4: the cap is already spent, so the marker
+        // must be skipped rather than 400 the request.
+        let system = Some(SystemPrompt::Blocks(vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: "be brief".to_string(),
+            cache_control: Some(CacheControl::ephemeral()),
+        }]));
+        let mut messages = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+            native_text_message("user", "q2"),
+        ];
+        AnthropicModelProvider::apply_prior_turn_breakpoint_within_budget(
+            system.as_ref(),
+            true,
+            true,
+            &mut messages,
+        );
+        assert!(matches!(
+            &messages[1].content[0],
+            NativeContentOut::Text {
+                cache_control: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_within_budget_allows_oauth_without_tools() {
+        // OAuth prefix (1) + system text (1) + rolling marker (1) = 3: one
+        // slot left, so the marker lands.
+        let system = Some(SystemPrompt::Blocks(vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: "be brief".to_string(),
+            cache_control: Some(CacheControl::ephemeral()),
+        }]));
+        let mut messages = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+            native_text_message("user", "q2"),
+        ];
+        AnthropicModelProvider::apply_prior_turn_breakpoint_within_budget(
+            system.as_ref(),
+            true,
+            false,
+            &mut messages,
+        );
+        assert!(matches!(
+            &messages[1].content[0],
+            NativeContentOut::Text {
+                cache_control: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn prior_turn_breakpoint_within_budget_counts_only_landed_rolling_marker() {
+        // The last message ends on a tool call, so the rolling marker never
+        // landed: OAuth prefix (1) + system text (1) + tools (1) = 3, one
+        // slot free, and the prior-turn rule still finds a candidate.
+        let system = Some(SystemPrompt::Blocks(vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: "be brief".to_string(),
+            cache_control: Some(CacheControl::ephemeral()),
+        }]));
+        let mut messages = vec![
+            native_text_message("user", "q1"),
+            native_text_message("assistant", "a1"),
+            native_text_message("user", "q2"),
+            native_tool_call_carrier(),
+        ];
+        AnthropicModelProvider::apply_prior_turn_breakpoint_within_budget(
+            system.as_ref(),
+            true,
+            true,
+            &mut messages,
+        );
+        assert!(matches!(
+            &messages[1].content[0],
+            NativeContentOut::Text {
+                cache_control: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn marked_system_block_count_reads_block_markers() {
+        assert_eq!(AnthropicModelProvider::marked_system_block_count(None), 0);
+        assert_eq!(
+            AnthropicModelProvider::marked_system_block_count(Some(&SystemPrompt::String(
+                "be brief".to_string()
+            ))),
+            0
+        );
+        let marked = Some(SystemPrompt::Blocks(vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: "be brief".to_string(),
+            cache_control: Some(CacheControl::ephemeral()),
+        }]));
+        assert_eq!(
+            AnthropicModelProvider::marked_system_block_count(marked.as_ref()),
+            1
+        );
+    }
+
     /// Provider instance for `convert_tools` tests — conversion is a `&self`
     /// method so each schema is cleaned once through the provider's memo.
     fn make_convert_provider() -> AnthropicModelProvider {
@@ -4837,6 +5126,128 @@ data: {\"type\":\"message_stop\"}\n\n";
         assert!(
             api_tools[0]["input_schema"].is_object(),
             "Missing input_schema"
+        );
+
+        server_handle.abort();
+    }
+
+    /// OAuth setup token, tools, and multi-turn history: the request already
+    /// spends all four breakpoint slots (identity prefix, system text, last
+    /// tool definition, rolling marker), so the prior-turn marker must be
+    /// skipped rather than exceed the API's four-block cap and 400 every
+    /// request.
+    #[tokio::test]
+    async fn oauth_tool_request_stays_inside_four_breakpoint_cap() {
+        use axum::{Json, Router, routing::post};
+        use std::sync::{Arc, Mutex};
+        use tokio::net::TcpListener;
+
+        let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let captured_clone = captured.clone();
+
+        let app = Router::new().route(
+            "/v1/messages",
+            post(move |Json(body): Json<serde_json::Value>| {
+                let cap = captured_clone.clone();
+                async move {
+                    *cap.lock().unwrap() = Some(body);
+                    Json(serde_json::json!({
+                        "id": "msg_test",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "ok"}],
+                        "model": "claude-opus-4-6",
+                        "stop_reason": "end_turn",
+                        "usage": {"input_tokens": 100, "output_tokens": 20}
+                    }))
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_handle = zeroclaw_spawn::spawn!(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let model_provider = AnthropicModelProvider {
+            alias: "test".to_string(),
+            // Setup-token shape: routes through the OAuth system prefix.
+            credential: Some("sk-ant-oat01-test".to_string()),
+            base_url: format!("http://{addr}"),
+            max_tokens: 4096,
+            timeout_secs: 120,
+            schema_cache: zeroclaw_api::schema::SchemaCleanCache::new(),
+        };
+
+        let messages = vec![
+            ChatMessage::system("You are a helpful assistant."),
+            ChatMessage::user("gen a 2 sum in golang"),
+            ChatMessage::assistant("here is the code"),
+            ChatMessage::user("what's meaning of make here?"),
+        ];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Run a shell command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"}
+                    },
+                    "required": ["command"]
+                }
+            }
+        })];
+
+        let result = model_provider
+            .chat_with_tools(&messages, &tools, "claude-opus-4-6", None)
+            .await;
+        assert!(result.is_ok(), "chat_with_tools failed: {:?}", result.err());
+
+        let body = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("no request captured");
+
+        // Total markers: OAuth prefix + system text + last tool + rolling.
+        // The prior-turn slot is the one the budget skips.
+        assert_eq!(
+            body.to_string().matches("cache_control").count(),
+            4,
+            "OAuth tool request must carry exactly the four committed breakpoints: {body}"
+        );
+
+        // The system field carries both the identity prefix and the system
+        // text markers.
+        let system_blocks = body["system"].as_array().expect("system blocks");
+        assert_eq!(system_blocks.len(), 2, "OAuth prefix must be present");
+        assert!(
+            system_blocks[0]["text"]
+                .as_str()
+                .unwrap()
+                .starts_with("You are Claude Code"),
+            "identity prefix must stay first"
+        );
+        assert_eq!(
+            system_blocks[0]["cache_control"]["type"], "ephemeral",
+            "prefix block keeps its marker"
+        );
+        assert_eq!(
+            system_blocks[1]["cache_control"]["type"], "ephemeral",
+            "system text block keeps its marker"
+        );
+
+        // The middle assistant message (the previous turn's last message)
+        // carries no marker: the budget skipped the prior-turn placement.
+        let wire_messages = body["messages"].as_array().unwrap();
+        let assistant_message = &wire_messages[1];
+        assert_eq!(assistant_message["role"], "assistant");
+        assert!(
+            !assistant_message.to_string().contains("cache_control"),
+            "prior-turn marker must be skipped on the OAuth tool path: {assistant_message}"
         );
 
         server_handle.abort();

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -712,6 +712,52 @@ impl AnthropicModelProvider {
         None
     }
 
+    /// Place the prior-turn breakpoint when the request's marker budget
+    /// allows it.
+    ///
+    /// Anthropic caps a request at four `cache_control` blocks counting
+    /// tools, system, and messages together. OAuth requests spend two system
+    /// slots (the identity prefix and the system text) and tool-bearing
+    /// requests spend one on the last tool definition, so the prior-turn
+    /// marker is placed only when those committed markers plus the rolling
+    /// marker leave a free slot. Placing past the cap would 400 every
+    /// request in that configuration, so the marker is skipped there instead;
+    /// the rolling breakpoint still covers the newest history.
+    fn apply_prior_turn_breakpoint_within_budget(
+        system: Option<&SystemPrompt>,
+        is_oauth: bool,
+        has_tools: bool,
+        messages: &mut [NativeMessage],
+    ) {
+        let committed_markers = Self::marked_system_block_count(system)
+            + usize::from(is_oauth)
+            + usize::from(has_tools)
+            + usize::from(
+                messages
+                    .last()
+                    .is_some_and(Self::has_cacheable_trailing_block),
+            );
+        if committed_markers >= 4 {
+            return;
+        }
+        if let Some(index) = Self::prior_turn_breakpoint_index(messages) {
+            Self::apply_cache_to_message_at(messages, index);
+        }
+    }
+
+    /// Number of system blocks that already carry a marker. The converted
+    /// system prompt is a single marked block today, so this is 0 or 1; the
+    /// count reads the blocks rather than assuming that shape.
+    fn marked_system_block_count(system: Option<&SystemPrompt>) -> usize {
+        match system {
+            Some(SystemPrompt::Blocks(blocks)) => blocks
+                .iter()
+                .filter(|block| block.cache_control.is_some())
+                .count(),
+            _ => 0,
+        }
+    }
+
     fn convert_tools(&self, tools: Option<&[ToolSpec]>) -> Option<Vec<NativeToolSpec>> {
         let items = tools?;
         if items.is_empty() {
@@ -2550,9 +2596,12 @@ impl ModelProvider for AnthropicModelProvider {
         // Auto-cache last message if conversation is long
         if Self::should_cache_conversation(request.messages) {
             Self::apply_cache_to_last_message(&mut messages);
-            if let Some(index) = Self::prior_turn_breakpoint_index(&messages) {
-                Self::apply_cache_to_message_at(&mut messages, index);
-            }
+            Self::apply_prior_turn_breakpoint_within_budget(
+                system_prompt.as_ref(),
+                Self::is_setup_token(credential),
+                request.tools.is_some_and(|tools| !tools.is_empty()),
+                &mut messages,
+            );
         }
 
         // Check for tool_choice override from the agent loop (e.g. "any"
@@ -2755,9 +2804,12 @@ impl ModelProvider for AnthropicModelProvider {
         let (system_prompt, mut messages) = Self::convert_messages(request.messages);
         if Self::should_cache_conversation(request.messages) {
             Self::apply_cache_to_last_message(&mut messages);
-            if let Some(index) = Self::prior_turn_breakpoint_index(&messages) {
-                Self::apply_cache_to_message_at(&mut messages, index);
-            }
+            Self::apply_prior_turn_breakpoint_within_budget(
+                system_prompt.as_ref(),
+                Self::is_setup_token(&credential),
+                request.tools.is_some_and(|tools| !tools.is_empty()),
+                &mut messages,
+            );
         }
 
         let tool_choice_override = zeroclaw_api::TOOL_CHOICE_OVERRIDE

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -643,8 +643,18 @@ impl AnthropicModelProvider {
 
     /// Apply cache control to the last message content block
     fn apply_cache_to_last_message(messages: &mut [NativeMessage]) {
-        if let Some(last_msg) = messages.last_mut()
-            && let Some(last_content) = last_msg.content.last_mut()
+        if let Some(index) = messages.len().checked_sub(1) {
+            Self::apply_cache_to_message_at(messages, index);
+        }
+    }
+
+    /// Apply the conversation cache breakpoint to the final cacheable block
+    /// of `messages[index]`, with the same block-type gate
+    /// `apply_cache_to_last_message` applies to the final message.
+    fn apply_cache_to_message_at(messages: &mut [NativeMessage], index: usize) {
+        if let Some(last_content) = messages
+            .get_mut(index)
+            .and_then(|message| message.content.last_mut())
         {
             match last_content {
                 NativeContentOut::Text { cache_control, .. }
@@ -656,6 +666,50 @@ impl AnthropicModelProvider {
                 | NativeContentOut::Thinking { .. } => {}
             }
         }
+    }
+
+    /// Whether a breakpoint would land on this message: the trailing block
+    /// must be text or a tool result, the same gate `apply_cache_to_last_message`
+    /// applies to the final message. Assistant tool-call carriers always end
+    /// on a `tool_use` block (text precedes the calls in the converted
+    /// block order), so they are never cacheable.
+    fn has_cacheable_trailing_block(message: &NativeMessage) -> bool {
+        matches!(
+            message.content.last(),
+            Some(NativeContentOut::Text { .. } | NativeContentOut::ToolResult { .. })
+        )
+    }
+
+    /// Index of the prior turn's final message for the third cache
+    /// breakpoint, or `None` when no valid placement exists.
+    ///
+    /// The last user message starts the current turn, so the message before
+    /// it is the previous turn's last message (usually the assistant's final
+    /// text), and every request within the current turn shares the wire
+    /// prefix through that index byte-for-byte. A candidate with no markable
+    /// trailing block is rejected, walking back at most two steps
+    /// (tool-call carriers and image-only messages are breakpoint-transparent)
+    /// before giving up, because a marker placed further back would not
+    /// survive the turn and prefix stability is worth more than the extra
+    /// cache hit. The candidate can never be the final message: it starts at
+    /// least one index before the last user message and only moves backwards,
+    /// so it never collides with the rolling marker. The system prompt is a
+    /// separate request field here, never a list element, so the shared
+    /// rule's system/carrier clause is vacuous on this side.
+    ///
+    /// Twin of `prior_turn_breakpoint_index` in `compatible.rs`; duplicated
+    /// because a shared trait would drag the two providers' wire message
+    /// types across module boundaries.
+    fn prior_turn_breakpoint_index(messages: &[NativeMessage]) -> Option<usize> {
+        let last_user = messages.iter().rposition(|m| m.role == "user")?;
+        let mut candidate = last_user.checked_sub(1)?;
+        for _ in 0..3 {
+            if candidate > 0 && Self::has_cacheable_trailing_block(&messages[candidate]) {
+                return Some(candidate);
+            }
+            candidate = candidate.checked_sub(1)?;
+        }
+        None
     }
 
     fn convert_tools(&self, tools: Option<&[ToolSpec]>) -> Option<Vec<NativeToolSpec>> {

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1304,6 +1304,18 @@ struct UsageInfo {
     prompt_tokens_details: Option<PromptTokensDetails>,
     #[serde(default, deserialize_with = "deserialize_optional_token_count")]
     prompt_cache_hit_tokens: Option<u64>,
+    /// Anthropic-shaped cache counters, forwarded by translating gateways
+    /// on Anthropic-backed routes. `cache_read_input_tokens` is the
+    /// authoritative cached-read count (it comes from the upstream API
+    /// itself), so it takes precedence over the gateway-accounted OpenAI
+    /// and DeepSeek shapes.
+    #[serde(default, deserialize_with = "deserialize_optional_token_count")]
+    cache_read_input_tokens: Option<u64>,
+    /// Anthropic-shaped cache-write counter. Not part of `TokenUsage`
+    /// (cached reads are the billing-relevant figure there); logged so
+    /// write-premium spend is visible in logs.
+    #[serde(default, deserialize_with = "deserialize_optional_token_count")]
+    cache_creation_input_tokens: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -1313,15 +1325,33 @@ struct PromptTokensDetails {
 }
 
 impl UsageInfo {
+    /// Cached-read tokens across the three coexisting provider shapes.
+    /// Precedence: Anthropic `cache_read_input_tokens` (upstream-reported
+    /// on translated routes) over DeepSeek `prompt_cache_hit_tokens` over
+    /// OpenAI `prompt_tokens_details.cached_tokens` (gateway-accounted).
     fn cached_input_tokens(&self) -> Option<u64> {
-        self.prompt_cache_hit_tokens.or_else(|| {
-            self.prompt_tokens_details
-                .as_ref()
-                .and_then(|details| details.cached_tokens)
-        })
+        self.cache_read_input_tokens
+            .or(self.prompt_cache_hit_tokens)
+            .or_else(|| {
+                self.prompt_tokens_details
+                    .as_ref()
+                    .and_then(|details| details.cached_tokens)
+            })
     }
 
     fn into_provider_usage(self) -> zeroclaw_api::model_provider::TokenUsage {
+        if let Some(creation) = self.cache_creation_input_tokens.filter(|count| *count > 0) {
+            ::zeroclaw_log::record!(
+                DEBUG,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Success)
+                    .with_attrs(::serde_json::json!({
+                        "cache_creation_input_tokens": creation,
+                        "cache_read_input_tokens": self.cache_read_input_tokens,
+                    })),
+                "gateway-reported Anthropic cache write (billed at the write premium)"
+            );
+        }
         let cached_input_tokens = self.cached_input_tokens();
         zeroclaw_api::model_provider::TokenUsage {
             input_tokens: self.prompt_tokens,
@@ -8678,6 +8708,169 @@ mod tests {
         assert_eq!(usage.input_tokens, Some(13313));
         assert_eq!(usage.output_tokens, Some(175));
         assert_eq!(usage.cached_input_tokens, Some(384));
+    }
+
+    #[test]
+    fn api_response_parses_anthropic_cache_read_tokens() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 4863,
+                "completion_tokens": 0,
+                "cache_read_input_tokens": 4802,
+                "cache_creation_input_tokens": 0
+            }
+        }"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.unwrap().into_provider_usage();
+        assert_eq!(usage.input_tokens, Some(4863));
+        assert_eq!(usage.cached_input_tokens, Some(4802));
+    }
+
+    /// All three cached-token shapes on one response: the Anthropic fields
+    /// are upstream-reported and win over the gateway-accounted DeepSeek
+    /// and OpenAI shapes, which keep their existing relative order.
+    #[test]
+    fn api_response_prefers_anthropic_cache_read_across_all_shapes() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 4863,
+                "completion_tokens": 0,
+                "cache_read_input_tokens": 4802,
+                "prompt_cache_hit_tokens": 100,
+                "prompt_tokens_details": {"cached_tokens": 80}
+            }
+        }"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.unwrap().into_provider_usage();
+        assert_eq!(usage.cached_input_tokens, Some(4802));
+    }
+
+    /// An upstream-reported zero is authoritative, not missing data: when
+    /// the Anthropic shape says zero reads, the gateway-accounted OpenAI
+    /// figure must NOT be substituted (that would double-count gateway-side
+    /// accounting against the upstream's authoritative answer).
+    #[test]
+    fn api_response_anthropic_zero_read_blocks_openai_fallback() {
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 4863,
+                "completion_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "prompt_tokens_details": {"cached_tokens": 80}
+            }
+        }"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.unwrap().into_provider_usage();
+        assert_eq!(usage.cached_input_tokens, Some(0));
+    }
+
+    #[test]
+    fn stream_chunk_parses_anthropic_cache_read_tokens() {
+        let json = r#"{
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 99,
+                "completion_tokens": 11,
+                "cache_read_input_tokens": 42,
+                "cache_creation_input_tokens": 0
+            }
+        }"#;
+        let chunk: StreamChunkResponse = serde_json::from_str(json).unwrap();
+        let usage = chunk.usage.unwrap().into_provider_usage();
+        assert_eq!(usage.input_tokens, Some(99));
+        assert_eq!(usage.output_tokens, Some(11));
+        assert_eq!(usage.cached_input_tokens, Some(42));
+    }
+
+    /// Cache-write tokens are logged for write-premium visibility. The log
+    /// must carry the counts, not the prompt content.
+    #[test]
+    fn cache_creation_tokens_are_logged_with_counts_only() {
+        let _writer_guard = zeroclaw_log::__private_test_writer_lock();
+        let _hook_guard = zeroclaw_log::__private_test_hook_lock();
+        zeroclaw_log::try_install_capture_subscriber();
+        let mut rx = zeroclaw_log::subscribe_or_install();
+        while rx.try_recv().is_ok() {}
+
+        let json = r#"{
+            "choices": [{"message": {"content": "Hello"}}],
+            "usage": {
+                "prompt_tokens": 4863,
+                "completion_tokens": 0,
+                "cache_creation_input_tokens": 4803
+            }
+        }"#;
+        let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage.unwrap().into_provider_usage();
+        // Write-only response: upstream reported no cache read, so the
+        // cached-token figure stays unset.
+        assert_eq!(usage.cached_input_tokens, None);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let found = 'search: loop {
+            while let Ok(event) = rx.try_recv() {
+                let matches_message = event.get("message").and_then(|value| value.as_str())
+                    == Some("gateway-reported Anthropic cache write (billed at the write premium)");
+                let matches_counts = event
+                    .get("attributes")
+                    .and_then(|attributes| attributes.get("cache_creation_input_tokens"))
+                    == Some(&serde_json::json!(4803));
+                if matches_message && matches_counts && matches_source_file(&event) {
+                    break 'search true;
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                break 'search false;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+        assert!(found, "cache-write log record with counts must be emitted");
+    }
+
+    fn matches_source_file(event: &serde_json::Value) -> bool {
+        event
+            .get("attributes")
+            .and_then(|attributes| attributes.get("_file"))
+            .and_then(|value| value.as_str())
+            .is_some_and(|file| file.ends_with("compatible.rs"))
+    }
+
+    /// End to end on the tools path: a translated-gateway response carrying
+    /// Anthropic-shaped usage populates `TokenUsage.cached_input_tokens`.
+    /// Parsing is flag-independent (the gateway sends these fields on
+    /// Anthropic-backed routes regardless of the client flag).
+    #[tokio::test]
+    async fn chat_with_tools_surfaces_anthropic_cache_read_tokens() {
+        let (provider, _captured, server) = mock_non_streaming_response(serde_json::json!({
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {
+                "prompt_tokens": 4863,
+                "completion_tokens": 4,
+                "cache_read_input_tokens": 4802,
+                "cache_creation_input_tokens": 0
+            }
+        }))
+        .await;
+        let messages = vec![ChatMessage::user("hi")];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })];
+        let response = provider
+            .chat_with_tools(&messages, &tools, "test-model", None)
+            .await;
+        server.abort();
+        let response = response.unwrap_or_else(|error| panic!("tools request failed: {error}"));
+        let usage = response.usage.expect("usage must be captured");
+        assert_eq!(usage.cached_input_tokens, Some(4802));
+        assert_eq!(usage.input_tokens, Some(4863));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -8873,6 +8873,53 @@ mod tests {
         assert_eq!(usage.input_tokens, Some(4863));
     }
 
+    /// Flag interaction: the thinking object reaches the wire through
+    /// `extra_body` (the same surface the thinking-passthrough feature
+    /// uses), and it must ride alongside the cache breakpoints in one
+    /// request: neither injection disturbs the other, and both land
+    /// together on real deployments that enable both flags.
+    #[tokio::test]
+    async fn cache_breakpoints_coexist_with_thinking_object_in_one_request() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        // Builder-level extra_body mirrors what provider_extra supplies for
+        // thinking-capable gateways; swap in the flag-side equivalent when
+        // the thinking-passthrough provider flag lands in this tree.
+        let provider = OpenAiCompatibleModelProvider {
+            extra_body: Some(serde_json::json!({
+                "thinking": {"type": "enabled", "budget_tokens": 2048},
+            })),
+            ..provider
+        };
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello"),
+            ChatMessage::user("bye"),
+        ];
+        let result = provider
+            .chat_with_history(&messages, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("combined request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["thinking"],
+            serde_json::json!({"type": "enabled", "budget_tokens": 2048}),
+            "the thinking object must ride at the top level untouched"
+        );
+        assert_eq!(
+            requests[0]["messages"][0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"}),
+            "system cache breakpoint present alongside the thinking object"
+        );
+        assert_eq!(
+            requests[0]["messages"][3]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"}),
+            "rolling cache breakpoint present alongside the thinking object"
+        );
+    }
+
     #[test]
     fn api_response_parses_without_usage() {
         let json = r#"{"choices": [{"message": {"content": "Hello"}}]}"#;

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -974,6 +974,40 @@ impl OpenAiCompatibleModelProvider {
         })
     }
 
+    /// Inject Anthropic prompt-cache breakpoints behind `cache_passthrough`.
+    ///
+    /// The native Anthropic provider is the source of truth for placement:
+    /// `AnthropicModelProvider::should_cache_conversation` and
+    /// `apply_cache_to_last_message` in `anthropic.rs`. (a) The system prompt
+    /// always carries a breakpoint when one exists on the wire. (b) The last
+    /// message's trailing text part carries a rolling breakpoint once the
+    /// conversation has more than one non-system message, the same gate the
+    /// native provider applies before `apply_cache_to_last_message`. At most
+    /// two breakpoints per request; only breakpoint-carrying messages convert
+    /// from string content to block form, every other message serializes
+    /// exactly as before.
+    fn apply_cache_breakpoints<T: CacheBreakpointMessage>(&self, messages: &mut [T]) {
+        if !self.cache_passthrough {
+            return;
+        }
+        if let Some(system) = messages.iter_mut().find(|m| m.cache_role() == "system")
+            && let Some(content) = system.cache_content()
+        {
+            content.apply_cache_control();
+        }
+        let non_system_count = messages
+            .iter()
+            .filter(|m| m.cache_role() != "system")
+            .count();
+        if non_system_count > 1
+            && let Some(last) = messages.last_mut()
+            && last.cache_role() != "system"
+            && let Some(content) = last.cache_content()
+        {
+            content.apply_cache_control();
+        }
+    }
+
     /// Build the full URL for chat completions, detecting if base_url already includes the path.
     /// This allows custom model_providers with non-standard endpoints (e.g., VolcEngine ARK uses
     /// `/api/coding/v3/chat/completions` instead of `/v1/chat/completions`).
@@ -1160,11 +1194,71 @@ enum MessageContent {
     Parts(Vec<MessagePart>),
 }
 
+impl MessageContent {
+    /// Mark this content as an Anthropic prompt-cache breakpoint: plain
+    /// string content converts to the single-text-block wire form (block
+    /// conversion touches only breakpoint-carrying messages); block-form
+    /// content gains the marker on its trailing text part. Trailing
+    /// non-text parts (images) are left unmarked, mirroring the native
+    /// Anthropic provider's placement, which never marks image blocks.
+    fn apply_cache_control(&mut self) {
+        match self {
+            MessageContent::Text(text) => {
+                *self = MessageContent::Parts(vec![MessagePart::Text {
+                    text: std::mem::take(text),
+                    cache_control: Some(crate::anthropic::CacheControl::ephemeral()),
+                }]);
+            }
+            MessageContent::Parts(parts) => {
+                if let Some(MessagePart::Text { cache_control, .. }) = parts.last_mut() {
+                    *cache_control = Some(crate::anthropic::CacheControl::ephemeral());
+                }
+            }
+        }
+    }
+}
+
+/// Uniform (role, content) access over the two wire message shapes so one
+/// breakpoint-injection routine serves both the no-tools and the native-tools
+/// request types.
+trait CacheBreakpointMessage {
+    fn cache_role(&self) -> &str;
+    fn cache_content(&mut self) -> Option<&mut MessageContent>;
+}
+
+impl CacheBreakpointMessage for Message {
+    fn cache_role(&self) -> &str {
+        &self.role
+    }
+
+    fn cache_content(&mut self) -> Option<&mut MessageContent> {
+        Some(&mut self.content)
+    }
+}
+
+impl CacheBreakpointMessage for NativeMessage {
+    fn cache_role(&self) -> &str {
+        &self.role
+    }
+
+    fn cache_content(&mut self) -> Option<&mut MessageContent> {
+        self.content.as_mut()
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum MessagePart {
-    Text { text: String },
-    ImageUrl { image_url: ImageUrlPart },
+    Text {
+        text: String,
+        /// Anthropic prompt-cache breakpoint, injected only behind
+        /// `cache_passthrough` and only on breakpoint-carrying messages.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<crate::anthropic::CacheControl>,
+    },
+    ImageUrl {
+        image_url: ImageUrlPart,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -2256,10 +2350,13 @@ impl OpenAiCompatibleModelProvider {
     ) -> NativeChatRequest {
         let has_tool_entries = tools.as_ref().is_some_and(|tools| !tools.is_empty());
         let tool_choice = has_tool_entries.then(|| "auto".to_string());
+        let mut messages =
+            self.convert_messages_for_native(effective_messages, allow_user_image_parts);
+        self.apply_cache_breakpoints(&mut messages);
 
         NativeChatRequest {
             model: model.to_string(),
-            messages: self.convert_messages_for_native(effective_messages, allow_user_image_parts),
+            messages,
             temperature,
             stream: Some(false),
             // Non-streaming path; `usage` is on the final response body, not
@@ -2283,9 +2380,12 @@ impl OpenAiCompatibleModelProvider {
         allow_user_image_parts: bool,
     ) -> NativeChatRequest<&'a [serde_json::Value]> {
         let has_tool_entries = tools.is_some_and(|tools| !tools.is_empty());
+        let mut messages =
+            self.convert_messages_for_native(effective_messages, allow_user_image_parts);
+        self.apply_cache_breakpoints(&mut messages);
         NativeChatRequest {
             model: model.to_string(),
-            messages: self.convert_messages_for_native(effective_messages, allow_user_image_parts),
+            messages,
             temperature,
             stream: Some(false),
             stream_options: None,
@@ -2317,9 +2417,11 @@ impl OpenAiCompatibleModelProvider {
         let tool_choice = tools
             .as_ref()
             .and_then(|t| (!t.is_empty()).then(|| "auto".to_string()));
+        let mut messages = self.convert_messages_for_native(effective_messages, !merge);
+        self.apply_cache_breakpoints(&mut messages);
         NativeChatRequest {
             model: model.to_string(),
-            messages: self.convert_messages_for_native(effective_messages, !merge),
+            messages,
             temperature,
             reasoning_effort: self.reasoning_effort_for_model(model),
             tool_stream: if options_enabled {
@@ -2391,6 +2493,7 @@ impl OpenAiCompatibleModelProvider {
         if !trimmed_text.is_empty() {
             parts.push(MessagePart::Text {
                 text: trimmed_text.to_string(),
+                cache_control: None,
             });
         }
 
@@ -3080,7 +3183,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             });
         }
 
-        let request = ApiChatRequest {
+        let mut request = ApiChatRequest {
             model: model.to_string(),
             messages,
             temperature,
@@ -3093,6 +3196,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             max_tokens: self.max_tokens,
             extra_body: self.extra_body.clone(),
         };
+        self.apply_cache_breakpoints(&mut request.messages);
 
         let url = self.chat_completions_url();
 
@@ -3170,7 +3274,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             })
             .collect();
 
-        let request = ApiChatRequest {
+        let mut request = ApiChatRequest {
             model: model.to_string(),
             messages: api_messages,
             temperature,
@@ -3183,6 +3287,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             max_tokens: self.max_tokens,
             extra_body: self.extra_body.clone(),
         };
+        self.apply_cache_breakpoints(&mut request.messages);
 
         let url = self.chat_completions_url();
         let response = match self
@@ -3559,7 +3664,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                     merge,
                 ))
             } else {
-                let messages = effective_messages
+                let mut messages: Vec<Message> = effective_messages
                     .iter()
                     .map(|message| Message {
                         role: message.role.clone(),
@@ -3571,6 +3676,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                         ),
                     })
                     .collect();
+                provider.apply_cache_breakpoints(&mut messages);
 
                 serde_json::to_value(ApiChatRequest {
                     model: model.clone(),
@@ -3770,7 +3876,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 });
             }
 
-            let request = ApiChatRequest {
+            let mut request = ApiChatRequest {
                 model: model.clone(),
                 messages,
                 temperature,
@@ -3785,6 +3891,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 max_tokens: provider.max_tokens,
                 extra_body: provider.extra_body.clone(),
             };
+            provider.apply_cache_breakpoints(&mut request.messages);
 
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
@@ -3887,7 +3994,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 })
                 .collect();
 
-            let request = ApiChatRequest {
+            let mut request = ApiChatRequest {
                 model: model.clone(),
                 messages: api_messages,
                 temperature,
@@ -3902,6 +4009,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 max_tokens: provider.max_tokens,
                 extra_body: provider.extra_body.clone(),
             };
+            provider.apply_cache_breakpoints(&mut request.messages);
 
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
@@ -4240,6 +4348,295 @@ mod tests {
                 "stream": false,
             }),
             "flag-off request body must stay byte-identical to the pre-feature wire"
+        );
+    }
+
+    /// Streaming capture mock: records every request body, answers with a
+    /// minimal SSE stream. Returns the provider built with or without the
+    /// cache flag so tests can pin both wire paths.
+    async fn mock_streaming_cache_capture(
+        cache_passthrough: bool,
+    ) -> (
+        OpenAiCompatibleModelProvider,
+        std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use axum::{Json, Router, http::StatusCode, response::IntoResponse, routing::post};
+        use tokio::net::TcpListener;
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured_for_route = std::sync::Arc::clone(&captured);
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move |Json(body): Json<serde_json::Value>| {
+                let captured = std::sync::Arc::clone(&captured_for_route);
+                async move {
+                    let streaming =
+                        body.get("stream").and_then(serde_json::Value::as_bool) == Some(true);
+                    captured.lock().unwrap().push(body);
+                    if streaming {
+                        return (
+                            StatusCode::OK,
+                            [("content-type", "text/event-stream")],
+                            concat!(
+                                "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+                                "data: [DONE]\n\n"
+                            ),
+                        )
+                            .into_response();
+                    }
+                    Json(serde_json::json!({
+                        "choices": [{"message": {"content": "ok"}}]
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = ::zeroclaw_spawn::spawn!(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let mut builder = OpenAiCompatibleModelProvider::builder("test")
+            .display_name("custom")
+            .base_url(&format!("http://{addr}"))
+            .auth_style(AuthStyle::Bearer);
+        if cache_passthrough {
+            builder = builder.with_cache_passthrough();
+        }
+        let provider = builder.build();
+
+        (provider, captured, server)
+    }
+
+    /// D3 wire shape: behind the flag, the system prompt converts from
+    /// string content to the single-text-block form carrying
+    /// `cache_control`, while every other message keeps its existing
+    /// serialization untouched.
+    #[tokio::test]
+    async fn cache_passthrough_system_breakpoint_serializes_block_form() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let result = provider
+            .chat_with_system(Some("be brief"), "hello", "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0],
+            serde_json::json!({
+                "model": "test-model",
+                "messages": [
+                    {"role": "system", "content": [
+                        {"type": "text", "text": "be brief",
+                         "cache_control": {"type": "ephemeral"}},
+                    ]},
+                    {"role": "user", "content": "hello"},
+                ],
+                "stream": false,
+            }),
+            "system prompt must serialize as a cache_control text block; other messages untouched"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            1,
+            "single exchange must carry exactly one breakpoint"
+        );
+    }
+
+    /// Rolling breakpoint: once the conversation has more than one
+    /// non-system message (the native provider's gate), the last message
+    /// gains the second breakpoint and converts to block form; messages in
+    /// between serialize exactly as before.
+    #[tokio::test]
+    async fn cache_passthrough_rolling_breakpoint_after_first_exchange() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello"),
+            ChatMessage::user("bye"),
+        ];
+        let result = provider
+            .chat_with_history(&messages, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on history request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0]["messages"],
+            serde_json::json!([
+                {"role": "system", "content": [
+                    {"type": "text", "text": "you are brief",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "bye",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+            ]),
+            "system and last message carry the breakpoints; middle messages untouched"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            2,
+            "rolling breakpoint must never exceed two per request"
+        );
+    }
+
+    /// The rolling breakpoint follows the native provider's gate: a
+    /// conversation with only one non-system message gets the system
+    /// breakpoint alone.
+    #[tokio::test]
+    async fn cache_passthrough_single_exchange_skips_rolling_breakpoint() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("hi"),
+        ];
+        let result = provider
+            .chat_with_history(&messages, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on history request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            1,
+            "one non-system message means no rolling breakpoint"
+        );
+        assert_eq!(
+            requests[0]["messages"][1]["content"],
+            serde_json::json!("hi"),
+            "first user message must stay a plain string"
+        );
+    }
+
+    /// Streaming twin of the system-breakpoint pin: the injection must be
+    /// identical on the streaming path (a previous feature shipped the
+    /// non-streaming path and silently missed streaming).
+    #[tokio::test]
+    async fn cache_passthrough_streaming_system_breakpoint_matches_non_streaming() {
+        use futures_util::StreamExt as _;
+
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let events = provider
+            .stream_chat_with_system(
+                Some("be brief"),
+                "hello",
+                "test-model",
+                None,
+                StreamOptions {
+                    enabled: true,
+                    count_tokens: false,
+                },
+            )
+            .collect::<Vec<_>>()
+            .await;
+        server.abort();
+        assert!(
+            events.iter().all(Result::is_ok),
+            "streaming request must succeed: {events:?}"
+        );
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["messages"][0],
+            serde_json::json!({
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "be brief",
+                     "cache_control": {"type": "ephemeral"}},
+                ],
+            }),
+            "streaming path must inject the system breakpoint identically"
+        );
+        assert_eq!(
+            requests[0]["messages"][1]["content"],
+            serde_json::json!("hello"),
+            "streaming user message must stay a plain string"
+        );
+    }
+
+    /// Flag-off streaming twin: the default path stays byte-identical on
+    /// the streaming wire too.
+    #[tokio::test]
+    async fn cache_passthrough_flag_off_streaming_body_unmarked() {
+        use futures_util::StreamExt as _;
+
+        let (provider, captured, server) = mock_streaming_cache_capture(false).await;
+        let events = provider
+            .stream_chat_with_system(
+                Some("be brief"),
+                "hello",
+                "test-model",
+                None,
+                StreamOptions {
+                    enabled: true,
+                    count_tokens: false,
+                },
+            )
+            .collect::<Vec<_>>()
+            .await;
+        server.abort();
+        assert!(events.iter().all(Result::is_ok));
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["messages"][0]["content"],
+            serde_json::json!("be brief"),
+            "flag-off system message must stay a plain string"
+        );
+        assert!(
+            !requests[0].to_string().contains("cache_control"),
+            "flag-off streaming body must carry no cache markers"
+        );
+    }
+
+    /// Native-tools path: the same two-breakpoint placement applies to the
+    /// native-tools request builder, so tool-bearing agent loops get the
+    /// same caching shape as plain conversations.
+    #[tokio::test]
+    async fn cache_passthrough_tools_path_rolls_breakpoint_onto_last_message() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello"),
+            ChatMessage::user("bye"),
+        ];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })];
+        let result = provider
+            .chat_with_tools(&messages, &tools, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on tools request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            2,
+            "tools path must carry at most the two standard breakpoints"
+        );
+        assert_eq!(
+            requests[0]["messages"][0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"}),
+            "system breakpoint present on the tools path"
+        );
+        assert_eq!(
+            requests[0]["messages"].as_array().unwrap().last().unwrap()["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"}),
+            "rolling breakpoint lands on the last message of the tools path"
         );
     }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -62,6 +62,10 @@ pub struct OpenAiCompatibleModelProvider {
     /// assistant history messages. Some providers reject reasoning fields as
     /// input even though they may return them in responses.
     replay_assistant_reasoning: bool,
+    /// Whether Anthropic prompt-cache breakpoints should be injected into
+    /// outbound request bodies (system prompt; rolling last message).
+    /// Drives `capabilities().prompt_caching` and the request-build path.
+    cache_passthrough: bool,
     /// Custom API path suffix (e.g. "/v2/generate").
     /// When set, overrides the default `/chat/completions` path detection.
     api_path: Option<String>,
@@ -426,6 +430,9 @@ pub struct OpenAiCompatibleBuilder {
     /// [`OpenAiCompatibleBuilder::without_assistant_reasoning_replay`]. `None`
     /// preserves the default (replay enabled).
     replay_assistant_reasoning_override: Option<bool>,
+    /// Set by [`OpenAiCompatibleBuilder::with_cache_passthrough`]. Default
+    /// `false`: requests and capability reporting are unchanged.
+    cache_passthrough: bool,
     api_path: Option<String>,
     max_tokens: Option<u32>,
     models_dev_key: Option<String>,
@@ -554,6 +561,17 @@ impl OpenAiCompatibleBuilder {
     /// history messages.
     pub fn without_assistant_reasoning_replay(mut self) -> Self {
         self.replay_assistant_reasoning_override = Some(false);
+        self
+    }
+
+    /// Opt this provider into Anthropic prompt-cache passthrough: request
+    /// bodies gain `cache_control` breakpoints (system prompt; rolling last
+    /// message once the conversation has more than one non-system message),
+    /// mirroring the native Anthropic provider's placement strategy, and
+    /// gateway-reported cache usage is captured. The flag also reports
+    /// `prompt_caching` in the provider capabilities.
+    pub fn with_cache_passthrough(mut self) -> Self {
+        self.cache_passthrough = true;
         self
     }
 
@@ -691,6 +709,7 @@ impl OpenAiCompatibleBuilder {
             extra_headers: self.extra_headers,
             reasoning_effort: self.reasoning_effort,
             replay_assistant_reasoning: self.replay_assistant_reasoning_override.unwrap_or(true),
+            cache_passthrough: self.cache_passthrough,
             api_path: self.api_path,
             max_tokens: self.max_tokens,
             models_dev_key: self.models_dev_key,
@@ -730,6 +749,7 @@ impl OpenAiCompatibleModelProvider {
             extra_headers: std::collections::HashMap::new(),
             reasoning_effort: None,
             replay_assistant_reasoning_override: None,
+            cache_passthrough: false,
             api_path: None,
             max_tokens: None,
             models_dev_key: None,
@@ -2823,7 +2843,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
         zeroclaw_api::model_provider::ProviderCapabilities {
             native_tool_calling: self.native_tool_calling,
             vision: self.supports_vision,
-            prompt_caching: false,
+            prompt_caching: self.cache_passthrough,
             extended_thinking: false,
         }
     }
@@ -4168,6 +4188,59 @@ mod tests {
         let provider = make_model_provider("custom", &format!("http://{addr}"), Some("test-key"));
 
         (provider, captured, server)
+    }
+
+    fn make_cache_passthrough_model_provider(
+        name: &str,
+        url: &str,
+    ) -> OpenAiCompatibleModelProvider {
+        OpenAiCompatibleModelProvider::builder("test")
+            .display_name(name)
+            .base_url(url)
+            .auth_style(AuthStyle::Bearer)
+            .with_cache_passthrough()
+            .build()
+    }
+
+    /// Capability pin: the compat provider reports prompt caching exactly
+    /// when the flag is set, so routing and UI gating can trust capability
+    /// reporting instead of probing the wire.
+    #[test]
+    fn cache_passthrough_capability_reports_flag_state() {
+        let off = make_model_provider("custom", "http://127.0.0.1:1", None);
+        assert!(!off.capabilities().prompt_caching);
+        let on = make_cache_passthrough_model_provider("custom", "http://127.0.0.1:1");
+        assert!(on.capabilities().prompt_caching);
+    }
+
+    /// Byte-identity pin for the default path: the flag-off request body is
+    /// fully specified, so any future injection work that leaks into the
+    /// default path fails this test instead of silently changing the wire.
+    #[tokio::test]
+    async fn cache_passthrough_flag_off_request_body_is_pinned() {
+        let (provider, captured, server) = mock_non_streaming_response(serde_json::json!({
+            "choices": [{"message": {"content": "ok"}}]
+        }))
+        .await;
+        let result = provider
+            .chat_with_system(Some("be brief"), "hello", "test-model", None)
+            .await;
+        server.abort();
+        let result = result.unwrap_or_else(|error| panic!("flag-off request failed: {error}"));
+        assert_eq!(result, "ok");
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0],
+            serde_json::json!({
+                "model": "test-model",
+                "messages": [
+                    {"role": "system", "content": "be brief"},
+                    {"role": "user", "content": "hello"},
+                ],
+                "stream": false,
+            }),
+            "flag-off request body must stay byte-identical to the pre-feature wire"
+        );
     }
 
     fn non_streaming_response_cases() -> Vec<(&'static str, serde_json::Value, Option<&'static str>)>

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -9069,10 +9069,10 @@ mod tests {
     }
 
     // ═══════════════════════════════════════════════════════════════════════
-    // merged-system carrier + usage-capture boundary tests (audit repairs)
+    // merged-system carrier + usage-capture boundary tests
     // ═══════════════════════════════════════════════════════════════════════
 
-    /// Audit blocker 2, single-turn: with `merge_system_into_user`, the
+    /// Merged-carrier, single-turn: with `merge_system_into_user`, the
     /// system role never reaches the wire, so the merged first user message
     /// is the only system-equivalent carrier and must carry the breakpoint
     /// unconditionally. Before the repair this shape sent zero breakpoints.
@@ -9119,7 +9119,7 @@ mod tests {
         );
     }
 
-    /// Audit blocker 2, multi-turn: the carrier keeps the system breakpoint
+    /// Merged-carrier, multi-turn: the carrier keeps the system breakpoint
     /// and the rolling breakpoint still lands on the last message, exactly
     /// two total, middle messages untouched.
     #[tokio::test]
@@ -9171,7 +9171,7 @@ mod tests {
         );
     }
 
-    /// Audit blocker 2, assistant-first history: the merged user is not
+    /// Merged-carrier, assistant-first history: the merged user is not
     /// message zero; the carrier index must follow the first user wherever
     /// it sits.
     #[tokio::test]
@@ -9303,7 +9303,7 @@ mod tests {
         );
     }
 
-    /// Audit blocker 1 regression: the text-only helpers must never emit
+    /// Capture-boundary regression: the text-only helpers must never emit
     /// cache breakpoints even with the flag on, because their responses
     /// drop usage and could never account for the premium.
     #[tokio::test]
@@ -9332,7 +9332,7 @@ mod tests {
         }
     }
 
-    /// Audit blocker 1 regression, streaming side: the legacy chunk stream
+    /// Capture-boundary regression, streaming side: the legacy chunk stream
     /// drops usage, so it must not trigger premium writes either.
     #[tokio::test]
     async fn cache_passthrough_legacy_stream_emits_no_breakpoints_even_when_enabled() {

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -784,7 +784,13 @@ impl OpenAiCompatibleModelProvider {
     /// Collect all `system` role messages and keep them in a provider-safe
     /// shape. Strict OpenAI-compatible endpoints accept a leading system
     /// message but reject system messages later in the history.
-    fn flatten_system_messages(messages: &[ChatMessage], merge: bool) -> Vec<ChatMessage> {
+    /// Flatten system messages per `merge`. Returns the flattened list plus
+    /// whether the system content was merged INTO a user message (or a
+    /// synthetic user inserted for it): that first user message is the
+    /// system-equivalent carrier and the only place a system-role
+    /// breakpoint can ride when merging is on. `false` means a system-role
+    /// message still exists on the wire (or there never was one).
+    fn flatten_system_messages(messages: &[ChatMessage], merge: bool) -> (Vec<ChatMessage>, bool) {
         let mut saw_system = false;
         let mut system_content = String::new();
         let mut result: Vec<ChatMessage> = Vec::with_capacity(messages.len());
@@ -804,28 +810,26 @@ impl OpenAiCompatibleModelProvider {
         }
 
         if !saw_system {
-            return messages.to_vec();
+            return (messages.to_vec(), false);
         }
 
         if system_content.is_empty() {
-            return result;
+            return (result, false);
         }
 
         if !merge {
             result.insert(0, ChatMessage::system(system_content));
-            return result;
+            return (result, false);
         }
 
         if let Some(first_user) = result.iter_mut().find(|m| m.role == "user") {
-            if !system_content.is_empty() {
-                first_user.content = format!("{system_content}\n\n{}", first_user.content);
-            }
+            first_user.content = format!("{system_content}\n\n{}", first_user.content);
         } else {
             // No user message found: insert a synthetic user message with system content
             result.insert(0, ChatMessage::user(&system_content));
         }
 
-        result
+        (result, true)
     }
 
     fn http_client(&self) -> Client {
@@ -979,21 +983,40 @@ impl OpenAiCompatibleModelProvider {
     /// The native Anthropic provider is the source of truth for placement:
     /// `AnthropicModelProvider::should_cache_conversation` and
     /// `apply_cache_to_last_message` in `anthropic.rs`. (a) The system prompt
-    /// always carries a breakpoint when one exists on the wire. (b) The last
-    /// message's trailing text part carries a rolling breakpoint once the
-    /// conversation has more than one non-system message, the same gate the
-    /// native provider applies before `apply_cache_to_last_message`. At most
-    /// two breakpoints per request; only breakpoint-carrying messages convert
-    /// from string content to block form, every other message serializes
-    /// exactly as before.
-    fn apply_cache_breakpoints<T: CacheBreakpointMessage>(&self, messages: &mut [T]) {
+    /// always carries a breakpoint when one exists on the wire. With
+    /// `merge_system_into_user`, the system role disappears from the wire,
+    /// so the carrier index of the merged system content (the first user
+    /// message, or the synthetic user carrying it) takes over that role and
+    /// is marked unconditionally. (b) The last message's trailing text part
+    /// carries a rolling breakpoint once the conversation has more than one
+    /// non-system message, the same gate the native provider applies before
+    /// `apply_cache_to_last_message`. At most two breakpoints per request;
+    /// only breakpoint-carrying messages convert from string content to
+    /// block form, every other message serializes exactly as before.
+    fn apply_cache_breakpoints<T: CacheBreakpointMessage>(
+        &self,
+        messages: &mut [T],
+        merged_system_carrier: Option<usize>,
+    ) {
         if !self.cache_passthrough {
             return;
         }
-        if let Some(system) = messages.iter_mut().find(|m| m.cache_role() == "system")
-            && let Some(content) = system.cache_content()
-        {
-            content.apply_cache_control();
+        let carrier = merged_system_carrier.and_then(|idx| {
+            (idx < messages.len() && messages[idx].cache_role() != "system").then_some(idx)
+        });
+        match carrier {
+            Some(idx) => {
+                if let Some(content) = messages[idx].cache_content() {
+                    content.apply_cache_control();
+                }
+            }
+            None => {
+                if let Some(system) = messages.iter_mut().find(|m| m.cache_role() == "system")
+                    && let Some(content) = system.cache_content()
+                {
+                    content.apply_cache_control();
+                }
+            }
         }
         let non_system_count = messages
             .iter()
@@ -1005,6 +1028,19 @@ impl OpenAiCompatibleModelProvider {
             && let Some(content) = last.cache_content()
         {
             content.apply_cache_control();
+        }
+    }
+
+    /// Index of the merged system-content carrier (the first user message)
+    /// when `flatten_system_messages` reported a merge, else `None`.
+    fn merged_system_carrier_index<T: CacheBreakpointMessage>(
+        messages: &[T],
+        system_merged: bool,
+    ) -> Option<usize> {
+        if system_merged {
+            messages.iter().position(|m| m.cache_role() == "user")
+        } else {
+            None
         }
     }
 
@@ -2377,12 +2413,14 @@ impl OpenAiCompatibleModelProvider {
         model: &str,
         temperature: Option<f64>,
         allow_user_image_parts: bool,
+        system_merged: bool,
     ) -> NativeChatRequest {
         let has_tool_entries = tools.as_ref().is_some_and(|tools| !tools.is_empty());
         let tool_choice = has_tool_entries.then(|| "auto".to_string());
         let mut messages =
             self.convert_messages_for_native(effective_messages, allow_user_image_parts);
-        self.apply_cache_breakpoints(&mut messages);
+        let carrier = Self::merged_system_carrier_index(&messages, system_merged);
+        self.apply_cache_breakpoints(&mut messages, carrier);
 
         NativeChatRequest {
             model: model.to_string(),
@@ -2408,11 +2446,13 @@ impl OpenAiCompatibleModelProvider {
         model: &str,
         temperature: Option<f64>,
         allow_user_image_parts: bool,
+        system_merged: bool,
     ) -> NativeChatRequest<&'a [serde_json::Value]> {
         let has_tool_entries = tools.is_some_and(|tools| !tools.is_empty());
         let mut messages =
             self.convert_messages_for_native(effective_messages, allow_user_image_parts);
-        self.apply_cache_breakpoints(&mut messages);
+        let carrier = Self::merged_system_carrier_index(&messages, system_merged);
+        self.apply_cache_breakpoints(&mut messages, carrier);
         NativeChatRequest {
             model: model.to_string(),
             messages,
@@ -2438,6 +2478,7 @@ impl OpenAiCompatibleModelProvider {
         temperature: Option<f64>,
         options_enabled: bool,
         merge: bool,
+        system_merged: bool,
     ) -> NativeChatRequest {
         // Guard on the converted tools being non-empty (not just the raw
         // input being non-empty): convert_tool_specs_for_model can sanitize
@@ -2448,7 +2489,8 @@ impl OpenAiCompatibleModelProvider {
             .as_ref()
             .and_then(|t| (!t.is_empty()).then(|| "auto".to_string()));
         let mut messages = self.convert_messages_for_native(effective_messages, !merge);
-        self.apply_cache_breakpoints(&mut messages);
+        let carrier = Self::merged_system_carrier_index(&messages, system_merged);
+        self.apply_cache_breakpoints(&mut messages, carrier);
         NativeChatRequest {
             model: model.to_string(),
             messages,
@@ -3213,7 +3255,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             });
         }
 
-        let mut request = ApiChatRequest {
+        let request = ApiChatRequest {
             model: model.to_string(),
             messages,
             temperature,
@@ -3226,7 +3268,13 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             max_tokens: self.max_tokens,
             extra_body: self.extra_body.clone(),
         };
-        self.apply_cache_breakpoints(&mut request.messages);
+        // No cache breakpoints here, deliberately: this text-only helper
+        // never surfaces response usage to dispatch accounting, so a
+        // premium cache write it triggered could never be accounted for
+        // (fallback re-entries through this path return `usage: None`).
+        // The flag is honored on the structured paths (`chat`,
+        // `chat_with_tools`, `stream_chat`), which capture usage; the
+        // provider docs describe this usage-capture boundary.
 
         let url = self.chat_completions_url();
 
@@ -3293,7 +3341,8 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
         let normalized = self.normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
-        let effective_messages = Self::flatten_system_messages(&normalized, merge);
+        let (effective_messages, _system_merged) =
+            Self::flatten_system_messages(&normalized, merge);
         // Strip native tool constructs for non-native-tool model_providers.
         let effective_messages = self.strip_native_tool_messages(&effective_messages);
         let api_messages: Vec<Message> = effective_messages
@@ -3304,7 +3353,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             })
             .collect();
 
-        let mut request = ApiChatRequest {
+        let request = ApiChatRequest {
             model: model.to_string(),
             messages: api_messages,
             temperature,
@@ -3317,7 +3366,13 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             max_tokens: self.max_tokens,
             extra_body: self.extra_body.clone(),
         };
-        self.apply_cache_breakpoints(&mut request.messages);
+        // No cache breakpoints here, deliberately: this text-only helper
+        // never surfaces response usage to dispatch accounting, so a
+        // premium cache write it triggered could never be accounted for
+        // (fallback re-entries through this path return `usage: None`).
+        // The flag is honored on the structured paths (`chat`,
+        // `chat_with_tools`, `stream_chat`), which capture usage; the
+        // provider docs describe this usage-capture boundary.
 
         let url = self.chat_completions_url();
         let response = match self
@@ -3379,7 +3434,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
 
         let normalized = self.normalize_messages_for_upstream(messages).await?;
         let merge = self.effective_merge_system(model);
-        let effective_messages = Self::flatten_system_messages(&normalized, merge);
+        let (effective_messages, system_merged) = Self::flatten_system_messages(&normalized, merge);
         let effective_messages = if self.native_tool_calling {
             effective_messages
         } else {
@@ -3391,6 +3446,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             model,
             temperature,
             !merge,
+            system_merged,
         );
         let mut payload = serde_json::to_value(request)?;
         let tools_count = payload
@@ -3493,7 +3549,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             .normalize_messages_for_upstream(request.messages)
             .await?;
         let merge = self.effective_merge_system(model);
-        let effective_messages = Self::flatten_system_messages(&normalized, merge);
+        let (effective_messages, system_merged) = Self::flatten_system_messages(&normalized, merge);
         let effective_messages = if self.native_tool_calling {
             effective_messages
         } else {
@@ -3507,6 +3563,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             model,
             temperature,
             !merge,
+            system_merged,
         );
         let mut payload = serde_json::to_value(native_request)?;
         let tools_count = payload
@@ -3673,7 +3730,8 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             };
 
             let merge = provider.effective_merge_system(&model);
-            let effective_messages = Self::flatten_system_messages(&normalized, merge);
+            let (effective_messages, system_merged) =
+                Self::flatten_system_messages(&normalized, merge);
             let effective_messages = provider.strip_native_tool_messages(&effective_messages);
             let tools = provider.convert_tool_specs_for_model(tools_owned.as_deref(), &model);
             let tools_count = tools.as_ref().map_or(0, Vec::len);
@@ -3692,6 +3750,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                     temperature,
                     options_enabled,
                     merge,
+                    system_merged,
                 ))
             } else {
                 let mut messages: Vec<Message> = effective_messages
@@ -3706,7 +3765,8 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                         ),
                     })
                     .collect();
-                provider.apply_cache_breakpoints(&mut messages);
+                let carrier = Self::merged_system_carrier_index(&messages, system_merged);
+                provider.apply_cache_breakpoints(&mut messages, carrier);
 
                 serde_json::to_value(ApiChatRequest {
                     model: model.clone(),
@@ -3906,7 +3966,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 });
             }
 
-            let mut request = ApiChatRequest {
+            let request = ApiChatRequest {
                 model: model.clone(),
                 messages,
                 temperature,
@@ -3921,7 +3981,12 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 max_tokens: provider.max_tokens,
                 extra_body: provider.extra_body.clone(),
             };
-            provider.apply_cache_breakpoints(&mut request.messages);
+            // No cache breakpoints here, deliberately: this legacy chunk
+            // stream never converts the final usage chunk into a
+            // `TokenUsage`, so a premium cache write it triggered could
+            // never be accounted for. The flag is honored on the structured
+            // streaming path (`stream_chat`), which emits
+            // `StreamEvent::Usage`.
 
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
@@ -4014,7 +4079,8 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
             };
 
             let merge = provider.effective_merge_system(&model);
-            let effective_messages = Self::flatten_system_messages(&normalized, merge);
+            let (effective_messages, _system_merged) =
+                Self::flatten_system_messages(&normalized, merge);
             let effective_messages = provider.strip_native_tool_messages(&effective_messages);
             let api_messages: Vec<Message> = effective_messages
                 .iter()
@@ -4024,7 +4090,7 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 })
                 .collect();
 
-            let mut request = ApiChatRequest {
+            let request = ApiChatRequest {
                 model: model.clone(),
                 messages: api_messages,
                 temperature,
@@ -4039,7 +4105,12 @@ impl ModelProvider for OpenAiCompatibleModelProvider {
                 max_tokens: provider.max_tokens,
                 extra_body: provider.extra_body.clone(),
             };
-            provider.apply_cache_breakpoints(&mut request.messages);
+            // No cache breakpoints here, deliberately: this legacy chunk
+            // stream never converts the final usage chunk into a
+            // `TokenUsage`, so a premium cache write it triggered could
+            // never be accounted for. The flag is honored on the structured
+            // streaming path (`stream_chat`), which emits
+            // `StreamEvent::Usage`.
 
             let url = provider.chat_completions_url();
             let client = provider.streaming_http_client();
@@ -4447,8 +4518,17 @@ mod tests {
     #[tokio::test]
     async fn cache_passthrough_system_breakpoint_serializes_block_form() {
         let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![ChatMessage::system("be brief"), ChatMessage::user("hello")];
         let result = provider
-            .chat_with_system(Some("be brief"), "hello", "test-model", None)
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
             .await;
         server.abort();
         result.unwrap_or_else(|error| panic!("flag-on request failed: {error}"));
@@ -4489,7 +4569,15 @@ mod tests {
             ChatMessage::user("bye"),
         ];
         let result = provider
-            .chat_with_history(&messages, "test-model", None)
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
             .await;
         server.abort();
         result.unwrap_or_else(|error| panic!("flag-on history request failed: {error}"));
@@ -4528,7 +4616,15 @@ mod tests {
             ChatMessage::user("hi"),
         ];
         let result = provider
-            .chat_with_history(&messages, "test-model", None)
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
             .await;
         server.abort();
         result.unwrap_or_else(|error| panic!("flag-on history request failed: {error}"));
@@ -4554,9 +4650,12 @@ mod tests {
 
         let (provider, captured, server) = mock_streaming_cache_capture(true).await;
         let events = provider
-            .stream_chat_with_system(
-                Some("be brief"),
-                "hello",
+            .stream_chat(
+                ProviderChatRequest {
+                    messages: &[ChatMessage::system("be brief"), ChatMessage::user("hello")],
+                    tools: None,
+                    thinking: None,
+                },
                 "test-model",
                 None,
                 StreamOptions {
@@ -4599,9 +4698,12 @@ mod tests {
 
         let (provider, captured, server) = mock_streaming_cache_capture(false).await;
         let events = provider
-            .stream_chat_with_system(
-                Some("be brief"),
-                "hello",
+            .stream_chat(
+                ProviderChatRequest {
+                    messages: &[ChatMessage::system("be brief"), ChatMessage::user("hello")],
+                    tools: None,
+                    thinking: None,
+                },
                 "test-model",
                 None,
                 StreamOptions {
@@ -4830,6 +4932,7 @@ mod tests {
             Some(0.5),
             true,
             false,
+            false,
         ))
         .unwrap();
 
@@ -4860,6 +4963,7 @@ mod tests {
             Some(vec![]),
             None,
             true,
+            false,
             false,
         ))
         .unwrap();
@@ -4928,7 +5032,8 @@ mod tests {
         // directly.
 
         // None tools → no tool_choice key.
-        let req = p.build_native_tool_chat_request(&messages, None, "test-model", None, false);
+        let req =
+            p.build_native_tool_chat_request(&messages, None, "test-model", None, false, false);
         let value = serde_json::to_value(&req).unwrap();
         assert!(
             value.get("tool_choice").is_none(),
@@ -4936,8 +5041,14 @@ mod tests {
         );
 
         // Empty tools vec → still no tool_choice key.
-        let req_empty =
-            p.build_native_tool_chat_request(&messages, Some(vec![]), "test-model", None, false);
+        let req_empty = p.build_native_tool_chat_request(
+            &messages,
+            Some(vec![]),
+            "test-model",
+            None,
+            false,
+            false,
+        );
         let value_empty = serde_json::to_value(&req_empty).unwrap();
         assert!(
             value_empty.get("tool_choice").is_none(),
@@ -4959,8 +5070,14 @@ mod tests {
                 parameters: std::sync::Arc::new(serde_json::json!({})),
             },
         }];
-        let req =
-            p.build_native_tool_chat_request(&messages, Some(tools), "test-model", None, false);
+        let req = p.build_native_tool_chat_request(
+            &messages,
+            Some(tools),
+            "test-model",
+            None,
+            false,
+            false,
+        );
         let value = serde_json::to_value(&req).unwrap();
         assert_eq!(
             value.get("tool_choice").and_then(serde_json::Value::as_str),
@@ -4993,7 +5110,8 @@ mod tests {
             },
         }];
 
-        let req = p.build_native_tool_chat_request(&messages, Some(tools), "gpt-5", None, false);
+        let req =
+            p.build_native_tool_chat_request(&messages, Some(tools), "gpt-5", None, false, false);
         let value = serde_json::to_value(&req).unwrap();
         assert_eq!(
             value
@@ -5018,7 +5136,7 @@ mod tests {
             .build();
         let messages = vec![ChatMessage::user("hello")];
 
-        let req = p.build_native_tool_chat_request(&messages, None, "gpt-5", None, false);
+        let req = p.build_native_tool_chat_request(&messages, None, "gpt-5", None, false, false);
         let value = serde_json::to_value(&req).unwrap();
         assert_eq!(
             value
@@ -7372,7 +7490,9 @@ mod tests {
             ChatMessage::assistant("post-user"),
         ];
 
-        let output = OpenAiCompatibleModelProvider::flatten_system_messages(&input, true);
+        let (output, system_merged) =
+            OpenAiCompatibleModelProvider::flatten_system_messages(&input, true);
+        assert!(system_merged, "merged into the existing user message");
         assert_eq!(output.len(), 3);
         assert_eq!(output[0].role, "assistant");
         assert_eq!(output[0].content, "ack");
@@ -7390,7 +7510,9 @@ mod tests {
             ChatMessage::assistant("ack"),
         ];
 
-        let output = OpenAiCompatibleModelProvider::flatten_system_messages(&input, true);
+        let (output, system_merged) =
+            OpenAiCompatibleModelProvider::flatten_system_messages(&input, true);
+        assert!(system_merged, "synthetic user inserted as the carrier");
         assert_eq!(output.len(), 2);
         assert_eq!(output[0].role, "user");
         assert_eq!(output[0].content, "core policy");
@@ -8115,6 +8237,7 @@ mod tests {
             "deepseek-v4-flash",
             Some(0.7),
             true,
+            false,
         );
         let value = serde_json::to_value(&request).unwrap();
         let first_message = &value["messages"][0];
@@ -8151,7 +8274,9 @@ mod tests {
             ChatMessage::tool(r#"{"ok":true}"#),
         ];
 
-        let flattened = OpenAiCompatibleModelProvider::flatten_system_messages(&messages, true);
+        let (flattened, system_merged) =
+            OpenAiCompatibleModelProvider::flatten_system_messages(&messages, true);
+        assert!(system_merged);
         assert_eq!(flattened.len(), 3);
         assert_eq!(flattened[0].role, "assistant");
         assert_eq!(
@@ -8173,7 +8298,9 @@ mod tests {
             ChatMessage::user("Follow-up"),
         ];
 
-        let flattened = OpenAiCompatibleModelProvider::flatten_system_messages(&messages, false);
+        let (flattened, system_merged) =
+            OpenAiCompatibleModelProvider::flatten_system_messages(&messages, false);
+        assert!(!system_merged);
         assert_eq!(
             flattened
                 .iter()
@@ -8200,7 +8327,9 @@ mod tests {
             ChatMessage::system(""),
         ];
 
-        let flattened = OpenAiCompatibleModelProvider::flatten_system_messages(&messages, false);
+        let (flattened, system_merged) =
+            OpenAiCompatibleModelProvider::flatten_system_messages(&messages, false);
+        assert!(!system_merged, "empty system content merged nothing");
 
         assert_eq!(flattened.len(), 1);
         assert_eq!(flattened[0].role, "user");
@@ -8214,7 +8343,9 @@ mod tests {
             ChatMessage::system("Synthetic system"),
         ];
 
-        let flattened = OpenAiCompatibleModelProvider::flatten_system_messages(&messages, true);
+        let (flattened, system_merged) =
+            OpenAiCompatibleModelProvider::flatten_system_messages(&messages, true);
+        assert!(system_merged);
         assert_eq!(flattened.len(), 2);
         assert_eq!(flattened[0].role, "user");
         assert_eq!(flattened[0].content, "Synthetic system");
@@ -8876,8 +9007,10 @@ mod tests {
     /// Flag interaction: the thinking object reaches the wire through
     /// `extra_body` (the same surface the thinking-passthrough feature
     /// uses), and it must ride alongside the cache breakpoints in one
-    /// request: neither injection disturbs the other, and both land
-    /// together on real deployments that enable both flags.
+    /// request: neither injection disturbs the other. This proves generic
+    /// flattened-body coexistence on the structured path; full proof that
+    /// the two operator flags compose awaits the thinking-passthrough
+    /// provider flag landing in this tree.
     #[tokio::test]
     async fn cache_breakpoints_coexist_with_thinking_object_in_one_request() {
         let (provider, captured, server) = mock_streaming_cache_capture(true).await;
@@ -8897,7 +9030,15 @@ mod tests {
             ChatMessage::user("bye"),
         ];
         let result = provider
-            .chat_with_history(&messages, "test-model", None)
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
             .await;
         server.abort();
         result.unwrap_or_else(|error| panic!("combined request failed: {error}"));
@@ -8925,6 +9066,300 @@ mod tests {
         let json = r#"{"choices": [{"message": {"content": "Hello"}}]}"#;
         let resp: ApiChatResponse = serde_json::from_str(json).unwrap();
         assert!(resp.usage.is_none());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // merged-system carrier + usage-capture boundary tests (audit repairs)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// Audit blocker 2, single-turn: with `merge_system_into_user`, the
+    /// system role never reaches the wire, so the merged first user message
+    /// is the only system-equivalent carrier and must carry the breakpoint
+    /// unconditionally. Before the repair this shape sent zero breakpoints.
+    #[tokio::test]
+    async fn cache_passthrough_merged_system_marks_first_user_single_turn() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let provider = OpenAiCompatibleModelProvider {
+            merge_system_into_user: true,
+            ..provider
+        };
+        let messages = vec![
+            ChatMessage::system("core policy"),
+            ChatMessage::user("hello"),
+        ];
+        let result = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("merged single-turn request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["messages"],
+            serde_json::json!([
+                {"role": "user", "content": [
+                    {"type": "text", "text": "core policy\n\nhello",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+            ]),
+            "merged user message is the system-equivalent carrier and must be marked"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            1,
+            "single exchange carries exactly the carrier breakpoint"
+        );
+    }
+
+    /// Audit blocker 2, multi-turn: the carrier keeps the system breakpoint
+    /// and the rolling breakpoint still lands on the last message, exactly
+    /// two total, middle messages untouched.
+    #[tokio::test]
+    async fn cache_passthrough_merged_system_carrier_plus_rolling_multi_turn() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let provider = OpenAiCompatibleModelProvider {
+            merge_system_into_user: true,
+            ..provider
+        };
+        let messages = vec![
+            ChatMessage::system("core policy"),
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello"),
+            ChatMessage::user("bye"),
+        ];
+        let result = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("merged multi-turn request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0]["messages"],
+            serde_json::json!([
+                {"role": "user", "content": [
+                    {"type": "text", "text": "core policy\n\nhi",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "bye",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+            ]),
+            "merged carrier and rolling breakpoint with middle messages untouched"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            2,
+            "merged multi-turn must carry exactly two breakpoints"
+        );
+    }
+
+    /// Audit blocker 2, assistant-first history: the merged user is not
+    /// message zero; the carrier index must follow the first user wherever
+    /// it sits.
+    #[tokio::test]
+    async fn cache_passthrough_merged_system_marks_first_user_after_assistant() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let provider = OpenAiCompatibleModelProvider {
+            merge_system_into_user: true,
+            ..provider
+        };
+        let messages = vec![
+            ChatMessage::assistant("ack"),
+            ChatMessage::system("core policy"),
+            ChatMessage::user("hello"),
+        ];
+        let result = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("assistant-first merged request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0]["messages"],
+            serde_json::json!([
+                {"role": "assistant", "content": "ack"},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "core policy\n\nhello",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+            ]),
+            "carrier breakpoint lands on the merged user, not on message zero"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            1,
+            "assistant + merged user is a single exchange: no rolling breakpoint"
+        );
+    }
+
+    /// Streaming twin of the merged-carrier pin.
+    #[tokio::test]
+    async fn cache_passthrough_merged_system_streaming_matches_non_streaming() {
+        use futures_util::StreamExt as _;
+
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let provider = OpenAiCompatibleModelProvider {
+            merge_system_into_user: true,
+            ..provider
+        };
+        let events = provider
+            .stream_chat(
+                ProviderChatRequest {
+                    messages: &[ChatMessage::system("be brief"), ChatMessage::user("hello")],
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+                StreamOptions {
+                    enabled: true,
+                    count_tokens: false,
+                },
+            )
+            .collect::<Vec<_>>()
+            .await;
+        server.abort();
+        assert!(
+            events.iter().all(Result::is_ok),
+            "merged streaming request must succeed: {events:?}"
+        );
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0]["messages"],
+            serde_json::json!([
+                {"role": "user", "content": [
+                    {"type": "text", "text": "be brief\n\nhello",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
+            ]),
+            "streaming merged carrier carries the breakpoint identically"
+        );
+    }
+
+    /// Flag-off merged: the merge behavior is unchanged and the wire stays
+    /// free of markers.
+    #[tokio::test]
+    async fn cache_passthrough_merged_flag_off_body_unmarked() {
+        let (provider, captured, server) = mock_streaming_cache_capture(false).await;
+        let provider = OpenAiCompatibleModelProvider {
+            merge_system_into_user: true,
+            ..provider
+        };
+        let messages = vec![
+            ChatMessage::system("core policy"),
+            ChatMessage::user("hello"),
+        ];
+        let result = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-off merged request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0]["messages"],
+            serde_json::json!([
+                {"role": "user", "content": "core policy\n\nhello"},
+            ]),
+            "flag-off merged body must be byte-identical to the pre-feature wire"
+        );
+        assert!(
+            !requests[0].to_string().contains("cache_control"),
+            "flag-off merged request must carry no cache markers"
+        );
+    }
+
+    /// Audit blocker 1 regression: the text-only helpers must never emit
+    /// cache breakpoints even with the flag on, because their responses
+    /// drop usage and could never account for the premium.
+    #[tokio::test]
+    async fn cache_passthrough_simple_paths_emit_no_breakpoints_even_when_enabled() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let _ = provider
+            .chat_with_system(Some("be brief"), "hello", "test-model", None)
+            .await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello"),
+            ChatMessage::user("bye"),
+        ];
+        let _ = provider
+            .chat_with_history(&messages, "test-model", None)
+            .await;
+        server.abort();
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        for (index, request) in requests.iter().enumerate() {
+            assert!(
+                !request.to_string().contains("cache_control"),
+                "simple path {index} must not emit cache breakpoints: {request}"
+            );
+        }
+    }
+
+    /// Audit blocker 1 regression, streaming side: the legacy chunk stream
+    /// drops usage, so it must not trigger premium writes either.
+    #[tokio::test]
+    async fn cache_passthrough_legacy_stream_emits_no_breakpoints_even_when_enabled() {
+        use futures_util::StreamExt as _;
+
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let events = provider
+            .stream_chat_with_system(
+                Some("be brief"),
+                "hello",
+                "test-model",
+                None,
+                StreamOptions {
+                    enabled: true,
+                    count_tokens: false,
+                },
+            )
+            .collect::<Vec<_>>()
+            .await;
+        server.abort();
+        let _ = events;
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(
+            !requests[0].to_string().contains("cache_control"),
+            "legacy chunk stream must carry no cache markers even with the flag on"
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -9043,6 +9478,7 @@ mod tests {
             "openai/gpt-oss-120b",
             None,
             true,
+            false,
         );
         let default_message = &default_request.messages[0];
         assert_eq!(default_message.role, "assistant");
@@ -9078,6 +9514,7 @@ mod tests {
             "openai/gpt-oss-120b",
             None,
             true,
+            false,
         );
         let groq_message = &groq_request.messages[0];
         assert_eq!(groq_message.role, "assistant");

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -990,9 +990,13 @@ impl OpenAiCompatibleModelProvider {
     /// is marked unconditionally. (b) The last message's trailing text part
     /// carries a rolling breakpoint once the conversation has more than one
     /// non-system message, the same gate the native provider applies before
-    /// `apply_cache_to_last_message`. At most two breakpoints per request;
-    /// only breakpoint-carrying messages convert from string content to
-    /// block form, every other message serializes exactly as before.
+    /// `apply_cache_to_last_message`. (c) The previous turn's last message
+    /// (the index before the last user message) carries the prior-turn
+    /// breakpoint under the shared placement rule, so turn-boundary cache
+    /// misses fall back to the previous turn instead of the system prompt.
+    /// At most three breakpoints per request; only breakpoint-carrying
+    /// messages convert from string content to block form, every other
+    /// message serializes exactly as before.
     fn apply_cache_breakpoints<T: CacheBreakpointMessage>(
         &self,
         messages: &mut [T],
@@ -1026,6 +1030,11 @@ impl OpenAiCompatibleModelProvider {
             && let Some(last) = messages.last_mut()
             && last.cache_role() != "system"
             && let Some(content) = last.cache_content()
+        {
+            content.apply_cache_control();
+        }
+        if let Some(index) = Self::prior_turn_breakpoint_index(messages, carrier)
+            && let Some(content) = messages[index].cache_content()
         {
             content.apply_cache_control();
         }

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1044,6 +1044,45 @@ impl OpenAiCompatibleModelProvider {
         }
     }
 
+    /// Index of the prior turn's final message for the third cache
+    /// breakpoint, or `None` when no valid placement exists.
+    ///
+    /// The last user message starts the current turn, so the message before
+    /// it is the previous turn's last message (usually the assistant's final
+    /// text), and every request within the current turn shares the wire
+    /// prefix through that index byte-for-byte. The candidate is rejected
+    /// when it sits at the system/carrier position or carries no markable
+    /// content; rejection walks back at most two steps (tool-call carriers
+    /// and trailing-image messages are breakpoint-transparent) and then gives
+    /// up, because a marker placed further back would not survive the turn
+    /// and prefix stability is worth more than the extra cache hit. The
+    /// candidate can never be the final message: it starts at least one index
+    /// before the last user message and only moves backwards, so it never
+    /// collides with the rolling marker.
+    ///
+    /// Twin of `AnthropicModelProvider::prior_turn_breakpoint_index` in
+    /// `anthropic.rs`; duplicated because a shared trait would drag the two
+    /// providers' wire message types across module boundaries.
+    fn prior_turn_breakpoint_index<T: CacheBreakpointMessage>(
+        messages: &[T],
+        carrier: Option<usize>,
+    ) -> Option<usize> {
+        let last_user = messages.iter().rposition(|m| m.cache_role() == "user")?;
+        let mut candidate = last_user.checked_sub(1)?;
+        for _ in 0..3 {
+            let after_carrier = carrier.is_none_or(|idx| candidate > idx);
+            if candidate > 0
+                && after_carrier
+                && messages[candidate].cache_role() != "system"
+                && messages[candidate].has_cacheable_content()
+            {
+                return Some(candidate);
+            }
+            candidate = candidate.checked_sub(1)?;
+        }
+        None
+    }
+
     /// Build the full URL for chat completions, detecting if base_url already includes the path.
     /// This allows custom model_providers with non-standard endpoints (e.g., VolcEngine ARK uses
     /// `/api/coding/v3/chat/completions` instead of `/v1/chat/completions`).
@@ -1252,6 +1291,17 @@ impl MessageContent {
             }
         }
     }
+
+    /// Whether `apply_cache_control` would actually land a marker: plain
+    /// text always, block form only when it ends on a text part (trailing
+    /// image parts are left unmarked, mirroring the native Anthropic
+    /// provider's block-type gate).
+    fn cacheable(&self) -> bool {
+        match self {
+            MessageContent::Text(_) => true,
+            MessageContent::Parts(parts) => matches!(parts.last(), Some(MessagePart::Text { .. })),
+        }
+    }
 }
 
 /// Uniform (role, content) access over the two wire message shapes so one
@@ -1260,6 +1310,12 @@ impl MessageContent {
 trait CacheBreakpointMessage {
     fn cache_role(&self) -> &str;
     fn cache_content(&mut self) -> Option<&mut MessageContent>;
+    /// Whether a breakpoint on this message would actually land. Tool-call
+    /// carriers are the `tool_use` analog: on the native wire those blocks
+    /// always trail the message, so the native placement match skips them,
+    /// and the field-form carrier is skipped for the same reason even when
+    /// incidental text rides along.
+    fn has_cacheable_content(&self) -> bool;
 }
 
 impl CacheBreakpointMessage for Message {
@@ -1270,6 +1326,10 @@ impl CacheBreakpointMessage for Message {
     fn cache_content(&mut self) -> Option<&mut MessageContent> {
         Some(&mut self.content)
     }
+
+    fn has_cacheable_content(&self) -> bool {
+        self.content.cacheable()
+    }
 }
 
 impl CacheBreakpointMessage for NativeMessage {
@@ -1279,6 +1339,10 @@ impl CacheBreakpointMessage for NativeMessage {
 
     fn cache_content(&mut self) -> Option<&mut MessageContent> {
         self.content.as_mut()
+    }
+
+    fn has_cacheable_content(&self) -> bool {
+        self.tool_calls.is_none() && self.content.as_ref().is_some_and(MessageContent::cacheable)
     }
 }
 

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -4663,18 +4663,22 @@ mod tests {
                      "cache_control": {"type": "ephemeral"}},
                 ]},
                 {"role": "user", "content": "hi"},
-                {"role": "assistant", "content": "hello"},
+                {"role": "assistant", "content": [
+                    {"type": "text", "text": "hello",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
                 {"role": "user", "content": [
                     {"type": "text", "text": "bye",
                      "cache_control": {"type": "ephemeral"}},
                 ]},
             ]),
-            "system and last message carry the breakpoints; middle messages untouched"
+            "system, previous turn's last message, and current last message carry the \
+             breakpoints; earlier messages untouched"
         );
         assert_eq!(
             requests[0].to_string().matches("cache_control").count(),
-            2,
-            "rolling breakpoint must never exceed two per request"
+            3,
+            "two-turn history must carry the system, prior-turn, and rolling breakpoints"
         );
     }
 
@@ -4830,8 +4834,8 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert_eq!(
             requests[0].to_string().matches("cache_control").count(),
-            2,
-            "tools path must carry at most the two standard breakpoints"
+            3,
+            "tools path must carry at most the three standard breakpoints"
         );
         assert_eq!(
             requests[0]["messages"][0]["content"][0]["cache_control"],
@@ -9192,9 +9196,10 @@ mod tests {
         );
     }
 
-    /// Merged-carrier, multi-turn: the carrier keeps the system breakpoint
-    /// and the rolling breakpoint still lands on the last message, exactly
-    /// two total, middle messages untouched.
+    /// Merged-carrier, multi-turn: the carrier keeps the system breakpoint,
+    /// the previous turn's last message takes the prior-turn breakpoint
+    /// after it, and the rolling breakpoint still lands on the last message,
+    /// exactly three total, earlier messages untouched.
     #[tokio::test]
     async fn cache_passthrough_merged_system_carrier_plus_rolling_multi_turn() {
         let (provider, captured, server) = mock_streaming_cache_capture(true).await;
@@ -9229,18 +9234,222 @@ mod tests {
                     {"type": "text", "text": "core policy\n\nhi",
                      "cache_control": {"type": "ephemeral"}},
                 ]},
-                {"role": "assistant", "content": "hello"},
+                {"role": "assistant", "content": [
+                    {"type": "text", "text": "hello",
+                     "cache_control": {"type": "ephemeral"}},
+                ]},
                 {"role": "user", "content": [
                     {"type": "text", "text": "bye",
                      "cache_control": {"type": "ephemeral"}},
                 ]},
             ]),
-            "merged carrier and rolling breakpoint with middle messages untouched"
+            "merged carrier, prior-turn, and rolling breakpoint with earlier messages untouched"
         );
         assert_eq!(
             requests[0].to_string().matches("cache_control").count(),
+            3,
+            "merged multi-turn must carry exactly three breakpoints"
+        );
+    }
+
+    /// Single completed turn: the rolling breakpoint lands on the assistant
+    /// reply, and the prior-turn rule stays silent because the only user
+    /// message opens the turn. Exactly two markers.
+    #[tokio::test]
+    async fn cache_passthrough_single_turn_carries_two_markers() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello"),
+        ];
+        let result = provider
+            .chat(
+                ProviderChatRequest {
+                    messages: &messages,
+                    tools: None,
+                    thinking: None,
+                },
+                "test-model",
+                None,
+            )
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on single-turn request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
             2,
-            "merged multi-turn must carry exactly two breakpoints"
+            "a single turn carries the system and rolling breakpoints only"
+        );
+        assert_eq!(
+            requests[0]["messages"][2]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"}),
+            "rolling breakpoint lands on the assistant reply"
+        );
+    }
+
+    /// Two-turn tool-heavy history: the prior-turn marker lands on the
+    /// previous turn's final assistant text even though tool traffic fills
+    /// the middle. Three markers total; the tool-call carrier and the tool
+    /// result inside the turns carry none.
+    #[tokio::test]
+    async fn cache_passthrough_two_turn_tool_history_marks_prior_assistant_text() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("list the files"),
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "call_1", "name": "list_files", "arguments": "{}"}
+                    ]
+                })
+                .to_string(),
+            ),
+            ChatMessage::tool("a.txt\nb.txt"),
+            ChatMessage::assistant("two files: a.txt and b.txt"),
+            ChatMessage::user("which is larger?"),
+        ];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "list_files",
+                "description": "List files",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })];
+        let result = provider
+            .chat_with_tools(&messages, &tools, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on tool history request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        let wire_messages = requests[0]["messages"].as_array().unwrap();
+        assert_eq!(
+            wire_messages.len(),
+            6,
+            "tool history wire shape changed: {wire_messages:?}"
+        );
+        let marked: Vec<usize> = wire_messages
+            .iter()
+            .enumerate()
+            .filter(|(_, message)| message.to_string().contains("cache_control"))
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(
+            marked,
+            vec![0, 4, 5],
+            "system, previous turn's last assistant text, and current last message carry \
+             the markers"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            3,
+            "never more than three breakpoints per request"
+        );
+    }
+
+    /// The previous turn was cut short after its tool result: the prior-turn
+    /// marker lands on the tool result message itself.
+    #[tokio::test]
+    async fn cache_passthrough_prior_turn_marker_lands_on_tool_result() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("list the files"),
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "call_1", "name": "list_files", "arguments": "{}"}
+                    ]
+                })
+                .to_string(),
+            ),
+            ChatMessage::tool("a.txt\nb.txt"),
+            ChatMessage::user("which is larger?"),
+        ];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "list_files",
+                "description": "List files",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })];
+        let result = provider
+            .chat_with_tools(&messages, &tools, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on interrupted-turn request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        let wire_messages = requests[0]["messages"].as_array().unwrap();
+        let marked: Vec<usize> = wire_messages
+            .iter()
+            .enumerate()
+            .filter(|(_, message)| message.to_string().contains("cache_control"))
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(
+            marked,
+            vec![0, 3, 4],
+            "system, the trailing tool result of the interrupted turn, and the current last \
+             message carry the markers"
+        );
+    }
+
+    /// An orphaned tool-call carrier sits between the previous user message
+    /// and the new turn: the carrier is breakpoint-transparent (the tool_use
+    /// analog), so the marker walks back onto the previous user message.
+    #[tokio::test]
+    async fn cache_passthrough_prior_turn_walks_back_off_tool_call_carrier() {
+        let (provider, captured, server) = mock_streaming_cache_capture(true).await;
+        let messages = vec![
+            ChatMessage::system("you are brief"),
+            ChatMessage::user("list the files"),
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "call_1", "name": "list_files", "arguments": "{}"}
+                    ]
+                })
+                .to_string(),
+            ),
+            ChatMessage::user("never mind, which files exist?"),
+        ];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "list_files",
+                "description": "List files",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })];
+        let result = provider
+            .chat_with_tools(&messages, &tools, "test-model", None)
+            .await;
+        server.abort();
+        result.unwrap_or_else(|error| panic!("flag-on orphaned-carrier request failed: {error}"));
+        let requests = captured.lock().unwrap();
+        let wire_messages = requests[0]["messages"].as_array().unwrap();
+        let marked: Vec<usize> = wire_messages
+            .iter()
+            .enumerate()
+            .filter(|(_, message)| message.to_string().contains("cache_control"))
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(
+            marked,
+            vec![0, 1, 3],
+            "the marker steps back off the carrier onto the previous user message"
+        );
+        assert_eq!(
+            requests[0].to_string().matches("cache_control").count(),
+            3,
+            "the walk-back still stays inside the three-marker cap"
         );
     }
 

--- a/crates/zeroclaw-providers/src/factory.rs
+++ b/crates/zeroclaw-providers/src/factory.rs
@@ -254,6 +254,9 @@ pub fn apply_compat_options(
     if opts.replay_assistant_reasoning == Some(false) {
         b = b.without_assistant_reasoning_replay();
     }
+    if opts.cache_passthrough {
+        b = b.with_cache_passthrough();
+    }
     // `provider_extra` alias is captured before `build()` because the WARN
     // path below reads it for logging. Only object-shaped JSON is threaded
     // through; other shapes produce a WARN and are ignored (matching the
@@ -1811,6 +1814,33 @@ impl FamilyProviderFactory for zeroclaw_config::schema::ModelProviderConfig {
 mod tests {
     use super::*;
     use zeroclaw_config::schema::{ModelProviderConfig, WireApi};
+
+    #[test]
+    fn cache_passthrough_runtime_option_reaches_provider_capability() {
+        let provider = apply_compat_options(
+            OpenAiCompatibleModelProvider::builder("test")
+                .display_name("custom")
+                .base_url("http://127.0.0.1:1")
+                .auth_style(AuthStyle::Bearer),
+            &ModelProviderRuntimeOptions {
+                cache_passthrough: true,
+                ..ModelProviderRuntimeOptions::default()
+            },
+        );
+        assert!(
+            provider.capabilities().prompt_caching,
+            "factory must thread cache_passthrough into the provider capability"
+        );
+
+        let default_provider = apply_compat_options(
+            OpenAiCompatibleModelProvider::builder("test")
+                .display_name("custom")
+                .base_url("http://127.0.0.1:1")
+                .auth_style(AuthStyle::Bearer),
+            &ModelProviderRuntimeOptions::default(),
+        );
+        assert!(!default_provider.capabilities().prompt_caching);
+    }
 
     #[test]
     fn endpoint_registry_classifies_every_canonical_family() {

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -632,6 +632,11 @@ pub struct ModelProviderRuntimeOptions {
     /// When `Some(false)`, strip assistant reasoning fields from outbound
     /// history replay. `None` honours provider default.
     pub replay_assistant_reasoning: Option<bool>,
+    /// Forward Anthropic prompt caching through OpenAI-compatible providers:
+    /// inject `cache_control` breakpoints (system prompt; rolling last
+    /// message) into request bodies and capture gateway-reported cache
+    /// usage. Propagated from `ModelProviderConfig::cache_passthrough`.
+    pub cache_passthrough: bool,
     /// When set, the provider is asked to use its native tool-calling
     /// schema instead of OpenAI-compat tool calls. Generic across families.
     pub native_tools: Option<bool>,
@@ -677,6 +682,7 @@ impl Default for ModelProviderRuntimeOptions {
             merge_system_into_user: false,
             provider_extra: None,
             replay_assistant_reasoning: None,
+            cache_passthrough: false,
             native_tools: None,
             wire_api: None,
             think: None,
@@ -741,6 +747,7 @@ pub fn model_provider_runtime_options_from_model_provider_entry(
         merge_system_into_user,
         provider_extra: entry.and_then(|e| e.provider_extra.clone()),
         replay_assistant_reasoning: entry.and_then(|e| e.replay_assistant_reasoning),
+        cache_passthrough: entry.is_some_and(|e| e.cache_passthrough),
         native_tools: entry.and_then(|e| e.native_tools),
         wire_api: entry.and_then(|e| e.wire_api.map(|w| w.as_str().to_string())),
         think: entry.and_then(|e| e.think),
@@ -2734,6 +2741,23 @@ mod tests {
             Some(&entry),
         );
         assert_eq!(opts.tool_result_image_policy, ToolResultImagePolicy::Omit);
+    }
+
+    #[test]
+    fn cache_passthrough_config_field_maps_into_runtime_options() {
+        use zeroclaw_config::schema::{Config, ModelProviderConfig};
+        let entry = ModelProviderConfig {
+            cache_passthrough: true,
+            ..Default::default()
+        };
+        let opts = model_provider_runtime_options_from_model_provider_entry(
+            &Config::default(),
+            Some(&entry),
+        );
+        assert!(opts.cache_passthrough);
+        let defaults =
+            model_provider_runtime_options_from_model_provider_entry(&Config::default(), None);
+        assert!(!defaults.cache_passthrough);
     }
 
     #[test]

--- a/docs/book/src/providers/configuration.md
+++ b/docs/book/src/providers/configuration.md
@@ -22,6 +22,7 @@ Almost every family also takes the shared fields from `ModelProviderConfig`:
 - `wire_api`, `native_tools`, `provider_extra`, `think`, and `chat_template_kwargs`: advanced protocol and request-body overrides.
 - `vision`: override the provider's image-input (vision) capability. Leave unset to use the family's built-in default. Set `false` for a text-only model served by a vision-capable family (for example, a text model behind llama.cpp) so image messages route to a configured `[multimodal] vision_model_provider` instead of erroring; set `true` to force it on.
 - `tool_result_image_policy`: handling for image markers in native `role = "tool"` results sent to compatible chat-completions providers. Defaults to `"image_url"`; set to `"omit"` to remove image URI/base64 payloads and append a fixed notice. This does not change direct user images or OpenAI Responses providers.
+- `cache_passthrough`: opt into Anthropic prompt caching on chat-completions gateways that translate to the Anthropic Messages API. Adds at most two `cache_control` breakpoints per request and surfaces gateway-reported cache reads in token usage. Default `false`, requests unchanged. Requires route qualification before production use; see [Prompt cache passthrough](#prompt-cache-passthrough-chat-completions-gateways).
 - `tls_ca_cert_path`: absolute path to a PEM-encoded CA certificate for TLS connections to this provider (a per-provider trust override, distinct from the gateway TLS `ca_cert_path`). Shell expansion such as `~` is not performed; leave unset to use the system trust store.
 
 Family-specific entries add their own typed fields on top of these shared fields.
@@ -137,6 +138,62 @@ The setting requires an Anthropic account enrolled in the
 `thinking-display-updates` beta; without enrollment the API rejects the
 request. Set `display = "off"` (or remove the field) to return to the
 previous wire behavior.
+
+## Prompt cache passthrough (chat-completions gateways)
+
+`cache_passthrough = true` on a chat-completions provider alias opts its
+requests into Anthropic prompt caching. Use it on gateways that translate
+Chat Completions into the Anthropic Messages API (LiteLLM, TrueFoundry,
+and similar); the native Anthropic family already caches by default and
+ignores this field.
+
+With the flag on, requests gain at most two `cache_control` breakpoints,
+placed the same way the native Anthropic provider places them: one on the
+system prompt, and one rolling breakpoint on the last message once the
+conversation has more than one non-system message. Only messages carrying
+a breakpoint change serialization. With the flag off (the default),
+request bodies are byte-identical to previous versions.
+
+```toml
+[providers.models.custom.claude-via-gateway]
+uri = "https://<gateway-host>/v1"
+model = "<anthropic-routed model>"
+api_key = "op://platform/gateway/api-key"
+cache_passthrough = true
+```
+
+Requirements and caveats:
+
+- **Gateway support is required.** The breakpoint reaches Anthropic only
+  when the gateway forwards block-form content with `cache_control` into
+  the native Messages API. Routes that proxy the OpenAI API proper ignore
+  the field. A non-Anthropic-routed model behind the same gateway does not
+  fail loudly: the field is accepted and dropped, and the gateway may still
+  meter cache-write tokens on that route in its own usage accounting. Give
+  Anthropic-routed models a dedicated alias instead of enabling the flag on
+  a mixed entry.
+- **Size and TTL.** Anthropic caches only prefixes of at least 1024 tokens
+  (2048 on some smaller models), and entries expire after roughly five
+  minutes, refreshed on each read. Short or infrequent conversations see
+  no benefit.
+- **Writes bill at a premium.** Tokens written to the cache are billed at
+  a premium (1.25x on the observed route) and reads come back at a large
+  discount. A route that writes the cache on every request without ever
+  reading it costs more than no caching at all.
+- **Qualify the exact route first.** A gateway exposes many model aliases
+  to the same upstream account, and an alias that accepts and bills cache
+  writes can still never serve cache reads. Before relying on the flag in
+  production, send one flagged request and check the usage reports
+  `cache_creation_input_tokens > 0`; then immediately repeat the
+  byte-identical request and check for `cache_read_input_tokens > 0`.
+  Cache creation alone is not evidence that caching works. Re-run the pair
+  after any model-alias or gateway-route change.
+- **Usage reporting.** When the gateway forwards the Anthropic-shaped
+  usage counters, `cache_read_input_tokens` fills the cached-input figure
+  in token usage and cost reporting, and `cache_creation_input_tokens` is
+  written to the debug log with counts only. A response that reports zero
+  cache reads keeps the cached figure at zero rather than substituting the
+  OpenAI-shaped counter.
 
 ## Per-family knobs: worked examples
 

--- a/docs/book/src/providers/configuration.md
+++ b/docs/book/src/providers/configuration.md
@@ -150,9 +150,20 @@ ignores this field.
 With the flag on, requests gain at most two `cache_control` breakpoints,
 placed the same way the native Anthropic provider places them: one on the
 system prompt, and one rolling breakpoint on the last message once the
-conversation has more than one non-system message. Only messages carrying
-a breakpoint change serialization. With the flag off (the default),
-request bodies are byte-identical to previous versions.
+conversation has more than one non-system message. With
+`merge_system_into_user` the system role never reaches the wire, so the
+merged first user message (or the synthetic user carrying the system text)
+carries the system-equivalent breakpoint instead. Only breakpoint-carrying
+messages change serialization.
+
+The flag also scopes to the structured request paths: agent turns, tool
+calls, and structured streaming. The text-only helpers (`chat_with_system`,
+`chat_with_history`, the legacy chunk-stream APIs) deliberately emit no
+breakpoints even with the flag on, because their responses drop token usage
+entirely; a premium cache write they triggered could never show up in
+accounting. On those helpers the flag is inert, which also means fallback
+re-entries that route through them send unmarked requests. With the flag
+off (the default), request bodies are byte-identical to previous versions.
 
 ```toml
 [providers.models.custom.claude-via-gateway]
@@ -193,7 +204,15 @@ Requirements and caveats:
   in token usage and cost reporting, and `cache_creation_input_tokens` is
   written to the debug log with counts only. A response that reports zero
   cache reads keeps the cached figure at zero rather than substituting the
-  OpenAI-shaped counter.
+  OpenAI-shaped counter. This accounting covers the structured paths only,
+  which is exactly why the helpers without usage capture stay inert above.
+- **Tool definitions are not separately marked.** The native Anthropic
+  provider additionally marks the last tool definition, which covers
+  tool-schema tokens when no system prompt exists. This flag does not mark
+  tool definitions; requests with tools but no system prompt cache only the
+  rolling message breakpoint. The live gateway qualification showed that
+  with a system prompt present, tool-schema tokens sit inside the cached
+  prefix anyway.
 
 ## Per-family knobs: worked examples
 

--- a/docs/book/src/providers/configuration.md
+++ b/docs/book/src/providers/configuration.md
@@ -22,7 +22,7 @@ Almost every family also takes the shared fields from `ModelProviderConfig`:
 - `wire_api`, `native_tools`, `provider_extra`, `think`, and `chat_template_kwargs`: advanced protocol and request-body overrides.
 - `vision`: override the provider's image-input (vision) capability. Leave unset to use the family's built-in default. Set `false` for a text-only model served by a vision-capable family (for example, a text model behind llama.cpp) so image messages route to a configured `[multimodal] vision_model_provider` instead of erroring; set `true` to force it on.
 - `tool_result_image_policy`: handling for image markers in native `role = "tool"` results sent to compatible chat-completions providers. Defaults to `"image_url"`; set to `"omit"` to remove image URI/base64 payloads and append a fixed notice. This does not change direct user images or OpenAI Responses providers.
-- `cache_passthrough`: opt into Anthropic prompt caching on chat-completions gateways that translate to the Anthropic Messages API. Adds at most two `cache_control` breakpoints per request and surfaces gateway-reported cache reads in token usage. Default `false`, requests unchanged. Requires route qualification before production use; see [Prompt cache passthrough](#prompt-cache-passthrough-chat-completions-gateways).
+- `cache_passthrough`: opt into Anthropic prompt caching on chat-completions gateways that translate to the Anthropic Messages API. Adds at most three `cache_control` breakpoints per request (system, previous turn's last message, current last message) and surfaces gateway-reported cache reads in token usage. Default `false`, requests unchanged. Requires route qualification before production use; see [Prompt cache passthrough](#prompt-cache-passthrough-chat-completions-gateways).
 - `tls_ca_cert_path`: absolute path to a PEM-encoded CA certificate for TLS connections to this provider (a per-provider trust override, distinct from the gateway TLS `ca_cert_path`). Shell expansion such as `~` is not performed; leave unset to use the system trust store.
 
 Family-specific entries add their own typed fields on top of these shared fields.
@@ -147,14 +147,21 @@ Chat Completions into the Anthropic Messages API (LiteLLM, TrueFoundry,
 and similar); the native Anthropic family already caches by default and
 ignores this field.
 
-With the flag on, requests gain at most two `cache_control` breakpoints,
+With the flag on, requests gain at most three `cache_control` breakpoints,
 placed the same way the native Anthropic provider places them: one on the
-system prompt, and one rolling breakpoint on the last message once the
-conversation has more than one non-system message. With
-`merge_system_into_user` the system role never reaches the wire, so the
-merged first user message (or the synthetic user carrying the system text)
-carries the system-equivalent breakpoint instead. Only breakpoint-carrying
-messages change serialization.
+system prompt, one on the previous turn's last message, and one rolling
+breakpoint on the last message once the conversation has more than one
+non-system message. Turn-boundary cache misses fall back to the previous
+turn instead of the system prompt. On the native provider the prior-turn
+marker is placed only when the request's breakpoint budget allows it:
+Anthropic caps a request at four breakpoints counting tools, system, and
+messages together, so OAuth requests, which mark both the identity prefix
+and the system text, skip it when tool definitions spend the last slot.
+Compat requests never mark tool definitions, so all three markers always
+fit. With `merge_system_into_user` the system role never reaches the wire,
+so the merged first user message (or the synthetic user carrying the system
+text) carries the system-equivalent breakpoint instead. Only
+breakpoint-carrying messages change serialization.
 
 The flag also scopes to the structured request paths: agent turns, tool
 calls, and structured streaming. The text-only helpers (`chat_with_system`,


### PR DESCRIPTION
Closes #10660. Depends on #10623 (this branch includes its commits; the diff against master will collapse to this change once #10623 merges).

## What

Both Anthropic cache-breakpoint strategies placed exactly two `cache_control` markers: system prompt and last message. Anthropic serves a cache read only for a prefix ending at a *cached* marker, so the conversation history between those two had no marker of its own. When the last-message marker missed at a turn boundary, the longest cached prefix fell back to the system prompt and the whole history re-wrote at the write premium.

This adds a third marker on the last message of the previous turn (the message before the most recent user message), in both the native Anthropic provider and the OpenAI-compatible cache passthrough, with a shared placement rule: index of the last user message minus one, walking back at most three messages to find cacheable content, never on the system message or merged carrier, never on index 0.

## Budget

Anthropic caps a request at four markers. The native OAuth path with tools already uses all four (OAuth prefix block, system block, last tool definition, rolling last message), so the prior-turn marker is placed only when the request-wide total stays at or below four. OAuth plus tools keeps today's layout unchanged; a wire-level test pins exactly four markers and no fifth. Freeing the OAuth prefix slot is tracked separately.

## Evidence

Production ledger before the change (215k-token session, gateway-routed Claude, passthrough enabled):

| Request | input_tokens | cached_input_tokens | cost |
|---|---:|---:|---:|
| in-turn follow-up | 218,392 | 218,000 (99.8%) | $0.23 |
| first request of next turn | 217,227 | 37,011 (17.0%) | $1.90 |

37,011 is the system prompt; it was the cached count on every partial miss. Three such misses were ~55% of the session's spend.

Live two-turn test on this branch through the same gateway:

| Turn | total input | cached_input_tokens | cache write |
|---|---:|---:|---:|
| 1 | 25,443 | 0 | 25,341 |
| 2 | 25,646 | 25,341 | 303 |

Turn 2 read the entire prior history and wrote only the 303-token delta.

## Tests

19 breakpoint tests across both providers: placement on the previous assistant text, on a tool result, walk-back past non-cacheable trailing blocks, single exchange (no prior-turn marker), merged-system carrier on the compatible side, marker count within budget for plain keys / OAuth without tools / OAuth with tools, passthrough-off byte identity unchanged.

## Docs

One paragraph each in the native caching notes and the `cache_passthrough` section describing the three-marker layout and the four-marker budget.
