### PR TITLE
ci(tests): scope sibling workflow edits out of the Windows nextest selector

### DIFF
--- a/scripts/ci/windows_test_scope.py
+++ b/scripts/ci/windows_test_scope.py
@@ -224,7 +224,11 @@ def is_obviously_irrelevant(path: str) -> bool:
         return True
     if path.startswith(".github/actions/"):
         return False
-    if path.startswith(".github/") and not path.startswith(".github/workflows/"):
+    if path.startswith(".github/workflows/"):
+        # Only the Quality Gate workflow drives the Windows suite; sibling
+        # workflows (labelers, audits, release) cannot change what it tests.
+        return path != ".github/workflows/ci.yml"
+    if path.startswith(".github/"):
         return True
     if path.startswith("scripts/") and not path.startswith("scripts/ci/"):
         return True
@@ -272,7 +276,7 @@ def select_pull_request(
                 "Workspace-wide or ambiguous Rust-affecting change requires the full suite.",
                 needs_plugin_host,
             )
-        if path.startswith(".github/workflows/") or path.startswith("scripts/ci/"):
+        if path.startswith("scripts/ci/"):
             return full(
                 "Workspace-wide or ambiguous Rust-affecting change requires the full suite.",
                 needs_plugin_host,

--- a/scripts/ci/windows_test_scope.test.sh
+++ b/scripts/ci/windows_test_scope.test.sh
@@ -176,6 +176,12 @@ assert_selection "Rust toolchain" full '[]' '' "$paths_file" true
 printf '%s\n' '.github/workflows/ci.yml' > "$paths_file"
 assert_selection "workflow itself exercises plugin host path" full '[]' '' "$paths_file" true
 
+printf '%s\n' '.github/workflows/pr-size-labeler.yml' > "$paths_file"
+assert_selection "sibling workflow only" skip '[]' 'No covered Rust compilation or test paths changed.' "$paths_file"
+
+printf '%s\n' '.github/workflows/pr-size-labeler.yml' 'crates/zeroclaw-channels/src/lib.rs' > "$paths_file"
+assert_selection "sibling workflow with package source" scoped '["zeroclaw","zeroclaw-channels"]' '' "$paths_file"
+
 printf '%s\n' 'scripts/ci/windows_test_scope.py' > "$paths_file"
 assert_selection "selector itself exercises plugin host path" full '[]' '' "$paths_file" true
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The advisory Windows nextest selector (`scripts/ci/windows_test_scope.py`, added in #10350) treated every file under `.github/workflows/` as a full-suite trigger. Only `.github/workflows/ci.yml` defines the Windows job, so edits to sibling workflows (labelers, audits, release, CodeQL) were forcing a full Windows run, capped at 90 minutes, for changes that cannot affect what the suite tests. #10649 (two YAML lines in `pr-size-labeler.yml`) is the motivating example.
  - Sibling workflows are now classified as obviously irrelevant; `ci.yml` keeps its explicit full-suite trigger via `FULL_PATHS`. Nothing else in the trigger table moves: `.github/actions/`, `scripts/ci/`, `.cargo/`, `Cargo.toml`, `Cargo.lock`, and the toolchain files still force full mode.
  - Two contract cases added to `windows_test_scope.test.sh`: a sibling workflow alone selects `skip`, and a sibling workflow plus a crate source file scopes to that crate's reverse-dependent closure.
- **Scope boundary:** Does not touch the required Quality Gate, the Windows job definition, the plugin-host detection, the `scripts/ci/` full-suite rule, or any Rust code. Advisory-only selector behavior.
- **Blast radius:** Which PRs get an advisory Windows nextest run and at what scope. The job is `continue-on-error` and absent from `CI Required Gate`, so no merge decision changes.
- **Linked issue(s):** Related #10350. Related #10649.
- **Labels:** `type:ci`, `scripts`, `risk:medium`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the selector contract test below is the behavioral proof; the live proof is this PR's own advisory Windows job, which should select `full` because the selector itself is a `FULL_PATHS` entry.

### How I tested

- **CI checks relied on and why they cover this change:** The `windows-test-scope` job in `ci.yml` runs `bash scripts/ci/windows_test_scope.test.sh` on every PR before selecting a mode, so the changed contract (including the two new cases) executes in required-workflow context on this head. Because `scripts/ci/windows_test_scope.py` is itself a `FULL_PATHS` entry, this PR also exercises the full advisory Windows lane.
- **Known CI coverage gap, if any:** None beyond the advisory job being non-blocking by design.
- **Commands run and tail output:**

```text
$ bash scripts/ci/windows_test_scope.test.sh
windows test scope contract tests: pass

$ python3 -m compileall -q scripts/ci/windows_test_scope.py
[no output; exit 0]

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check upstream/master...HEAD
[no output; exit 0]
```

- **Beyond CI, what did you manually verify?** Walked `select_pull_request` ordering: `FULL_PATHS` and `.cargo/` are checked before the irrelevance filter, so `ci.yml` cannot reach the new branch; `.github/actions/` still returns "not irrelevant" ahead of the workflows check; `requires_plugin_host` is untouched, so plugin-host detection for `ci.yml` and `.github/actions/` is unchanged. Confirmed `ci.yml` references no reusable workflows (`workflow_call` / `uses: ./.github/workflows/...`), so no sibling workflow can feed the Windows job indirectly.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Cargo is unrelated to this Python/Bash-only selector change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**
- Prompt injection or untrusted model-visible text introduced/changed? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**
- Rust/MSRV/toolchain floor changed? **No**

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <sha>`; sibling workflow edits go back to forcing a full advisory Windows run.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** A PR that changes only a non-`ci.yml` workflow shows `Advisory Windows nextest` skipped where it previously ran full; a PR that changes `ci.yml` should still show `(full, ...)` in the job name. If a `ci.yml`-only PR ever shows `skip`, the ordering assumption above has been broken.
