### PR TITLE
feat(cost): attribute ledger records to the chat conversation

### DIFF
--- a/crates/zeroclaw-config/src/cost/tracker.rs
+++ b/crates/zeroclaw-config/src/cost/tracker.rs
@@ -201,6 +201,27 @@ impl CostTracker {
         self.record_usage_with_owned_task_attribution_inner(usage, agent_alias, task_id, true)
     }
 
+    /// Record a usage event attributed to an agent, a durable task, and the
+    /// chat session that incurred it. `conversation_id` is the runtime
+    /// session key scoped around the turn; `None` keeps the record
+    /// attributable only to the daemon-lifetime tracker id.
+    pub fn record_usage_attributed(
+        &self,
+        usage: TokenUsage,
+        agent_alias: Option<&str>,
+        task_id: Option<String>,
+        conversation_id: Option<String>,
+    ) -> Result<()> {
+        self.record_usage_with_owned_task_attribution_inner_with_sync(
+            usage,
+            agent_alias,
+            task_id,
+            conversation_id,
+            true,
+            File::sync_all,
+        )
+    }
+
     pub fn record_scoped_usage_with_owned_task_attribution(
         &self,
         usage: TokenUsage,
@@ -221,6 +242,7 @@ impl CostTracker {
             usage,
             agent_alias,
             task_id,
+            None,
             honor_enabled,
             File::sync_all,
         )
@@ -231,6 +253,7 @@ impl CostTracker {
         usage: TokenUsage,
         agent_alias: Option<&str>,
         task_id: Option<String>,
+        conversation_id: Option<String>,
         honor_enabled: bool,
         sync_file: fn(&File) -> std::io::Result<()>,
     ) -> Result<()> {
@@ -261,7 +284,8 @@ impl CostTracker {
         let cost_usd = usage.cost_usd;
         let total_tokens = usage.total_tokens;
         let record =
-            CostRecord::with_attribution(&self.session_id, effective_alias.clone(), task_id, usage);
+            CostRecord::with_attribution(&self.session_id, effective_alias.clone(), task_id, usage)
+                .with_conversation_id(conversation_id);
 
         let mut storage = self.lock_storage();
         let append_outcome = storage.add_record_with_sync(record, sync_file)?;
@@ -1258,6 +1282,7 @@ mod tests {
                 usage,
                 None,
                 Some("task-a".to_string()),
+                None,
                 true,
                 fail_sync,
             )

--- a/crates/zeroclaw-config/src/cost/types.rs
+++ b/crates/zeroclaw-config/src/cost/types.rs
@@ -142,8 +142,16 @@ pub struct CostRecord {
     pub id: String,
     /// Token usage details
     pub usage: TokenUsage,
-    /// Session identifier (for grouping)
+    /// Tracker identifier: one random UUID per daemon process, grouping every
+    /// record this daemon emits. This is NOT the chat session — attribute
+    /// per-conversation spend through `conversation_id`.
     pub session_id: String,
+    /// Chat-session identifier (the runtime session key scoped around the
+    /// turn), so per-conversation spend can be separated across the sessions
+    /// one daemon serves. `None` for records persisted before the field
+    /// existed or turns without a chat-session scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
     /// Alias of the agent that incurred this cost (HashMap key in
     /// `config.agents`). `None` for records persisted before per-agent
     /// attribution, or when `[cost].track_per_agent = false`.
@@ -165,6 +173,7 @@ impl CostRecord {
             id: uuid::Uuid::new_v4().to_string(),
             usage,
             session_id: session_id.into(),
+            conversation_id: None,
             agent_alias: None,
             task_id: None,
         }
@@ -180,6 +189,7 @@ impl CostRecord {
             id: uuid::Uuid::new_v4().to_string(),
             usage,
             session_id: session_id.into(),
+            conversation_id: None,
             agent_alias,
             task_id: None,
         }
@@ -196,9 +206,18 @@ impl CostRecord {
             id: uuid::Uuid::new_v4().to_string(),
             usage,
             session_id: session_id.into(),
+            conversation_id: None,
             agent_alias,
             task_id,
         }
+    }
+
+    /// Attach the chat-session identifier this spend belongs to. The ledger
+    /// is append-only JSONL, so the field is additive and older rows read
+    /// back as `None`.
+    pub fn with_conversation_id(mut self, conversation_id: Option<String>) -> Self {
+        self.conversation_id = conversation_id;
+        self
     }
 }
 
@@ -430,5 +449,19 @@ mod tests {
         assert_eq!(parsed.task_id.as_deref(), Some("task-123"));
         assert!(parsed.usage.pricing_available);
         assert_eq!(parsed.usage.unpriced_tokens, 0);
+        // Rows persisted before conversation attribution existed read as None.
+        assert!(parsed.conversation_id.is_none());
+    }
+
+    #[test]
+    fn cost_record_conversation_attribution_roundtrips() {
+        let usage = TokenUsage::new("test/model", 100, 50, 0, 1.0, 2.0, 0.0);
+        let record =
+            CostRecord::new("tracker-1", usage).with_conversation_id(Some("chat-session-9".into()));
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(json.contains("conversation_id"));
+        let parsed: CostRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.session_id, "tracker-1");
+        assert_eq!(parsed.conversation_id.as_deref(), Some("chat-session-9"));
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/cost.rs
+++ b/crates/zeroclaw-runtime/src/agent/cost.rs
@@ -476,9 +476,19 @@ fn record_tool_loop_cost_usage_inner(
         }
     }
 
+    // The session key scoped around this turn is the chat conversation the
+    // spend belongs to; the tracker's own id is daemon-lifetime scoped.
+    let conversation_id = zeroclaw_api::TOOL_LOOP_SESSION_KEY
+        .try_with(Clone::clone)
+        .ok()
+        .flatten();
     if let Some(tracker) = &ctx.tracker
-        && let Err(error) =
-            tracker.record_usage_with_agent(cost_usage.clone(), ctx.agent_alias.as_deref())
+        && let Err(error) = tracker.record_usage_attributed(
+            cost_usage.clone(),
+            ctx.agent_alias.as_deref(),
+            None,
+            conversation_id,
+        )
     {
         ::zeroclaw_log::record!(WARN, ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note).with_category(::zeroclaw_log::EventCategory::Provider).with_outcome(::zeroclaw_log::EventOutcome::Unknown).with_attrs(::serde_json::json!({"model_provider": model_provider_name, "model": model, "error": format!("{}", error)})), "Failed to record cost tracking usage: ");
     }
