### PR TITLE
fix(docs): keep the zoomed diagram accessible inside the dialog

### DIFF
--- a/docs/book/theme/pc-enhance.js
+++ b/docs/book/theme/pc-enhance.js
@@ -459,16 +459,9 @@
       document.documentElement.classList.remove('pc-diagram-modal-open');
 
       if (activeDiagram) {
-        const {
-          svg,
-          placeholder,
-          originalTransform,
-          originalAriaHidden,
-          originalTabIndex,
-        } = activeDiagram;
+        const { svg, placeholder, originalTransform, originalTabIndex } =
+          activeDiagram;
         svg.style.transform = originalTransform;
-        if (originalAriaHidden === null) svg.removeAttribute('aria-hidden');
-        else svg.setAttribute('aria-hidden', originalAriaHidden);
         if (originalTabIndex === null) svg.removeAttribute('tabindex');
         else svg.setAttribute('tabindex', originalTabIndex);
         if (placeholder.isConnected) placeholder.replaceWith(svg);
@@ -503,11 +496,12 @@
         svg: svg,
         placeholder: placeholder,
         originalTransform: svg.style.transform,
-        originalAriaHidden: svg.getAttribute('aria-hidden'),
         originalTabIndex: svg.getAttribute('tabindex'),
       };
       svg.replaceWith(placeholder);
-      svg.setAttribute('aria-hidden', 'true');
+      // The live node must stay exposed to assistive technology inside the
+      // dialog: its Mermaid <title>/<desc> are the accessible name and
+      // description of the diagram while it is zoomed (#10548).
       svg.removeAttribute('tabindex');
       stage.replaceChildren(svg);
       modal.hidden = false;
@@ -551,6 +545,36 @@
     stage.addEventListener('pointercancel', stopDragging);
     document.addEventListener('keydown', function (e) {
       if (!modal.hidden && e.key === 'Escape') closeModal();
+    });
+    // The dialog declares aria-modal="true", so keyboard focus must stay
+    // inside it until it closes. Cycle Tab/Shift+Tab across the dialog's
+    // enabled controls; disabled zoom buttons are skipped (disabled controls
+    // are not focusable, so they must not become a wrap target).
+    function modalFocusables() {
+      return Array.from(
+        modal.querySelectorAll(
+          'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter(function (el) {
+        return el.getClientRects().length > 0;
+      });
+    }
+    document.addEventListener('keydown', function (e) {
+      if (modal.hidden || e.key !== 'Tab') return;
+      const focusable = modalFocusables();
+      if (focusable.length === 0) {
+        e.preventDefault();
+        close.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const current = document.activeElement;
+      if (!modal.contains(current) || (e.shiftKey && current === first)
+        || (!e.shiftKey && current === last)) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+      }
     });
 
     controls.append(zoomOut, zoomValue, zoomIn, zoomReset);


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Stop setting `aria-hidden="true"` on the live Mermaid SVG after it is moved into the diagram zoom dialog, so the diagram's Mermaid `<title>`/`<desc>` stay exposed to assistive technology while the dialog is open.
  - Add `Tab`/`Shift+Tab` focus containment inside the zoom dialog, matching its existing `aria-modal="true"` declaration: focus cycles across the dialog's enabled controls (disabled zoom buttons are skipped) instead of escaping into the page behind the modal.
  - Focus restoration to the diagram trigger on close already existed and is unchanged.
- **Scope boundary:** This PR does not change zoom/pan behavior, Escape handling, ordinary-image zoom (mdBook built-in), the visual layout of the dialog, or any application code; `docs/book/theme/custom.css` is untouched.
- **Blast radius:** Docs theme only (`docs/book/theme/pc-enhance.js`), shared by all five published locales; readers of diagram zoom on the generated docs site. No runtime, config, or generated-content surface is affected.
- **Linked issue(s):** Fixes #10548
- **Labels:** `bug`, `docs`, `experienced contributor`, `risk:low`, `size:XS`, `type:docs`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `web` (generated docs site)
- **Setup / preconditions:** `cargo mdbook build`, then serve the generated `book/master` site (the assembled site root is the directory containing `master/` and `_shared/`) and open a page containing a Mermaid diagram, for example `master/en/architecture/overview.html`.
- **Steps to run:** Focus a diagram and press Enter; inspect the open dialog's SVG `aria-hidden` state with a screen reader or the DOM; press `Tab` and `Shift+Tab` repeatedly; press `Escape`.
- **Expected on this branch (after):** The moved SVG inside the open dialog has no `aria-hidden`, so its accessible title/description are readable; `Tab` cycles Close → Zoom in → Reset zoom (Zoom out is disabled at 100% and skipped) and wraps in both directions without ever leaving the dialog; `Escape` closes the dialog and focus returns to the diagram trigger.
- **Prior behavior on master (before):** The SVG inside the open dialog carries `aria-hidden="true"`, hiding its accessible title and description, and `Tab`/`Shift+Tab` move focus out of the dialog that declares `aria-modal="true"` (reported in #10548 and reproduced on the `master` build of this branch).

### How I tested

- **CI checks relied on and why they cover this change:** The full docs build exercises theme script bundling, Mermaid preprocessing, all five locales, and the internal link gate; no Rust surface changed.
- **Known CI coverage gap, if any:** CI does not assert ARIA state or keyboard focus behavior of the theme layer; covered by the manual DOM-level A/B below.
- **Commands run and tail output:**

```text
$ node --check docs/book/theme/pc-enhance.js
status: passed

$ cargo mdbook build
==> Generated hardware reference snippets from registry + catalog
==> Generated feature-matrix snippets from code registries
==> Internal link check passed
==> Assembling site (rustdoc + locale redirect)
==> Extracting shared chrome layer
==> Done.
status: passed
```

- **Beyond CI, what did I manually verify?** DOM-level A/B against the pre-fix theme on the same build: on the `master` theme the open dialog's SVG reports `aria-hidden="true"`; on this branch it has none. On this branch, 13 consecutive synthetic `Tab`/`Shift+Tab` presses never left `#pc-diagram-modal`; forward wrap goes Reset zoom → Close diagram, backward wrap goes Close diagram → Reset zoom; the disabled Zoom out button is not a wrap target; `Escape` hides the dialog, returns focus to the `.pc-diagram-zoomable` trigger, and restores the live SVG into its page host. Rendering was confirmed unchanged in a browser screenshot of the open dialog. The deployed site and real screen-reader output were not exercised.
- **Visual interface changed?** Yes
- **Tested revision, interface, and terminal or viewport dimensions:** This branch at `c1461c1e`, generated docs site in Chromium, 1280×720 viewport.
- **Screenshot evidence:** The dialog's visual presentation is unchanged by design (no CSS or layout changes); the changed state is ARIA-exposed semantics and keyboard focus, verified as DOM state above.
- **Action or changed state and observed result:** Enter opened the dialog with the SVG un-hidden; `Tab`/`Shift+Tab` cycled within the dialog as described; `Escape` closed it and restored trigger focus and the inline SVG.
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback

Low-risk change: `git revert <sha>` is the plan.
