### PR TITLE
ci(zerorelay): pin published relay base images by digest

### DIFF
--- a/apps/zerorelay/Dockerfile
+++ b/apps/zerorelay/Dockerfile
@@ -17,8 +17,15 @@
 # --registration-mode open|allowlist with --allow/--deny keyed on the daemon pubkey
 # FINGERPRINT (sha256 hex), plus an optional shared-secret gate via --relay-token.
 
+# >>> generated:base-arg-rust-slim from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_RUST_SLIM=rust:1.98-slim@sha256:17d1ba895198f9934c6314ec5346a0d5115372f3243390c3d731e242f35c2f27
+# >>> end generated:base-arg-rust-slim <<<
+# >>> generated:base-arg-distroless from dev/ci/container-base-images.toml by `cargo generate installers` - do not edit <<<
+ARG ZEROCLAW_BASE_DISTROLESS=gcr.io/distroless/cc-debian13:nonroot@sha256:c31ff9abcb1910f3ab25c7957bdaf0bfe12a01eb546e8df2282f1c8f682b606c
+# >>> end generated:base-arg-distroless <<<
+
 # --- Stage 1: build only the relay binary ---
-FROM rust:1.98-slim AS builder
+FROM ${ZEROCLAW_BASE_RUST_SLIM} AS builder
 WORKDIR /app
 COPY . .
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
@@ -33,7 +40,7 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
 RUN mkdir -p /seed/data && chown -R 65532:65532 /seed/data
 
 # --- Stage 2: minimal distroless runtime (no shell) ---
-FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
+FROM ${ZEROCLAW_BASE_DISTROLESS} AS runtime
 COPY --from=builder /usr/local/bin/zerorelay /usr/local/bin/zerorelay
 # /data must exist in the image owned by nonroot (65532) or a fresh named
 # volume mounts root-owned and self-provisioning fails with

--- a/tests/architecture/container_release.rs
+++ b/tests/architecture/container_release.rs
@@ -1,6 +1,10 @@
 //! Release invariants for published container variants and scheduled scans.
 
-use std::{collections::HashSet, fs, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+};
 
 fn workflow(name: &str) -> String {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -119,6 +123,68 @@ fn cargo_cache_mounts(containerfile: &str) -> Vec<(&str, Option<&str>)> {
             })
         })
         .collect()
