### PR TITLE
fix(runtime): deliver pre-tool narration and terminal fallback to event consumers

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -2561,3 +2561,73 @@ async fn safety_net_terminal_malformed_fallback_reaches_event_consumer_after_too
         "the valid tool round must have executed exactly once"
     );
 }
+
+#[tokio::test]
+async fn safety_net_text_parsed_tool_call_emits_no_narration_chunk() {
+    // A provider that conveys the tool call inside the text (no native tool
+    // calls): the parser strips the markup, so the display residue is not
+    // separable narration. Parity with the on_delta relay: neither consumer
+    // emits a Chunk for it before the ToolCall event.
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut agent = build_agent(
+        Box::new(ScriptedProvider::new(vec![
+            text_response(
+                "Working on it.<tool_call>{\"name\": \"echo\", \"arguments\": {}}</tool_call>",
+            ),
+            text_response("all done"),
+        ])),
+        vec![Box::new(CountingTool {
+            name: "echo",
+            calls: Arc::clone(&calls),
+        })],
+    );
+
+    let (tx, mut rx) = mpsc::channel(256);
+    let handle = zeroclaw_spawn::spawn!(async move {
+        agent
+            .turn_streamed_with_steering_state("markup tool call", tx, None, None)
+            .await
+    });
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    handle
+        .await
+        .expect("task join")
+        .expect("streamed turn should succeed");
+
+    let pos_tool_call = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolCall { name, .. } if name == "echo"))
+        .expect("the text-parsed tool call must emit its ToolCall event");
+    assert!(
+        !events[..pos_tool_call]
+            .iter()
+            .any(|e| matches!(e, TurnEvent::Chunk { .. })),
+        "no narration Chunk may precede the ToolCall event for a text-parsed call"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains("Working on it."))),
+        "the markup-stripped residue must not surface as a narration Chunk"
+    );
+    let pos_tool_result = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolResult { name, .. } if name == "echo"))
+        .expect("the text-parsed tool call must emit its ToolResult event");
+    let pos_final = events
+        .iter()
+        .rposition(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains("all done")))
+        .expect("final response text must be emitted as a Chunk");
+    assert!(
+        pos_tool_result < pos_final,
+        "final-round Chunk must follow the ToolResult"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the text-parsed tool call must have executed exactly once"
+    );
+}

--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -2481,3 +2481,83 @@ async fn safety_net_narration_reaches_both_draft_and_event_channels_once() {
         "event channel must receive the narration exactly once"
     );
 }
+
+#[tokio::test]
+async fn safety_net_terminal_malformed_fallback_reaches_event_consumer_after_tool() {
+    // A narrated valid tool round, then the malformed-protocol retry budget
+    // exhausts. The terminal fallback is the turn's last word on the event
+    // channel: it must be emitted as a Chunk after the ToolResult, because a
+    // client that already flushed streamed narration hides the TurnComplete
+    // payload and would otherwise settle the turn with no explanation.
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut agent = build_agent(
+        Box::new(ScriptedProvider::new(vec![
+            narrated_tool_response("let me check that for you", "tc-1", "echo"),
+            text_response(r#"{"toolcalls":[{"call_id":"call_1","arguments":{"value":"X"}}]}"#),
+            text_response(r#"{"toolcalls":[{"call_id":"call_2","arguments":{"value":"Y"}}]}"#),
+            text_response(r#"{"toolcalls":[{"call_id":"call_3","arguments":{"value":"Z"}}]}"#),
+        ])),
+        vec![Box::new(CountingTool {
+            name: "echo",
+            calls: Arc::clone(&calls),
+        })],
+    );
+
+    let (tx, mut rx) = mpsc::channel(256);
+    let handle = zeroclaw_spawn::spawn!(async move {
+        agent
+            .turn_streamed_with_steering_state("narrate then break", tx, None, None)
+            .await
+    });
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    handle
+        .await
+        .expect("task join")
+        .expect("turn should end with the safe fallback");
+
+    let fallback_text =
+        crate::i18n::get_english_cli_string_with_args("channel-runtime-malformed-tool-output", &[]);
+    let pos_narration = events
+        .iter()
+        .position(|e| {
+            matches!(e, TurnEvent::Chunk { delta } if delta.contains("let me check that for you"))
+        })
+        .expect("pre-tool narration must be emitted as a Chunk");
+    let pos_tool_call = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolCall { id, .. } if id == "tc-1"))
+        .expect("the valid tool call must emit its ToolCall event");
+    let pos_tool_result = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolResult { id, .. } if id == "tc-1"))
+        .expect("the valid tool call must emit its ToolResult event");
+    let pos_fallback = events
+        .iter()
+        .rposition(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains(&fallback_text)))
+        .expect("terminal malformed-output fallback must reach the event consumer as a Chunk");
+
+    assert!(
+        pos_narration < pos_tool_call,
+        "narration Chunk must precede that round's ToolCall event"
+    );
+    assert!(
+        pos_tool_result < pos_fallback,
+        "the terminal fallback must follow the tool result"
+    );
+    let fallback_chunks = events
+        .iter()
+        .filter(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains(&fallback_text)))
+        .count();
+    assert_eq!(
+        fallback_chunks, 1,
+        "the terminal fallback must be emitted exactly once"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the valid tool round must have executed exactly once"
+    );
+}

