### PR TITLE
docs(review): ground reviews in current evidence

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -5,15 +5,9 @@ description: "Human-reviewer co-pilot for ZeroClaw PR reviews. Use this skill wh
 
 # ZeroClaw PR Review Session — Human Reviewer Co-Pilot
 
-You are assisting the **active `gh` account holder** in conducting PR reviews
-for the `zeroclaw-labs/zeroclaw` repository. Reviewer identity is resolved from
-`tmp/handoff.md` at session start (the `reviewer:` field); if absent, detect it
-via `gh auth status` and persist it to the handoff immediately so continuation
-sessions reuse it without a redundant call. You read everything, cross-check
-against the local source, write the review body, and post it via `gh` — but the
-judgment and identity are the reviewer's. Every review is posted under the
-logged-in account, in the first-person voice of that reviewer — never as "an AI"
-or in a third party's voice.
+You are assisting the **active `gh` account holder** in conducting PR reviews for the `zeroclaw-labs/zeroclaw` repository. Cached reviewer identity in `tmp/handoff.md` is session context; verify the active account before posting.
+
+You read everything, cross-check against the local source, write the review body, and post it via `gh`. The judgment and identity are the reviewer's. Every review is posted under the logged-in account, in the first-person voice of that reviewer, never as "an AI" or in a third party's voice.
 
 ---
 
@@ -73,16 +67,10 @@ is 1234 ready to merge
 
 ### Phase 1 — Load context
 
-1. **Resolve reviewer identity.** Check whether `tmp/handoff.md` contains a
-   stored `reviewer:` field. If it does, use that value for all subsequent `gh`
-   commands and review prose. If it does not (new session or no handoff yet),
-   run `gh auth status` to capture the active account login, record the result
-   as `reviewer: <login>` in `tmp/handoff.md` immediately, and use it for the
-   rest of the session. Never hardcode any identity.
+1. **Resolve reviewer identity.** Use the cached `reviewer:` field in `tmp/handoff.md` for orientation, or read the active login with `gh api user --jq .login` when absent. Never hardcode an identity.
 2. Read `tmp/handoff.md`. Establish which PRs have already been reviewed this
    session, which verdict was posted, and what commit that verdict was on.
-3. For the target PR, check if `tmp/review-<number>.md` already exists. If it
-   does, read it — this session already posted a review for this PR.
+3. Read `tmp/review-<number>.md` if present. It may be an unposted draft; establish prior publication from the PR's submitted reviews, including the author and reviewed commit.
 4. If working in queue mode, identify the next PR that needs attention based on
    the handoff.
 
@@ -153,13 +141,13 @@ fetches sequentially wastes time and the results are independent.
 3. Show the draft to the active reviewer before posting. Prefer a link to
    `tmp/review-<number>.md` plus a short summary; if the full draft needs to be
    inline, paste it as regular text rather than a fenced Markdown block.
-4. Post using the verdict flag from the decision tree:
+4. Immediately before posting, verify the active login with `gh api user --jq .login`. If it differs from the identity used for the approved draft, reconcile the draft and confirmation before proceeding. Post using the verdict flag from the decision tree:
    ```bash
    gh pr review <number> --repo zeroclaw-labs/zeroclaw \
      <--approve | --request-changes | --comment> \
      --body-file tmp/review-<number>.md
    ```
-5. Confirm the post succeeded.
+5. Confirm the submitted review through the PR reviews API, checking its remote ID, author, body, verdict, and reviewed commit. A local file does not prove publication.
 
 ### Phase 3.5 — Milestone alignment
 
@@ -307,16 +295,11 @@ These norms are documented in
 1. **Always read `tmp/handoff.md` first.** It carries session state and the
    cached reviewer identity — reading it first avoids a redundant auth call on
    warm sessions.
-2. **Always resolve reviewer identity from the handoff before falling back to
-   `gh auth status`.** If the handoff has no `reviewer:` field, detect it,
-   write it to the handoff immediately, and use it for the rest of the session.
-   Never hardcode a username.
+2. **Verify the active reviewer before posting.** Cached identity is sufficient for orientation, not publication.
 3. **Always follow the protocol in
    `docs/book/src/contributing/pr-review-protocol.md`.** Do not improvise the
    fetch sequence or skip the foundations document step.
-4. **Always write to `tmp/review-<number>.md` before posting.** The tmp file
-   is the source of truth for what was posted. It also lets you inspect before
-   posting if the user asks.
+4. **Always write to `tmp/review-<number>.md` before posting.** The file holds the intended text; the submitted remote review establishes what was posted.
 5. **Always apply the PR-review Markdown checkpoint before showing or posting.**
    Formal review findings must use H3 headings that start with the taxonomy
    emoji, such as `### 🔴 Blocking — ...`; headings such as