+}
+
+/// Digest shape, mirroring `xtask::generate::container_base::valid_digest`.
+fn has_pinned_digest(image_ref: &str) -> bool {
+    image_ref
+        .split_once("@sha256:")
+        .is_some_and(|(_, hex)| hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// The image a `FROM` names, skipping flags such as `--platform=$BUILDPLATFORM`.
+/// The image is the first non-flag token, so the trailing `AS <stage>` is past it.
+fn from_image_ref(line: &str) -> Option<&str> {
+    let mut tokens = line.split_whitespace();
+    if !tokens.next()?.eq_ignore_ascii_case("FROM") {
+        return None;
+    }
+    tokens.find(|token| !token.starts_with("--"))
+}
+
+/// The stage a `FROM ... AS <stage>` declares.
+fn from_stage_name(line: &str) -> Option<&str> {
+    let mut after_as = line
+        .split_whitespace()
+        .skip_while(|token| !token.eq_ignore_ascii_case("AS"));
+    after_as.next()?;
+    after_as.next()
+}
+
+/// `FROM` references that are neither an earlier build stage nor pinned to a
+/// digest — directly, or through an `ARG` declared in the same file.
+fn unpinned_base_images(dockerfile: &str) -> Vec<&str> {
+    let args: HashMap<&str, &str> = dockerfile
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("ARG "))
+        .filter_map(|declaration| declaration.split_once('='))
+        .map(|(name, value)| (name.trim(), value.trim()))
+        .collect();
+
+    let mut stages: HashSet<&str> = HashSet::new();
+    let mut unpinned = Vec::new();
+
+    for line in dockerfile.lines() {
+        let Some(image_ref) = from_image_ref(line) else {
+            continue;
+        };
+
+        // An undeclared `${ARG}` resolves to nothing, which is not pinned.
+        let resolved = image_ref
+            .strip_prefix("${")
+            .and_then(|name| name.strip_suffix('}'))
+            .map_or(image_ref, |name| args.get(name).copied().unwrap_or_default());
+
+        if !stages.contains(image_ref) && !has_pinned_digest(resolved) {
+            unpinned.push(image_ref);
+        }
+
+        if let Some(stage) = from_stage_name(line) {
+            stages.insert(stage);
+        }
+    }
+
+    unpinned
 }
 
 #[test]
@@ -496,5 +562,48 @@ fn cargo_cache_guard_parses_option_order_and_exact_values() {
         mounts[2].1,
         Some("locked"),
         "dst alias and reordered locked mount must be found"
+    );
+}
+
+#[test]
+fn published_relay_image_pins_its_base_images_by_digest() {
+    let dockerfile = repository_file("apps/zerorelay/Dockerfile");
+
+    let unpinned = unpinned_base_images(&dockerfile);
+    assert!(
+        unpinned.is_empty(),
+        "apps/zerorelay/Dockerfile ships as a signed release image, so a mutable \
+         base tag would let the published image drift from the pinned source ref; \
+         unpinned: {unpinned:?}"
+    );
+
+    // Pinning by hand would freeze a digest nothing keeps current. The generated
+    // zones are what put these pins under `cargo generate installers` and the
+    // `installer-drift` gate.
+    for zone in ["base-arg-rust-slim", "base-arg-distroless"] {
+        assert!(
+            dockerfile.contains(&format!("# >>> generated:{zone} from")),
+            "the relay's base pins must stay generator-maintained: \
+             missing generated:{zone} zone"
+        );
+    }
+}
+
+#[test]
+fn base_image_pin_guard_reads_args_flags_and_stage_references() {
+    let unpinned = unpinned_base_images(
+        "ARG PINNED=rust:1.98-slim@sha256:17d1ba895198f9934c6314ec5346a0d5115372f3243390c3d731e242f35c2f27\n\
+         ARG LOOSE=rust:1.98-slim\n\
+         FROM --platform=$BUILDPLATFORM ${PINNED} AS builder\n\
+         FROM ${LOOSE} AS loose\n\
+         FROM ${UNDECLARED} AS undeclared\n\
+         FROM debian:bookworm-slim AS bare\n\
+         FROM builder AS derived",
+    );
+
+    assert_eq!(
+        unpinned,
+        vec!["${LOOSE}", "${UNDECLARED}", "debian:bookworm-slim"],
+        "only digest-backed ARGs and earlier stages may pass the guard"
     );
 }

