### PR TITLE
fix(tests): match publish-contract escape exceptions on Windows

### DIFF
--- a/tests/architecture/publish_contract.rs
+++ b/tests/architecture/publish_contract.rs
@@ -691,6 +691,50 @@ const ESCAPE_EXCEPTIONS: &[(&str, &str)] = &[(
     "../../web/dist",
 )];
 
+/// A repository-relative path written the way `ESCAPE_EXCEPTIONS` spells it.
+///
+/// The exception list is a source literal, so it uses `/`. `Path::display` and
+/// `to_string_lossy` use the platform separator, so on Windows the same file
+/// renders as `crates\zeroclaw-gateway\src\static_files.rs` and no entry can
+/// ever match by string equality. The lookup then reports the one include the
+/// list exists to allow, failing this test on Windows for every branch.
+fn repo_relative_slug(path: &Path) -> String {
+    path.strip_prefix(repo_root())
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Every `ESCAPE_EXCEPTIONS` entry must match the file it names, on every
+/// platform.
+///
+/// The list is keyed by a `/`-separated source literal. Building the same path
+/// with `Path::join` yields the platform separator, so a lookup that compares
+/// raw strings matches on Unix and silently never matches on Windows - which
+/// turns the one deliberately allowed include into a violation and fails the
+/// contract test on every Windows run.
+#[test]
+fn escape_exceptions_match_their_files_on_every_platform() {
+    for (relative, _) in ESCAPE_EXCEPTIONS {
+        let native = relative
+            .split('/')
+            .fold(repo_root().to_path_buf(), |path, segment| {
+                path.join(segment)
+            });
+        assert!(
+            native.is_file(),
+            "exception names a file that does not exist: {relative}"
+        );
+        assert_eq!(
+            repo_relative_slug(&native),
+            *relative,
+            "the exception lookup must find this file on this platform"
+        );
+    }
+}
+
 #[test]
 fn published_crates_never_include_files_outside_their_own_directory() {
     let mut violations = Vec::new();
@@ -733,11 +777,7 @@ fn published_crates_never_include_files_outside_their_own_directory() {
                         .to_path_buf()
                 };
                 let resolved = normalize(&base, &include.path);
-                let rel = source_path
-                    .strip_prefix(repo_root())
-                    .unwrap_or(&source_path)
-                    .to_string_lossy()
-                    .into_owned();
+                let rel = repo_relative_slug(&source_path);
                 let excepted = ESCAPE_EXCEPTIONS
                     .iter()
                     .any(|(f, p)| *f == rel && *p == include.path);


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `ESCAPE_EXCEPTIONS` in `tests/architecture/publish_contract.rs` is keyed by a `/`-separated source literal, but the value it was compared against came from `to_string_lossy()` on a native path. On Windows that renders as `crates\zeroclaw-gateway\src\static_files.rs`, so the list's only entry never matched.
  - The result: the one include the list exists to allow was reported as a violation, and `published_crates_never_include_files_outside_their_own_directory` failed on **every** Windows run, on every branch.
  - Nothing is wrong with the packaging. The lookup was separator-sensitive; the fix routes it through `repo_relative_slug`, which joins path components with `/` regardless of platform.
  - Added a test asserting every exception entry resolves to a real file *and* is found through that lookup, so a future entry that only works on one platform fails the suite instead of the include it names.
- **Scope boundary:** Test-only. No production code, no manifest, no packaging behavior, and no change to which includes are allowed. The other `display()` calls in this file build error messages rather than compare, so they are untouched.
- **Blast radius:** `Advisory Windows nextest` in full mode, which runs the root package's `architecture` suite. Fixing this removes a permanent red from that job. Nothing else reads `ESCAPE_EXCEPTIONS`.
- **Linked issue(s):** None filed; found while investigating the advisory Windows failure on an unrelated PR.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the failure only reproduces on a Windows runner, and this PR's own `Advisory Windows nextest` job is the A/B: it is red on `master` and should be green here.

### How I tested

Local runs are on macOS, where the separator is already `/`, so they confirm the suite stays green but **cannot** reproduce the Windows failure. The real evidence is the CI output that printed the mismatched path, and this PR's own Windows job.

```sh
$ cargo test --locked --test architecture publish_contract
test publish_contract::escape_exceptions_match_their_files_on_every_platform ... ok
test publish_contract::published_crates_never_include_files_outside_their_own_directory ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 30 filtered out; finished in 12.72s

$ cargo fmt --all -- --check    # clean
```

Observed failure this fixes, from `Advisory Windows nextest (full, plugin-host=true)` on an unrelated PR — note the mixed separators in the printed path, which is the mismatched string itself:

```
FAIL zeroclaw::architecture publish_contract::published_crates_never_include_files_outside_their_own_directory

these compile-time includes reference files the published crate will not contain:
  crates/zeroclaw-gateway\src\static_files.rs (zeroclaw-gateway)
      includes `../../web/dist`
      -> D:\a\zeroclaw\zeroclaw\web\dist
```

Every test suite in that job passed; this was the only failure.

- **CI checks relied on and why they cover this change:** `Advisory Windows nextest` in full mode is the only job that exercises the failing path — it runs the root package's `architecture` suite on Windows. `Test` covers the Unix side and the new test.
- **Known CI coverage gap, if any:** The advisory Windows job is skipped on `master` pushes and runs only on pull requests, which is why this stayed invisible in master's own CI history.
- **Commands run and tail output:** above.
- **Beyond CI, what did you manually verify?** That `ESCAPE_EXCEPTIONS` has exactly one entry and that `crates/zeroclaw-gateway/src/static_files.rs` exists and still carries the `../../web/dist` include; that the remaining `display()` uses in this file feed error strings rather than comparisons. I did **not** verify on a Windows host — I have no Windows machine, so the Windows behavior rests on reading the CI output and on this PR's own advisory job.
- **Visual interface changed?** `N/A`
- **If any command was intentionally skipped, why:** Full-workspace clippy was skipped; the change is confined to one test file, and `Lint` covers it in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.
