### PR TITLE
fix(providers): preserve tool image references through normalization

### DIFF
--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -7481,9 +7481,12 @@ data: {\"type\":\"message_stop\"}\n\n";
             "a prepared local image must not be reported as omitted: {wire}"
         );
         assert!(
-            !wire.to_string().contains("screenshot.png"),
-            "the raw local path must not leak onto the wire: {wire}"
+            texts
+                .iter()
+                .any(|text| text.contains(&format!("Image reference: {}", image_path.display()))),
+            "the tool delivery target must remain visible in text metadata: {wire}"
         );
+        assert!(!image.to_string().contains("screenshot.png"));
     }
 
     /// Regression guard: ordinary user-message images take the user arm and

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -6372,6 +6372,40 @@ mod tests {
         assert_eq!(converted[0].tool_call_id.as_deref(), Some("call_img"));
     }
 
+    #[tokio::test]
+    async fn normalized_tool_image_keeps_delivery_target_in_upstream_text() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("render with spaces.png");
+        std::fs::write(&path, b"\x89PNG\r\n\x1a\n").unwrap();
+        let input = vec![ChatMessage::tool(serde_json::json!({
+            "tool_call_id": "render", "content": format!("review: OK\n[IMAGE:{}]", path.display()),
+        }).to_string())];
+        let provider = make_model_provider("test", "https://example.com", None);
+        let normalized = provider
+            .normalize_messages_for_upstream(&input)
+            .await
+            .unwrap();
+        let converted = provider.convert_messages_for_native(&normalized, true);
+        assert_eq!(converted[0].tool_call_id.as_deref(), Some("render"));
+        let content = serde_json::to_value(converted[0].content.as_ref().unwrap()).unwrap();
+        let parts = content.as_array().unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["type"], "text");
+        assert!(
+            parts[0]["text"]
+                .as_str()
+                .unwrap()
+                .contains(&format!("Image reference: {}", path.display()))
+        );
+        assert!(
+            parts[1]["image_url"]["url"]
+                .as_str()
+                .unwrap()
+                .starts_with("data:image/png;base64,")
+        );
+        assert!(!parts[1].to_string().contains(&path.display().to_string()));
+    }
+
     #[test]
     fn convert_messages_for_native_sanitizes_malformed_tool_result_json() {
         let input = vec![ChatMessage::tool(

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -641,12 +641,39 @@ fn should_normalize_message_images(
     message.role == "user"
 }
 
+/// Image payload normalization must not erase a tool's file/URL reference:
+/// the model still needs the original target to return a delivery marker or
+/// pass the artifact to another tool. Keep it as ordinary text so repeated
+/// preparation cannot mistake the reference for another image payload.
+/// The original tool result is the source of truth; data URIs are never copied
+/// into the text reference, and user-upload paths retain their existing policy.
+fn with_tool_image_references(cleaned: &str, refs: &[String]) -> String {
+    let mut text = cleaned.to_string();
+    let mut seen = HashSet::new();
+    for reference in refs {
+        if !(Path::new(reference).is_absolute()
+            || reference.starts_with("https://")
+            || reference.starts_with("http://"))
+            || !seen.insert(reference)
+        {
+            continue;
+        }
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str("Image reference: ");
+        text.push_str(reference);
+    }
+    text
+}
+
 fn stripped_image_marker_text(content: &str) -> String {
     let (cleaned, refs) = parse_image_markers(content);
     if refs.is_empty() {
         return content.to_string();
     }
 
+    let cleaned = with_tool_image_references(&cleaned, &refs);
     if cleaned.trim().is_empty() {
         "[image removed from history]".to_string()
     } else {
@@ -715,6 +742,7 @@ async fn normalize_native_tool_result_json(
     if refs.is_empty() {
         return None;
     }
+    let cleaned_text = with_tool_image_references(&cleaned_text, &refs);
 
     let normalized =
         normalize_image_references(&refs, config, max_bytes, remote_client, ctx, cache).await;
@@ -834,6 +862,11 @@ async fn prepare_messages_inner(
             normalized_messages.push(message.clone());
             continue;
         }
+        let cleaned_text = if is_tool_result_carrier(message) {
+            with_tool_image_references(&cleaned_text, &refs)
+        } else {
+            cleaned_text
+        };
 
         let normalized = normalize_image_references(
             &refs,
@@ -2264,8 +2297,8 @@ mod tests {
             "local image path inside tool content should be rewritten to a data URI"
         );
         assert!(
-            !inner.contains("native-tool-result.png"),
-            "raw local path must not leak after normalization"
+            inner.contains(&format!("Image reference: {}", image_path.display())),
+            "tool delivery target must remain available as text metadata"
         );
     }
 
@@ -2301,7 +2334,7 @@ mod tests {
         assert!(inner.contains("generated screenshot"));
         assert!(inner.contains("1 attached image(s) could not be loaded"));
         assert!(!inner.contains("[IMAGE:"));
-        assert!(!inner.contains("https://example.com/missing.png"));
+        assert!(inner.contains("Image reference: https://example.com/missing.png"));
     }
 
     #[tokio::test]
@@ -2347,8 +2380,8 @@ mod tests {
         assert!(inner.contains("generated"));
         assert!(inner.contains("data:image/png;base64,"));
         assert!(inner.contains("1 of 2 attached image(s) could not be loaded"));
-        assert!(!inner.contains("mixed-native-tool-result.png"));
-        assert!(!inner.contains("https://example.com/missing.png"));
+        assert!(inner.contains(&format!("Image reference: {}", image_path.display())));
+        assert!(inner.contains("Image reference: https://example.com/missing.png"));
     }
 
     #[tokio::test]
@@ -2399,7 +2432,7 @@ mod tests {
         assert!(inner.contains("generated screenshot"));
         assert!(!inner.contains("[IMAGE:"));
         assert!(!inner.contains("data:image"));
-        assert!(!inner.contains("stale-native-tool-result.png"));
+        assert!(inner.contains(&format!("Image reference: {}", image_path.display())));
     }
 
     #[tokio::test]
@@ -2434,9 +2467,9 @@ mod tests {
         assert!(!prepared.messages[0].content.contains("[IMAGE:"));
         assert!(!prepared.messages[0].content.contains("data:image"));
         assert!(
-            !prepared.messages[0]
+            prepared.messages[0]
                 .content
-                .contains("stale-prompt-tool-result.png")
+                .contains(&format!("Image reference: {}", image_path.display()))
         );
     }
 
@@ -2482,7 +2515,7 @@ mod tests {
         assert!(inner.contains("generated screenshot"));
         assert!(!inner.contains("[IMAGE:"));
         assert!(!inner.contains("data:image"));
-        assert!(!inner.contains("stale-tool-result.png"));
+        assert!(inner.contains(&format!("Image reference: {}", stale_path.display())));
 
         let (cleaned, refs) = parse_image_markers(&prepared.messages[2].content);
         assert_eq!(cleaned, "Now inspect this");
@@ -2514,6 +2547,81 @@ mod tests {
         ];
 
         assert_eq!(count_image_markers(&messages), 1);
+    }
+
+    #[tokio::test]
+    async fn tool_image_references_survive_normalization_and_later_tool_turns() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("generated picture.png");
+        std::fs::write(&path, b"\x89PNG\r\n\x1a\n").unwrap();
+        let target = path.display().to_string();
+        for native in [false, true] {
+            let raw = format!("review: OK\n[IMAGE:{target}]");
+            let message = if native {
+                ChatMessage::tool(
+                    serde_json::json!({"tool_call_id":"render1","content":raw}).to_string(),
+                )
+            } else {
+                ChatMessage::user(format!("[Tool results]\nshell: {raw}"))
+            };
+            let prepared = prepare_messages_for_provider(
+                std::slice::from_ref(&message),
+                &MultimodalConfig::default(),
+            )
+            .await
+            .unwrap();
+            assert!(prepared.contains_images);
+            assert!(
+                prepared.messages[0]
+                    .content
+                    .contains(&format!("Image reference: {target}"))
+            );
+            assert!(
+                prepared.messages[0]
+                    .content
+                    .contains("data:image/png;base64,")
+            );
+
+            // Providers may prepare an already prepared turn again.
+            let repeated =
+                prepare_messages_for_provider(&prepared.messages, &MultimodalConfig::default())
+                    .await
+                    .unwrap();
+            assert_eq!(
+                repeated.messages[0]
+                    .content
+                    .matches("Image reference:")
+                    .count(),
+                1
+            );
+
+            let later = vec![
+                message,
+                ChatMessage::assistant("Checking settings"),
+                ChatMessage::tool("settings OK"),
+            ];
+            let replayed = prepare_messages_for_provider(&later, &MultimodalConfig::default())
+                .await
+                .unwrap();
+            assert!(!replayed.contains_images);
+            assert!(
+                replayed.messages[0]
+                    .content
+                    .contains(&format!("Image reference: {target}"))
+            );
+            assert!(!replayed.messages[0].content.contains("data:image"));
+        }
+    }
+
+    #[test]
+    fn tool_reference_metadata_never_repeats_inline_image_data() {
+        let refs = vec![
+            "data:image/png;base64,PRIVATE".into(),
+            "https://example.com/p.png".into(),
+            "https://example.com/p.png".into(),
+        ];
+        let text = with_tool_image_references("done", &refs);
+        assert_eq!(text, "done\nImage reference: https://example.com/p.png");
     }
 
     #[test]

--- a/docs/book/src/providers/configuration.md
+++ b/docs/book/src/providers/configuration.md
@@ -24,6 +24,13 @@ Almost every family also takes the shared fields from `ModelProviderConfig`:
 - `tool_result_image_policy`: handling for image markers in native `role = "tool"` results sent to compatible chat-completions providers. Defaults to `"image_url"`; set to `"omit"` to remove image URI/base64 payloads and append a fixed notice. This does not change direct user images or OpenAI Responses providers.
 - `tls_ca_cert_path`: absolute path to a PEM-encoded CA certificate for TLS connections to this provider (a per-provider trust override, distinct from the gateway TLS `ca_cert_path`). Shell expansion such as `~` is not performed; leave unset to use the system trust store.
 
+Tool-produced image paths and URLs remain available as `Image reference:` text
+when their image payloads are normalized or removed from older tool turns. Agents
+can use that exact reference for subsequent file tools or outbound image markers.
+Inline base64 data is never repeated as a text reference. This metadata preserves
+the original tool-supplied target; channel attachment permissions still determine
+whether an outbound marker may be delivered.
+
 Family-specific entries add their own typed fields on top of these shared fields.
 
 ## Field resolution order


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Preserve the original absolute path or HTTP(S) URL from a tool's image marker as `Image reference:` text when converting the image to provider payloads. The agent needs that reference to deliver the image or pass it to another tool.
  - Keep the reference after later tool turns remove old image payloads. Deduplicate references without repeating inline base64 data or changing user-upload handling.
  - Cover native tool results, prompt-style tool results, compatible-provider content parts, and Anthropic wire serialization; document the model-visible metadata.
- **Scope boundary:** Provider message preparation only. No channel attachment allowlists, filesystem access, configuration, or rendering tools change.
- **Blast radius:** Providers receiving normalized tool images now receive the original tool-supplied target as text alongside the existing image content or omission notice.
- **Linked issue(s):** None; found during delegated image-delivery verification.
- **Labels:** None manually applied; automated labels pending.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes.
- **Interface(s) exercised:** `surface=cli`; outbound Discord attachment delivery was checked separately through `channel send`.
- **Setup / preconditions:** A vision-capable compatible provider and a tool that creates a PNG in the recipient channel's workspace and returns `[IMAGE:<absolute path>]`.
- **Steps to run:** Ask the agent to use the image tool and return its exact attachment target. Inspect the prepared provider request. Repeat with an intervening tool call before asking the agent to reuse the image. Send the returned marker through the configured channel.
- **Expected on this branch (after):** The request includes `Image reference: <original target>` as ordinary text. The current image still becomes image content; the target survives when an older image payload is removed. The agent can relay the original filename.
- **Prior behavior on `master` (before):** Image normalization discards the target; later tool turns also strip it. The image bytes remain visible, but the model lacks the tool's original filename and can invent an undeliverable path.

### How I tested

- **CI checks relied on and why they cover this change:** None; local checks cover the provider crate and changed documentation. CI has not run for this draft.
- **Known CI coverage gap, if any:** Full workspace and platform matrices were not run locally. Provider tests include local mock HTTP servers and were run with loopback access.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
exit 0

cargo test --locked -p zeroclaw-providers --lib --quiet
test result: ok. 1527 passed; 0 failed; 4 ignored

cargo clippy --locked -p zeroclaw-providers --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 59.59s

DOCS_FILES=docs/book/src/providers/configuration.md scripts/ci/docs_quality_gate.sh
Summary: 0 error(s)

DOCS_FILES=docs/book/src/providers/configuration.md scripts/ci/docs_links_gate.sh
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** Applied the same patch to an existing local deployment branch, built the release binary with its existing `channel-mqtt` feature, and restarted the service. Six real image jobs traversed agent delegation, shell policy, an authenticated render gateway, rendering, vision QC, and the parent agent's final reply. The replies then passed through ZeroClaw's Discord sender; downloaded attachments matched the generated PNG bytes. Outputs ranged from 512 to 2048 pixels square and included two-pass refinement, model upscaling, and image-to-image. The integration also used a separate local renderer fix to stage images in the recipient workspace. Discord inbound websocket handling was not exercised. Private channel identifiers, traces, and deployment paths are excluded from this PR.
- **Visual interface changed?** N/A; this changes internal provider message metadata and preserves existing attachment targets, with no layout or presentation changes.
- **If any command was intentionally skipped, why:** Full workspace tests and cross-platform builds were omitted because this patch changes only provider message preparation. The deployed branch's provider suite also passed (1512 tests; 4 ignored); its release build and live integration evidence are distinct from the current upstream branch's 1527-test result above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**
- Prompt injection or untrusted model-visible text introduced/changed? **Yes.** Tool-supplied paths and URLs remain visible as ordinary text, including in older tool turns. This can expose path information that was previously discarded; it is necessary for artifact reuse and delivery. References retain tool-result provenance, inline data is excluded, user-upload policy is unchanged, and channel attachment validation continues to enforce its existing boundaries.

## Compatibility (required)

- Backward compatible? **Yes.** Image payload formats and tool-result envelopes are preserved; tool-result text gains the original reference.
- Config / env / CLI surface changed? **No.**
- Rust/MSRV/toolchain floor changed? **No.**
- Exact upgrade steps: None beyond rebuilding and restarting the running binary.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this commit, rebuild, and restart the service; alternatively restore the previous binary.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Missing or duplicated `Image reference:` metadata in provider requests, or incorrect attachment paths in agent replies. Reverting restores the previous filename-loss behavior.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A; this PR does not supersede another contribution.