--- a/crates/zeroclaw-runtime/src/agent/safety_net.rs
+++ b/crates/zeroclaw-runtime/src/agent/safety_net.rs
@@ -2115,3 +2115,369 @@ async fn safety_net_loop_cron_add_does_not_trust_model_supplied_approved_arg() {
         "model-supplied approved=true must be stripped even with no approval gate"
     );
 }
+
+// ── seam: pre-tool narration must reach event consumers in order ────────
+// ACP and other event-driven channels render message content exclusively
+// from `TurnEvent::Chunk`. Narration that accompanies a tool-call response
+// must be emitted as a Chunk before that round's ToolCall event, or the
+// client drops it and only the text after the last tool call renders.
+
+type StreamScriptItem =
+    zeroclaw_api::model_provider::StreamResult<zeroclaw_api::model_provider::StreamEvent>;
+
+/// Streams one scripted event list per provider call; the non-streaming
+/// `chat` path answers with a marker so a test that expected the streaming
+/// engine fails loudly instead of silently changing subject.
+struct ScriptedStreamProvider {
+    scripts: parking_lot::Mutex<VecDeque<Vec<StreamScriptItem>>>,
+}
+
+impl ScriptedStreamProvider {
+    fn new(scripts: Vec<Vec<StreamScriptItem>>) -> Self {
+        Self {
+            scripts: parking_lot::Mutex::new(scripts.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProvider for ScriptedStreamProvider {
+    async fn chat_with_system(
+        &self,
+        _: Option<&str>,
+        _: &str,
+        _: &str,
+        _: Option<f64>,
+    ) -> Result<String> {
+        Ok("ok".into())
+    }
+    async fn chat(&self, _: ChatRequest<'_>, _: &str, _: Option<f64>) -> Result<ChatResponse> {
+        Ok(text_response("unexpected non-streamed fallback"))
+    }
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+    fn supports_streaming_tool_events(&self) -> bool {
+        true
+    }
+    fn stream_chat(
+        &self,
+        _: ChatRequest<'_>,
+        _: &str,
+        _: Option<f64>,
+        _: zeroclaw_providers::traits::StreamOptions,
+    ) -> futures_util::stream::BoxStream<'static, StreamScriptItem> {
+        use futures_util::StreamExt as _;
+        let script = self
+            .scripts
+            .lock()
+            .pop_front()
+            .unwrap_or_else(|| vec![Ok(zeroclaw_api::model_provider::StreamEvent::Final)]);
+        futures_util::stream::iter(script).boxed()
+    }
+}
+
+impl ::zeroclaw_api::attribution::Attributable for ScriptedStreamProvider {
+    fn role(&self) -> ::zeroclaw_api::attribution::Role {
+        ::zeroclaw_api::attribution::Role::Provider(
+            ::zeroclaw_api::attribution::ProviderKind::Model(
+                ::zeroclaw_api::attribution::ModelProviderKind::Custom,
+            ),
+        )
+    }
+    fn alias(&self) -> &str {
+        "ScriptedStreamProvider"
+    }
+}
+
+fn narrated_tool_response(narration: &str, id: &str, name: &str) -> ChatResponse {
+    let mut response = tool_response(vec![tool_call(id, name)]);
+    response.text = Some(narration.into());
+    response
+}
+
+#[tokio::test]
+async fn safety_net_pretool_narration_chunk_precedes_tool_call_events() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut agent = build_agent(
+        Box::new(ScriptedProvider::new(vec![
+            narrated_tool_response("let me check that for you", "tc-1", "echo"),
+            text_response("all done"),
+        ])),
+        vec![Box::new(CountingTool {
+            name: "echo",
+            calls,
+        })],
+    );
+
+    let (tx, mut rx) = mpsc::channel(256);
+    let handle = zeroclaw_spawn::spawn!(async move {
+        agent
+            .turn_streamed_with_steering_state("narrate then act", tx, None, None)
+            .await
+    });
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    handle
+        .await
+        .expect("task join")
+        .expect("streamed turn should succeed");
+
+    let pos_narration = events
+        .iter()
+        .position(|e| {
+            matches!(e, TurnEvent::Chunk { delta } if delta.contains("let me check that for you"))
+        })
+        .expect("pre-tool narration must be emitted as a Chunk");
+    let pos_tool_call = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolCall { id, .. } if id == "tc-1"))
+        .expect("ToolCall event must be emitted");
+    let pos_tool_result = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolResult { id, .. } if id == "tc-1"))
+        .expect("ToolResult event must be emitted");
+    let pos_final = events
+        .iter()
+        .rposition(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains("all done")))
+        .expect("final response text must be emitted as a Chunk");
+
+    assert!(
+        pos_narration < pos_tool_call,
+        "narration Chunk must precede that round's ToolCall event"
+    );
+    assert!(
+        pos_tool_call < pos_tool_result,
+        "ToolCall must precede its ToolResult"
+    );
+    assert!(
+        pos_tool_result < pos_final,
+        "final-round Chunk must follow the ToolResult"
+    );
+    let narration_chunks = events
+        .iter()
+        .filter(|e| {
+            matches!(e, TurnEvent::Chunk { delta } if delta.contains("let me check that for you"))
+        })
+        .count();
+    assert_eq!(
+        narration_chunks, 1,
+        "narration must be emitted exactly once"
+    );
+}
+
+#[tokio::test]
+async fn safety_net_live_streamed_tool_turn_does_not_duplicate_narration_chunk() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut agent = build_agent(
+        Box::new(ScriptedStreamProvider::new(vec![
+            vec![
+                text_delta("thinking aloud"),
+                Ok(zeroclaw_api::model_provider::StreamEvent::ToolCall(
+                    tool_call("tc-1", "echo"),
+                )),
+                Ok(zeroclaw_api::model_provider::StreamEvent::Final),
+            ],
+            vec![
+                text_delta("all done"),
+                Ok(zeroclaw_api::model_provider::StreamEvent::Final),
+            ],
+        ])),
+        vec![Box::new(CountingTool {
+            name: "echo",
+            calls,
+        })],
+    );
+
+    let (tx, mut rx) = mpsc::channel(256);
+    let handle = zeroclaw_spawn::spawn!(async move {
+        agent
+            .turn_streamed_with_steering_state("stream narrate then act", tx, None, None)
+            .await
+    });
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    handle
+        .await
+        .expect("task join")
+        .expect("streamed turn should succeed");
+
+    let narration_chunks = events
+        .iter()
+        .filter(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains("thinking aloud")))
+        .count();
+    assert_eq!(
+        narration_chunks, 1,
+        "live-streamed narration must appear exactly once (no post-hoc duplicate)"
+    );
+    let pos_narration = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains("thinking aloud")))
+        .expect("live narration Chunk must be emitted");
+    let pos_tool_call = events
+        .iter()
+        .position(|e| matches!(e, TurnEvent::ToolCall { id, .. } if id == "tc-1"))
+        .expect("ToolCall event must be emitted");
+    assert!(
+        pos_narration < pos_tool_call,
+        "live narration Chunk must precede that round's ToolCall event"
+    );
+}
+
+#[tokio::test]
+async fn safety_net_protocol_suppressed_tool_turn_emits_no_narration_chunk() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    // Round 1 streams visible narration followed by an internal tool-protocol
+    // envelope. The stream text guard withholds the envelope (and everything
+    // after it), so the turn is protocol-suppressed: the withheld bytes must
+    // never surface as a Chunk, and the already-forwarded narration must not
+    // gain a post-hoc duplicate.
+    let mut agent = build_agent(
+        Box::new(ScriptedStreamProvider::new(vec![
+            vec![
+                text_delta("thinking aloud"),
+                text_delta("<tool_call>{\"name\": \"echo\", \"arguments\": {}}</tool_call>"),
+                Ok(zeroclaw_api::model_provider::StreamEvent::ToolCall(
+                    tool_call("tc-1", "echo"),
+                )),
+                Ok(zeroclaw_api::model_provider::StreamEvent::Final),
+            ],
+            vec![
+                text_delta("all done"),
+                Ok(zeroclaw_api::model_provider::StreamEvent::Final),
+            ],
+        ])),
+        vec![Box::new(CountingTool {
+            name: "echo",
+            calls,
+        })],
+    );
+
+    let (tx, mut rx) = mpsc::channel(256);
+    let handle = zeroclaw_spawn::spawn!(async move {
+        agent
+            .turn_streamed_with_steering_state("suppressed envelope", tx, None, None)
+            .await
+    });
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    handle
+        .await
+        .expect("task join")
+        .expect("streamed turn should succeed");
+
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            TurnEvent::Chunk { delta } if delta.contains("tool_call")
+        )),
+        "protocol-suppressed bytes must never surface as a Chunk"
+    );
+    let narration_chunks = events
+        .iter()
+        .filter(|e| matches!(e, TurnEvent::Chunk { delta } if delta.contains("thinking aloud")))
+        .count();
+    assert_eq!(
+        narration_chunks, 1,
+        "protocol-suppressed turn must not duplicate the already-forwarded narration"
+    );
+}
+
+#[tokio::test]
+async fn safety_net_narration_reaches_both_draft_and_event_channels_once() {
+    let exec_count = Arc::new(AtomicUsize::new(0));
+    let provider = ScriptedProvider::new(vec![
+        narrated_tool_response("let me check that for you", "tc-1", "echo"),
+        text_response("all done"),
+    ]);
+    let tools_registry =
+        crate::tools::scoped::ScopedToolRegistry::from_raw_for_test(vec![Box::new(CountingTool {
+            name: "echo",
+            calls: Arc::clone(&exec_count),
+        })]);
+    let mut history = vec![ChatMessage::user("hi")];
+    let (dtx, mut drx) = mpsc::channel(256);
+    let (etx, mut erx) = mpsc::channel(256);
+    let turn_id = uuid::Uuid::new_v4().to_string();
+    crate::agent::loop_::run_tool_call_loop(crate::agent::loop_::ToolLoop {
+        parent_agent_alias: None,
+        sop_reassembly: None,
+        exec: crate::agent::loop_::ResolvedAgentExecution {
+            model_access: crate::agent::loop_::ResolvedModelAccess {
+                model_provider: &provider,
+                provider_name: "mock",
+                model: "mock-model",
+                temperature: None,
+            },
+            tools_registry: &tools_registry,
+            observer: &observability::NoopObserver {},
+            silent: true,
+            approval: None,
+            multimodal_config: &zeroclaw_config::schema::MultimodalConfig::default(),
+            config: None,
+            max_tool_iterations: 5,
+            hooks: None,
+            excluded_tools: &[],
+            dedup_exempt_tools: &[],
+            activated_tools: None,
+            model_switch_callback: None,
+            pacing: &zeroclaw_config::schema::PacingConfig::default(),
+            strict_tool_parsing: false,
+            parallel_tools: false,
+            max_tool_result_chars: 30_000,
+            context_token_budget: 100_000,
+            receipt_generator: None,
+            knobs: &crate::agent::loop_::LoopKnobs::default(),
+        },
+        history: &mut history,
+        channel_name: "cli",
+        channel_reply_target: None,
+        cancellation_token: None,
+        on_delta: Some(dtx),
+        shared_budget: None,
+        channel: None,
+        collected_receipts: None,
+        event_tx: Some(etx),
+        steering: None,
+        new_messages_out: None,
+        image_cache: None,
+        memory: None,
+        ingress: IngressContext::sub_turn(),
+        agent_alias: None,
+        turn_id: &turn_id,
+    })
+    .await
+    .expect("loop should succeed");
+
+    let mut draft_narration = 0;
+    while let Ok(delta) = drx.try_recv() {
+        if let crate::agent::loop_::StreamDelta::Text(t) = &delta
+            && t.contains("let me check that for you")
+        {
+            draft_narration += 1;
+        }
+    }
+    assert_eq!(
+        draft_narration, 1,
+        "draft channel must receive the narration exactly once"
+    );
+
+    let mut event_narration = 0;
+    while let Some(ev) = erx.recv().await {
+        if let TurnEvent::Chunk { delta } = &ev
+            && delta.contains("let me check that for you")
+        {
+            event_narration += 1;
+        }
+    }
+    assert_eq!(
+        event_narration, 1,
+        "event channel must receive the narration exactly once"
+    );
+}

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1172,8 +1172,16 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
             let remainder = unforwarded_narration(&display_text, &streamed_visible_text);
             // If narration wasn't streamed live, send the unforwarded remainder
             // now as a post-hoc Chunk. Gated on event_tx independently of