--- a/.claude/skills/pr-architecture-check/SKILL.md
+++ b/.claude/skills/pr-architecture-check/SKILL.md
@@ -56,11 +56,11 @@ gh pr view <N> --repo zeroclaw-labs/zeroclaw --json files,title,baseRefName,labe
 
 | Files touched | Also load |
 |---|---|
-| `crates/zeroclaw-api/` | Extension examples: `docs/book/src/developing/extension-examples.md` |
+| `crates/zeroclaw-api/` | `docs/book/src/architecture/overview.md#core-traits` and the changed trait definitions |
 | `crates/zeroclaw-runtime/` | FND-001 §Phase 2 (runtime extraction) |
 | `crates/zeroclaw-gateway/` | FND-001 §Phase 3 (gateway separation) |
 | `crates/zeroclaw-plugins/` | FND-001 §Phase 4 (plugin platform) |
-| `crates/zeroclaw-channels/` or `crates/zeroclaw-tools/` | Extension examples doc |
+| `crates/zeroclaw-channels/` or `crates/zeroclaw-tools/` | Relevant channel or tool references from `docs/book/src/contributing/architecture-map.md` |
 | `crates/zeroclaw-config/` or `crates/zeroclaw-macros/` | Config schema conventions in AGENTS.md |
 | `.github/workflows/` | FND-003 governance, CI risk tier (high risk per AGENTS.md) |
 

--- a/docs/book/src/contributing/pr-review-protocol.md
+++ b/docs/book/src/contributing/pr-review-protocol.md
@@ -242,6 +242,8 @@ gh pr review <number> --repo zeroclaw-labs/zeroclaw \
 
 Always show the full draft and get explicit approval from the human before posting. Continuation words like "next" or "move on" don't count as approval, only an unambiguous "yes" / "approve" / "go" does.
 
+Preserve submitted review history. A substantive re-review of a later head must be a new formal review bound to that head, even when the verdict is unchanged; use `### ✅ Resolved` to acknowledge earlier findings. Edit an existing review only to correct what that review said about the head it originally assessed, such as a typo or inaccurate statement; never replace it with findings from a later head.
+
 ## After posting
 
 If a session-level handoff file exists (`tmp/handoff.md`), update it with the verdict, the head commit reviewed, and what remains open. The handoff is what lets a new session pick up cold without re-reading the whole conversation.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:** Preserve submitted reviews when reassessing later commits, verify the active reviewer before posting, use remote reviews to establish publication, and replace the missing architecture reference.
- **Scope boundary:** Review protocol plus two review skills; no runtime behavior or verdict taxonomy changes.
- **Blast radius:** Assistants following the changed repository guidance.
- **Linked issue(s):** None; this self-contained documentation correction is carried by the PR.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`.

### What this does, simply

A saved draft can exist even when nothing was posted, and a cached account name can be stale. These instructions use GitHub to establish who is posting and what was submitted, preserve earlier reviews when code changes, and point architecture checks to documentation that exists.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; documentation instructions only.

### How I tested

- **CI checks relied on and why they cover this change:** No CI result is claimed for the proposed additions. Local documentation and source checks cover the changed instructions.
- **Known CI coverage gap, if any:** Static checks do not prove how every assistant will follow the guidance.
- **Commands run and tail output:**

```sh
git diff --check
# exit 0
DOCS_FILES='.claude/skills/github-pr-review-session/SKILL.md
.claude/skills/pr-architecture-check/SKILL.md' BASE_SHA=HEAD bash scripts/ci/docs_links_gate.sh
# 6 tests passed; 0 added Markdown links; exit 0
DOCS_FILES='.claude/skills/github-pr-review-session/SKILL.md
.claude/skills/pr-architecture-check/SKILL.md' BASE_SHA=HEAD bash scripts/ci/docs_quality_gate.sh
# exit 1: existing prose em-dashes in legacy skill files
```

- **Beyond CI, what did you manually verify?** Verified the architecture overview's Core traits heading and the architecture map's channel/tool references. Inspected the local-draft, changed-account, and later-commit cases. No review was posted. Compared remaining em-dash findings with the pre-edit files; no new em-dash lines were added. The link gate reports no Markdown links, so code-formatted documentation references were checked directly.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** No Cargo or runtime smoke; these are instruction-only changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? Yes, guidance only: read the active GitHub account and submitted reviews through the existing authenticated GitHub CLI. No new service or runtime network path is introduced.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No new untrusted input source. Existing fetched-content rules still apply.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.

## Rollback (required for medium/high-risk PRs)

Revert the documentation change. No migration is needed.

