### PR TITLE
feat(security): make the docker sandbox image configurable

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -3992,6 +3992,7 @@ mod tests {
             sandbox_enabled: Some(true),
             sandbox_backend: Some("firejail".into()),
             firejail_args: vec!["--net=none".into()],
+            sandbox_image: None,
         };
 
         let policy = SecurityPolicy::from_profiles(&rp, None, Path::new("/ws"));

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -376,6 +376,10 @@ pub struct SecurityPolicy {
     /// Extra arguments forwarded to firejail when `sandbox_backend`
     /// resolves to `"firejail"`.
     pub firejail_args: Vec<String>,
+    /// Container image for the docker sandbox backend. `None` inherits the
+    /// built-in default; carried here so status surfaces report the image the
+    /// sandbox will actually run rather than assuming the default.
+    pub sandbox_image: Option<String>,
     pub tracker: PerSenderTracker,
 }
 
@@ -774,6 +778,7 @@ impl Default for SecurityPolicy {
             sandbox_enabled: None,
             sandbox_backend: None,
             firejail_args: vec![],
+            sandbox_image: None,
             tracker: PerSenderTracker::new(),
         }
     }
@@ -3627,6 +3632,7 @@ impl SecurityPolicy {
             always_ask: risk_profile.always_ask.clone(),
             sandbox_enabled: risk_profile.sandbox_enabled,
             sandbox_backend: risk_profile.sandbox_backend.clone(),
+            sandbox_image: risk_profile.sandbox_image.clone(),
             firejail_args: risk_profile.firejail_args.clone(),
             tracker: PerSenderTracker::new(),
         }

--- a/crates/zeroclaw-config/src/presets.rs
+++ b/crates/zeroclaw-config/src/presets.rs
@@ -87,6 +87,7 @@ fn locked_down_risk() -> RiskProfileConfig {
         excluded_tools: vec![],
         sandbox_enabled: Some(true),
         sandbox_backend: None,
+        sandbox_image: None,
         firejail_args: vec![],
     }
 }
@@ -111,6 +112,7 @@ fn balanced_risk() -> RiskProfileConfig {
         excluded_tools: vec![],
         sandbox_enabled: Some(true),
         sandbox_backend: None,
+        sandbox_image: None,
         firejail_args: vec![],
     }
 }
@@ -135,6 +137,7 @@ fn yolo_risk() -> RiskProfileConfig {
         excluded_tools: vec![],
         sandbox_enabled: Some(false),
         sandbox_backend: None,
+        sandbox_image: None,
         firejail_args: vec![],
     }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12858,6 +12858,13 @@ impl RiskProfileConfig {
             enabled: self.sandbox_enabled,
             backend,
             firejail_args: self.firejail_args.clone(),
+            image: self
+                .sandbox_image
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(default_sandbox_image),
         }
     }
 }
@@ -12982,6 +12989,11 @@ pub struct RiskProfileConfig {
     pub sandbox_backend: Option<String>,
     /// Extra arguments forwarded to firejail when sandbox_backend = "firejail".
     pub firejail_args: Vec<String>,
+    /// Container image the docker sandbox runs commands in when
+    /// `sandbox_backend = "docker"`. `None` inherits the built-in default.
+    /// Set this to pin a digest or a specific tag so the sandbox stops
+    /// tracking whatever the default tag moves to.
+    pub sandbox_image: Option<String>,
 }
 
 impl Default for RiskProfileConfig {
@@ -13004,6 +13016,7 @@ impl Default for RiskProfileConfig {
             sandbox_enabled: None,
             sandbox_backend: None,
             firejail_args: Vec::new(),
+            sandbox_image: None,
         }
     }
 }
