### PR TITLE
fix(channels/whatsapp): bind transcription to the owning agent's provider

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10233,7 +10233,8 @@ pub fn register_channels_for_tools(
     feature = "channel-telegram",
     feature = "channel-discord",
     feature = "voice-wake",
-    feature = "channel-matrix"
+    feature = "channel-matrix",
+    feature = "whatsapp-web"
 ))]
 fn resolve_agent_transcription_provider(config: &Config, channel_key: &str) -> String {
     let enabled_agents = enabled_agent_aliases(config);
@@ -10250,6 +10251,40 @@ fn configure_discord_transcription(
     config: &Config,
     channel_key: &str,
 ) -> DiscordChannel {
+    if !config.transcription.enabled {
+        return channel;
+    }
+
+    let provider = resolve_agent_transcription_provider(config, channel_key);
+    match crate::transcription::TranscriptionManager::from_config_with_provider(config, provider) {
+        Ok(manager) => channel.with_transcription_manager(config.transcription.clone(), manager),
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"e": e.to_string()})),
+                "transcription manager init failed, voice transcription disabled"
+            );
+            channel
+        }
+    }
+}
+
+/// Bind the WhatsApp Web channel's transcription manager to the owning
+/// agent's `transcription_provider`.
+///
+/// `WhatsAppWebChannel::with_transcription` registers legacy `[transcription]`
+/// providers only and leaves the agent alias empty, so typed
+/// `[providers.transcription.<type>.<alias>]` entries are never reachable and
+/// `transcribe()` bails before dispatching. Mirrors
+/// `configure_discord_transcription`.
+#[cfg(feature = "whatsapp-web")]
+fn configure_whatsapp_transcription(
+    channel: WhatsAppWebChannel,
+    config: &Config,
+    channel_key: &str,
+) -> WhatsAppWebChannel {
     if !config.transcription.enabled {
         return channel;
     }
@@ -10884,7 +10919,7 @@ fn collect_configured_channels(
                         display_name: "WhatsApp",
                         alias: Some(alias.clone()),
                         channel: crate::paced_channel::PacedChannel::wrap(
-                            Arc::new(
+                            Arc::new(configure_whatsapp_transcription(
                                 WhatsAppWebChannel::new(
                                     wa,
                                     alias.clone(),
@@ -10892,12 +10927,13 @@ fn collect_configured_channels(
                                     allowed_groups_resolver,
                                 )
                                 .with_persistence(config_arc.clone())
-                                .with_transcription(config.transcription.clone())
                                 .with_tts(&config)
                                 .with_workspace_dir(workspace_dir)
                                 .with_dm_mention_patterns(wa.dm_mention_patterns.clone())
                                 .with_group_mention_patterns(wa.group_mention_patterns.clone()),
-                            ),
+                                &config,
+                                &format!("whatsapp.{alias}"),
+                            )),
                             wa,
                         ),
                     });
@@ -30731,6 +30767,60 @@ This is an example JSON object for profile settings."#;
         assert_ne!(
             resolved, "frontdoor",
             "must not resolve to the channel alias"
+        );
+    }
+
+    /// Regression: the WhatsApp Web channel built its manager from the legacy
+    /// `[transcription]` section alone, so typed
+    /// `[providers.transcription.*]` entries never registered and the owning
+    /// agent's alias stayed empty — `transcribe()` then bailed with "Agent has
+    /// no transcription_provider configured" for every voice note.
+    #[cfg(feature = "whatsapp-web")]
+    #[test]
+    fn whatsapp_transcription_registers_typed_provider_and_binds_the_agent_alias() {
+        let mut config = Config::default();
+        config.transcription.enabled = true;
+        config.channels.whatsapp.insert(
+            "default".to_string(),
+            zeroclaw_config::schema::WhatsAppConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        );
+        config.providers.transcription.groq.insert(
+            "fast".to_string(),
+            zeroclaw_config::schema::GroqTranscriptionProviderConfig {
+                base: zeroclaw_config::schema::TranscriptionProviderConfig {
+                    api_key: Some("test-key".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        config.agents.insert(
+            "voice-agent".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec!["whatsapp.default".into()],
+                transcription_provider: "groq.fast".into(),
+                ..Default::default()
+            },
+        );
+
+        let provider = resolve_agent_transcription_provider(&config, "whatsapp.default");
+        assert_eq!(
+            provider, "groq.fast",
+            "the owning agent's provider must resolve for a whatsapp.<alias> key"
+        );
+
+        let manager = crate::transcription::TranscriptionManager::from_config_with_provider(
+            &config, provider,
+        )
+        .expect("typed provider must build a manager");
+        assert!(
+            manager.available_providers().contains(&"groq.fast"),
+            "typed provider must register, got {:?}",
+            manager.available_providers()
         );
     }
 

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -650,6 +650,26 @@ impl WhatsAppWebChannel {
         self
     }
 
+    /// Attach a transcription manager the caller already resolved against the
+    /// owning agent's `transcription_provider`.
+    ///
+    /// [`Self::with_transcription`] registers legacy `[transcription]`
+    /// providers only and leaves the agent alias empty, so
+    /// `TranscriptionManager::transcribe` can never select a provider. Channel
+    /// wiring uses this instead, mirroring [`Self::with_tts`], which already
+    /// binds the channel-owning agent.
+    #[cfg(feature = "whatsapp-web")]
+    #[must_use]
+    pub fn with_transcription_manager(
+        mut self,
+        config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: super::transcription::TranscriptionManager,
+    ) -> Self {
+        self.transcription_manager = Some(std::sync::Arc::new(manager));
+        self.transcription = Some(config);
+        self
+    }
+
     #[cfg(feature = "whatsapp-web")]
     pub fn with_tts(mut self, config: &zeroclaw_config::schema::Config) -> Self {
         if config.tts.enabled {
@@ -5080,6 +5100,50 @@ mod tests {
         .with_transcription(tc);
         assert!(ch.transcription.is_some());
         assert!(ch.transcription_manager.is_some());
+    }
+
+    /// Regression: channel wiring must be able to install a manager the caller
+    /// already bound to the owning agent's provider, instead of the
+    /// legacy-only manager `with_transcription` builds.
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn with_transcription_manager_installs_caller_resolved_manager() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.transcription.enabled = true;
+        config.providers.transcription.groq.insert(
+            "fast".to_string(),
+            zeroclaw_config::schema::GroqTranscriptionProviderConfig {
+                base: zeroclaw_config::schema::TranscriptionProviderConfig {
+                    api_key: Some("test-key".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let manager = super::super::transcription::TranscriptionManager::from_config_with_provider(
+            &config,
+            "groq.fast".to_string(),
+        )
+        .expect("typed provider must build a manager");
+
+        let cfg = zeroclaw_config::schema::WhatsAppConfig {
+            enabled: true,
+            session_path: Some("/tmp/test-whatsapp.db".into()),
+            ..Default::default()
+        };
+        let ch = WhatsAppWebChannel::new(
+            &cfg,
+            "whatsapp_web_test_alias",
+            Arc::new(|| vec!["+1234567890".into()]),
+            Arc::new(Vec::new),
+        )
+        .with_transcription_manager(config.transcription.clone(), manager);
+
+        assert!(ch.transcription.is_some());
+        assert!(
+            ch.transcription_manager.is_some(),
+            "caller-resolved manager must be installed on the channel"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - WhatsApp Web built its transcription manager with `WhatsAppWebChannel::with_transcription`, which calls `TranscriptionManager::new` and therefore registers legacy `[transcription]` providers only, leaving `agent_transcription_provider` empty.
  - `TranscriptionManager::transcribe` bails on an empty alias ("there is no global default"), so **every** inbound WhatsApp voice note failed regardless of configuration, and typed `[providers.transcription.<type>.<alias>]` entries were unreachable from this channel. There was no config workaround.
  - Added `configure_whatsapp_transcription` in the orchestrator: it resolves the owning agent's `transcription_provider` for the `whatsapp.<alias>` key and builds the manager via `TranscriptionManager::from_config_with_provider`, mirroring `configure_discord_transcription`.
  - Added `WhatsAppWebChannel::with_transcription_manager` so wiring can install a caller-resolved manager, mirroring `with_tts`, which already binds the channel-owning agent one line below in the same builder.
  - Extended the `resolve_agent_transcription_provider` cfg gate with `whatsapp-web`.
- **Scope boundary:** Does not change transcription provider implementations, the media-pipeline attachment path (quoted/forwarded audio, which already resolved the agent provider correctly), TTS, or any other channel's wiring. `with_transcription` is left in place and untouched — only the WhatsApp listener wiring stops using it. `build_channel_by_id` (the one-shot outbound send path) is unchanged; it never attached transcription and does not ingest audio.
- **Blast radius:** WhatsApp Web inbound voice notes only. Behaviour is unchanged when `transcription.enabled = false` (early return) and when manager construction fails (warn + unchanged channel, same as Discord).
- **Linked issue(s):** Fixes #10688. Related #6999, Related #9905, Related #10486 — the same defect previously fixed for Telegram, Discord and Matrix; WhatsApp Web was the last channel still on the legacy wiring.
- **Labels:** `bug`, `channel`, `config`, `provider`, `channel:core`, `channel:whatsapp`, `risk:medium`, `size:S`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `channel` (`whatsapp`)
- **Setup / preconditions:**

  ```toml
  [transcription]
  enabled = true

  [providers.transcription.groq.fast]
  api_key = "..."
  model = "whisper-large-v3-turbo"

  [agents.default]
  channels = ["whatsapp.default"]
  transcription_provider = "groq.fast"
  ```

- **Steps to run:** Link WhatsApp Web, start the daemon, send a hold-to-record voice note from an allowlisted number.
- **Expected on this branch (after):** the log shows `transcribing voice note (N bytes, file=voice.ogg)` and the agent replies to the transcript; the message reaches the agent as `[Voice] <transcript>`.
- **Prior behavior on `master` (before):** the same steps fail. The voice note is downloaded and then dropped, and because `media_fallback_content` has no audio branch the message ends up empty and is discarded with `ignoring empty or non-text message from <sender>`. Sending the audio as a **quoted** message on `master` does work, because that path goes through the media pipeline, which resolves the agent provider correctly — that asymmetry is the clearest before/after signal.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passes at `b769c3c4b0ae048a8e347f069831ca8b7978f21e`. The new tests require `whatsapp-web`; their execution is supported by the feature-enabled local suite reported below, rather than inferred from the broad CI result.
- **Known CI coverage gap, if any:** No automated end-to-end coverage of a live WhatsApp Web voice note. The manual account below documents the baseline failure and a successful quoted-audio control; it does not identify a successful post-fix fresh voice-note run. The nonrequired Windows job failed before compilation because its generated command contained malformed package arguments.
- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(no output)

$ cargo clippy -p zeroclaw-channels --features whatsapp-web --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.77s

$ cargo test -p zeroclaw-channels --features whatsapp-web
test result: ok. 1781 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 12.28s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.00s

$ cargo check -p zeroclaw-channels --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 55.68s
```

- **Beyond CI, what did you manually verify?** Reproduced the original failure on a linked WhatsApp Web account: a fresh voice note produced no `transcribing voice note` log line at all, confirming `try_transcribe_voice_note` returned at its `transcription_manager?` early exit rather than failing at the API call. Confirmed the same account transcribed a **quoted** audio successfully via the media pipeline, isolating the fault to the channel's manager wiring. Verified the `no-default-features` build still compiles, since the change widens a cfg gate. Not verified: non-Groq transcription families, and the media-pipeline path is untouched by this PR.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No — the provider was already configured and reachable; this only selects it.
- Secrets / tokens / credentials handling changed? No. The API key continues to be read from the existing provider config; the added tests use the literal `"test-key"`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No. `[transcription]` and `[providers.transcription.*]` are both already-shipped surfaces; this makes the documented `agents.<alias>.transcription_provider` binding take effect for WhatsApp Web, which is what the existing docs already describe.
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

After landing, obtain the squash commit with `gh pr view 10692 --repo zeroclaw-labs/zeroclaw --json mergeCommit --jq '.mergeCommit.oid'`. Revert that commit on a non-`master` branch and open a revert PR. This restores the previous wiring; no data or configuration migration is required.