--- a/tests/architecture/container_release.rs
+++ b/tests/architecture/container_release.rs
@@ -173,7 +173,9 @@ fn unpinned_base_images(dockerfile: &str) -> Vec<&str> {
         let resolved = image_ref
             .strip_prefix("${")
             .and_then(|name| name.strip_suffix('}'))
-            .map_or(image_ref, |name| args.get(name).copied().unwrap_or_default());
+            .map_or(image_ref, |name| {
+                args.get(name).copied().unwrap_or_default()
+            });
 
         if !stages.contains(image_ref) && !has_pinned_digest(resolved) {
             unpinned.push(image_ref);

--- a/xtask/src/generate/mod.rs
+++ b/xtask/src/generate/mod.rs
@@ -106,6 +106,14 @@ fn registry() -> Vec<Surface> {
             file: "Dockerfile.alpine",
             render: |root, cur| render_docker_arg(root, cur),
         },
+        // Base-image pins only: the relay builds `-p zerorelay` with no feature
+        // selection, so it carries no `docker-features-arg` zone and must not go
+        // through `render_docker_arg`.
+        Surface {
+            name: "dockerfile-zerorelay",
+            file: "apps/zerorelay/Dockerfile",
+            render: |root, cur| container_base::splice_zones(root, cur),
+        },
         Surface {
             name: "pkgbuild",
             file: "dist/aur/PKGBUILD",


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `apps/zerorelay/Dockerfile` ships as a cosign-signed release image (`docker-publish.yml`, job `publish-relay`), but both of its base images used mutable tags. The published image could therefore drift from the pinned source ref and `Cargo.lock`.
  - Both images are **already** rows in `dev/ci/container-base-images.toml` with resolved digests and exactly matching tags (`base-arg-rust-slim` for `rust:1.98-slim`, `base-arg-distroless` for `gcr.io/distroless/cc-debian13:nonroot`). The relay now consumes those pins through generated ARG zones instead of carrying its own copies, so no new TOML rows were needed.
  - Registering the file as a `dockerfile-zerorelay` surface puts the digests under `cargo generate installers` and the `installer-drift` gate, so write-mode regeneration can refresh them from the canonical rows rather than leaving hand-maintained copies.
  - The surface renders through `container_base::splice_zones` directly, not `render_docker_arg`. The latter splices `docker-features-arg` first and hard-errors on a file with no such zone; the relay builds `-p zerorelay` with no feature selection.
  - A contract test in `tests/architecture/container_release.rs` asserts every `FROM` resolves to a digest, and that both generated zones are still present.
- **Scope boundary:** zerorelay only. `master` has other unpinned `FROM` lines (`Dockerfile.debian:201`, `Dockerfile.ci:14`, `demo/Dockerfile:14,:51`), all `debian:bookworm-slim` or `rust:1.98-slim-bookworm`. Those need *new* TOML rows, since the TOML carries `debian:trixie-slim`, a different suite, and none is a published release artifact. No change to `dev/ci/container-base-images.toml`, to relay runtime behavior, or to the publish workflow.
- **Blast radius:** the relay image build (`relay-container-smoke` in CI, `publish-relay` on release tags) and `cargo generate installers`, which now also writes `apps/zerorelay/Dockerfile`. No runtime or library code is touched.
- **Linked issue(s):** Closes #10277
- **Labels:** `ci`, `tests`, `risk:high`, `size:S`, `type:ci`.

Two notes for the reviewer, since the issue text is slightly out of date:

1. Issue 10277 calls `dev/ci/Dockerfile:3` "the canonical digest-pinning policy". It is not — that file is a hand-pinned outlier nothing automates. The canonical mechanism is `dev/ci/container-base-images.toml`, then `xtask/src/generate/container_base.rs`, then `cargo generate installers`, gated by `installer-drift`. This PR adopts that mechanism, which is the issue's own second option ("or add them to the canonical digest-pinning policy").
2. The issue quotes line 21 as `rust:1.96.1-slim`; `master` is now `rust:1.98-slim`.

**Why the contract test is not redundant with `installer-drift`:** `run(check)` is render-and-compare, and `splice_zones` *skips* rows whose sentinel is absent rather than erroring. So deleting both zones and restoring a bare `FROM rust:1.98-slim` renders identically to itself and reports no drift. `container_base::check` catches an ARG-backed FROM whose zone is gone, but not a bare-tag FROM after the zone is removed; it is only called from a unit test, never from the production `--check` path. The test closes exactly that hole.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `N/A` — no user-visible behavior changes; the meaningful signal is CI-run (`installer-drift`, `relay-container-smoke`) rather than reviewer click-through.

### How I tested

I want to be straightforward about a gap: **this workstation has no Rust and no Docker toolchain** (`cargo`, `rustc`, `docker`, and `podman` are all absent), so I could not run `cargo generate installers --check`, `cargo test`, `cargo clippy`, or the relay image build locally. I am relying on required CI for those, and I have not pasted output I did not produce.

What I verified statically instead:

- **ARG lines are byte-exact against the TOML.** Reconstructed the `ARG name=image_ref:tag@digest` format from `container_base::arg_line` for each row and compared against the file:

```
OK   base-arg-rust-slim
OK   base-arg-distroless
```

- **Sentinels match the root `Dockerfile` character-for-character** — all four lines, `grep -cxF` returning 1 in both files. The zone structure is exactly BEGIN, one ARG line, END, which is what `splice()` reconstructs, so `--check` should report `ok: dockerfile-zerorelay in sync`.
- **Test logic**, by reimplementing the guard's algorithm in `awk` and running it on both inputs:

```
=== real: apps/zerorelay/Dockerfile ===
  (none - PASS)
=== synthetic fixture (expect LOOSE, UNDECLARED, debian:bookworm-slim) ===
  UNPINNED: ${LOOSE}
  UNPINNED: ${UNDECLARED}
  UNPINNED: debian:bookworm-slim
```

- **Negative check** — reverting the builder `FROM` to a bare tag on a scratch copy makes the guard fire, proving the test bites rather than passing vacuously:

```
=== NEGATIVE CHECK: revert builder FROM to a bare tag (on a copy) ===
  UNPINNED: rust:1.98-slim
```

- No CRLF introduced (`.gitattributes` has `* text=auto`; the diff shows only the intended lines).

- **CI checks relied on and why they cover this change:** `Installer Drift` runs the exact `cargo generate installers --check` that validates the new surface and its zones. `Relay Container Fresh-Volume Smoke` is path-filtered on `apps/zerorelay/Dockerfile`, so it runs `docker build -f apps/zerorelay/Dockerfile` plus `smoke_relay_fresh_volume.sh` — that is the real proof the ARG-in-FROM refactor still builds and that the distroless stage still self-provisions TLS into a fresh named volume. `Test` runs the new `tests/architecture` cases; `Lint` covers clippy on the new test code.
- **Known CI coverage gap, if any:** none in CI. The gap is local, described above — every gate for this change runs in required CI.
- **Beyond CI, what did you manually verify?** The static checks above. I did **not** build the relay image, run the fresh-volume smoke, execute the Rust tests, or run clippy — no toolchain available. The two risks I could not rule out locally are a clippy lint under `-D warnings` and a borrow-checker complaint in the new helpers; I removed one likely lint proactively by rewriting `from_stage_name` off `while let Some(x) = iter.next()` (`clippy::while_let_on_iterator`). Happy to push a fixup if CI flags anything.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** not intentional — `cargo` and `docker` are unavailable on this machine, as noted.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — `refresh_source` already queries every TOML row on write-mode runs; reusing existing rows adds none, and `--check` is network-free.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

Net effect is a security improvement: the published relay image can no longer pick up a silently-moved base layer.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` (additive, dev tooling only) — `cargo generate installers` gains a `dockerfile-zerorelay` target and now also writes `apps/zerorelay/Dockerfile` on a full run. No user-facing config, env var, or `zeroclaw` CLI surface changes. No upgrade steps for existing users; contributors need only re-run `cargo generate installers` as they already would.
- Rust/MSRV/toolchain floor changed? `No` — `rust:1.98-slim` is the tag already in the TOML and already in use by the other Dockerfiles.

## Rollback

Reverting the landed squash commit restores the mutable tags for subsequent builds; it does not remove or replace already-published images. The rollback details below apply to this published release artifact:

- **Fast rollback command/path:** revert the landed squash commit; the Dockerfile returns to bare tags and the `dockerfile-zerorelay` surface disappears from the generator registry. Already-published images remain unchanged; replacing them requires a separate build and publication.
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** `installer-drift` failing with `DRIFT: dockerfile-zerorelay is out of sync with the spec`, or `relay-container-smoke` failing at `docker build` with an unresolved base ARG (an empty `FROM`). Both fail in CI before any image is published.
