### PR TITLE
test(channels/discord): prove STT dispatch selects the agent's provider

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -30614,6 +30614,16 @@ This is an example JSON object for profile settings."#;
         );
     }
 
+    /// A voice note on a configured Discord channel must reach the STT server
+    /// named by the owning agent's `transcription_provider`.
+    ///
+    /// Two providers are registered so the assertion distinguishes *selection*
+    /// from *presence*: against a lone registered provider, a dispatch that
+    /// ignored the named alias and reached whatever happened to be configured
+    /// would look identical to a correct one. The decoy must receive nothing.
+    ///
+    /// The channel alias, the agent alias and the provider aliases share no
+    /// name, so nothing can route correctly by coincidence.
     #[cfg(feature = "channel-discord")]
     #[tokio::test]
     async fn configured_discord_transcription_dispatches_to_routed_agent_provider() {
@@ -30623,6 +30633,7 @@ This is an example JSON object for profile settings."#;
 
         let media_server = MockServer::start().await;
         let whisper_server = MockServer::start().await;
+        let decoy_server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/voice.ogg"))
             .respond_with(ResponseTemplate::new(200).set_body_bytes(b"fake-audio"))
@@ -30637,6 +30648,15 @@ This is an example JSON object for profile settings."#;
             )
             .expect(1)
             .mount(&whisper_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/transcribe"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"text": "decoy transcript"})),
+            )
+            .expect(0)
+            .mount(&decoy_server)
             .await;
 
         let mut config = Config::default();
@@ -30662,6 +30682,13 @@ This is an example JSON object for profile settings."#;
             "routed".to_string(),
             LocalWhisperTranscriptionProviderConfig {
                 uri: format!("{}/v1/transcribe", whisper_server.uri()),
+                ..Default::default()
+            },
+        );
+        config.providers.transcription.local_whisper.insert(
+            "decoy".to_string(),
+            LocalWhisperTranscriptionProviderConfig {
+                uri: format!("{}/v1/transcribe", decoy_server.uri()),
                 ..Default::default()
             },
         );
@@ -30695,8 +30722,19 @@ This is an example JSON object for profile settings."#;
             media.is_empty(),
             "successful direct-channel transcription must not fall back to media"
         );
+        assert!(
+            decoy_server.received_requests().await.unwrap().is_empty(),
+            "the provider the agent did not name must never be called"
+        );
+        let routed = whisper_server.received_requests().await.unwrap();
+        assert_eq!(routed.len(), 1, "exactly one transcription request");
+        assert!(
+            routed[0].body.windows(10).any(|w| w == b"fake-audio"),
+            "the routed request must carry the downloaded audio bytes verbatim"
+        );
         media_server.verify().await;
         whisper_server.verify().await;
+        decoy_server.verify().await;
     }
 
     // Regression: Voice Wake bound its transcription manager to its own


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - #10624 added a configured-route STT regression for Matrix and noted in passing that the Discord equivalent, `configured_discord_transcription_dispatches_to_routed_agent_provider`, registers only one transcription provider. The review there suggested keeping that as a separate follow-up rather than folding it in. This is that follow-up.
  - With a single provider registered, the test asserts that transcription happened *through a configured alias* — not that dispatch *selected the alias the owning agent names*. Those two outcomes are indistinguishable when there is only one provider to reach.
  - This registers a decoy provider on a second mock STT server, leaves the agent pointed at `local_whisper.routed`, and asserts the decoy receives nothing: an `.expect(0)` mock plus an explicit message-bearing assertion, so the guard does not rest on wiremock drop semantics. It also asserts the routed server received the downloaded bytes, which the Matrix regression checks and this one did not.
  - **One assumption in #10624's body was wrong and is corrected below:** that `TranscriptionManager::from_config_with_provider` falls back to a sole registered provider. It does not — that fallback lives in `build_transcription_manager`, which is Matrix-only.