@@ -18022,6 +18035,23 @@ pub struct SandboxConfig {
     /// Custom Firejail arguments (when backend = firejail)
     #[serde(default)]
     pub firejail_args: Vec<String>,
+
+    /// Container image the Docker sandbox runs commands in (when backend =
+    /// docker). Pin a digest or a specific tag if you need the sandbox to stop
+    /// tracking upstream changes to the default tag.
+    #[serde(default = "default_sandbox_image")]
+    pub image: String,
+}
+
+/// Default container image for the Docker sandbox backend.
+///
+/// The single source for this value: the serde default below and
+/// `DockerSandbox`'s own default both read it, so a change here cannot leave
+/// one path on a stale image.
+pub const DEFAULT_SANDBOX_IMAGE: &str = "alpine:latest";
+
+fn default_sandbox_image() -> String {
+    DEFAULT_SANDBOX_IMAGE.to_string()
 }
 
 impl Default for SandboxConfig {
@@ -18030,6 +18060,7 @@ impl Default for SandboxConfig {
             enabled: None, // Auto-detect
             backend: SandboxBackend::Auto,
             firejail_args: Vec::new(),
+            image: default_sandbox_image(),
         }
     }
 }
@@ -28850,6 +28881,58 @@ reasoning_effort = "HIGH"
     }
 
     #[test]
