### PR TITLE
fix(providers): satisfy Windows Clippy for cache builder

### DIFF
--- a/crates/zeroclaw-providers/src/copilot.rs
+++ b/crates/zeroclaw-providers/src/copilot.rs
@@ -732,7 +732,10 @@ fn admit_cache_dir(path: &Path) -> io::Result<Arc<Dir>> {
         }
         Ok(_) => {}
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            #[cfg(unix)]
             let mut builder = cap_std::fs::DirBuilder::new();
+            #[cfg(not(unix))]
+            let builder = cap_std::fs::DirBuilder::new();
             #[cfg(unix)]
             {
                 use cap_std::fs::DirBuilderExt;


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Declare the cache-directory builder as mutable only on Unix, where `DirBuilderExt::mode` applies the existing `0700` mode.
  - Keep the same immutable builder on non-Unix targets so whole-workspace Windows Clippy no longer reports `unused_mut`.
- **Scope boundary:** Does not change cache paths, permissions, provider behavior, APIs, dependencies, workflows, or policy.
- **Blast radius:** Limited to compilation of the Copilot provider cache-directory creation path; runtime behavior is unchanged on every platform.
- **Linked issue(s):** No issue — this is a self-contained mechanical lint repair reproduced by scheduled run [34111603615](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34111603615).
- **Labels:** `bug`, `provider`, `provider:copilot`, `distinguished contributor`, `risk:low`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — exact hosted Windows Clippy is the direct behavioral proof for this target-specific lint repair.

### How I tested

- **CI checks relied on and why they cover this change:** The exact-head [required CI gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/34165877929/job/101882019659) passed, including the Windows `cargo check` job. Exact-head [Cross-Platform Clippy run 34166016352](https://github.com/Audacity88/zeroclaw/actions/runs/34166016352) checked `zeroclaw-providers` on `x86_64-pc-windows-msvc` with warnings denied and did not reproduce the original `copilot.rs` diagnostic. Its macOS job passed. The Windows job later failed while compiling unchanged `zeroclaw-runtime` test code because of 11 base-owned unused-import and dead-code errors in `skills/mod.rs` and `tools/delegate.rs`.
- **Known CI coverage gap, if any:** The changed provider package passed its exact Windows Clippy stage, but the whole Windows job is not green because of the unrelated downstream `zeroclaw-runtime` test-code errors described above.
- **Commands run and tail output:**

```text
$ cargo fmt --all -- --check
[exit 0]

$ bash scripts/ci/comment_hygiene_gate.sh
Comment hygiene gate passed.

$ git diff --check
[exit 0]

$ cargo clippy -p zeroclaw-providers --all-targets --target x86_64-pc-windows-msvc -- -D warnings
fatal error: 'assert.h' file not found
error: failed to run custom build command for `ring v0.17.14`
```

- **Beyond CI, what did you manually verify?** Inspected the conditional compilation boundary: Unix retains the mutable builder used to apply mode `0700`; non-Unix receives the same builder without unnecessary mutability. I did not claim a successful Windows cross-compile from macOS because the host lacks Windows SDK headers.
- **Visual interface changed?** N/A — no visual interface changed.
- **If any command was intentionally skipped, why:** Broader local tests do not prove the Windows-only lint fact. The focused macOS-to-Windows cross-target attempt stopped in `ring` before compiling ZeroClaw because the Windows SDK header `assert.h` is unavailable; exact hosted Windows Clippy is required instead.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk rollback: `git revert 8f1fba6c05e73924808c4564c5c3602b66243e6d`.