- **Scope boundary:** Test-only. No production code, config, schema, or public API is touched, and no other channel or test is modified. The existing test name, the `routed` alias, and every existing assertion are unchanged — the diff is +38/−0. **Where the mirror stops short:** the Discord test still drives the pipeline through `process_attachments_for_test`, a `#[cfg(test)]` shortcut, where the Matrix test goes through real `register_event_handlers` and sync dispatch. Provider *selection* is production-derived either way — the manager comes from `build_configured_discord_channel` — but closing that gap needs a production change, so it is out of scope here rather than silently claimed.
- **Blast radius:** None outside this one test. It cannot affect runtime behaviour; the only risk it carries is being wrong about what it asserts, which the breakage runs below are meant to settle.
- **Linked issue(s):** Related #10624
- **Labels:** `channel`, `tests`, `channel:core`, `channel:discord`, `risk:medium`, `size:XS`, `type:test`.

## Correcting the assumption behind the original offer

#10624's body offered this change on the grounds that the Discord test "shares the sole-provider blind spot", because `from_config_with_provider` "would still land on `local_whisper.routed` if the agent's preference were dropped, and the test would stay green". That reasoning does not hold on the Discord path:

- `build_transcription_manager` — the function that binds a lone registered provider when the agent states no preference — is defined in `crates/zeroclaw-channels/src/matrix.rs` and is `pub(crate)`. Its only non-test callers sit inside `#[cfg(feature = "channel-matrix")]` channel construction.
- `configure_discord_transcription` calls `TranscriptionManager::from_config_with_provider` **directly**. That constructor binds the alias it is handed, verbatim; there is no fallback in it. `transcribe` then bails when the bound alias is empty, and `transcribe_with_provider` errors when it is not registered.
- The test also already set `transcription_provider: "local_whisper.routed"`, so the fallback's trigger condition — an *empty* preference — was never met in the first place.

Run 3 below is that exact experiment: preference dropped, one provider registered. The claim predicted green; it fails.

**The narrower case that does hold.** With one registered provider the test still cannot distinguish selection from presence, and one concrete regression makes that matter: routing Discord through `build_transcription_manager`, which is the obvious cleanup once both channels want the same helper. Under that change a one-provider fixture goes green through the sole-provider fallback whenever the resolved preference is empty. With two providers registered there is no sole provider to bind, the alias stays empty, and dispatch bails.

To be precise about the limit: against a hypothetical "picks an arbitrary registered provider" bug the decoy is only probabilistic, since `transcription_providers` is a `HashMap` with the default randomized hasher and two entries. Run 2b shows the guard is load-bearing rather than decoration.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — test-only change with no user-visible behavior; the coverage claim is verifiable from the deliberate-breakage runs below and from required CI, which executes this test.

### How I tested

All runs in a pinned container (no host Rust toolchain), on `e6f568fa`.

**Every assertion has a run in which it is the one that fires.** A breakage run only validates the first assertion to trip, so one run per claim rather than one run overall — that caught a real problem in this change, noted under Run 2c.

**Run 1 — baseline, as committed. PASSES.**

```
$ cargo nextest run --locked -p zeroclaw-channels --lib configured_discord_transcription_dispatches_to_routed_agent_provider
        PASS [   0.050s] (1/1) zeroclaw-channels orchestrator::tests::configured_discord_transcription_dispatches_to_routed_agent_provider
     Summary [   0.051s] 1 test run: 1 passed, 1549 skipped
```

**Run 2 — agent repointed at the decoy (`transcription_provider: "local_whisper.decoy"`). FAILS on the transcript assertion.**

```
    panicked at crates/zeroclaw-channels/src/orchestrator/mod.rs:30720:9:
    assertion `left == right` failed
      left: "[Voice] decoy transcript"
     right: "[Voice] routed transcript"
```

**Run 2b — the decoy guard on its own.** Run 2 trips the transcript assertion, which fires first, so it proves routing is caught and nothing about the decoy guard. Repeated with the decoy returning *identical* text, so the observable transcript is correct and only the decoy guard can catch the misroute. **FAILS on that guard.**