-            // on_delta (never nested — §8.4).
-            if !remainder.is_empty() && !response_streamed_live && !protocol_suppressed {
+            // on_delta (never nested — §8.4). The native-tool-calls condition
+            // is parity with the on_delta relay below: text-parsed tool calls
+            // have their markup stripped from display, so only native
+            // providers carry separable narration. Loosen both together if a
+            // parsed-tool provider is ever shown to leave visible narration.
+            if !remainder.is_empty()
+                && !response_streamed_live
+                && !protocol_suppressed
+                && !native_tool_calls.is_empty()
+            {
                 events::emit_posthoc_turn_chunk(event_tx.as_ref(), remainder).await;
             }
             // `protocol_suppressed` withholds the whole turn; the empty-remainder

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1164,20 +1164,25 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
         // Relay only the portion of narration the live stream did not already
         // deliver: re-sending the whole thing duplicates it.
         if !display_text.is_empty() {
+            let remainder = unforwarded_narration(&display_text, &streamed_visible_text);
+            // If narration wasn't streamed live, send the unforwarded remainder
+            // now as a post-hoc Chunk. Gated on event_tx independently of
+            // on_delta (never nested — §8.4).
+            if !remainder.is_empty() && !response_streamed_live && !protocol_suppressed {
+                events::emit_posthoc_turn_chunk(event_tx.as_ref(), remainder).await;
+            }
             // `protocol_suppressed` withholds the whole turn; the empty-remainder
             // skip below handles the guard-passed case where the live stream already forwarded every byte.
             if !native_tool_calls.is_empty()
                 && !protocol_suppressed
+                && !remainder.is_empty()
                 && let Some(ref tx) = on_delta
             {
-                let remainder = unforwarded_narration(&display_text, &streamed_visible_text);
-                if !remainder.is_empty() {
-                    let mut narration = remainder.to_string();
-                    if !narration.ends_with('\n') {
-                        narration.push('\n');
-                    }
-                    let _ = tx.send(StreamDelta::Text(narration)).await;
+                let mut narration = remainder.to_string();
+                if !narration.ends_with('\n') {
+                    narration.push('\n');
                 }
+                let _ = tx.send(StreamDelta::Text(narration)).await;
             }
             if !silent {
                 eprint!("{display_text}");

--- a/crates/zeroclaw-runtime/src/agent/turn/mod.rs
+++ b/crates/zeroclaw-runtime/src/agent/turn/mod.rs
@@ -1066,6 +1066,11 @@ pub async fn run_tool_call_loop(mut p: ToolLoop<'_>) -> Result<String> {
             let fallback =
                 crate::i18n::get_required_cli_string("channel-runtime-malformed-tool-output");
             accumulated_display_text.push_str(&fallback);
+            // The fallback is synthesized here, never streamed live, and is the
+            // turn's only visible output on this exit: an event consumer that
+            // already flushed streamed narration would otherwise hide the
+            // TurnComplete payload. Same rationale as the max-iteration emit.
+            events::emit_posthoc_turn_chunk(event_tx.as_ref(), &fallback).await;
             if let Some(ref tx) = on_delta {
                 let _ = tx.send(StreamDelta::Text(fallback.to_string())).await;
             }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Narration that accompanies a response with tool calls was relayed only through the legacy channel draft sender (`on_delta`). ACP and RPC consumers drive the loop with `on_delta: None` and receive `TurnEvent`s on `event_tx` instead, so every byte of pre-tool narration was dropped for them and only the text after the last tool call rendered. The with-tool-calls branch now emits the unforwarded remainder as a post-hoc `TurnEvent::Chunk`, even when an earlier prefix streamed live, while retaining the protocol-suppression guard, before that round's `ToolCall` events.
  - The terminal malformed-protocol fallback (the safe canned message returned when parse retries are exhausted) had the same shape: sent only via `on_delta` and returned as the `TurnComplete` payload. Event-driven clients that have already flushed streamed narration hide that payload, so the turn settled with no explanation after an executed tool. The fallback is now emitted as a post-hoc `Chunk`, mirroring the existing max-iteration exit emit; the text is synthesized locally and never streamed live, so no live-vs-post-hoc guard applies.
  - The narration emit is additionally gated on `!native_tool_calls.is_empty()` for parity with the `on_delta` relay: text-parsed tool calls have their markup stripped from display, so the residue is not separable narration. Both gates are to be loosened together if a parsed-tool provider is ever shown to leave visible narration.
- **Scope boundary:** No client changes: the ZeroCode flush and `commit_turn` behavior are untouched and already correct. No change to `on_delta` semantics, the final-response branch, history persistence, or the streaming path's live `Chunk` forwarding. Protocol-suppressed turns still emit nothing.
- **Blast radius:** Every `event_tx` consumer (ACP, RPC, the ZeroCode Code pane) now receives pre-tool narration Chunks and the terminal fallback Chunk. Channel draft consumers (`on_delta`) see identical narration as before. Replay and persistence are unaffected: these sends are display-only, history append is unchanged, and no config, schema, or approval surface is touched.
- **Linked issue(s):** Closes #10697
- **Labels:** `bug`, `agent`, `runtime`, `distinguished contributor`, `risk:medium`, `zerocode`, `size:L`, `channel:acp`, and `topic:zerocode` are currently applied.

### What this does, simply

When ZeroClaw uses a tool, it may first explain what it is about to do. That explanation already appeared in chat channels, but event-driven clients such as ZeroCode could lose it and show only the tool activity and final answer. If the model then repeatedly returned malformed tool instructions, those clients could also end the turn without showing ZeroClaw's safe fallback explanation.

The #10697 fix delivers both messages through the event stream those clients actually display, in the correct order and without repeating narration that already streamed live. Its event-delivery changes preserve tool execution, saved history, chat-channel behavior, configuration, and approval policy. The PR also includes the bounded CI repairs described below.

### Included CI repairs and scope

Shared failures in the required 16-thread parallel suite blocked validation of the event-delivery fix. This PR retains two bounded repairs so validation can proceed without waiting for separate upstream integration; they are not functional dependencies of #10697. The production peer-turn change heap-pins the existing future before the nested cost scopes, preserving recipient attribution, shared-budget checks, and detached delivery. It reuses the repair carried by #10480 and #10351.

At current head `16c60d20aa5734c38d18613bfb213db2dc9a1594`, master includes merged #10832. Its album waits, fixture-client helper, and lifecycle regression are no longer part of this PR's remaining diff. The remaining Telegram change switches 14 additional mock API setups to that existing helper; production Telegram behavior is unchanged. The historical validation sections below explain why the repairs were introduced. The [current Parallel Runtime Test](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35271124493/job/105370766149) and [CI Required Gate](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35271124493/job/105376288015) pass at this head.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A`: a manual A/B needs a live provider-backed daemon with a Code-pane session; the event-ordering behavior is pinned deterministically in the runtime crate (below).

### Peer-turn stack repair

The repair at `043537f0d326a72d4a6eaa2f3e30544cd32e211f` heap-pins the recipient's `process_message` future before the nested cost scopes, reusing the bounded repair carried by #10480 and #10351. Detached delivery, recipient attribution, shared-budget enforcement, and the existing execute-boundary regression are unchanged. The previous head aborted in that regression with stack overflow and SIGABRT under `--test-threads=16`.

`git diff --check`, Format, Test, and Lint passed at `043537f0d326a72d4a6eaa2f3e30544cd32e211f`. The [parallel job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35213593333/job/105176882603) passed all three runtime repetitions (4,441 tests each), including the peer-turn regression. Channels repetitions one and two passed; repetition three failed `media_group_stays_pending_when_a_later_unsupported_member_follows_an_ordinary_update` with the album-dispatch timeout tracked in #10939 and #10875. That prior head's required gate failed. Earlier validation below applies only to its stated revisions.

### Telegram album wait repair

Commit `e391a9667369a61772b2114f01d12d5f018c334a` incorporates the wait-only repair from #10832 (`47b3a1796f7a`). Fifteen positive delivery and offset waits in four album tests reuse the existing 30-second `LISTEN_HANG_GUARD` instead of one-to-four-second deadlines. Ordering, content, exact-once, offset, and negative assertions are preserved. That commit leaves production Telegram behavior and HTTP-client construction unchanged.

The repair's stable patch ID matches the original commit. `rustfmt --edition 2024 --check crates/zeroclaw-channels/src/telegram.rs` and `git diff --check` pass. At `e391a9667369a61772b2114f01d12d5f018c334a`, the fresh [Parallel Runtime Test](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35255276504/job/105317487657) passed all three runtime repetitions and channels repetition one. Channels repetition two failed the same album test because the delivered turn contained one supported photo instead of two. The wait-only repair was insufficient; that historical head was not green.

### Telegram fixture isolation

Commit `7f1636049442140ad741845a031150ddabe52655` ports #10832's fixture-client isolation (`47aea55466a2`), including its runtime-shutdown regression. All 74 existing mock API setups use an independently constructed client per fixture, preserving the existing proxy builder and connection reuse within each fixture. The test-only override leaves production client construction unchanged. This addresses a reproduced cross-runtime connection-lifetime defect; the preceding album failure's transport cause is not proven by its log.

The helper and lifecycle regression match the donor exactly. `rustfmt --edition 2024 --check crates/zeroclaw-channels/src/telegram.rs` and `git diff --check` pass. Hosted Parallel Runtime Test and CI Required Gate passed at `7f1636049442140ad741845a031150ddabe52655`; no local Cargo tests were run for this port. Current-head validation is linked above.

### How I tested

Six original `safety_net` turn-loop regressions passed on prior head `87eadc011cf0447d396ece9c29675f87f7c706a8`. A seventh focused event-channel regression was added on prior head `683cce7d855bbd6c3898272cc026065111080425`:

1. `safety_net_pretool_narration_chunk_precedes_tool_call_events`: non-streaming provider returns text + tool call, then final text; events arrive as `Chunk(text1)`, `ToolCall`, `ToolResult`, `Chunk(text2)` in that order, narration exactly once.
2. `safety_net_live_streamed_tool_turn_does_not_duplicate_narration_chunk`: live-streamed narration appears exactly once (no post-hoc duplicate).
3. `safety_net_protocol_suppressed_tool_turn_emits_no_narration_chunk`: suppressed protocol bytes never surface as a Chunk; no duplicate of already-forwarded narration.
4. `safety_net_narration_reaches_both_draft_and_event_channels_once`: with both sinks attached, each receives the narration exactly once.
5. `safety_net_terminal_malformed_fallback_reaches_event_consumer_after_tool`: a narrated valid tool round followed by three malformed replies; the fallback reaches the event consumer as a `Chunk` after the `ToolResult`, exactly once.
6. `safety_net_text_parsed_tool_call_emits_no_narration_chunk`: a text-parsed tool call with display residue emits no Chunk before the `ToolCall` event (parity gate).
7. `streamed_prefix_relays_only_unforwarded_native_narration_suffix`: a live prefix plus a remaining suffix emits only the suffix as an event Chunk, without replaying the prefix.

Commands run on prior head `87eadc011cf0447d396ece9c29675f87f7c706a8` (all through the repo's locked, external-target-dir cargo route):

```sh
cargo fmt -p zeroclaw-runtime -- --check
# no output, exit 0

cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
#    Checking zeroclaw-runtime v0.8.5
#    Finished `dev` profile [unoptimized + debuginfo] target(s) in 31.82s

cargo test -p zeroclaw-runtime turn
# test result: ok. 449 passed; 0 failed; 1 ignored; 0 measured; 3787 filtered out

cargo test -p zeroclaw-runtime --lib -- safety_net
# running 29 tests
# test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 4208 filtered out
```

On prior head `87eadc011cf0447d396ece9c29675f87f7c706a8`, the full `zeroclaw-runtime` suite reported `test result: ok. 4232 passed; 0 failed; 5 ignored`. One pre-existing, network-dependent flake was observed once during validation (`tools::model_switch::tests::list_models_prefers_live_catalog_when_reachable` races the live models.dev catalog between its own fetches); it passes on rerun and is untouched by this diff.

On prior head `683cce7d855bbd6c3898272cc026065111080425`, `rustfmt --check` on the two touched files and `git diff --check` passed. A focused local Cargo test could not reach execution because the compiler process was killed before the runtime test harness completed; no assertion or source error was reported. That head subsequently failed the Parallel Runtime Test with the peer-turn stack overflow addressed below.

Beyond CI: falsification runs: the malformed-fallback regression fails with the new fallback emit removed, and the text-parsed parity test fails with the native-tool-calls gate removed (both restored and green). NOT verified: a live daemon and Code-pane end-to-end run; no claim of one is made here.

- **CI checks relied on and why they cover this change:** required Rust CI compiles and tests the runtime crate; the added focused tests pin the event-ordering surface this change touches.
- **Known CI coverage gap, if any:** the live Code-pane rendering path is exercised only indirectly; the client-side flush and `commit_turn` behavior already have their own upstream tests.
- **Visual interface changed?** `N/A` (text delivery ordering only; no layout or rendering change).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`): the emitted narration is the already display-resolved text that history and replay carry, under the same suppression gates; the fallback is a canned i18n string.

## Compatibility (required)

- Backward compatible? (`Yes`): event consumers previously received nothing for these cases; channel draft behavior is unchanged.
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the merged commit with `git revert <merged-sha>` and redeploy the runtime. No config or data migration must be undone; this restores the previous event-delivery behavior, including the missing pre-tool narration and terminal fallback in event-driven clients.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** ACP/RPC event consumers show missing or duplicated `TurnEvent::Chunk` text before `ToolCall`, or omit the malformed-protocol fallback after a `ToolResult`. Compare the event order and rendered Code-pane transcript for an affected tool turn.
