### PR TITLE
fix(daemon): fail fast on a local IPC socket path over the platform limit

### DIFF
--- a/apps/zerocode/src/main.rs
+++ b/apps/zerocode/src/main.rs
@@ -1474,6 +1474,11 @@ async fn await_spawned_daemon_ready(
     socket: &std::path::Path,
     daemon: &mut SpawnedDaemon,
 ) -> anyhow::Result<client::RpcClient> {
+    eprintln!(
+        "zerocode: waiting for daemon at {} (up to {}s)…",
+        socket.display(),
+        SPAWNED_DAEMON_CONNECT_TIMEOUT.as_secs(),
+    );
     let deadline = tokio::time::Instant::now() + SPAWNED_DAEMON_CONNECT_TIMEOUT;
     loop {
         if let Some(exit) = daemon.poll_exit()? {
@@ -1481,7 +1486,8 @@ async fn await_spawned_daemon_ready(
         }
         if tokio::time::Instant::now() >= deadline {
             anyhow::bail!(
-                "daemon did not become ready within {}s (socket: {})",
+                "daemon did not become ready within {}s (socket: {}); if the socket path is \
+                 long, set ZEROCLAW_SOCKET to a shorter path or use a shorter --config-dir",
                 SPAWNED_DAEMON_CONNECT_TIMEOUT.as_secs(),
                 socket.display(),
             );

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -18,7 +18,10 @@ enum SocketStartupState {
     #[default]
     Pending,
     Ready,
-    Fatal(String),
+    Fatal {
+        kind: std::io::ErrorKind,
+        message: String,
+    },
 }
 
 #[derive(Clone)]
@@ -50,13 +53,16 @@ impl SocketStartupTracker {
     }
 
     fn record_error(&self, error: &anyhow::Error) {
-        if !is_addr_in_use(error) {
+        let Some(kind) = fatal_socket_startup_kind(error) else {
             return;
-        }
+        };
 
         self.state_tx.send_if_modified(|state| {
             if matches!(state, SocketStartupState::Pending) {
-                *state = SocketStartupState::Fatal(format!("{error:#}"));
+                *state = SocketStartupState::Fatal {
+                    kind,
+                    message: format!("{error:#}"),
+                };
                 true
             } else {
                 false
@@ -65,10 +71,20 @@ impl SocketStartupTracker {
     }
 }
 
-fn is_addr_in_use(error: &anyhow::Error) -> bool {
+/// Startup errors no supervisor restart can recover from: the endpoint is
+/// already owned by another daemon, or the configured path can never be bound
+/// (for example a Unix socket path over the platform `sun_path` limit, which
+/// `std` reports as `InvalidInput` before the syscall).
+fn fatal_socket_startup_kind(error: &anyhow::Error) -> Option<std::io::ErrorKind> {
     error
         .downcast_ref::<std::io::Error>()
-        .is_some_and(|error| error.kind() == std::io::ErrorKind::AddrInUse)
+        .map(std::io::Error::kind)
+        .filter(|kind| {
+            matches!(
+                kind,
+                std::io::ErrorKind::AddrInUse | std::io::ErrorKind::InvalidInput
+            )
+        })
 }
 
 #[derive(Clone)]
@@ -1133,8 +1149,8 @@ async fn await_socket_startup(
         .map(|state| state.clone())
     {
         Ok(SocketStartupState::Ready) => Ok(()),
-        Ok(SocketStartupState::Fatal(message)) => {
-            Err(std::io::Error::new(std::io::ErrorKind::AddrInUse, message).into())
+        Ok(SocketStartupState::Fatal { kind, message }) => {
+            Err(std::io::Error::new(kind, message).into())
         }
         Ok(SocketStartupState::Pending) => unreachable!("wait_for excludes pending state"),
         Err(_) => Ok(()),
@@ -1297,17 +1313,17 @@ where
                     }
                 }
                 Err(e) => {
-                    crate::health::mark_component_error(name, e.to_string());
+                    crate::health::mark_component_error(name, format!("{e:#}"));
                     ::zeroclaw_log::record!(
                         ERROR,
                         ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
                             .with_outcome(::zeroclaw_log::EventOutcome::Failure)
                             .with_attrs(::serde_json::json!({
-                                "error": format!("{}", e),
+                                "error": format!("{e:#}"),
                                 "name": name,
                                 "ran_for_secs": ran_for.as_secs(),
                             })),
-                        &format!("Daemon component '{name}' failed: {e}")
+                        &format!("Daemon component '{name}' failed: {e:#}")
                     );
                     // A long-lived run that eventually errors is not a
                     // fast-fail loop; let it reset so a component that ran fine
@@ -3713,6 +3729,81 @@ mod tests {
                 "daemon should return the startup socket ownership error with startup_feedback_enabled={startup_feedback_enabled}, got: {error:#}"
             );
         }
+    }
+
+    #[test]
+    fn fatal_socket_startup_kind_covers_unbindable_paths_through_context() {
+        use std::io;
+
+        let unbindable = anyhow::Error::from(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "local IPC socket path is 104 bytes but this platform allows at most 103",
+        ))
+        .context("binding local IPC endpoint");
+        assert_eq!(
+            fatal_socket_startup_kind(&unbindable),
+            Some(io::ErrorKind::InvalidInput)
+        );
+
+        let owned = anyhow::Error::from(io::Error::from(io::ErrorKind::AddrInUse));
+        assert_eq!(
+            fatal_socket_startup_kind(&owned),
+            Some(io::ErrorKind::AddrInUse)
+        );
+
+        let transient = anyhow::Error::from(io::Error::from(io::ErrorKind::PermissionDenied));
+        assert_eq!(fatal_socket_startup_kind(&transient), None);
+        assert_eq!(
+            fatal_socket_startup_kind(&anyhow::Error::msg("not an io error")),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_socket_invalid_input_fails_daemon_startup() {
+        use std::io;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_socket = attempts.clone();
+
+        let mut registry = DaemonRegistry::new();
+        registry.register_socket(Box::new(move |_ctx, _cancel, _client_count, _readiness| {
+            let attempts = attempts_for_socket.clone();
+            Box::pin(async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(anyhow::Error::from(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "local IPC socket path is 104 bytes but this platform allows at most 103",
+                ))
+                .context("binding local IPC endpoint"))
+            })
+        }));
+
+        let result = tokio::time::timeout(
+            DAEMON_DEADLOCK_GUARD,
+            run(config, "127.0.0.1".to_string(), 0, registry, false, false),
+        )
+        .await
+        .expect("daemon must not restart-loop an unbindable socket path");
+        let error = result.expect_err("daemon startup should fail on an unbindable socket path");
+
+        assert_eq!(
+            error.downcast_ref::<io::Error>().map(io::Error::kind),
+            Some(io::ErrorKind::InvalidInput),
+            "the startup error should keep the bind error kind, got: {error:#}"
+        );
+        let message = format!("{error:#}");
+        assert!(message.contains("binding local IPC endpoint"), "{message}");
+        assert!(message.contains("allows at most 103"), "{message}");
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "an unbindable path must fail closed instead of being retried"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-runtime/src/rpc/local.rs
+++ b/crates/zeroclaw-runtime/src/rpc/local.rs
@@ -534,7 +534,41 @@ mod platform {
         ))
     }
 
+    /// Longest socket path `bind(2)` accepts on this platform, in bytes.
+    ///
+    /// `sun_path` is the trailing field of `sockaddr_un` (104 bytes on macOS
+    /// and the BSDs, 108 on Linux) and one byte is reserved for the
+    /// terminating NUL, matching the check `std` performs before the syscall.
+    pub(super) const MAX_SOCKET_PATH_BYTES: usize = std::mem::size_of::<libc::sockaddr_un>()
+        - std::mem::offset_of!(libc::sockaddr_un, sun_path)
+        - 1;
+
+    /// Rejects a path `bind(2)` cannot address before any lifecycle state exists.
+    ///
+    /// `std` reports the same condition as a bare `InvalidInput` that names
+    /// neither the path nor the limit, and by then the sibling lock file
+    /// would already have been created for an endpoint that can never exist.
+    pub(super) fn require_bindable_path(path: &Path) -> Result<()> {
+        use std::os::unix::ffi::OsStrExt;
+
+        let len = path.as_os_str().as_bytes().len();
+        if len > MAX_SOCKET_PATH_BYTES {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "local IPC socket path {} is {len} bytes but this platform allows at most \
+                     {MAX_SOCKET_PATH_BYTES}; set ZEROCLAW_SOCKET to a shorter path or use a \
+                     shorter --config-dir",
+                    path.display()
+                ),
+            )
+            .into());
+        }
+        Ok(())
+    }
+
     pub async fn bind(path: &Path) -> Result<(LocalListener, EndpointGuard)> {
+        require_bindable_path(path)?;
         let lock = EndpointLock::acquire(path)?;
         bind_locked(path, lock).await
     }
@@ -963,6 +997,74 @@ mod tests {
 
         drop(listener);
         drop(guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn socket_path_length_check_matches_the_platform_bind_limit() {
+        use std::os::unix::net::SocketAddr;
+
+        let longest = PathBuf::from(format!(
+            "/{}",
+            "s".repeat(platform::MAX_SOCKET_PATH_BYTES - 1)
+        ));
+        assert_eq!(longest.as_os_str().len(), platform::MAX_SOCKET_PATH_BYTES);
+        platform::require_bindable_path(&longest).expect("a path at the limit must pass");
+        SocketAddr::from_pathname(&longest).expect("std must accept a path at the limit");
+
+        let over = PathBuf::from(format!("/{}", "s".repeat(platform::MAX_SOCKET_PATH_BYTES)));
+        let over_len = over.as_os_str().len();
+        let error = platform::require_bindable_path(&over)
+            .expect_err("a path one byte over the limit must be rejected");
+        assert_eq!(
+            error
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
+            Some(ErrorKind::InvalidInput)
+        );
+        let message = format!("{error:#}");
+        assert!(message.contains(&format!("{over_len} bytes")), "{message}");
+        assert!(message.contains(&over.display().to_string()), "{message}");
+        assert!(message.contains("ZEROCLAW_SOCKET"), "{message}");
+        assert!(message.contains("--config-dir"), "{message}");
+        assert_eq!(
+            SocketAddr::from_pathname(&over)
+                .map(|_| ())
+                .map_err(|error| error.kind()),
+            Err(ErrorKind::InvalidInput),
+            "std must reject the same path, so the check is no stricter than bind(2)"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bind_rejects_an_overlong_socket_path_before_creating_the_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base_len = tmp.path().as_os_str().len() + 1;
+        let padding = (platform::MAX_SOCKET_PATH_BYTES + 1)
+            .saturating_sub(base_len)
+            .max(1);
+        let sock_path = tmp.path().join("s".repeat(padding));
+
+        let error = match platform::bind(&sock_path).await {
+            Ok(_) => panic!("an overlong socket path must not bind"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
+            Some(ErrorKind::InvalidInput)
+        );
+        assert!(format!("{error:#}").contains("ZEROCLAW_SOCKET"));
+
+        let mut lock_name = sock_path.as_os_str().to_os_string();
+        lock_name.push(".lock");
+        assert!(
+            !PathBuf::from(lock_name).exists(),
+            "a rejected path must not leave a lifecycle lock behind"
+        );
+        assert!(!sock_path.exists());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - A local IPC socket path longer than `sun_path` (104 bytes on macOS and the BSDs, 108 on Linux, one reserved for the NUL) is rejected by `std` before the syscall as a bare `InvalidInput` ("path must be shorter than SUN_LEN"). The daemon supervisor only treated `AddrInUse` as fatal, so the socket component restart-looped (2 s, 4 s, 8 s) while HTTP kept serving, the runtime log dropped the cause chain, a `daemon.sock.lock` was left without a `daemon.sock`, and zerocode showed a blank terminal for 30 s before a message that named the path but not the cause.
  - `rpc/local.rs`: check the path byte length against libc's `sockaddr_un.sun_path` before acquiring the lifecycle lock; the error names the path, its length, the platform limit and the remedy (`ZEROCLAW_SOCKET` or a shorter `--config-dir`). Checking before `EndpointLock::acquire` means no lock file is created for an unbindable path, so the intentionally persistent lock design is untouched.
  - `daemon/mod.rs`: classify `InvalidInput` from the socket start as fatal alongside `AddrInUse`, so startup fails closed. `AddrInUse` behaviour is unchanged; the fatal state now carries the original `ErrorKind`. Supervisor log, `error` attribute and health entry use `{e:#}` so the cause chain reaches the operator.
  - zerocode: one stderr line before the readiness wait, and the `ZEROCLAW_SOCKET` / `--config-dir` hint on the 30 s bail. The 30 s default is unchanged.
- **Scope boundary:** Does not change lock-file persistence for other bind failures (documented design in `EndpointLock`), the 30 s readiness window, Windows named-pipe handling, gateway bind classification, or `doctor` (which still reports the daemon healthy while the socket component is down; follow-up).
- **Blast radius:** daemon socket startup on Unix; supervisor error text for all components (the cause chain is now included); zerocode ephemeral-daemon startup output.
- **Linked issue(s):** Related #10178, Related #10216, Related #9169, Related #8578.
- **Labels:** `bug`, `cli`, `daemon`, `risk:medium`, `runtime`, `size:S`, `zerocode`

Found while benchmarking the v0.8.5 release binaries on macOS with a config directory under a long temporary path. I verified the patch on built binaries; the A/B below is from that run.

## Testing (required)

### How you can test

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (daemon), `tui` (zerocode startup, before the alternate screen)
- **Setup / preconditions:** macOS or Linux; `zeroclaw` and `zerocode` built from this branch and from `master` (or the v0.8.5 release binaries for the before case).
- **Steps to run:**
  ```sh
  D=$(python3 -c 'print("/tmp/"+"z"*100)')   # data/daemon.sock becomes 122 bytes, over 103 (macOS) and 107 (Linux)
  mkdir -p "$D/data"; printf 'schema_version = 3\n' > "$D/config.toml"; chmod 600 "$D/config.toml"
  zeroclaw daemon --config-dir "$D" --port 8899
  # in a second shell:
  zerocode --config-dir "$D"
  ls "$D/data"
  # remedy check:
  ZEROCLAW_SOCKET=/tmp/zc-short.sock zeroclaw daemon --config-dir "$D" --port 8899
  ```
- **Expected on this branch (after):** the daemon exits with status 1 and `Error: binding local IPC endpoint: local IPC socket path …/data/daemon.sock is 122 bytes but this platform allows at most 103; set ZEROCLAW_SOCKET to a shorter path or use a shorter --config-dir`; `ls "$D/data"` shows no `daemon.sock.lock`; zerocode prints `zerocode: waiting for daemon at … (up to 30s)…` immediately and then, within about 1.5 s, `daemon exited before ready (status: exit status: 1); stderr: Error: binding local IPC endpoint: …`; the `ZEROCLAW_SOCKET` run binds normally.
- **Prior behavior on `master` (before):** the daemon keeps running and serving HTTP on 8899 while the runtime trace repeats `Daemon component 'socket' failed: binding local IPC endpoint` with growing backoff and no path, length or cause; `daemon.sock.lock` exists without `daemon.sock`; zerocode shows nothing for 30 s, then `daemon did not become ready within 30s (socket: …)`.

### How I tested

- **CI checks relied on and why they cover this change:** `Rust` (fmt, clippy `-D warnings`, nextest workspace) covers the two changed crates; the four new unit tests run in the workspace test job on Linux and macOS.
- **Known CI coverage gap, if any:** the end-to-end recipe above is manual (run on macOS 26.5, Apple M5 Max, see below); the length check is asserted against `std`'s own `SocketAddr::from_pathname` at the boundary so it cannot be stricter than `bind(2)` on any CI platform.
- **Commands run and tail output:**
  ```sh
  $ cargo +1.96.0 fmt --all -- --check
  (no output, exit 0)
  $ cargo +1.96.0 clippy -p zeroclaw-runtime -p zerocode --all-targets -- -D warnings
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 25s
  $ cargo +1.96.0 test -p zeroclaw-runtime --lib -- socket supervisor endpoint_lock stale
  test rpc::local::tests::socket_path_length_check_matches_the_platform_bind_limit ... ok
  test rpc::local::tests::bind_rejects_an_overlong_socket_path_before_creating_the_lock ... ok
  test daemon::tests::fatal_socket_startup_kind_covers_unbindable_paths_through_context ... ok
  test daemon::tests::initial_socket_invalid_input_fails_daemon_startup ... ok
  test daemon::tests::initial_socket_addr_in_use_fails_daemon_startup ... ok
  test daemon::tests::socket_addr_in_use_after_readiness_stays_supervised ... ok
  test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 4192 filtered out; finished in 4.60s
  $ cargo +1.96.0 test -p zerocode
  test result: ok. 274 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.08s
  test result: ok. 1013 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 2.49s
  $ bash scripts/ci/rust_quality_gate.sh
  ==> rust quality: cargo fmt --all -- --check
  ==> rust quality: cargo clippy --locked --workspace --exclude zeroclaw-desktop --all-targets -- -D clippy::correctness
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 41s
  ```
  (the gate's provider-dispatch step needs `rg`, which was not installed locally; the dispatch surface is untouched by this PR)
- **Beyond CI, what did you manually verify?** The A/B recipe above on built binaries: before (v0.8.5 release), daemon still running after 6 s with `daemon.sock.lock` present and no socket, zerocode zero bytes of output in 8 s; after (this branch, debug build), daemon exit 1 with the full message, no lock file, zerocode's waiting line at once and the daemon's stderr embedded in its failure at 1.3 s; `ZEROCLAW_SOCKET` pointing at a 63-byte path binds on both. Reviewed that `remove_stale` and `prepare_parent` cannot emit a transient `InvalidInput`, so the new fatal classification cannot swallow a recoverable error; post-readiness errors remain supervised because the tracker only records while `Pending`. Not verified: Linux end to end (the limit constant is derived from libc, and the boundary test covers it).
- **Visual interface changed?** N/A (one plain stderr line before the TUI starts)
- **If any command was intentionally skipped, why:** `--strict` workspace clippy (`--features ci-all`) not run locally; required CI runs it.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes (a path that could never bind now fails at startup with a message instead of looping)
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No (`offset_of!` is stable since 1.77; MSRV is 1.96)

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert the eventual squash commit with `git revert <squash-commit-sha>`.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** A bindable socket is rejected during startup, a recoverable socket error terminates the daemon, or ZeroCode startup diagnostics regress.
