### PR TITLE
fix(rpc): heap-pin the largest process_line dispatch branches for Windows stack

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -797,7 +797,8 @@ impl RpcDispatcher {
             Method::Initialize => self.handle_initialize(&req.params).await,
             Method::Status => self.handle_status().await,
             Method::Health => self.handle_health(),
-            Method::DoctorRun => self.handle_doctor_run().await,
+            // Heap-pinned for the same reason as `ConfigSet` below.
+            Method::DoctorRun => Box::pin(self.handle_doctor_run()).await,
 
             // Sessions
             Method::SessionNew => Box::pin(self.handle_session_new(&req.params)).await,
@@ -847,28 +848,42 @@ impl RpcDispatcher {
             Method::CronPatch => self.handle_cron_patch(&req.params).await,
             Method::CronDelete => self.handle_cron_delete(&req.params).await,
             Method::CronRuns => self.handle_cron_runs(&req.params).await,
-            Method::CronTrigger => self.handle_cron_trigger(&req.params).await,
+            // Heap-pinned for the same reason as `ConfigSet` above.
+            Method::CronTrigger => Box::pin(self.handle_cron_trigger(&req.params)).await,
             Method::CronSettings => self.handle_cron_settings(&req.params).await,
 
             // Config
             Method::ConfigGet => self.handle_config_get(&req.params),
-            Method::ConfigSet => self.handle_config_set(&req.params).await,
+            // Heap-pinned like `SessionNew` below: this handler's future is
+            // one of the largest in this match (see the stack-regression
+            // test in `tests`), and an exhaustive `match` sizes its state
+            // machine to the largest inline branch regardless of which arm
+            // actually runs. Boxing keeps that branch off this function's
+            // own stack frame.
+            Method::ConfigSet => Box::pin(self.handle_config_set(&req.params)).await,
             Method::ConfigValidate => self.handle_config_validate(),
             Method::ConfigReload => self.handle_config_reload(),
             Method::ConfigList => self.handle_config_list(&req.params),
-            Method::ConfigDelete => self.handle_config_delete(&req.params).await,
+            // Heap-pinned for the same reason as `ConfigSet` above.
+            Method::ConfigDelete => Box::pin(self.handle_config_delete(&req.params)).await,
             Method::ConfigMapKeys => self.handle_config_map_keys(&req.params),
             Method::ConfigResolveAliasSource => {
                 self.handle_config_resolve_alias_source(&req.params)
             }
-            Method::ConfigMapKeyCreate => self.handle_config_map_key_create(&req.params).await,
-            Method::ConfigMapKeyDelete => self.handle_config_map_key_delete(&req.params).await,
+            // Heap-pinned for the same reason as `ConfigSet` above.
+            Method::ConfigMapKeyCreate => {
+                Box::pin(self.handle_config_map_key_create(&req.params)).await
+            }
+            Method::ConfigMapKeyDelete => {
+                Box::pin(self.handle_config_map_key_delete(&req.params)).await
+            }
             Method::ConfigMapKeyRename => self.handle_config_map_key_rename(&req.params).await,
             Method::ConfigTemplates => self.handle_config_templates(),
 
             // Agents
             Method::AgentsList => self.handle_agents_list(),
-            Method::AgentsStatus => self.handle_agents_status().await,
+            // Heap-pinned for the same reason as `ConfigSet` above.
+            Method::AgentsStatus => Box::pin(self.handle_agents_status()).await,
 
             // Cost
             Method::CostQuery => self.handle_cost_query(&req.params),
@@ -891,7 +906,10 @@ impl RpcDispatcher {
             Method::ConfigSections => self.handle_config_sections(),
             Method::ConfigStatus => self.handle_config_status(),
             Method::ConfigCatalog => self.handle_config_catalog(),
-            Method::ConfigCatalogModels => self.handle_config_catalog_models(&req.params).await,
+            // Heap-pinned for the same reason as `ConfigSet` above.
+            Method::ConfigCatalogModels => {
+                Box::pin(self.handle_config_catalog_models(&req.params)).await
+            }
 
             // Logs
             Method::LogsSubscribe => self.handle_logs_subscribe().await,
@@ -915,7 +933,9 @@ impl RpcDispatcher {
             Method::QuickstartState => self.handle_quickstart_state(),
             Method::QuickstartFields => self.handle_quickstart_fields(&req.params),
             Method::QuickstartValidate => self.handle_quickstart_validate(&req.params),
-            Method::QuickstartApply => self.handle_quickstart_apply(&req.params).await,
+            // Heap-pinned for the same reason as `ConfigSet` above; this is
+            // currently the single largest inline branch in this match.
+            Method::QuickstartApply => Box::pin(self.handle_quickstart_apply(&req.params)).await,
             Method::QuickstartDismiss => self.handle_quickstart_dismiss(&req.params),
             Method::CertRenew => self.handle_renew_cert(&req.params).await,
 
@@ -12781,6 +12801,34 @@ mod tests {
             .expect("stack regression thread should spawn")
             .join()
             .expect("session/new should not exhaust a two-megabyte stack");
+    }
+
+    /// `process_line`'s exhaustive `match` sizes its generated state machine
+    /// to the largest inline-awaited branch, regardless of which arm a given
+    /// call actually takes — so a large future added to any one method can
+    /// blow the constrained-stack regression above even though that method
+    /// has nothing to do with `session/new`. Catch a regrowth here on every
+    /// platform instead of only on the Windows-only advisory job where the
+    /// stack overflow actually reproduces. The threshold is a generous
+    /// multiple of the current heap-pinned baseline (a few KB), not a tight
+    /// bound: the intent is to catch a new multi-hundred-KB branch, not to
+    /// force every incidental size change through this test.
+    #[test]
+    fn process_line_future_stays_small_enough_for_a_two_megabyte_stack() {
+        let tmp = tempfile::TempDir::new().expect("temporary test directory");
+        let config = make_acp_test_config(&tmp);
+        let (mut dispatcher, _sessions, _rx) = make_acp_test_dispatcher_with_receiver(config);
+        let fut = dispatcher.process_line("{}");
+        let size = std::mem::size_of_val(&fut);
+        assert!(
+            size < 32 * 1024,
+            "process_line's future grew to {size} bytes; a new or changed handler is now \
+             inlined into this match without Box::pin, which can overflow the 2MB Windows \
+             thread stack this exists to protect (see \
+             process_line_session_new_creates_session_on_two_megabyte_stack). Box::pin the \
+             large new branch the same way ConfigSet, QuickstartApply, and the other handlers \
+             above are"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `RpcDispatcher::process_line`'s exhaustive `match` over `Method` sizes its generated async state machine to the *largest* inline-awaited branch, regardless of which arm a given call actually takes. Only `Method::SessionNew` was `Box::pin`-wrapped (from #2621/#9439). Measuring with `std::mem::size_of_val` on a debug build showed `process_line`'s own future at 100648 bytes, which is deep enough to overflow the 2MB thread stack Windows RPC connections use in production — the exact scenario `process_line_session_new_creates_session_on_two_megabyte_stack` guards, and the reason it aborts with a stack overflow on the Advisory Windows nextest job (see #10734).
  - `Box::pin` the nine largest offending branches (`handle_doctor_run`, `handle_cron_trigger`, `handle_config_set`, `handle_config_delete`, `handle_config_map_key_create`, `handle_config_map_key_delete`, `handle_agents_status`, `handle_config_catalog_models`, `handle_quickstart_apply`), matching the existing `SessionNew` precedent from #9439. `process_line`'s future drops from 100648 to 3160 bytes.
  - Added a same-platform regression (`process_line_future_stays_small_enough_for_a_two_megabyte_stack`) that fails if a future handler regrows this past a generous threshold, instead of relying solely on the Windows-only advisory job to catch it.
- **Scope boundary:** no behavior change. `Box::pin` only changes where a future's state lives (heap vs. inline); it does not change what any handler does, its return value, or its error handling.
- **Blast radius:** `RpcDispatcher::process_line`'s own stack frame only. Each boxed handler's own behavior, timing, and error paths are unchanged.
- **Linked issue(s):** Related #10734
- **Labels:** `bug`, `risk:low`, `runtime`, `size:XS`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; this is a future-size/stack-footprint fix with no observable behavior change. The regression test and the hosted Windows advisory job are the relevant evidence.

### How I tested

```sh
$ cargo fmt --all -- --check                                                   # clean
$ cargo clippy --locked -p zeroclaw-runtime --all-targets -- -D warnings       # clean, 0 warnings
$ cargo test --locked -p zeroclaw-runtime --lib rpc::dispatch -- --test-threads=1
# 185 passed; 0 failed
$ cargo test --locked -p zeroclaw-runtime --lib process_line_session_new_creates_session_on_two_megabyte_stack -- --nocapture
test rpc::dispatch::tests::process_line_session_new_creates_session_on_two_megabyte_stack ... ok
$ cargo test --locked -p zeroclaw-runtime --lib process_line_future_stays_small -- --nocapture
test rpc::dispatch::tests::process_line_future_stays_small_enough_for_a_two_megabyte_stack ... ok
```

Future sizes measured locally with a temporary `std::mem::size_of_val` probe (removed before this push), on the debug profile:

```
process_line (before)         = 100648 bytes
handle_quickstart_apply       = 100112 bytes  (dominant contributor)
handle_config_set             =  80024 bytes
handle_config_delete/
  map_key_create/map_key_delete = 60224-60232 bytes each
handle_cron_trigger            =  20840 bytes
handle_config_catalog_models    =  20520 bytes
handle_agents_status            =  19832 bytes
handle_doctor_run                =  40088 bytes
process_line (after all nine boxed) = 3160 bytes
```

- **CI checks relied on and why they cover this change:** required CI's `Check x86_64-pc-windows-msvc` compiles this on Windows but does not execute tests there. The non-required `Advisory Windows nextest` job is the only CI surface that actually runs `process_line_session_new_creates_session_on_two_megabyte_stack` on a real Windows thread stack; watching it turn green on this exact head is the platform evidence, same as #9439's validation.
- **Known CI coverage gap, if any:** local measurement is on Linux/glibc; MSVC's per-frame stack usage differs in absolute terms, though not in which branch dominates. The hosted Windows advisory job is the actual proof, not a substitute for it.
- **Beyond CI, what did you manually verify?** Confirmed the fix is behavior-preserving: `Box::pin(fut).await` polls the identical future, just heap-allocated: no change to what any of the nine handlers returns, awaits internally, or how they handle errors. Full `zeroclaw-runtime::rpc::dispatch` test module (185 tests) passes unchanged.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** full workspace `cargo test` was not run; this change is isolated to one file/module and the affected module's own 185 tests plus fmt/clippy are the relevant local evidence. Broader workspace coverage comes from required CI on this head.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is `No` or either surface/floor question is `Yes`: N/A

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>` is the plan.