```
    panicked at crates/zeroclaw-channels/src/orchestrator/mod.rs:30725:9:
    the provider the agent did not name must never be called
```

**Run 2c — the payload assertion on its own.** Media server serves different bytes; routing is correct, so the decoy guard passes and only the payload check can fail. **FAILS on it.**

```
    panicked at crates/zeroclaw-channels/src/orchestrator/mod.rs:30731:9:
    the routed request must carry the downloaded audio bytes verbatim
```

Run 2c is why the decoy assertion precedes the payload assertions. Ordered the other way — which is how the Matrix regression is ordered — Run 2b tripped `exactly one transcription request` instead and the decoy guard went unproven. It also gives the better diagnostic: a routing regression names the routing, not a request count.

**Run 3 — the disproof of the assumption above.** Agent preference emptied and the decoy deregistered, so exactly one provider is registered. **FAILS**: `transcribe` bails on the empty alias and the attachment falls back to media.

```
    panicked at crates/zeroclaw-channels/src/orchestrator/mod.rs:30713:9:
    assertion `left == right` failed
      left: "[AUDIO:/root/.zeroclaw/agents/listener/workspace/discord_files/...voice.ogg]"
     right: "[Voice] routed transcript"
```

The same experiment on the Matrix side passes, which is what the sole-provider fallback there produces. The opposite result here is the evidence that the Discord path has no such fallback.

**Gates, on the committed state:**

```
$ cargo nextest run --locked -p zeroclaw-channels --lib orchestrator::
     Summary [   5.290s] 583 tests run: 583 passed, 967 skipped

$ ZEROCLAW_PARALLEL_TEST_SCOPE=channels scripts/ci/parallel_runtime_test_gate.sh   # 3x, 16 threads
test result: ok. 1547 passed; 0 failed; 2 ignored; 0 measured; 1 filtered out; finished in 9.24s
test result: ok. 1547 passed; 0 failed; 2 ignored; 0 measured; 1 filtered out; finished in 9.27s
test result: ok. 1547 passed; 0 failed; 2 ignored; 0 measured; 1 filtered out; finished in 9.14s

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ bash scripts/ci/rust_quality_gate.sh --strict
==> rust quality: provider dispatch gate clean
```

- **CI checks relied on and why they cover this change:** Two required jobs. `test` runs `cargo nextest run --locked --workspace --exclude zeroclaw-desktop`; `channel-discord` is in `default-channels`, which is `default` in `crates/zeroclaw-channels/Cargo.toml`, and that step applies no `--features` flag and no test-name filter, so this test compiles and executes there. `parallel-runtime-test` also fires — `crates/zeroclaw-channels/*` gives `scope=channels` in `scripts/ci/parallel_runtime_test_scope.sh` — and runs the whole `zeroclaw-channels` lib 3× at 16 threads. That one matters here because this PR adds a third `wiremock` listener to a test running under that contention, so I ran it locally rather than relying on it. `Lint` covers the added doc comment through the comment-hygiene gate.
- **Known CI coverage gap, if any:** None. This test has always run in required CI.
- **Commands run and tail output:** Above.
- **Beyond CI, what did you manually verify?** That each assertion fails on its own (Runs 2, 2b, 2c), and that the sole-provider assumption does not hold on this path (Run 3), traced through `configure_discord_transcription` → `from_config_with_provider` → `transcribe` / `transcribe_with_provider`. **What I did NOT verify:** anything against a live Discord gateway or a real STT backend — every endpoint here is a `wiremock` mock, and I make no claim about real-world Discord attachment shapes beyond the fixture the test already used. One pre-existing failure is excluded from the parallel gate above: `tts::tests::edge_tts_removes_temp_output_when_read_fails` asserts a permission error and my container runs as root, so it fails locally and passes in CI. I confirmed it fails identically on `master` with this change absent rather than assuming it was unrelated.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — the added mock server binds a loopback port inside the test process, like the two already there.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Revert the landed squash commit. Reverting restores the previous single-provider fixture and affects nothing else.
