### PR TITLE
chore(deps): bump js-yaml to 4.3.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2225,9 +2225,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -62,6 +62,6 @@
   },
   "overrides": {
     "@redocly/openapi-core": "1.34.7",
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.2"
   }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Resolve `js-yaml` from 4.3.1 to 4.3.2, the first release outside the GHSA-2883-xcg3-v3hh advisory range (`>=4.0.0 <4.3.2`). The daily audit lane has been red since the advisory published; this restores a clean `npm audit --audit-level=high`.
  - Raise the existing `overrides.js-yaml` floor from `^4.3.1` to `^4.3.2` so a fresh resolution cannot fall back into the affected range. That override exists for exactly this purpose — it was introduced to force js-yaml past an earlier variant of the same merge-key DoS, and its floor has been raised twice since.
  - The package is development-only (`"dev": true`), reached through `openapi-typescript` to `@redocly/openapi-core` (itself pinned by the sibling override). No shipped artifact changes.
- **Scope boundary:** Changes only the js-yaml resolution and its override floor. No direct dependency added or removed, no other package re-resolved, no application code, and no change to the audit workflow. The sibling `@redocly/openapi-core` pin is untouched.
- **Blast radius:** Web development and build dependency resolution only. The affected package remains transitive and development-only; its sole consumer is the OpenAPI-to-TypeScript generation step, which parses the repository's own spec.
- **Linked issue(s):** Closes #10728
- **Labels:** `type:dependencies`, `risk:low`, `web`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — a lockfile resolution bump with no user-visible behavior; the audit and install gates below are the whole signal.

### How I tested

- **CI checks relied on and why they cover this change:**
  - `Web Permission Tests` — triggered because `web/package-lock.json` matches the `web` path filter. It runs `npm ci` (which fails on a manifest/lockfile mismatch), then `cargo web check`, `npm run test:permissions`, and `npm run test:contexts`. This is the gate that proves the new resolution installs and the generated dashboard contract still typechecks.
  - `npm Dependency Review` — runs on the `web/package-lock.json` path with `fail-on-severity: high`; it is the direct check that the advisory is gone.
- **Known CI coverage gap, if any:** The `Daily npm Audit` workflow is `schedule`-triggered, so it does not re-run on this PR. I ran its exact audit command locally instead (output below). Rust is not installed on my machine, so I could not run `cargo web check`; CI covers it, and I exercised the one dependency this PR actually changes directly (see the last command below).
- **Commands run and tail output:**

```console
$ cd web && npm ci --ignore-scripts --no-audit --no-fund
added 226 packages in 9s

$ node -e "console.log(require('./node_modules/js-yaml/package.json').version)"
4.3.2

$ npm audit --audit-level=high          # exact command from daily-npm-audit.yml
found 0 vulnerabilities

$ npm run test:permissions
i tests 5
i pass 5
i fail 0

$ npx openapi-typescript /tmp/spec.yaml -o /tmp/out.ts   # exercises js-yaml, incl. a merge key
* openapi-typescript 7.13.0
* /tmp/spec.yaml -> /tmp/out.ts [20.9ms]
```

- **Beyond CI, what did you manually verify?**
  - The diff is surgical: 4 insertions, 4 deletions across two files. In the lockfile only the single `node_modules/js-yaml` entry changed (`version`, `resolved`, `integrity`); no other package moved. There is one js-yaml entry in the tree, and the advisory reports `effects: []`, so this resolves the whole graph.
  - `@redocly/openapi-core@1.34.7` requires `js-yaml: ^4.1.0`, which 4.3.2 satisfies, so nothing else needed to move. 4.3.2 is the newest 4.x; 5.x is a major bump and out of scope here.
  - Because YAML parsing is the changed dependency's whole job, I ran `openapi-typescript` against a YAML OpenAPI document containing a merge key — the construct the advisory concerns — and confirmed it parses and generates correct TypeScript under 4.3.2.
  - `npm run test:contexts` reports 8 failures in `src/contexts/sessionLifecycle.test.ts` on my Windows machine. I verified these are **pre-existing and unrelated**: checking out `master`'s `web/package.json` and `web/package-lock.json`, reinstalling, and re-running gives the identical `19 tests / 11 pass / 8 fail`. They stem from the `pretest:contexts` hook's POSIX inline env-var syntax and Windows-only React test behavior; CI runs `ubuntu-latest`.
  - What I did NOT verify: the full `npm run build` and `cargo web check`, both of which need the Rust-generated API files that are absent from my tree.
- **Visual interface changed?** `N/A`

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

This clears a denial-of-service advisory rather than introducing risk. Practical exposure was already negligible: the package is build-time only and parses the repository's own OpenAPI spec, not attacker-controlled input.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>`.