+    async fn sandbox_image_defaults_to_the_shared_constant() {
+        // The default has to come from one place; a second literal anywhere is
+        // how the docs and the sandbox drifted apart before.
+        assert_eq!(SandboxConfig::default().image, DEFAULT_SANDBOX_IMAGE);
+        assert_eq!(DEFAULT_SANDBOX_IMAGE, "alpine:latest");
+    }
+
+    #[test]
+    async fn sandbox_image_is_configurable() {
+        // The sandbox is configured per risk profile, not under a
+        // `[security.sandbox]` table: `SandboxConfig` is a runtime view that
+        // `sandbox_config()` assembles from these flat keys.
+        let raw = r#"
+[risk_profiles.custom]
+sandbox_backend = "docker"
+sandbox_image = "alpine:3.20"
+"#;
+        let cfg = toml::from_str::<Config>(raw).expect("config with a sandbox image should parse");
+        let profile = cfg
+            .risk_profiles
+            .get("custom")
+            .expect("the custom profile should deserialize");
+        assert_eq!(profile.sandbox_image.as_deref(), Some("alpine:3.20"));
+        assert_eq!(profile.sandbox_config().image, "alpine:3.20");
+    }
+
+    #[test]
+    async fn sandbox_image_absent_falls_back_to_the_default() {
+        let raw = r#"
+[risk_profiles.custom]
+sandbox_backend = "docker"
+"#;
+        let cfg = toml::from_str::<Config>(raw).expect("config without an image should parse");
+        let profile = cfg.risk_profiles.get("custom").expect("profile");
+        assert_eq!(profile.sandbox_image, None);
+        assert_eq!(profile.sandbox_config().image, DEFAULT_SANDBOX_IMAGE);
+    }
+
+    #[test]
+    async fn sandbox_image_blank_is_treated_as_unset() {
+        // An empty or whitespace value must not hand Docker an empty image
+        // name; it falls back the same way an absent key does.
+        let raw = r#"
+[risk_profiles.custom]
+sandbox_image = "   "
+"#;
+        let cfg = toml::from_str::<Config>(raw).expect("config should parse");
+        let profile = cfg.risk_profiles.get("custom").expect("profile");
+        assert_eq!(profile.sandbox_config().image, DEFAULT_SANDBOX_IMAGE);
+    }
+
+    #[tokio::test]
     async fn runtime_reasoning_effort_rejects_invalid_values() {
         let raw = r#"
 default_temperature = 0.7

--- a/crates/zeroclaw-runtime/src/security/detect.rs
+++ b/crates/zeroclaw-runtime/src/security/detect.rs
@@ -352,7 +352,7 @@ pub fn create_sandbox(
 
     match backend {
         SandboxBackend::Auto | SandboxBackend::None => {
-            detect_best_sandbox(runtime_kind, workspace_dir, extra_roots)
+            detect_best_sandbox(runtime_kind, workspace_dir, extra_roots, &sandbox.image)
         }
         requested => {
             let selected =
@@ -367,8 +367,10 @@ pub fn create_sandbox(
                 }
                 return Arc::new(super::traits::NoopSandbox);
             }
-            if let Some(sandbox) = create_selected_sandbox(selected, workspace_dir, extra_roots) {
-                return sandbox;
+            if let Some(built) =
+                create_selected_sandbox(selected, workspace_dir, extra_roots, &sandbox.image)
+            {
+                return built;
             }
             log_requested_backend_unavailable(selected_backend_label(requested));
             Arc::new(super::traits::NoopSandbox)
@@ -380,13 +382,14 @@ fn detect_best_sandbox(
     runtime_kind: RuntimeKind,
     workspace_dir: Option<&Path>,
     extra_roots: &SandboxExtraRoots,
+    image: &str,
 ) -> Arc<dyn Sandbox> {
     let selected = detect_best_backend(runtime_kind, workspace_dir, extra_roots);
     if matches!(selected, SelectedSandboxBackend::DockerRuntime) {
         log_auto_backend_selection(selected, runtime_kind);
         return Arc::new(super::traits::NoopSandbox);
     }
-    if let Some(sandbox) = create_selected_sandbox(selected, workspace_dir, extra_roots) {
+    if let Some(sandbox) = create_selected_sandbox(selected, workspace_dir, extra_roots, image) {
         log_auto_backend_selection(selected, runtime_kind);
         return sandbox;
     }
@@ -399,6 +402,7 @@ fn create_selected_sandbox(
     selected: SelectedSandboxBackend,
     workspace_dir: Option<&Path>,
     extra_roots: &SandboxExtraRoots,
+    image: &str,
 ) -> Option<Arc<dyn Sandbox>> {
     match selected {
         SelectedSandboxBackend::None => None,
@@ -458,12 +462,9 @@ fn create_selected_sandbox(
         }
         SelectedSandboxBackend::Docker => {
             let result = if let Some(ws) = workspace_dir {
-                super::docker::DockerSandbox::with_workspace(
-                    super::docker::DockerSandbox::default_image(),
-                    ws.to_path_buf(),
-                )
+                super::docker::DockerSandbox::with_workspace(image.to_string(), ws.to_path_buf())
             } else {
-                super::docker::DockerSandbox::new()
+                super::docker::DockerSandbox::with_image(image.to_string())
             };
             result
                 .map(|sandbox| Arc::new(sandbox) as Arc<dyn Sandbox>)
@@ -633,11 +634,16 @@ pub fn linux_memcg_available() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeroclaw_config::schema::DEFAULT_SANDBOX_IMAGE;
 
     #[test]
     fn detect_best_sandbox_returns_something() {
-        let sandbox =
-            detect_best_sandbox(RuntimeKind::Cloudflare, None, &SandboxExtraRoots::default());
+        let sandbox = detect_best_sandbox(
+            RuntimeKind::Cloudflare,
+            None,
+            &SandboxExtraRoots::default(),
+            DEFAULT_SANDBOX_IMAGE,
+        );
         // Should always return at least NoopSandbox
         assert!(sandbox.is_available());
     }
@@ -648,6 +654,7 @@ mod tests {
             enabled: Some(false),
             backend: SandboxBackend::None,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
         let sandbox = create_sandbox(
             &sandbox_cfg,
@@ -664,6 +671,7 @@ mod tests {
             enabled: Some(false),
             backend: SandboxBackend::None,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
         let posture = sandbox_posture(
             &sandbox_cfg,
@@ -682,6 +690,7 @@ mod tests {
             enabled: None, // Auto-detect
             backend: SandboxBackend::Auto,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
         let sandbox = create_sandbox(
             &sandbox_cfg,
@@ -698,7 +707,12 @@ mod tests {
         // When runtime.kind = "native", Docker must be skipped in auto-detection
         // even when Docker is installed on the host. The sandbox must be
         // NoopSandbox or something OS-native (Landlock, Firejail, Seatbelt).
-        let sandbox = detect_best_sandbox(RuntimeKind::Native, None, &SandboxExtraRoots::default());
+        let sandbox = detect_best_sandbox(
+            RuntimeKind::Native,
+            None,
+            &SandboxExtraRoots::default(),
+            DEFAULT_SANDBOX_IMAGE,
+        );
         assert_ne!(sandbox.name(), "docker");
     }
 
@@ -708,6 +722,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::Auto,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
         let posture = sandbox_posture(
             &sandbox_cfg,
@@ -724,6 +739,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::Auto,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
         let sandbox = create_sandbox(
             &sandbox_cfg,
@@ -749,6 +765,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::Docker,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
         let sandbox = create_sandbox(
             &sandbox_cfg,
@@ -807,6 +824,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::Docker,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
 
         let sandbox = create_sandbox(
@@ -825,6 +843,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::Docker,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
 
         let posture = sandbox_posture(
@@ -854,6 +873,7 @@ mod tests {
             enabled: Some(false),
             backend: SandboxBackend::Auto,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
 
         let posture = sandbox_posture(
@@ -874,6 +894,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::None,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
 
         let posture = sandbox_posture(
@@ -909,6 +930,7 @@ mod tests {
             enabled: None,
             backend: SandboxBackend::Auto,
             firejail_args: Vec::new(),
+            ..SandboxConfig::default()
         };
 
         let posture = sandbox_posture(

--- a/crates/zeroclaw-runtime/src/security/docker.rs
+++ b/crates/zeroclaw-runtime/src/security/docker.rs
@@ -14,7 +14,9 @@ pub struct DockerSandbox {
 impl Default for DockerSandbox {
     fn default() -> Self {
         Self {
-            image: "alpine:latest".to_string(),
+            // Read from the config crate so the sandbox default and the
+            // `[security.sandbox].image` serde default cannot drift apart.
+            image: zeroclaw_config::schema::DEFAULT_SANDBOX_IMAGE.to_string(),
             workspace_dir: None,
         }
     }
@@ -149,8 +151,15 @@ mod tests {
     }
 
     #[test]
-    fn docker_sandbox_default_image() {
+    fn docker_sandbox_default_image_tracks_the_config_default() {
+        // Asserting against the constant rather than a literal is the point:
+        // the sandbox default and `[security.sandbox].image` now have one
+        // source, and this fails if someone reintroduces a second one.
         let sandbox = DockerSandbox::default();
+        assert_eq!(
+            sandbox.image,
+            zeroclaw_config::schema::DEFAULT_SANDBOX_IMAGE
+        );
         assert_eq!(sandbox.image, "alpine:latest");
     }
 

--- a/docs/book/src/ops/troubleshooting.md
+++ b/docs/book/src/ops/troubleshooting.md
@@ -338,7 +338,7 @@ See [Security → Autonomy levels](../security/autonomy.md).
 
 ### Tool invocations fail inside Docker sandbox
 
-- Container image isn't pulled, run `docker pull <image>` for whatever you have configured under `[security.sandbox].image` (default: `alpine:latest`)
+- Container image isn't pulled, run `docker pull <image>` for the image the sandbox uses. That is `sandbox_image` on the active risk profile (`[risk_profiles.<name>].sandbox_image`), or `alpine:latest` when it is unset
 - Docker daemon not reachable from the ZeroClaw user, check `docker info`
 - Tool needs a device that's not passed through, extend `allow_devices`
 

--- a/src/security_status.rs
+++ b/src/security_status.rs
@@ -3,7 +3,9 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use zeroclaw_config::config::CredentialSurfaceClass;
 use zeroclaw_config::policy::SecurityPolicy;
-use zeroclaw_config::schema::{RiskProfileConfig, SandboxBackend, SandboxConfig};
+use zeroclaw_config::schema::{
+    DEFAULT_SANDBOX_IMAGE, RiskProfileConfig, SandboxBackend, SandboxConfig,
+};
 
 use crate::config::Config;
 
@@ -405,6 +407,13 @@ fn sandbox_config_from_policy(policy: &SecurityPolicy) -> SandboxConfig {
             .map(parse_sandbox_backend)
             .unwrap_or_default(),
         firejail_args: policy.firejail_args.clone(),
+        image: policy
+            .sandbox_image
+            .as_deref()
+            .map(str::trim)
+            .filter(|image| !image.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| DEFAULT_SANDBOX_IMAGE.to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `docs/book/src/ops/troubleshooting.md` told operators to check "whatever you have configured under `[security.sandbox].image`". Nothing could be configured there, and the sandbox image was not configurable at all.
  - `SandboxConfig` carries `#[prefix = "security.sandbox"]`, but it is never a field on `Config`. Its only construction is `RiskProfileConfig::sandbox_config()`, which assembles it at runtime from flat `sandbox_*` keys on the risk profile. `[security.sandbox]` is not a deserialization target, so that table is not read from `config.toml` at all.
  - The image was hardcoded via `DockerSandbox::default_image()`. An operator who needed to pin a digest, or move off a floating tag, had no way to.
- **What this adds:** `sandbox_image` on the risk profile, beside the `sandbox_enabled` and `sandbox_backend` keys that already configure this backend, threaded through `create_sandbox` to where the sandbox is built. Real path: `[risk_profiles.<name>].sandbox_image`.
- **Default is unchanged** at `alpine:latest`, now `DEFAULT_SANDBOX_IMAGE` in the config crate. `DockerSandbox::default()` reads that constant instead of holding its own copy of the literal. Two independent defaults for one value is how the docs and the code drifted apart to begin with.
- **Scope boundary:** does not change which backend is selected, when the sandbox engages, or any other sandbox behaviour. Does not touch `[runtime.docker].image`, which is a separate key for a separate purpose.
- **Blast radius:** `create_sandbox` and its two internal helpers gain an `image` parameter; `RiskProfileConfig` gains an `Option<String>` field, so the three preset profiles and two struct literals in tests were updated. Existing configs are unaffected: the key is optional and absent means the previous hardcoded value.
- **Linked issue(s):** none. Found while auditing user-facing docs for claims the code does not support.
- **Labels:** applied after opening; suggested `security`, `config`, `docs`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `Yes`, if you have Docker available.
- **Interface(s) exercised:** `cli`
- **Setup / preconditions:** a config with a risk profile using the docker sandbox backend.
- **Steps to run:** set `sandbox_image = "alpine:3.20"` under `[risk_profiles.<name>]`, run a shell command through the agent, and observe which image the container runs. Then remove the key and repeat.
- **Expected on this branch (after):** the configured image is used; with the key absent the sandbox runs `alpine:latest` exactly as before.
- **Prior behavior on `master` (before):** the image is always `alpine:latest`; setting anything under `[security.sandbox]` has no effect, because that table is never read.

### How I tested

- **CI checks relied on and why they cover this change:** the target checks and `Test` build and exercise both changed crates; `Docs Style` covers the changed Markdown.
- **Known CI coverage gap, if any:** no test builds a real `DockerSandbox` end to end, because construction requires Docker to be installed and would make the test environment-dependent. The tests cover the config boundary and the shared default; the wiring from `create_sandbox` into `DockerSandbox::with_image` is covered by the type system rather than by an assertion on a built sandbox.
- **Commands run and tail output:**

  ```text
  $ cargo test -p zeroclaw-config --lib sandbox_image
  test schema::tests::sandbox_image_defaults_to_the_shared_constant ... ok
  test schema::tests::sandbox_image_is_configurable ... ok
  test schema::tests::sandbox_image_absent_falls_back_to_the_default ... ok
  test schema::tests::sandbox_image_blank_is_treated_as_unset ... ok
  test result: ok. 4 passed; 0 failed

  $ cargo test -p zeroclaw-config --lib
  test result: ok. 1501 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

  $ cargo fmt --all -- --check          # clean
  $ cargo clippy -p zeroclaw-config -p zeroclaw-runtime --all-targets   # no warnings
  ```

- **Beyond CI, what did you manually verify?** That the key reaches the sandbox rather than only parsing: `sandbox_config()` is asserted to carry the configured image, the default, and the fallback for a blank value. A blank or whitespace value falls back rather than handing Docker an empty image name.
- **Visual interface changed?** `N/A`

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`. The sandbox already pulls its image; this only changes which tag that is.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`
- If any `Yes`, describe the risk and mitigation: n/a

Worth a reviewer's judgement rather than mine: this lets an operator point the sandbox at any image, including one with more installed than `alpine` has. That is the point of the key, but it is a containment-relevant surface, so if you would rather it were validated against an allowlist, say so.

## Compatibility (required)

- Backward compatible? `Yes`. The key is optional and its absence reproduces the previous hardcoded value exactly.
- Config / env / CLI surface changed? `Yes`, additive: `[risk_profiles.<name>].sandbox_image`.
- Rust/MSRV/toolchain floor changed? `No`
- If backward compatibility is `No` or either surface/floor question is `Yes`: no upgrade steps.

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>` restores the hardcoded image. Any config setting the new key would then be ignored rather than failing.
