### PR TITLE
chore(meta): link the site from the README and crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.8.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zeroclaw-labs/zeroclaw"
+homepage = "https://www.zeroclaw.com"
 rust-version = "1.96.0"
 
 [workspace.dependencies]
@@ -46,6 +47,8 @@ authors = ["theonlyhennygod"]
 license.workspace = true
 description = "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
 repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.zeroclaw.com"
 readme = "README.md"
 keywords = ["ai", "agent", "cli", "assistant", "chatbot"]
 categories = ["command-line-utilities", "api-bindings"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 </p>
 
 <p align="center">
+  <a href="https://www.zeroclaw.com">Website</a> ·
   <a href="https://docs.zeroclaw.com/master/en/introduction.html">Docs</a> ·
   <a href="docs/book/src/philosophy/index.md">Philosophy</a> ·
   <a href="docs/book/src/getting-started/quickstart.md">Quick start</a> ·

--- a/apps/zerocode/Cargo.toml
+++ b/apps/zerocode/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zerocode"
 version.workspace = true
+homepage.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Interactive TUI config manager for ZeroClaw."

--- a/apps/zerorelay/Cargo.toml
+++ b/apps/zerorelay/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zerorelay"
 version.workspace = true
+homepage.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/zeroclaw-api/Cargo.toml
+++ b/crates/zeroclaw-api/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Trait definitions and shared types for ZeroClaw — the API layer."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-channels/Cargo.toml
+++ b/crates/zeroclaw-channels/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Channel implementations for messaging platform integrations."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-commands/Cargo.toml
+++ b/crates/zeroclaw-commands/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Shared built-in slash command catalogue for ZeroClaw surfaces."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-config/Cargo.toml
+++ b/crates/zeroclaw-config/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Configuration schema, secrets, and related types for ZeroClaw."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-eval/Cargo.toml
+++ b/crates/zeroclaw-eval/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Agent evaluation harness for ZeroClaw — Phase 0: deterministic replay of LLM trace fixtures through the real agent loop."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-gateway/Cargo.toml
+++ b/crates/zeroclaw-gateway/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "HTTP/WebSocket gateway for ZeroClaw — REST API, web dashboard, webhooks."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-hardware/Cargo.toml
+++ b/crates/zeroclaw-hardware/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Hardware discovery, peripherals, and device management for ZeroClaw."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-infra/Cargo.toml
+++ b/crates/zeroclaw-infra/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Channel infrastructure: session backends, debouncing, stall watchdog."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-log/Cargo.toml
+++ b/crates/zeroclaw-log/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Unified log emission surface: structured event schema, JSONL persistence, broadcast hook, and the record! macro every other crate emits through."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-macros/Cargo.toml
+++ b/crates/zeroclaw-macros/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Proc macros for ZeroClaw (config field derivation)"
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [lib]

--- a/crates/zeroclaw-memory/Cargo.toml
+++ b/crates/zeroclaw-memory/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Memory backends, embeddings, consolidation, and retrieval for ZeroClaw."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-plugins/Cargo.toml
+++ b/crates/zeroclaw-plugins/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "WASM plugin system for ZeroClaw — host, manifests, signatures, execution bridge."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [features]

--- a/crates/zeroclaw-providers/Cargo.toml
+++ b/crates/zeroclaw-providers/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "LLM provider implementations, auth services, and multimodal processing."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-relay-proto/Cargo.toml
+++ b/crates/zeroclaw-relay-proto/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "Wire protocol (zeroclaw.relay.v1) for the ZeroClaw nominated relay: control frames shared by the relay, the daemon-side bridge, and clients."
 publish = true
 

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Miscellaneous ZeroClaw subsystems: security, observability, gateway, cron, SOP, skills, hardware, TUI, and more."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-sop-graph/Cargo.toml
+++ b/crates/zeroclaw-sop-graph/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Pure serde projection types for the ZeroClaw SOP Blueprint graph, shared by the runtime, gateway schema, and the zerocode TUI so every surface reads one wire shape."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-spawn/Cargo.toml
+++ b/crates/zeroclaw-spawn/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Attribution-propagating, lifecycle-logged wrapper around tokio::spawn for ZeroClaw."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-tls/Cargo.toml
+++ b/crates/zeroclaw-tls/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "Shared TLS / mTLS construction (server config, client verifier, certificate pinning, PEM loading) for ZeroClaw."
 publish = true
 

--- a/crates/zeroclaw-tool-call-parser/Cargo.toml
+++ b/crates/zeroclaw-tool-call-parser/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Tool call parsing for LLM responses — handles JSON, XML, GLM, MiniMax, Perl-style, and more."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]

--- a/crates/zeroclaw-tools/Cargo.toml
+++ b/crates/zeroclaw-tools/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Tool implementations for agent-callable capabilities."
 repository.workspace = true
+homepage.workspace = true
 publish = true
 
 [dependencies]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The README's link row gains `Website` → https://www.zeroclaw.com. The project just moved to zeroclaw.com and this repository is its most authoritative inbound link; until now the README linked only to the docs host.
  - `[workspace.package]` gains `homepage = "https://www.zeroclaw.com"`, inherited by every published crate (`homepage.workspace = true`), so each crates.io page links to the site. The `zeroclaw` binary crate also gets `documentation = "https://docs.zeroclaw.com"`, since docs.rs is not the right reference for a binary.
  - Metadata only; nothing executable changes.
- **Scope boundary:** no code, no CI, no docs-book content. Internal crates that are `publish = false` (fixtures, macro helpers, xtask, fill-translations) and `zeroclaw-desktop` are untouched.
- **Blast radius:** crates.io listings on the next publish; the README. No runtime effect.
- **Linked issue(s):** Related to the zeroclaw.com domain migration (website PR zeroclaw-labs/zeroclaw-website#40, docs PR #10616).
- **Labels:** `type:chore`, `risk:low`, `size:S` (path labeler applies the rest)

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — metadata and a README link; nothing to exercise.

### How I tested

- **CI checks relied on and why they cover this change:** the standard Rust checks parse every manifest, which is the only way this change can break anything.
- **Known CI coverage gap, if any:** None.
- **Commands run and tail output:**

```
$ cargo metadata --no-deps --format-version 1 --offline | (count packages with homepage)
23 of 33 have homepage; without: [zeroclaw-log-attribution-macro-support, zeroclaw-log-attribution-macro-consumer, zeroclaw-*-fixture (5), zeroclaw-desktop, fill-translations, xtask]
main crate documentation: https://docs.zeroclaw.com

$ bash scripts/ci/docs_quality_gate.sh
Summary: 0 error(s)
```

- **Beyond CI, what did you manually verify?** That every published crate now resolves `homepage` through the workspace and that the README row renders in order (Website · Docs · Philosophy · …). Not verified: the crates.io rendering, which only appears after the next publish.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** `cargo test` — no code changed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.