@@ -1329,6 +1339,60 @@ mod tests {
             serde_json::from_str(stored.lines().next().expect("one record")).unwrap();
         assert_eq!(record.usage.cached_input_tokens, 4_000);
         assert_eq!(record.usage.billable_input_tokens(), 1_000);
+    }
+
+    #[test]
+    fn record_tool_loop_cost_usage_attributes_records_to_the_chat_session() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let tracker = Arc::new(
+            CostTracker::new(
+                zeroclaw_config::schema::CostConfig::default(),
+                workspace.path(),
+            )
+            .unwrap(),
+        );
+        let ctx = ToolLoopCostTrackingContext::new(
+            Arc::clone(&tracker),
+            Arc::new(HashMap::from([(
+                "deepseek".to_string(),
+                pricing_with_cache("deepseek-chat", 0.27, 0.027, 1.10),
+            )])),
+        );
+        let usage = zeroclaw_providers::traits::TokenUsage {
+            input_tokens: Some(5_000),
+            output_tokens: Some(200),
+            cached_input_tokens: Some(4_000),
+        };
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for session in ["chat-session-a", "chat-session-b"] {
+            let ctx = ctx.clone();
+            let usage = usage.clone();
+            let session = session.to_string();
+            runtime.block_on(zeroclaw_api::TOOL_LOOP_SESSION_KEY.scope(
+                Some(session),
+                TOOL_LOOP_COST_TRACKING_CONTEXT.scope(Some(ctx), async {
+                    record_tool_loop_cost_usage("deepseek", "deepseek-chat", &usage)
+                        .expect("cost usage")
+                }),
+            ));
+        }
+
+        let stored = std::fs::read_to_string(workspace.path().join("state").join("costs.jsonl"))
+            .expect("costs.jsonl should be written");
+        let mut conversation_ids = Vec::new();
+        for line in stored.lines() {
+            let record: zeroclaw_config::cost::types::CostRecord =
+                serde_json::from_str(line).unwrap();
+            assert_eq!(record.session_id, tracker.session_id());
+            conversation_ids.push(record.conversation_id.expect("conversation id"));
+        }
+        conversation_ids.sort();
+        assert_eq!(
+            conversation_ids,
+            vec!["chat-session-a".to_string(), "chat-session-b".to_string()],
+            "two chat sessions on one daemon must stay separable in the ledger"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> **Maintainer’s note:** I changed the PR body’s issue link to partial coverage because this PR addresses ledger attribution; trace correlation remains open. The contributor’s implementation is unchanged.

## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `CostTracker.session_id` is one random UUID per daemon process, so every record in `costs.jsonl` for that daemon lifetime shares it across all agents and all chat sessions — per-conversation spend could only be reconstructed by joining timestamps against the runtime trace (measured in the issue: two concurrent sessions, 443k and 100k tokens, all records under one `session_id`).
  - Add `conversation_id: Option<String>` to `CostRecord`, threaded from the `TOOL_LOOP_SESSION_KEY` already scoped around each agent turn through the tool-loop cost bridge, so ledger rows carry the chat session that actually incurred the spend.
  - Keep the process-scope id (useful for grouping a daemon lifetime) and document it as what it is; the ledger is append-only JSONL, so the new field is additive and rows persisted before it read back as `None`.
- **Scope boundary:** No per-conversation budgets, aggregation views, or UI — this only records the identity so those become possible (the issue's explicit non-goal). The `session_id` JSON key is unchanged, so no ledger migration.
- **Blast radius:** Cost records only (one nullable field on `CostRecord`, one new tracker record method, the tool-loop bridge call). Budget checks, summaries, and existing consumers are untouched.
- **Linked issue(s):** Addresses the ledger-attribution portion of #10700.
- **Labels:** `agent`, `config`, `runtime`, `risk:medium`, `size:S`

## Testing

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the attribution contract is pinned by ledger-level unit tests; verifying it live needs a daemon serving two chat sessions, which the unit test simulates at the same boundary (two scoped turns, one tracker).
- **Interface(s) exercised:** cost ledger records (Rust surface)
- **Setup / preconditions:** N/A
- **Steps to run:** `cargo test -p zeroclaw-runtime --locked cost && cargo test -p zeroclaw-config --locked cost`
- **Expected on this branch (after):** two turns in different chat sessions on one tracker produce records with different `conversation_id`s and the same process `session_id`.
- **Prior behavior on master (before):** both records carry only the shared daemon-lifetime `session_id`; the field name suggests conversation scope it does not have.

### How I tested

- **CI checks relied on and why they cover this change:** the locked workspace test suite covers the changed record type, tracker persistence, and the tool-loop bridge; clippy and fmt cover the signature changes.
- **Known CI coverage gap, if any:** none for the recorded contract; live multi-session daemons were not exercised.
- **Commands run and tail output:**

```text
$ cargo test -p zeroclaw-runtime --locked cost
test result: ok. 50 passed; 0 failed

$ cargo test -p zeroclaw-config --locked cost
test result: ok. 50 passed; 0 failed

$ cargo fmt --all -- --check
status: passed
```

- **Beyond CI, what did I manually verify?** New tests pin: two scoped turns in different chat sessions persist distinct `conversation_id`s with the identical tracker `session_id`; the field round-trips through `CostRecord` JSON; a legacy ledger row without the field parses with `conversation_id: None`. Live multi-session behavior was not exercised.
- **If any command was intentionally skipped, why:** N/A

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility

- Backward compatible? Yes — additive nullable JSONL field; the `session_id` key and semantics are unchanged, so old ledgers and consumers work as before.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback

Low-risk change: `git revert <sha>` is the plan.
