### PR TITLE
fix(service): select the daemon log by content, not existence

### DIFF
--- a/crates/zeroclaw-runtime/src/service/mod.rs
+++ b/crates/zeroclaw-runtime/src/service/mod.rs
@@ -949,8 +949,6 @@ pub fn logs(config: &Config, init_system: InitSystem, lines: usize, follow: bool
 }
 
 fn logs_macos(config: &Config, lines: usize, follow: bool) -> Result<()> {
-    // Try the launchd log files first (StandardOutPath / StandardErrorPath from the plist).
-    // These are the most reliable source since they capture all daemon output.
     let exe = std::env::current_exe().ok();
     let homebrew_var_dir = exe.as_ref().and_then(|e| homebrew_var_dir_from_exe(e));
     let logs_dir = if let Some(ref var_dir) = homebrew_var_dir {
@@ -966,38 +964,15 @@ fn logs_macos(config: &Config, lines: usize, follow: bool) -> Result<()> {
     let stderr_log = logs_dir.join("daemon.stderr.log");
     let stdout_log = logs_dir.join("daemon.stdout.log");
 
-    // Prefer stderr log (most informative), fall back to stdout
-    let log_file = if stderr_log.exists() {
-        stderr_log
-    } else if stdout_log.exists() {
-        stdout_log
-    } else {
+    let targets = service_log_targets(&stdout_log, &stderr_log);
+    if targets.is_empty() {
         bail!(
             "No log files found in {}. Is the service installed?",
             logs_dir.display()
         );
-    };
-
-    if follow {
-        let status = Command::new("tail")
-            .args(["-n", &lines.to_string(), "-f"])
-            .arg(&log_file)
-            .status()
-            .context("Failed to run tail")?;
-        if !status.success() {
-            bail!("tail exited with non-zero status");
-        }
-    } else {
-        let status = Command::new("tail")
-            .args(["-n", &lines.to_string()])
-            .arg(&log_file)
-            .status()
-            .context("Failed to run tail")?;
-        if !status.success() {
-            bail!("tail exited with non-zero status");
-        }
     }
-    Ok(())
+    report_empty_capture(&targets, &logs_dir, follow);
+    tail_files(&targets, lines, follow)
 }
 
 fn logs_linux(config: &Config, init_system: InitSystem, lines: usize, follow: bool) -> Result<()> {
@@ -1013,21 +988,18 @@ fn logs_linux(config: &Config, init_system: InitSystem, lines: usize, follow: bo
             }
         }
         InitSystem::Openrc => {
-            // OpenRC logs go to /var/log/<service>/error.log (as configured in the init script).
             let log_dir = linux_openrc_log_dir(config);
-            let log_file = log_dir.join("error.log");
-            if !log_file.exists() {
-                // Fall back to access log
-                let access_log = log_dir.join("access.log");
-                if !access_log.exists() {
-                    bail!(
-                        "No log files found at {}. Is the service installed?",
-                        log_dir.display()
-                    );
-                }
-                return tail_file(&access_log, lines, follow);
+            let access_log = log_dir.join("access.log");
+            let error_log = log_dir.join("error.log");
+            let targets = service_log_targets(&access_log, &error_log);
+            if targets.is_empty() {
+                bail!(
+                    "No log files found at {}. Is the service installed?",
+                    log_dir.display()
+                );
             }
-            tail_file(&log_file, lines, follow)?;
+            report_empty_capture(&targets, &log_dir, follow);
+            tail_files(&targets, lines, follow)?;
         }
         InitSystem::Auto => unreachable!("Auto should be resolved before this point"),
     }
@@ -1044,61 +1016,100 @@ fn logs_windows(config: &Config, lines: usize, follow: bool) -> Result<()> {
     let stderr_log = logs_dir.join("daemon.stderr.log");
     let stdout_log = logs_dir.join("daemon.stdout.log");
 
-    let log_file = if stderr_log.exists() {
-        stderr_log
-    } else if stdout_log.exists() {
-        stdout_log
-    } else {
+    let targets = service_log_targets(&stdout_log, &stderr_log);
+    let Some((primary, rest)) = targets.split_first() else {
         bail!(
             "No log files found in {}. Is the service installed?",
             logs_dir.display()
         );
     };
+    report_empty_capture(&targets, &logs_dir, follow);
+    let label_each = !rest.is_empty();
 
-    if follow {
-        // Windows: use PowerShell Get-Content -Wait for tail -f equivalent
-        let status = Command::new("powershell")
-            .args([
-                "-Command",
-                &format!(
-                    "Get-Content -Path '{}' -Tail {} -Wait",
-                    log_file.display().to_string(),
-                    lines
-                ),
-            ])
-            .status()
-            .context("Failed to run PowerShell Get-Content")?;
-        if !status.success() {
-            bail!("PowerShell Get-Content exited with non-zero status");
+    if !follow {
+        for path in &targets {
+            if label_each {
+                println!("==> {} <==", path.display());
+            }
+            run_get_content(path, lines, false)?;
         }
-    } else {
-        let status = Command::new("powershell")
-            .args([
-                "-Command",
-                &format!(
-                    "Get-Content -Path '{}' -Tail {}",
-                    log_file.display().to_string(),
-                    lines
-                ),
-            ])
-            .status()
-            .context("Failed to run PowerShell Get-Content")?;
-        if !status.success() {
-            bail!("PowerShell Get-Content exited with non-zero status");
-        }
+        return Ok(());
+    }
+
+    // `Get-Content -Wait` blocks on one path, so only the primary stream is followed.
+    for path in rest {
+        println!("==> {} <==", path.display());
+        run_get_content(path, lines, false)?;
+    }
+    if label_each {
+        println!("==> {} <==", primary.display());
+    }
+    run_get_content(primary, lines, true)
+}
+
+fn get_content_command(path: &Path, lines: usize, follow: bool) -> String {
+    let quoted = path.display().to_string().replace('\'', "''");
+    let wait = if follow { " -Wait" } else { "" };
+    format!("Get-Content -LiteralPath '{quoted}' -Tail {lines}{wait}")
+}
+
+fn run_get_content(path: &Path, lines: usize, follow: bool) -> Result<()> {
+    let status = Command::new("powershell")
+        .args(["-Command", &get_content_command(path, lines, follow)])
+        .status()
+        .context("Failed to run PowerShell Get-Content")?;
+    if !status.success() {
+        bail!("PowerShell Get-Content exited with non-zero status");
     }
     Ok(())
 }
 
-/// Tail a log file using the system `tail` command.
-fn tail_file(path: &Path, lines: usize, follow: bool) -> Result<()> {
+fn service_log_targets(primary: &Path, secondary: &Path) -> Vec<PathBuf> {
+    let candidates = [primary, secondary];
+    let with_content: Vec<PathBuf> = candidates
+        .iter()
+        .filter(|path| has_content(path))
+        .map(|path| path.to_path_buf())
+        .collect();
+    if !with_content.is_empty() {
+        return with_content;
+    }
+    candidates
+        .iter()
+        .filter(|path| path.exists())
+        .map(|path| path.to_path_buf())
+        .collect()
+}
+
+fn has_content(path: &Path) -> bool {
+    fs::metadata(path).is_ok_and(|meta| meta.len() > 0)
+}
+
+fn report_empty_capture(targets: &[PathBuf], logs_dir: &Path, follow: bool) {
+    if targets.iter().any(|path| has_content(path)) {
+        return;
+    }
+    if follow {
+        eprintln!(
+            "No daemon output captured yet in {}; waiting for new output.",
+            logs_dir.display()
+        );
+    } else {
+        eprintln!("No daemon output captured yet in {}.", logs_dir.display());
+    }
+}
+
+fn tail_files(paths: &[PathBuf], lines: usize, follow: bool) -> Result<()> {
+    if paths.is_empty() {
+        bail!("No log files to tail");
+    }
     let mut args = vec!["-n".to_string(), lines.to_string()];
     if follow {
         args.push("-f".to_string());
     }
     let status = Command::new("tail")
         .args(&args)
-        .arg(path)
+        .args(paths)
         .status()
         .context("Failed to run tail")?;
     if !status.success() {
@@ -2857,20 +2868,126 @@ mod service_helper_tests {
 
     #[cfg(not(target_os = "windows"))]
     #[test]
-    fn tail_file_errors_on_missing_file() {
-        let missing = Path::new("/tmp/zeroclaw-test-nonexistent-log-file.log");
-        let result = tail_file(missing, 10, false);
+    fn tail_files_errors_on_missing_file() {
+        let missing = PathBuf::from("/tmp/zeroclaw-test-nonexistent-log-file.log");
+        let result = tail_files(&[missing], 10, false);
         assert!(result.is_err(), "tail on missing file should fail");
     }
 
     #[cfg(not(target_os = "windows"))]
     #[test]
-    fn tail_file_reads_existing_file() {
+    fn tail_files_reads_existing_file() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let log = dir.path().join("test-tail.log");
         fs::write(&log, "line1\nline2\nline3\nline4\nline5\n").unwrap();
-        // tail should succeed on existing file
-        let result = tail_file(&log, 3, false);
+        let result = tail_files(&[log], 3, false);
         assert!(result.is_ok(), "tail on existing file should succeed");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn tail_files_reads_every_named_file() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let first = dir.path().join("first.log");
+        let second = dir.path().join("second.log");
+        fs::write(&first, "first\n").unwrap();
+        fs::write(&second, "second\n").unwrap();
+        let result = tail_files(&[first, second], 3, false);
+        assert!(result.is_ok(), "tail on two existing files should succeed");
+    }
+
+    #[test]
+    fn tail_files_rejects_an_empty_selection() {
+        let result = tail_files(&[], 10, false);
+        assert!(result.is_err(), "tail with no paths should fail");
+    }
+
+    #[test]
+    fn service_log_targets_skips_the_stream_without_output() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let stdout_log = dir.path().join("daemon.stdout.log");
+        let stderr_log = dir.path().join("daemon.stderr.log");
+        fs::write(&stdout_log, "listening for messages\n").unwrap();
+        fs::write(&stderr_log, "").unwrap();
+
+        assert_eq!(
+            service_log_targets(&stdout_log, &stderr_log),
+            vec![stdout_log],
+            "an empty capture file must not hide the stream that has output"
+        );
+    }
+
+    #[test]
+    fn service_log_targets_lists_both_streams_when_both_have_output() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let stdout_log = dir.path().join("daemon.stdout.log");
+        let stderr_log = dir.path().join("daemon.stderr.log");
+        fs::write(&stdout_log, "listening for messages\n").unwrap();
+        fs::write(&stderr_log, "provider error\n").unwrap();
+
+        assert_eq!(
+            service_log_targets(&stdout_log, &stderr_log),
+            vec![stdout_log, stderr_log],
+            "both streams carry output, so both are shown, primary first"
+        );
+    }
+
+    #[test]
+    fn service_log_targets_keeps_empty_files_so_follow_can_attach() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let stdout_log = dir.path().join("daemon.stdout.log");
+        let stderr_log = dir.path().join("daemon.stderr.log");
+        fs::write(&stdout_log, "").unwrap();
+        fs::write(&stderr_log, "").unwrap();
+
+        assert_eq!(
+            service_log_targets(&stdout_log, &stderr_log),
+            vec![stdout_log, stderr_log],
+            "a daemon that has not written yet is still followable"
+        );
+    }
+
+    #[test]
+    fn service_log_targets_is_empty_when_nothing_was_captured() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let stdout_log = dir.path().join("daemon.stdout.log");
+        let stderr_log = dir.path().join("daemon.stderr.log");
+
+        assert!(
+            service_log_targets(&stdout_log, &stderr_log).is_empty(),
+            "no capture files means the caller reports a missing install"
+        );
+    }
+
+    #[test]
+    fn service_log_targets_ignores_a_missing_counterpart() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let stdout_log = dir.path().join("daemon.stdout.log");
+        let stderr_log = dir.path().join("daemon.stderr.log");
+        fs::write(&stdout_log, "listening for messages\n").unwrap();
+
+        assert_eq!(
+            service_log_targets(&stdout_log, &stderr_log),
+            vec![stdout_log],
+            "a capture file that was never created is not a target"
+        );
+    }
+
+    #[test]
+    fn get_content_command_uses_literal_path_and_doubles_quotes() {
+        let command = get_content_command(Path::new("C:\\logs\\o'brien[1].log"), 25, true);
+        assert_eq!(
+            command,
+            "Get-Content -LiteralPath 'C:\\logs\\o''brien[1].log' -Tail 25 -Wait"
+        );
+    }
+
+    #[test]
+    fn get_content_command_omits_wait_without_follow() {
+        let command = get_content_command(Path::new("C:\\logs\\daemon.stdout.log"), 50, false);
+        assert_eq!(
+            command,
+            "Get-Content -LiteralPath 'C:\\logs\\daemon.stdout.log' -Tail 50"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/service/mod.rs
+++ b/crates/zeroclaw-runtime/src/service/mod.rs
@@ -964,7 +964,11 @@ fn logs_macos(config: &Config, lines: usize, follow: bool) -> Result<()> {
     let stderr_log = logs_dir.join("daemon.stderr.log");
     let stdout_log = logs_dir.join("daemon.stdout.log");
 
-    let targets = service_log_targets(&stdout_log, &stderr_log);
+    let targets = if follow {
+        follow_log_targets(&stdout_log, &stderr_log)
+    } else {
+        service_log_targets(&stdout_log, &stderr_log)
+    };
     if targets.is_empty() {
         bail!(
             "No log files found in {}. Is the service installed?",
@@ -991,7 +995,11 @@ fn logs_linux(config: &Config, init_system: InitSystem, lines: usize, follow: bo
             let log_dir = linux_openrc_log_dir(config);
             let access_log = log_dir.join("access.log");
             let error_log = log_dir.join("error.log");
-            let targets = service_log_targets(&access_log, &error_log);
+            let targets = if follow {
+                follow_log_targets(&access_log, &error_log)
+            } else {
+                service_log_targets(&access_log, &error_log)
+            };
             if targets.is_empty() {
                 bail!(
                     "No log files found at {}. Is the service installed?",
@@ -1081,6 +1089,15 @@ fn service_log_targets(primary: &Path, secondary: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
+fn follow_log_targets(primary: &Path, secondary: &Path) -> Vec<PathBuf> {
+    // A follower keeps the empty stream too: it is where a later failure lands.
+    [primary, secondary]
+        .into_iter()
+        .filter(|path| path.exists())
+        .map(Path::to_path_buf)
+        .collect()
+}
+
 fn has_content(path: &Path) -> bool {
     fs::metadata(path).is_ok_and(|meta| meta.len() > 0)
 }
@@ -1099,17 +1116,21 @@ fn report_empty_capture(targets: &[PathBuf], logs_dir: &Path, follow: bool) {
     }
 }
 
+fn tail_command(paths: &[PathBuf], lines: usize, follow: bool) -> Command {
+    let mut command = Command::new("tail");
+    command.arg("-n").arg(lines.to_string());
+    if follow {
+        command.arg("-f");
+    }
+    command.args(paths);
+    command
+}
+
 fn tail_files(paths: &[PathBuf], lines: usize, follow: bool) -> Result<()> {
     if paths.is_empty() {
         bail!("No log files to tail");
     }
-    let mut args = vec!["-n".to_string(), lines.to_string()];
-    if follow {
-        args.push("-f".to_string());
-    }
-    let status = Command::new("tail")
-        .args(&args)
-        .args(paths)
+    let status = tail_command(paths, lines, follow)
         .status()
         .context("Failed to run tail")?;
     if !status.success() {
@@ -2988,6 +3009,63 @@ mod service_helper_tests {
         assert_eq!(
             command,
             "Get-Content -LiteralPath 'C:\\logs\\daemon.stdout.log' -Tail 50"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn follow_sees_a_failure_written_to_stderr_after_startup() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::process::Stdio;
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let stdout_log = dir.path().join("daemon.stdout.log");
+        let stderr_log = dir.path().join("daemon.stderr.log");
+        fs::write(&stdout_log, "listening for messages\n").unwrap();
+        fs::write(&stderr_log, "").unwrap();
+
+        let targets = follow_log_targets(&stdout_log, &stderr_log);
+        let mut viewer = tail_command(&targets, 10, true)
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("tail should start");
+        let output = viewer.stdout.take().expect("tail stdout is piped");
+        let (line_tx, line_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(output).lines().map_while(Result::ok) {
+                if line_tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        let saw = |needle: &str| {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while let Some(left) = deadline.checked_duration_since(Instant::now()) {
+                match line_rx.recv_timeout(left) {
+                    Ok(line) if line.contains(needle) => return true,
+                    Ok(_) => {}
+                    Err(_) => return false,
+                }
+            }
+            false
+        };
+
+        let attached = saw("daemon.stderr.log <==");
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&stderr_log)
+            .unwrap()
+            .write_all(b"launchd capture failed: child exited\n")
+            .unwrap();
+        let delivered = saw("launchd capture failed");
+        let _ = viewer.kill();
+        let _ = viewer.wait();
+
+        assert!(attached, "the follower must open the empty stderr file");
+        assert!(
+            delivered,
+            "a failure appended to stderr must reach the running viewer"
         );
     }
 }

--- a/docs/book/src/setup/service.md
+++ b/docs/book/src/setup/service.md
@@ -150,7 +150,7 @@ launchctl load ~/Library/LaunchAgents/com.zeroclaw.daemon.plist
 
 </div>
 
-Logs go to `<config-dir>/logs/` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `~/.zeroclaw/logs/`). Homebrew installs write to `$HOMEBREW_PREFIX/var/zeroclaw/logs/` instead. Each launchd capture file retains recent output within an 8 MiB bound. Reinstall and restart the service after upgrading so the generated LaunchAgent uses bounded capture.
+Logs go to `<config-dir>/logs/` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `~/.zeroclaw/logs/`). Homebrew installs write to `$HOMEBREW_PREFIX/var/zeroclaw/logs/` instead. Each launchd capture file retains recent output within an 8 MiB bound. Reinstall and restart the service after upgrading so the generated LaunchAgent uses bounded capture. `zeroclaw service logs` tails whichever of the two files hold output, so a daemon that only writes to stdout still shows up; when both hold output, `tail` labels each block with a `==> path <==` header.
 
 ### Homebrew-managed
 
@@ -180,7 +180,7 @@ Don't mix `zeroclaw service` CLI commands with `brew services`, pick one. Both e
 
 Verify in Task Scheduler GUI (`taskschd.msc`) under Task Scheduler Library → ZeroClaw Daemon.
 
-Logs go to `<config-dir>\logs\` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `%USERPROFILE%\.zeroclaw\logs\`):
+Logs go to `<config-dir>\logs\` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `%USERPROFILE%\.zeroclaw\logs\`). `zeroclaw service logs` prints whichever of the two files hold output, and `--follow` shows the others first and then streams `daemon.stdout.log`, because `Get-Content -Wait` tracks a single path. To read one directly:
 
 <div class="os-tabs-src">
 

--- a/docs/book/src/setup/service.md
+++ b/docs/book/src/setup/service.md
@@ -150,7 +150,7 @@ launchctl load ~/Library/LaunchAgents/com.zeroclaw.daemon.plist
 
 </div>
 
-Logs go to `<config-dir>/logs/` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `~/.zeroclaw/logs/`). Homebrew installs write to `$HOMEBREW_PREFIX/var/zeroclaw/logs/` instead. Each launchd capture file retains recent output within an 8 MiB bound. Reinstall and restart the service after upgrading so the generated LaunchAgent uses bounded capture. `zeroclaw service logs` tails whichever of the two files hold output, so a daemon that only writes to stdout still shows up; when both hold output, `tail` labels each block with a `==> path <==` header.
+Logs go to `<config-dir>/logs/` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `~/.zeroclaw/logs/`). Homebrew installs write to `$HOMEBREW_PREFIX/var/zeroclaw/logs/` instead. Each launchd capture file retains recent output within an 8 MiB bound. Reinstall and restart the service after upgrading so the generated LaunchAgent uses bounded capture. `zeroclaw service logs` tails whichever of the two files hold output, so a daemon that only writes to stdout still shows up; `--follow` watches both, so a failure written to `daemon.stderr.log` after startup still reaches a running viewer. When more than one file is shown, `tail` labels each block with a `==> path <==` header.
 
 ### Homebrew-managed
 
@@ -180,7 +180,7 @@ Don't mix `zeroclaw service` CLI commands with `brew services`, pick one. Both e
 
 Verify in Task Scheduler GUI (`taskschd.msc`) under Task Scheduler Library → ZeroClaw Daemon.
 
-Logs go to `<config-dir>\logs\` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `%USERPROFILE%\.zeroclaw\logs\`). `zeroclaw service logs` prints whichever of the two files hold output, and `--follow` shows the others first and then streams `daemon.stdout.log`, because `Get-Content -Wait` tracks a single path. To read one directly:
+Logs go to `<config-dir>\logs\` as `daemon.stdout.log` and `daemon.stderr.log` (for a default install, `%USERPROFILE%\.zeroclaw\logs\`). `zeroclaw service logs` prints whichever of the two files hold output, and `--follow` shows the others first and then streams `daemon.stdout.log`, or `daemon.stderr.log` when only that file holds output, because `Get-Content -Wait` tracks a single path. To read one directly:
 
 <div class="os-tabs-src">
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Linux with systemd already defines the correct behavior: `service logs` shells out to `journalctl`, which merges the daemon's stdout and stderr. The other three read paths pick one capture file instead, and pick it by asking whether the file exists. Existence is always true, because every capture backend creates both files at service start so a bootstrap failure has somewhere to land. A healthy daemon writes only to stdout, so the zero-byte stderr file always won and `tail -n N` on it printed nothing and exited 0. This brings the three outliers in line with the systemd path rather than inventing a new rule.
  - Selection now asks whether a file holds anything. The choice is no longer exclusive: when both streams carry output, both are shown.
  - `--follow` on macOS and OpenRC tails every capture file that exists, empty or not. The empty one is where a later failure lands: `run_with_launchd_capture` writes `launchd capture failed: ...` to stderr after a normal startup has already filled stdout.
  - An empty selected file previously printed nothing and exited successfully. Capture files that exist but hold nothing now get one line on stderr; the `No log files found` error is unchanged for a missing install.
  - macOS is where this bites hardest and it is not a coincidence of one machine. `install_global_subscriber` mutes the stderr layer with `EnvFilter::new("off")` unless `--verbose` is set, and neither the plist nor `run_launchd_daemon` can pass it, so normal tracing output does not populate the file the command preferred. Direct failure diagnostics can still write to stderr.
  - `logs_macos` claimed in a comment to read `StandardOutPath` / `StandardErrorPath` from the plist. The generated plist has neither key and `macos_plist_routes_only_launchd_through_bounded_capture` asserts their absence, so the comment is gone.
- **Scope boundary:** Read side only. `LaunchdCaptureWriters::open` keeps creating both files eagerly, which is what leaves the empty file behind, because `capture_opens_before_command_resolution` depends on it. No change to the systemd path, plist or init-script generation, the desktop launcher, bounded-log retention, structured runtime logging, config, or any CLI flag. The mismatch between the hardcoded `OPENRC_STDOUT_LOG` / `OPENRC_STDERR_LOG` constants and `linux_openrc_log_dir` for named instances is a separate defect and is left alone.
- **Blast radius:** `zeroclaw service logs` on macOS, Windows and Linux/OpenRC. Output shape changes in two cases: when both files carry output, and under `--follow` on macOS and OpenRC whenever both files exist, `tail` prints a `==> path <==` header before each block, so a pipeline expecting a single unheaded stream sees headers. On Windows `--follow` prints the other file as context and then streams the selected primary file (stdout when populated, otherwise stderr when it is the only populated file), because `Get-Content -Wait` blocks on one path.
- **Linked issue(s):** Closes #10731
- **Labels:** `bug`, `docs`, `runtime`, `service`, `experienced contributor`, `risk:medium`, `size:M`, `cli`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli`
- **Setup / preconditions:** A macOS host with the service installed and running normally, so `~/.zeroclaw/logs/daemon.stdout.log` has content and `daemon.stderr.log` is 0 bytes. No provider or channel setup is needed; the daemon only has to have printed its startup banner.
- **Steps to run:**
  ```sh
  zeroclaw service status
  ls -l ~/.zeroclaw/logs/
  zeroclaw service logs -n 5; echo "exit: $?"
  tail -n 5 ~/.zeroclaw/logs/daemon.stdout.log
  ```
- **Expected on this branch (after):** `service logs` prints the same last 5 lines the final `tail` shows.
- **Prior behavior on `master` (before):** `service logs` prints nothing and exits 0 while the final `tail` shows the output is present.

### How I tested

- **CI checks relied on and why they cover this change:** `Lint` runs `scripts/ci/run_clippy.sh` over the workspace with `--all-targets -D warnings`, which compiles the rewritten helpers and the tests calling them; `Test` runs the `zeroclaw-runtime` unit tests, where the new selection tests live; `Docs Style` covers the changed lines in `docs/book/src/setup/service.md`; `Comment Hygiene` and `PR Title` cover the rest.
- **Known CI coverage gap, if any:** The Windows advisory job ran the selector and PowerShell command-string tests successfully, but does not establish a real Windows service-path smoke. macOS and OpenRC host behavior is not established by hosted CI. The three read paths compile on every platform, because `logs` dispatches with runtime `cfg!()` rather than `#[cfg]`, so `logs_macos`, `logs_windows` and `logs_linux` compile everywhere. The PowerShell command is asserted as a string, not executed.
- **Commands run and tail output:**
  ```text
  $ cargo test -p zeroclaw-runtime --lib
  test result: ok. 4260 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 27.16s

  $ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.25s

  $ bash scripts/ci/rust_quality_gate.sh
  ==> rust quality: cargo fmt --all -- --check
  ==> rust quality: cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets -- -D clippy::correctness
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 21s
  ==> rust quality: provider dispatch gate clean
  (exit 0)

  $ cargo doc --no-deps --workspace --exclude zeroclaw-desktop
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 18s
  (exit 0, no warnings)

  $ BASE_SHA=$(git rev-parse upstream/master) bash scripts/ci/docs_quality_gate.sh
  No prose em-dashes in changed docs files.
  (exit 0)

  $ python3 scripts/ci/comment_hygiene_gate.py <changed files>
  Comment hygiene gate passed.
  ```
- **Beyond CI, what did you manually verify?**

  The new tests were run against the old selection logic first, to confirm they fail for the stated reason instead of passing in both states:

  ```text
  ---- service_log_targets_skips_the_stream_without_output stdout ----
  assertion `left == right` failed: an empty capture file must not hide the stream that has output
    left: [".../daemon.stderr.log"]
   right: [".../daemon.stdout.log"]

  test result: FAILED. 2 passed; 3 failed
  ```

  The follow check was run the same way. Against the old selection `tail` is never given the empty stderr file, so the appended failure never arrives:

  ```text
  ---- follow_sees_a_failure_written_to_stderr_after_startup stdout ----
  the follower must open the empty stderr file
  ```

  End to end against a real launchd install, released binary and this branch reading the same files:

  ```text
  $ zeroclaw service logs -n 4            # v0.8.5
  (exit 0)                                 # nothing printed

  $ ./target/debug/zeroclaw --config-dir ~/.zeroclaw service logs -n 4
    GET  /health    - health check
    GET  /metrics   - Prometheus metrics
    Press Ctrl+C to stop.
  (exit 0)
  ```

  All four selection branches exercised against a scratch config dir: both streams with content (both printed, stdout block first, `tail` headers); both present but empty (one line on stderr, exit 0, files still tailed so `--follow` attaches); neither present (`No log files found ... Is the service installed?`, exit 1); stderr only, the crashed-daemon case the old rule was written for (printed, exit 0, unchanged).

  Not verified on a host: Windows and OpenRC. I have neither machine, so those rest on the unit tests and on the writer side that creates each pair of files.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No. The same two files are read; only the choice between them changed.
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No. Tests use temp dirs and a synthetic Windows path.
- Prompt injection or untrusted model-visible text introduced/changed? No. Log contents go to the operator's terminal, never into a model context.
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes, with one observable output change: `tail`'s `==> path <==` headers appear when both capture files hold output, and under `--follow` on macOS and OpenRC whenever both exist, where previously one file was shown without headers.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Revert the landed squash commit to restore the previous log-selection behavior. Captured log files are not deleted or rewritten by this change or its revert.
