### PR TITLE
fix(daemon): accept channel instance composite key in heartbeat.target

### DIFF
--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -2520,17 +2520,25 @@ fn auto_detect_heartbeat_channel(config: &Config) -> Option<(String, String)> {
 }
 
 fn validate_heartbeat_channel_config(config: &Config, channel: &str) -> Result<()> {
-    if !config.channels.is_known_channel(channel) {
+    // A heartbeat target may be a bare channel type ("telegram") or a
+    // configured instance's composite key ("telegram.roy"). The channel
+    // registry (is_known_channel / is_channel_configured / is_channel_deliverable)
+    // is keyed by channel *type*, so validate the type segment. The delivery
+    // path (deliver_announcement) resolves the instance alias at send time,
+    // matching how cron delivery accepts `<type>.<alias>` refs — see
+    // cron_delivery_channel_pattern.
+    let channel_type = channel.split_once('.').map_or(channel, |(ty, _)| ty);
+    if !config.channels.is_known_channel(channel_type) {
         anyhow::bail!("unsupported heartbeat.target channel: {channel}");
     }
-    if !config.channels.is_channel_configured(channel) {
+    if !config.channels.is_channel_configured(channel_type) {
         anyhow::bail!(
-            "heartbeat.target is set to {channel} but channels.{channel} is not configured"
+            "heartbeat.target is set to {channel} but channels.{channel_type} is not configured"
         );
     }
-    if !config.channels.is_channel_deliverable(channel) {
+    if !config.channels.is_channel_deliverable(channel_type) {
         anyhow::bail!(
-            "heartbeat.target is set to {channel} but {channel} is an input-only channel that cannot deliver outbound messages"
+            "heartbeat.target is set to {channel} but {channel_type} is an input-only channel that cannot deliver outbound messages"
         );
     }
     Ok(())
@@ -3361,6 +3369,64 @@ mod tests {
             .channels
             .mqtt
             .insert("default".to_string(), Default::default());
+
+        let err = resolve_heartbeat_delivery(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("input-only channel"),
+            "expected input-only rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_delivery_accepts_composite_instance_target() {
+        // review: a heartbeat target may name a specific channel instance
+        // via its `<type>.<alias>` composite key. The delivery path requires
+        // this form to route to a non-default instance in a multi-instance
+        // setup, so validation must accept it rather than rejecting it as an
+        // unknown channel. The composite key is passed through verbatim so the
+        // delivery layer resolves the alias.
+        let mut config = Config::default();
+        config.heartbeat.target = Some("telegram.roy".into());
+        config.heartbeat.to = Some("-1003233270107".into());
+        config
+            .channels
+            .telegram
+            .insert("roy".to_string(), Default::default());
+
+        let target = resolve_heartbeat_delivery(&config).unwrap();
+        assert_eq!(
+            target,
+            Some(("telegram.roy".to_string(), "-1003233270107".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_delivery_rejects_composite_of_unknown_type() {
+        // The type segment of a composite key must still be a known channel;
+        // splitting on '.' must not let an unknown type slip through.
+        let mut config = Config::default();
+        config.heartbeat.target = Some("carrier_pigeon.roy".into());
+        config.heartbeat.to = Some("ops@example.com".into());
+        let err = resolve_heartbeat_delivery(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported heartbeat.target channel"),
+            "expected unsupported-channel rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_delivery_rejects_composite_of_undeliverable_type() {
+        // Deliverability is a property of the channel type, so a composite key
+        // whose type is input-only (mqtt) must be rejected just like the bare
+        // form rather than passing on the alias suffix.
+        let mut config = Config::default();
+        config.heartbeat.target = Some("mqtt.sensors".into());
+        config.heartbeat.to = Some("ops/heartbeat".into());
+        config
+            .channels
+            .mqtt
+            .insert("sensors".to_string(), Default::default());
 
         let err = resolve_heartbeat_delivery(&config).unwrap_err();
         assert!(


### PR DESCRIPTION
Fixes #10670.

## Problem

`heartbeat.target` rejects a channel instance's composite key (`<type>.<alias>`), so a heartbeat cannot be pointed at a specific instance when a channel type has more than one configured. Starting the daemon fails with:

```
unsupported heartbeat.target channel: telegram.roy
```

`validate_heartbeat_channel_config` validates the whole target string against `ChannelsConfig::is_known_channel`, which is keyed by channel **type** and never matches `telegram.roy`. The delivery path (`deliver_announcement`) is the mirror image: it requires the dotted `<type>.<alias>` form and only registers a bare-type key when the type has exactly one instance. In a multi-instance setup neither `telegram.roy` (rejected by validation) nor `telegram` (rejected by delivery: *"must be a dotted `<type>.<alias>` ref"*) works.

Follow-up to #6433, which generalized the old hardcoded allowlist to the type registry but stopped short of composite instance keys.

## Fix

Validate the channel **type** segment of the target (split on `.`), leaving instance-alias resolution to the delivery path — exactly how cron delivery treats channel refs (`cron_delivery_channel_pattern`). One function, `validate_heartbeat_channel_config`.

## Tests

- `resolve_delivery_accepts_composite_instance_target` — `telegram.roy` now validates and is passed through verbatim.
- `resolve_delivery_rejects_composite_of_unknown_type` — an unknown type segment (`carrier_pigeon.roy`) is still rejected.
- `resolve_delivery_rejects_composite_of_undeliverable_type` — an input-only type (`mqtt.sensors`) is still rejected, deliverability being a type property.

Existing bare-type tests (`resolve_delivery_accepts_matrix_target`, `..._rejects_unsupported_channel`, input-only rejections) continue to pass unchanged.
