### PR TITLE
fix(config): map openai-chat/openai_chat V2 kind to canonical openai family

### DIFF
--- a/crates/zeroclaw-config/src/schema/v2.rs
+++ b/crates/zeroclaw-config/src/schema/v2.rs
@@ -633,6 +633,16 @@ fn normalize_provider_type(
         "stepfun" | "step" => Some("stepfun"),
         // KiloCli: was kilocli|kilo-cli
         "kilocli" | "kilo-cli" => Some("kilocli"),
+        // OpenAI chat-completions: V2's `Provider::kind` default/legacy
+        // literal for a plain OpenAI-compatible endpoint was `openai-chat`
+        // (see zeroclaw-providers' wire-kind constant), never folded into
+        // the V3 typed-family name. Left unmapped, `dispatch_family_factory`
+        // rejects it post-migration with "Unknown model_provider family:
+        // openai-chat" for any config that never rewrote `kind` to the V3
+        // spelling -- exactly the case for a config carrying only `uri` +
+        // `model` (no `kind` at all) once written back out with the old
+        // default literal, or hand-written configs copied from older docs.
+        "openai-chat" | "openai_chat" => Some("openai"),
         _ => None,
     };
 

--- a/crates/zeroclaw-config/tests/migration.rs
+++ b/crates/zeroclaw-config/tests/migration.rs
@@ -164,6 +164,57 @@ api_key = "sk-cc-v2-test"
 }
 
 #[test]
+fn openai_chat_folds_under_openai() {
+    let v3 = migrate_v2(
+        r#"
+[providers.models.openai-chat]
+api_key = "sk-oc-v2-test"
+uri = "http://127.0.0.1:8002/v1"
+model = "coder"
+"#,
+    );
+    let model_providers = lookup_dotted(&v3, "providers.models")
+        .and_then(toml::Value::as_table)
+        .expect("providers.models present after V2→V3");
+    let entry = model_providers
+        .get("openai")
+        .and_then(toml::Value::as_table)
+        .and_then(|a| a.get("default"))
+        .and_then(toml::Value::as_table)
+        .expect("openai-chat folded under providers.models.openai.default");
+    assert_eq!(
+        entry.get("uri").and_then(toml::Value::as_str),
+        Some("http://127.0.0.1:8002/v1")
+    );
+    assert!(
+        !model_providers.contains_key("openai-chat"),
+        "standalone openai-chat provider must not appear in V3"
+    );
+}
+
+#[test]
+fn openai_underscore_chat_folds_under_openai() {
+    let v3 = migrate_v2(
+        r#"
+[providers.models.openai_chat]
+api_key = "sk-ocu-v2-test"
+uri = "http://127.0.0.1:8006/v1"
+"#,
+    );
+    let model_providers = lookup_dotted(&v3, "providers.models")
+        .and_then(toml::Value::as_table)
+        .expect("providers.models present after V2→V3");
+    assert!(
+        model_providers
+            .get("openai")
+            .and_then(toml::Value::as_table)
+            .and_then(|a| a.get("default"))
+            .is_some(),
+        "openai_chat folded under providers.models.openai.default"
+    );
+}
+
+#[test]
 fn v1_model_routes_preserved_at_providers_level() {
     let cfg = v3_config();
     assert!(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `normalize_provider_type()` in the V2→V3 config migration maps ~25 legacy vendor `kind` spellings (`azure_openai`, `xai`/`grok`, `gemini`/`google`, etc.) to their canonical V3 typed-family name, but never mapped the literal `openai-chat`/`openai_chat` spelling — a value used elsewhere in this same codebase as the historical/default wire-kind for a plain OpenAI-compatible endpoint. Left unmapped, it falls through the passthrough case and survives into V3 verbatim, where `dispatch_family_factory()` rejects it: `Unknown model_provider family: openai-chat`.
- **Scope boundary:** Only adds the missing synonym-table entry. Does not touch any other family mapping, the V3 schema, or provider construction logic.
- **Blast radius:** Any operator config carrying a literal `[providers.models.openai-chat]` or `[providers.models.openai_chat]` section (V2-era, or hand-written from older docs) that previously silently failed migration. No effect on configs that never used this spelling.
- **Linked issue(s):** None
- **Labels:** `bug`, `config`, `provider`, `distinguished contributor`, `provider:openai`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — pure config-migration logic, fully covered by the added unit tests below.

### How I tested

Added two migration tests mirroring the existing `claude_code_folded_under_anthropic` pattern: `openai_chat_folds_under_openai` and `openai_underscore_chat_folds_under_openai`, both asserting the V2 section correctly folds under `providers.models.openai.default` in V3 output.

- **CI checks relied on and why they cover this change:** Workspace `check`/`clippy` with `--features ci-all` cover the touched crate (`zeroclaw-config`) under the same feature set CI uses.
- **Known CI coverage gap, if any:** The non-required Windows nextest baseline did not execute because Cargo received invalid package-name arguments. Required CI passed. No refreshed merge-result validation against current master was run.
- **Commands run and tail output:**
  ```
  cargo fmt --all -- --check                                     → clean
  cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings   → clean
  cargo check --locked --features ci-all --all-targets           → clean
  cargo check --no-default-features                              → clean
  cargo test --test architecture (both arch guard tests)         → ok
  cargo test -p zeroclaw-config --test migration openai_chat_folds_under_openai       → ok
  cargo test -p zeroclaw-config --test migration openai_underscore_chat_folds_under_openai → ok
  cargo test --workspace --exclude zeroclaw-desktop              → 1009 passed, 0 failed (2 pre-existing unrelated tests excluded — see note)
  ```
- **Beyond CI, what did you manually verify?** Confirmed the same 2 tests fail without the fix (revert-and-rerun) and pass with it. Did not verify against a live deployed config carrying this exact legacy spelling — found via a local-provider `session/new` failure trace, not a field report.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Full workspace `cargo test` excludes 2 tests (`telegram_send_document_bytes_empty_filename`, `insecure_tls_prompt_preserves_default_sigint`) confirmed to fail identically on a clean `upstream/master` checkout with no changes — pre-existing, environment-sensitive (PTY/signal-timing), unrelated to this diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes — this only makes a previously-failing migration succeed; no existing passing config is affected.
- Config / env / CLI surface changed? The two legacy V2 family spellings now migrate to `openai.default`; no new config key, environment variable, or CLI option.
- Rust/MSRV/toolchain floor changed? No

## Rollback

- Risk: `risk:medium` because this changes config migration behavior, with a narrow scope limited to two legacy provider-family spellings.
- Rollback: revert the landed squash commit for this PR, not the contributor branch commit.
- Operator impact: reverting removes the synonym fix, so configs using either legacy spelling may fail migration again. Preserve the original config backup; use the canonical `openai` family spelling if rollback is needed.
