### PR TITLE
refactor(channels): build every channel's transcription manager one way

### DIFF
--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -270,33 +270,31 @@ impl DiscordChannel {
         self
     }
 
-    /// Configure voice transcription for audio attachments.
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
     pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
-        if !config.enabled {
-            return self;
-        }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(manager) => return self.with_transcription_manager(config, manager),
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, voice transcription disabled"
-                );
-            }
-        }
-        self
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
     }
 
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
     pub(crate) fn with_transcription_manager(
         mut self,
         config: zeroclaw_config::schema::TranscriptionConfig,
-        manager: super::transcription::TranscriptionManager,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        self.transcription_manager = Some(std::sync::Arc::new(manager));
-        self.transcription = Some(config);
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
+            self.transcription = Some(config);
+        }
         self
     }
 

--- a/crates/zeroclaw-channels/src/discord/mod.rs
+++ b/crates/zeroclaw-channels/src/discord/mod.rs
@@ -273,7 +273,7 @@ impl DiscordChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/lark.rs
+++ b/crates/zeroclaw-channels/src/lark.rs
@@ -1241,7 +1241,7 @@ impl LarkChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/lark.rs
+++ b/crates/zeroclaw-channels/src/lark.rs
@@ -1238,35 +1238,31 @@ impl LarkChannel {
         }
     }
 
-    pub fn with_transcription(
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
+    }
+
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
+    pub(crate) fn with_transcription_manager(
         mut self,
         config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        if !config.enabled {
-            return self;
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
+            self.transcription = Some(config);
         }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(m) => {
-                let names = m.available_providers();
-                let m = if names.len() == 1 {
-                    let only = names[0].to_string();
-                    m.with_agent_transcription_provider(only)
-                } else {
-                    m
-                };
-                self.transcription_manager = Some(Arc::new(m));
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, audio transcription disabled"
-                );
-            }
-        }
-        self.transcription = Some(config);
         self
     }
 
@@ -5800,6 +5796,10 @@ mod tests {
         assert!(ch.transcription_manager.is_none());
     }
 
+    /// The manager cannot be built (enabled, but no usable provider), so the
+    /// channel keeps running without transcription. It must not record the
+    /// config either: a config with no manager advertised transcription the
+    /// channel could not perform, which is the drift this shared path removed.
     #[test]
     fn lark_manager_none_and_warn_on_init_failure() {
         let tc = zeroclaw_config::schema::TranscriptionConfig {
@@ -5809,7 +5809,10 @@ mod tests {
         };
         let ch = make_channel().with_transcription(tc);
         assert!(ch.transcription_manager.is_none());
-        assert!(ch.transcription.is_some());
+        assert!(
+            ch.transcription.is_none(),
+            "config is recorded only alongside a manager"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/line.rs
+++ b/crates/zeroclaw-channels/src/line.rs
@@ -816,42 +816,29 @@ impl LineChannel {
         self
     }
 
-    /// Enable voice/audio transcription for incoming LINE audio messages.
-    /// When enabled, `type = "audio"` webhook events are downloaded from the
-    /// LINE Content API and transcribed before being forwarded to the agent.
-    pub fn with_transcription(
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
+    }
+
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
+    pub(crate) fn with_transcription_manager(
         mut self,
-        config: zeroclaw_config::schema::TranscriptionConfig,
+        _config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        if !config.enabled {
-            return self;
-        }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(m) => {
-                let m = if config.local_whisper.is_some() {
-                    m.with_agent_transcription_provider("local_whisper")
-                } else if config.openai.is_some() {
-                    m.with_agent_transcription_provider("openai")
-                } else if config.deepgram.is_some() {
-                    m.with_agent_transcription_provider("deepgram")
-                } else if config.assemblyai.is_some() {
-                    m.with_agent_transcription_provider("assemblyai")
-                } else if config.google.is_some() {
-                    m.with_agent_transcription_provider("google")
-                } else {
-                    m.with_agent_transcription_provider("groq")
-                };
-                self.transcription_manager = Some(Arc::new(m));
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, audio transcription disabled"
-                );
-            }
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
         }
         self
     }

--- a/crates/zeroclaw-channels/src/line.rs
+++ b/crates/zeroclaw-channels/src/line.rs
@@ -819,7 +819,7 @@ impl LineChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -2917,21 +2917,7 @@ pub(crate) fn build_transcription_manager(
     config: &zeroclaw_config::schema::Config,
     agent_provider: &str,
 ) -> anyhow::Result<crate::transcription::TranscriptionManager> {
-    let manager = crate::transcription::TranscriptionManager::from_config_with_provider(
-        config,
-        agent_provider.to_string(),
-    )?;
-    if !agent_provider.is_empty() {
-        return Ok(manager);
-    }
-    let sole_provider = match manager.available_providers().as_slice() {
-        [only] => Some((*only).to_string()),
-        _ => None,
-    };
-    Ok(match sole_provider {
-        Some(alias) => manager.with_agent_transcription_provider(alias),
-        None => manager,
-    })
+    crate::transcription::build_channel_transcription_manager(config, agent_provider)
 }
 
 /// Resolves transcription state from live config at message time. `None` means

--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -348,7 +348,7 @@ impl MattermostChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -345,34 +345,30 @@ impl MattermostChannel {
         self
     }
 
-    pub fn with_transcription(
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
+    }
+
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
+    pub(crate) fn with_transcription_manager(
         mut self,
         config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        if !config.enabled {
-            return self;
-        }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(m) => {
-                let names = m.available_providers();
-                let m = if names.len() == 1 {
-                    let only = names[0].to_string();
-                    m.with_agent_transcription_provider(only)
-                } else {
-                    m
-                };
-                self.transcription_manager = Some(Arc::new(m));
-                self.transcription = Some(config);
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, voice transcription disabled"
-                );
-            }
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
+            self.transcription = Some(config);
         }
         self
     }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -9112,7 +9112,10 @@ fn build_channel_by_id(
                 .with_api_base(tg.api_base_url.clone())
                 .with_ack_reactions(ack)
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
-                .with_transcription(config.transcription.clone())
+                .with_transcription_manager(
+                    config.transcription.clone(),
+                    resolved_transcription_manager(&config, &format!("telegram.{alias}")),
+                )
                 .with_tts(&config)
                 .with_workspace_dir(workspace_dir)
                 .with_approval_timeout_secs(tg.approval_timeout_secs),
@@ -9140,7 +9143,7 @@ fn build_channel_by_id(
                 DiscordChannel::new(
                     dc.bot_token.clone(),
                     dc.guild_ids.clone(),
-                    alias,
+                    alias.clone(),
                     peer_resolver,
                     dc.listen_to_bots,
                     dc.mention_only,
@@ -9152,7 +9155,10 @@ fn build_channel_by_id(
                     dc.draft_update_interval_ms,
                     dc.multi_message_delay_ms,
                 )
-                .with_transcription(config.transcription.clone())
+                .with_transcription_manager(
+                    config.transcription.clone(),
+                    resolved_transcription_manager(&config, &format!("discord.{alias}")),
+                )
                 .with_stall_timeout(dc.stall_timeout_secs)
                 .with_approval_timeout_secs(dc.approval_timeout_secs)
                 .with_intents_mask(dc.intents_mask)
@@ -9191,13 +9197,16 @@ fn build_channel_by_id(
                     bot_token,
                     sl.resolved_app_token(),
                     sl.channel_ids.clone(),
-                    alias,
+                    alias.clone(),
                     peer_resolver,
                 )
                 .with_thread_context_max_messages_resolver(thread_context_max_messages_resolver)
                 .with_workspace_dir(workspace_dir)
                 .with_markdown_blocks(sl.use_markdown_blocks)
-                .with_transcription(config.transcription.clone())
+                .with_transcription_manager(
+                    config.transcription.clone(),
+                    resolved_transcription_manager(&config, &format!("slack.{alias}")),
+                )
                 .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
                 .with_cancel_reaction(sl.cancel_reaction.clone())
                 .with_approval_timeout_secs(sl.approval_timeout_secs),
@@ -10232,6 +10241,12 @@ pub fn register_channels_for_tools(
 #[cfg(any(
     feature = "channel-telegram",
     feature = "channel-discord",
+    feature = "channel-slack",
+    feature = "channel-mattermost",
+    feature = "whatsapp-web",
+    feature = "channel-lark",
+    feature = "channel-line",
+    feature = "channel-qq",
     feature = "voice-wake",
     feature = "channel-matrix",
     feature = "whatsapp-web"
@@ -10245,64 +10260,58 @@ fn resolve_agent_transcription_provider(config: &Config, channel_key: &str) -> S
         .unwrap_or_default()
 }
 
+/// The transcription manager a configured channel instance stores, or `None`.
+///
+/// One path for every transcribing channel: gate on `[transcription].enabled`,
+/// resolve the owning agent's provider for `channel_key`, build the manager
+/// from live config through `transcription::build_channel_transcription_manager`
+/// (typed providers, legacy-key compatibility, sole-provider fallback), and
+/// on failure log once and leave the channel up without transcription.
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-discord",
+    feature = "channel-slack",
+    feature = "channel-mattermost",
+    feature = "whatsapp-web",
+    feature = "channel-lark",
+    feature = "channel-line",
+    feature = "channel-qq"
+))]
+fn resolved_transcription_manager(
+    config: &Config,
+    channel_key: &str,
+) -> Option<Arc<crate::transcription::TranscriptionManager>> {
+    if !config.transcription.enabled {
+        return None;
+    }
+    let provider = resolve_agent_transcription_provider(config, channel_key);
+    match crate::transcription::build_channel_transcription_manager(config, &provider) {
+        Ok(manager) => Some(Arc::new(manager)),
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(
+                        ::serde_json::json!({"channel_key": channel_key, "e": e.to_string()})
+                    ),
+                "transcription manager init failed, voice transcription disabled"
+            );
+            None
+        }
+    }
+}
+
 #[cfg(feature = "channel-discord")]
 fn configure_discord_transcription(
     channel: DiscordChannel,
     config: &Config,
     channel_key: &str,
 ) -> DiscordChannel {
-    if !config.transcription.enabled {
-        return channel;
-    }
-
-    let provider = resolve_agent_transcription_provider(config, channel_key);
-    match crate::transcription::TranscriptionManager::from_config_with_provider(config, provider) {
-        Ok(manager) => channel.with_transcription_manager(config.transcription.clone(), manager),
-        Err(e) => {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                "transcription manager init failed, voice transcription disabled"
-            );
-            channel
-        }
-    }
-}
-
-/// Bind the WhatsApp Web channel's transcription manager to the owning
-/// agent's `transcription_provider`.
-///
-/// `WhatsAppWebChannel::with_transcription` registers legacy `[transcription]`
-/// providers only and leaves the agent alias empty, so typed
-/// `[providers.transcription.<type>.<alias>]` entries are never reachable and
-/// `transcribe()` bails before dispatching. Mirrors
-/// `configure_discord_transcription`.
-#[cfg(feature = "whatsapp-web")]
-fn configure_whatsapp_transcription(
-    channel: WhatsAppWebChannel,
-    config: &Config,
-    channel_key: &str,
-) -> WhatsAppWebChannel {
-    if !config.transcription.enabled {
-        return channel;
-    }
-
-    let provider = resolve_agent_transcription_provider(config, channel_key);
-    match crate::transcription::TranscriptionManager::from_config_with_provider(config, provider) {
-        Ok(manager) => channel.with_transcription_manager(config.transcription.clone(), manager),
-        Err(e) => {
-            ::zeroclaw_log::record!(
-                WARN,
-                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                    .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                "transcription manager init failed, voice transcription disabled"
-            );
-            channel
-        }
-    }
+    channel.with_transcription_manager(
+        config.transcription.clone(),
+        resolved_transcription_manager(config, channel_key),
+    )
 }
 
 #[cfg(feature = "channel-discord")]
@@ -10454,9 +10463,6 @@ fn collect_configured_channels(
             let alias = alias.clone();
             Arc::new(move || cfg_arc.read().channel_voice_peers("telegram", &alias))
         };
-        let channel_key = format!("telegram.{alias}");
-        let agent_transcription_provider =
-            resolve_agent_transcription_provider(&config, &channel_key);
         channels.push(ConfiguredChannel {
             display_name: "Telegram",
             alias: Some(alias.clone()),
@@ -10473,11 +10479,9 @@ fn collect_configured_channels(
                     .with_api_base(tg.api_base_url.clone())
                     .with_ack_reactions(ack)
                     .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
-                    .with_transcription(config.transcription.clone())
-                    .with_agent_transcription_provider(agent_transcription_provider.clone())
-                    .with_typed_transcription_providers(
-                        &config.providers.transcription,
-                        &agent_transcription_provider,
+                    .with_transcription_manager(
+                        config.transcription.clone(),
+                        resolved_transcription_manager(&config, &format!("telegram.{alias}")),
                     )
                     .with_tts(&config)
                     .with_workspace_dir(config.channel_workspace_dir(&format!("telegram.{alias}")))
@@ -10610,7 +10614,10 @@ fn collect_configured_channels(
                     .with_workspace_dir(config.channel_workspace_dir(&format!("slack.{alias}")))
                     .with_markdown_blocks(sl.use_markdown_blocks)
                     .with_proxy_url(sl.proxy_url.clone())
-                    .with_transcription(config.transcription.clone())
+                    .with_transcription_manager(
+                        config.transcription.clone(),
+                        resolved_transcription_manager(&config, &format!("slack.{alias}")),
+                    )
                     .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
                     .with_cancel_reaction(sl.cancel_reaction.clone())
                     .with_approval_timeout_secs(sl.approval_timeout_secs),
@@ -10663,7 +10670,10 @@ fn collect_configured_channels(
                     .with_team_ids(mm.team_ids.clone())
                     .with_discover_dms(mm.discover_dms.unwrap_or(true))
                     .with_proxy_url(mm.proxy_url.clone())
-                    .with_transcription(config.transcription.clone())
+                    .with_transcription_manager(
+                        config.transcription.clone(),
+                        resolved_transcription_manager(&config, &format!("mattermost.{alias}")),
+                    )
                     .with_listen_mode(mm.listen_mode),
                 ),
                 mm,
@@ -10919,7 +10929,7 @@ fn collect_configured_channels(
                         display_name: "WhatsApp",
                         alias: Some(alias.clone()),
                         channel: crate::paced_channel::PacedChannel::wrap(
-                            Arc::new(configure_whatsapp_transcription(
+                            Arc::new(
                                 WhatsAppWebChannel::new(
                                     wa,
                                     alias.clone(),
@@ -10927,13 +10937,18 @@ fn collect_configured_channels(
                                     allowed_groups_resolver,
                                 )
                                 .with_persistence(config_arc.clone())
+                                .with_transcription_manager(
+                                    config.transcription.clone(),
+                                    resolved_transcription_manager(
+                                        &config,
+                                        &format!("whatsapp.{alias}"),
+                                    ),
+                                )
                                 .with_tts(&config)
                                 .with_workspace_dir(workspace_dir)
                                 .with_dm_mention_patterns(wa.dm_mention_patterns.clone())
                                 .with_group_mention_patterns(wa.group_mention_patterns.clone()),
-                                &config,
-                                &format!("whatsapp.{alias}"),
-                            )),
+                            ),
                             wa,
                         ),
                     });
@@ -11290,7 +11305,10 @@ fn collect_configured_channels(
                     .with_per_user_session(lk.per_user_session)
                     .with_ack_reactions(lk.ack_reactions.unwrap_or(config.channels.ack_reactions))
                     .with_streaming(lk.stream_mode, lk.draft_update_interval_ms)
-                    .with_transcription(config.transcription.clone()),
+                    .with_transcription_manager(
+                        config.transcription.clone(),
+                        resolved_transcription_manager(&config, &format!("lark.{alias}")),
+                    ),
             ),
         });
     }
@@ -11337,7 +11355,10 @@ fn collect_configured_channels(
             channel: Arc::new(
                 LineChannel::from_config(ln, alias.clone(), peer_resolver, sender_name_resolver)
                     .with_persistence(config_arc.clone())
-                    .with_transcription(config.transcription.clone()),
+                    .with_transcription_manager(
+                        config.transcription.clone(),
+                        resolved_transcription_manager(&config, &format!("line.{alias}")),
+                    ),
             ),
         });
     }
@@ -11416,7 +11437,10 @@ fn collect_configured_channels(
                 )
                 .with_workspace_dir(config.channel_workspace_dir(&format!("qq.{alias}")))
                 .with_proxy_url(qq.proxy_url.clone())
-                .with_transcription(config.transcription.clone()),
+                .with_transcription_manager(
+                    config.transcription.clone(),
+                    resolved_transcription_manager(&config, &format!("qq.{alias}")),
+                ),
             ),
         });
     }
@@ -11854,8 +11878,8 @@ fn collect_configured_channels(
                             &config,
                             &transcription_channel_key,
                         );
-                        crate::transcription::TranscriptionManager::from_config_with_provider(
-                            &config, provider,
+                        crate::transcription::build_channel_transcription_manager(
+                            &config, &provider,
                         )
                     }),
             ),
@@ -30851,15 +30875,66 @@ This is an example JSON object for profile settings."#;
             "the owning agent's provider must resolve for a whatsapp.<alias> key"
         );
 
-        let manager = crate::transcription::TranscriptionManager::from_config_with_provider(
-            &config, provider,
-        )
-        .expect("typed provider must build a manager");
+        let manager = resolved_transcription_manager(&config, "whatsapp.default")
+            .expect("the shared path must build a manager for the typed provider");
         assert!(
             manager.available_providers().contains(&"groq.fast"),
             "typed provider must register, got {:?}",
             manager.available_providers()
         );
+        assert_eq!(
+            manager.bound_provider(),
+            "groq.fast",
+            "the owning agent's typed provider must be bound, not just registered"
+        );
+    }
+
+    #[cfg(feature = "channel-slack")]
+    #[test]
+    fn resolved_transcription_manager_binds_the_owning_agents_provider() {
+        let mut config = Config {
+            transcription: zeroclaw_config::schema::TranscriptionConfig {
+                enabled: true,
+                api_key: Some("k".to_string()),
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        config.agents.insert(
+            "ops".to_string(),
+            zeroclaw_config::schema::AliasedAgentConfig {
+                enabled: true,
+                channels: vec!["slack.support".into()],
+                transcription_provider: "groq.default".into(),
+                ..Default::default()
+            },
+        );
+        let manager = resolved_transcription_manager(&config, "slack.support")
+            .expect("an enabled legacy groq section builds a manager");
+        // The agent's typed-alias preference resolves to the legacy type key
+        // that is actually registered, instead of failing at transcribe time.
+        assert_eq!(manager.available_providers(), vec!["groq"]);
+        let mut disabled = config.clone();
+        disabled.transcription.enabled = false;
+        assert!(resolved_transcription_manager(&disabled, "slack.support").is_none());
+    }
+
+    #[cfg(feature = "channel-slack")]
+    #[test]
+    fn resolved_transcription_manager_falls_back_to_the_sole_provider_without_a_preference() {
+        let config = Config {
+            transcription: zeroclaw_config::schema::TranscriptionConfig {
+                enabled: true,
+                api_key: Some("k".to_string()),
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        // No owning agent declares a preference: the lone provider is bound so
+        // a single-provider deployment keeps working.
+        let manager = resolved_transcription_manager(&config, "slack.support")
+            .expect("an enabled legacy groq section builds a manager");
+        assert_eq!(manager.available_providers(), vec!["groq"]);
     }
 
     #[cfg(feature = "voice-wake")]

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -361,43 +361,30 @@ impl QQChannel {
         self
     }
 
-    /// Configure voice transcription for QQ audio attachments.
-    pub fn with_transcription(
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
+    }
+
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
+    pub(crate) fn with_transcription_manager(
         mut self,
-        config: zeroclaw_config::schema::TranscriptionConfig,
+        _config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        if !config.enabled {
-            return self;
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
         }
-
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(manager) => {
-                let sole_provider = {
-                    let providers = manager.available_providers();
-                    if providers.len() == 1 {
-                        Some(providers[0].to_string())
-                    } else {
-                        None
-                    }
-                };
-                let manager = if let Some(provider) = sole_provider {
-                    manager.with_agent_transcription_provider(provider)
-                } else {
-                    manager
-                };
-                self.transcription_manager = Some(Arc::new(manager));
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                    "transcription manager init failed, QQ voice transcription disabled"
-                );
-            }
-        }
-
         self
     }
 

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -364,7 +364,7 @@ impl QQChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -586,28 +586,30 @@ impl SlackChannel {
         format!("https://slack.com/api/{method}")
     }
 
-    /// Configure voice transcription for audio file attachments.
-    pub fn with_transcription(
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
+    }
+
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
+    pub(crate) fn with_transcription_manager(
         mut self,
         config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        if !config.enabled {
-            return self;
-        }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(m) => {
-                self.transcription_manager = Some(std::sync::Arc::new(m));
-                self.transcription = Some(config);
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, voice transcription disabled"
-                );
-            }
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
+            self.transcription = Some(config);
         }
         self
     }
@@ -6141,6 +6143,30 @@ mod tests {
             Arc::new(Vec::new),
         );
         assert_eq!(ch.channel_ids, vec!["C12345".to_string()]);
+    }
+
+    /// REGRESSION: Slack's own `with_transcription` never bound a provider, so
+    /// every audio attachment failed with "no transcription_provider
+    /// configured" even in a single-provider deployment. The shared snapshot
+    /// path binds the lone provider; the daemon path binds the owning agent's.
+    #[test]
+    fn with_transcription_binds_the_sole_provider() {
+        let tc = zeroclaw_config::schema::TranscriptionConfig {
+            enabled: true,
+            api_key: Some("test_key".to_string()),
+            ..Default::default()
+        };
+        let ch = SlackChannel::new(
+            unique_test_bot_token(),
+            None,
+            vec!["C12345".into()],
+            "slack_test_alias",
+            Arc::new(Vec::new),
+        )
+        .with_transcription(tc);
+        let manager = ch.transcription_manager.as_ref().expect("manager is built");
+        assert_eq!(manager.bound_provider(), "groq");
+        assert!(ch.transcription.is_some());
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -589,7 +589,7 @@ impl SlackChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -990,86 +990,30 @@ impl TelegramChannel {
         self
     }
 
-    /// Configure voice transcription.
-    pub fn with_transcription(
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
+    }
+
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
+    pub(crate) fn with_transcription_manager(
         mut self,
         config: zeroclaw_config::schema::TranscriptionConfig,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        if !config.enabled {
-            return self;
-        }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(m) => {
-                let names = m.available_providers();
-                let m = if names.len() == 1 {
-                    let only = names[0].to_string();
-                    m.with_agent_transcription_provider(only)
-                } else {
-                    m
-                };
-                self.transcription_manager = Some(std::sync::Arc::new(m));
-                self.transcription = Some(config);
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, voice transcription disabled"
-                );
-            }
-        }
-        self
-    }
-
-    pub fn with_typed_transcription_providers(
-        mut self,
-        typed: &zeroclaw_config::providers::TranscriptionProviders,
-        agent_alias: &str,
-    ) -> Self {
-        if agent_alias.is_empty() || typed.is_empty() {
-            return self;
-        }
-        let base = match self.transcription_manager.take() {
-            Some(arc) => match std::sync::Arc::try_unwrap(arc) {
-                Ok(m) => m,
-                Err(arc) => {
-                    self.transcription_manager = Some(arc);
-                    return self;
-                }
-            },
-            None => super::transcription::TranscriptionManager::empty(),
-        };
-        let updated = base
-            .with_typed_providers(typed)
-            .with_agent_transcription_provider(agent_alias.to_string());
-        self.transcription_manager = Some(std::sync::Arc::new(updated));
-        self
-    }
-
-    /// Set the agent transcription provider alias on the internal TranscriptionManager.
-    /// Must be called after `with_transcription`. No-op if transcription was not configured.
-    /// The alias should be the provider type key ("groq", "openai", etc.) registered in
-    /// the TranscriptionManager, or the full "type.alias" form (the type prefix is extracted).
-    pub fn with_agent_transcription_provider(mut self, alias: impl Into<String>) -> Self {
-        let alias = alias.into();
-        if alias.is_empty() {
-            return self;
-        }
-        // Resolve "groq.default" → "groq" (TranscriptionManager keys by type, not full alias)
-        let key = alias.split('.').next().unwrap_or(&alias).to_string();
-        if let Some(manager) = self.transcription_manager.take() {
-            match std::sync::Arc::try_unwrap(manager) {
-                Ok(m) => {
-                    self.transcription_manager = Some(std::sync::Arc::new(
-                        m.with_agent_transcription_provider(key),
-                    ));
-                }
-                Err(arc) => {
-                    self.transcription_manager = Some(arc);
-                }
-            }
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
+            self.transcription = Some(config);
         }
         self
     }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -993,7 +993,7 @@ impl TelegramChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see

--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -1203,12 +1203,163 @@ impl TranscriptionManager {
         Ok(())
     }
 
+    /// The provider `transcribe` will dispatch to, or empty when unbound.
+    /// Test-only: lets channel tests assert the binding without a network
+    /// call.
+    #[cfg(all(
+        test,
+        any(
+            feature = "channel-telegram",
+            feature = "channel-discord",
+            feature = "channel-slack",
+            feature = "channel-mattermost",
+            feature = "whatsapp-web",
+            feature = "channel-lark",
+            feature = "channel-line",
+            feature = "channel-qq",
+            feature = "channel-matrix",
+            feature = "voice-wake",
+        )
+    ))]
+    pub(crate) fn bound_provider(&self) -> &str {
+        &self.agent_transcription_provider
+    }
+
     /// List registered transcription_provider names.
     pub fn available_providers(&self) -> Vec<&str> {
         self.transcription_providers
             .keys()
             .map(|k| k.as_str())
             .collect()
+    }
+}
+
+/// Bind the provider a channel's manager should dispatch to.
+///
+/// `agent_provider` is the owning agent's `transcription_provider` as the
+/// orchestrator resolved it — never a channel alias. The rules, in order:
+///
+/// 1. An explicit preference that names a registered provider wins as-is.
+/// 2. A `type.alias` preference whose exact key is not registered, but whose
+///    `type` is — a deployment with only the legacy `[transcription]` section
+///    and an agent that was written against typed aliases — binds the type
+///    key. This is the compatibility fallback one channel used to apply on
+///    its own; it now applies everywhere, and only when needed.
+/// 3. No preference and exactly one registered provider: bind it. A lone
+///    provider is unambiguous, and the alternative is a hard failure for every
+///    single-provider deployment.
+/// 4. Otherwise leave the choice unbound: with several providers a silent
+///    pick would route audio to an arbitrary vendor, and `transcribe` fails
+///    loud instead.
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-discord",
+    feature = "channel-slack",
+    feature = "channel-mattermost",
+    feature = "whatsapp-web",
+    feature = "channel-lark",
+    feature = "channel-line",
+    feature = "channel-qq",
+    feature = "channel-matrix",
+    feature = "voice-wake"
+))]
+fn bind_channel_provider(
+    manager: TranscriptionManager,
+    agent_provider: &str,
+) -> TranscriptionManager {
+    let registered: Vec<String> = manager
+        .available_providers()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    if !agent_provider.is_empty() {
+        if registered.iter().any(|name| name == agent_provider) {
+            return manager.with_agent_transcription_provider(agent_provider);
+        }
+        if let Some((family, _alias)) = agent_provider.split_once('.')
+            && registered.iter().any(|name| name == family)
+        {
+            return manager.with_agent_transcription_provider(family);
+        }
+        return manager.with_agent_transcription_provider(agent_provider);
+    }
+    match registered.as_slice() {
+        [only] => manager.with_agent_transcription_provider(only.clone()),
+        _ => manager,
+    }
+}
+
+/// The one way a channel builds its transcription manager from live config.
+///
+/// Registers every configured provider — legacy `[transcription]` and typed
+/// `[providers.transcription.<type>.<alias>]` alike — and binds the provider
+/// per [`bind_channel_provider`]. Built from `Config` rather than a
+/// `TranscriptionConfig` snapshot so typed providers are visible and
+/// reloadable provider policy is never copied into a channel handle.
+///
+/// # Errors
+///
+/// Returns the manager constructor's error: transcription is enabled but no
+/// provider registered, or an invalid audio bound.
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-discord",
+    feature = "channel-slack",
+    feature = "channel-mattermost",
+    feature = "whatsapp-web",
+    feature = "channel-lark",
+    feature = "channel-line",
+    feature = "channel-qq",
+    feature = "channel-matrix",
+    feature = "voice-wake"
+))]
+pub(crate) fn build_channel_transcription_manager(
+    config: &Config,
+    agent_provider: &str,
+) -> Result<TranscriptionManager> {
+    let manager =
+        TranscriptionManager::from_config_with_provider(config, agent_provider.to_string())?;
+    Ok(bind_channel_provider(manager, agent_provider))
+}
+
+/// Build a channel's manager from a `[transcription]` snapshot alone.
+///
+/// This is the compatibility and test path behind every channel's
+/// `with_transcription(config)`. It cannot see typed providers or the owning
+/// agent, so it can only bind a lone registered provider (rule 3 above). It
+/// returns `None` when transcription is disabled or the manager cannot be
+/// built; the failure is logged once here rather than in every channel, and
+/// the channel stays up without transcription.
+#[cfg(any(
+    feature = "channel-telegram",
+    feature = "channel-discord",
+    feature = "channel-slack",
+    feature = "channel-mattermost",
+    feature = "whatsapp-web",
+    feature = "channel-lark",
+    feature = "channel-line",
+    feature = "channel-qq",
+    feature = "channel-matrix",
+    feature = "voice-wake"
+))]
+pub(crate) fn manager_from_snapshot(
+    config: &TranscriptionConfig,
+) -> Option<std::sync::Arc<TranscriptionManager>> {
+    if !config.enabled {
+        return None;
+    }
+    match TranscriptionManager::new(config) {
+        Ok(manager) => Some(std::sync::Arc::new(bind_channel_provider(manager, ""))),
+        Err(e) => {
+            ::zeroclaw_log::record!(
+                WARN,
+                ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
+                    .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
+                    .with_attrs(::serde_json::json!({"e": e.to_string()})),
+                "transcription manager init failed, voice transcription disabled"
+            );
+            None
+        }
     }
 }
 
@@ -2660,6 +2811,102 @@ mod tests {
         assert!(
             !err.contains("no transcription_provider configured"),
             "dotted alias must resolve; got: {err}"
+        );
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        feature = "channel-telegram",
+        feature = "channel-discord",
+        feature = "channel-slack",
+        feature = "channel-mattermost",
+        feature = "whatsapp-web",
+        feature = "channel-lark",
+        feature = "channel-line",
+        feature = "channel-qq",
+        feature = "channel-matrix",
+        feature = "voice-wake"
+    )
+))]
+mod channel_builder_tests {
+    use super::*;
+
+    fn legacy_groq() -> TranscriptionConfig {
+        TranscriptionConfig {
+            enabled: true,
+            api_key: Some("k".to_string()),
+            ..TranscriptionConfig::default()
+        }
+    }
+
+    fn config_with_legacy_groq() -> Config {
+        Config {
+            transcription: legacy_groq(),
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn an_explicit_registered_provider_wins() {
+        let manager = build_channel_transcription_manager(&config_with_legacy_groq(), "groq")
+            .expect("legacy groq registers");
+        assert_eq!(manager.agent_transcription_provider, "groq");
+    }
+
+    #[test]
+    fn a_typed_alias_preference_binds_the_legacy_type_when_only_the_type_is_registered() {
+        // An agent written against `groq.default` on a deployment that only has
+        // the legacy `[transcription]` section: the exact key does not exist,
+        // the type does. Binding the type is what one channel used to do by
+        // hand; every channel now gets it.
+        let manager =
+            build_channel_transcription_manager(&config_with_legacy_groq(), "groq.default")
+                .expect("legacy groq registers");
+        assert_eq!(manager.agent_transcription_provider, "groq");
+    }
+
+    #[test]
+    fn an_unregistered_preference_is_bound_verbatim_so_transcribe_fails_loud_naming_it() {
+        let manager = build_channel_transcription_manager(&config_with_legacy_groq(), "deepgram.x")
+            .expect("legacy groq registers");
+        assert_eq!(manager.agent_transcription_provider, "deepgram.x");
+    }
+
+    #[test]
+    fn no_preference_binds_the_sole_provider_and_leaves_several_unbound() {
+        let sole = build_channel_transcription_manager(&config_with_legacy_groq(), "")
+            .expect("legacy groq registers");
+        assert_eq!(sole.agent_transcription_provider, "groq");
+
+        let mut two = config_with_legacy_groq();
+        two.transcription.openai = Some(zeroclaw_config::schema::OpenAiSttConfig {
+            api_key: Some("k".to_string()),
+            ..Default::default()
+        });
+        let manager =
+            build_channel_transcription_manager(&two, "").expect("two providers register");
+        assert_eq!(manager.available_providers().len(), 2);
+        assert!(
+            manager.agent_transcription_provider.is_empty(),
+            "with several providers the choice stays unbound rather than silently picked"
+        );
+    }
+
+    #[test]
+    fn snapshot_path_gates_on_enabled_binds_the_sole_provider_and_swallows_failure() {
+        assert!(manager_from_snapshot(&TranscriptionConfig::default()).is_none());
+        let manager = manager_from_snapshot(&legacy_groq()).expect("sole provider binds");
+        assert_eq!(manager.agent_transcription_provider, "groq");
+        let enabled_but_empty = TranscriptionConfig {
+            enabled: true,
+            ..TranscriptionConfig::default()
+        };
+        assert!(
+            manager_from_snapshot(&enabled_but_empty).is_none(),
+            "a manager that cannot be built is reported once and the channel stays up"
         );
     }
 }

--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -1205,22 +1205,9 @@ impl TranscriptionManager {
 
     /// The provider `transcribe` will dispatch to, or empty when unbound.
     /// Test-only: lets channel tests assert the binding without a network
-    /// call.
-    #[cfg(all(
-        test,
-        any(
-            feature = "channel-telegram",
-            feature = "channel-discord",
-            feature = "channel-slack",
-            feature = "channel-mattermost",
-            feature = "whatsapp-web",
-            feature = "channel-lark",
-            feature = "channel-line",
-            feature = "channel-qq",
-            feature = "channel-matrix",
-            feature = "voice-wake",
-        )
-    ))]
+    /// call. Gated on the two channels whose tests assert it, so no feature
+    /// shape compiles an unused method.
+    #[cfg(all(test, any(feature = "channel-slack", feature = "whatsapp-web")))]
     pub(crate) fn bound_provider(&self) -> &str {
         &self.agent_transcription_provider
     }

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -623,50 +623,33 @@ impl WhatsAppWebChannel {
         self.send(message).await
     }
 
-    /// Configure voice transcription (STT) for incoming voice notes.
+    /// Configure voice transcription from a `[transcription]` snapshot.
+    ///
+    /// Compatibility and test path. The daemon routes every channel through
+    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// config and the owning agent's resolved provider; this path can only see
+    /// the legacy section, so it binds a lone registered provider and
+    /// otherwise leaves the choice unbound (see
+    /// `transcription::manager_from_snapshot`).
     #[cfg(feature = "whatsapp-web")]
-    pub fn with_transcription(
-        mut self,
-        config: zeroclaw_config::schema::TranscriptionConfig,
-    ) -> Self {
-        if !config.enabled {
-            return self;
-        }
-        match super::transcription::TranscriptionManager::new(&config) {
-            Ok(m) => {
-                self.transcription_manager = Some(std::sync::Arc::new(m));
-                self.transcription = Some(config);
-            }
-            Err(e) => {
-                ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"e": e.to_string()})),
-                    "transcription manager init failed, voice transcription disabled"
-                );
-            }
-        }
-        self
+    pub fn with_transcription(self, config: zeroclaw_config::schema::TranscriptionConfig) -> Self {
+        let manager = super::transcription::manager_from_snapshot(&config);
+        self.with_transcription_manager(config, manager)
     }
 
-    /// Attach a transcription manager the caller already resolved against the
-    /// owning agent's `transcription_provider`.
-    ///
-    /// [`Self::with_transcription`] registers legacy `[transcription]`
-    /// providers only and leaves the agent alias empty, so
-    /// `TranscriptionManager::transcribe` can never select a provider. Channel
-    /// wiring uses this instead, mirroring [`Self::with_tts`], which already
-    /// binds the channel-owning agent.
+    /// Store an already-built transcription manager, or nothing. The config is
+    /// recorded only alongside a manager, so a channel never advertises
+    /// transcription it cannot perform.
     #[cfg(feature = "whatsapp-web")]
-    #[must_use]
-    pub fn with_transcription_manager(
+    pub(crate) fn with_transcription_manager(
         mut self,
         config: zeroclaw_config::schema::TranscriptionConfig,
-        manager: super::transcription::TranscriptionManager,
+        manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     ) -> Self {
-        self.transcription_manager = Some(std::sync::Arc::new(manager));
-        self.transcription = Some(config);
+        if let Some(manager) = manager {
+            self.transcription_manager = Some(manager);
+            self.transcription = Some(config);
+        }
         self
     }
 
@@ -3544,6 +3527,14 @@ impl WhatsAppWebChannel {
         self
     }
 
+    pub(crate) fn with_transcription_manager(
+        self,
+        _config: zeroclaw_config::schema::TranscriptionConfig,
+        _manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
+    ) -> Self {
+        self
+    }
+
     pub fn with_tts(self, _config: zeroclaw_config::schema::TtsConfig) -> Self {
         self
     }
@@ -5120,11 +5111,9 @@ mod tests {
                 ..Default::default()
             },
         );
-        let manager = super::super::transcription::TranscriptionManager::from_config_with_provider(
-            &config,
-            "groq.fast".to_string(),
-        )
-        .expect("typed provider must build a manager");
+        let manager =
+            super::super::transcription::build_channel_transcription_manager(&config, "groq.fast")
+                .expect("typed provider must build a manager");
 
         let cfg = zeroclaw_config::schema::WhatsAppConfig {
             enabled: true,
@@ -5137,13 +5126,41 @@ mod tests {
             Arc::new(|| vec!["+1234567890".into()]),
             Arc::new(Vec::new),
         )
-        .with_transcription_manager(config.transcription.clone(), manager);
+        .with_transcription_manager(config.transcription.clone(), Some(Arc::new(manager)));
 
         assert!(ch.transcription.is_some());
-        assert!(
-            ch.transcription_manager.is_some(),
-            "caller-resolved manager must be installed on the channel"
-        );
+        let manager = ch
+            .transcription_manager
+            .as_ref()
+            .expect("caller-resolved manager must be installed on the channel");
+        assert_eq!(manager.bound_provider(), "groq.fast");
+    }
+
+    /// REGRESSION: WhatsApp Web's own `with_transcription` never bound a
+    /// provider, so voice notes always failed with "no transcription_provider
+    /// configured". The shared snapshot path binds the lone provider.
+    #[test]
+    #[cfg(feature = "whatsapp-web")]
+    fn with_transcription_binds_the_sole_provider() {
+        let tc = zeroclaw_config::schema::TranscriptionConfig {
+            enabled: true,
+            api_key: Some("test_key".to_string()),
+            ..Default::default()
+        };
+        let cfg = zeroclaw_config::schema::WhatsAppConfig {
+            enabled: true,
+            session_path: Some("/tmp/test-whatsapp.db".into()),
+            ..Default::default()
+        };
+        let ch = WhatsAppWebChannel::new(
+            &cfg,
+            "whatsapp_web_test_alias",
+            Arc::new(|| vec!["+1234567890".into()]),
+            Arc::new(Vec::new),
+        )
+        .with_transcription(tc);
+        let manager = ch.transcription_manager.as_ref().expect("manager is built");
+        assert_eq!(manager.bound_provider(), "groq");
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -626,7 +626,7 @@ impl WhatsAppWebChannel {
     /// Configure voice transcription from a `[transcription]` snapshot.
     ///
     /// Compatibility and test path. The daemon routes every channel through
-    /// [`Self::with_transcription_manager`] with a manager built from live
+    /// `with_transcription_manager` with a manager built from live
     /// config and the owning agent's resolved provider; this path can only see
     /// the legacy section, so it binds a lone registered provider and
     /// otherwise leaves the choice unbound (see


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions).
- **What changed and why:** Eight native channels each carried a copy of `with_transcription`, and the copies had drifted in ways that produced four serially-fixed identical bugs (#9153, #10032, #10487, #10494) and left six channels unable to see the owning agent's `transcription_provider` at all (two of them could never transcribe). This PR puts the rule in one place:
  - `transcription::build_channel_transcription_manager(&Config, agent_provider)` builds from live config (legacy + typed providers), binds the owning agent's resolved provider, falls back to the legacy type key for a `type.alias` preference that only the type registers, binds a lone provider when there is no preference, and otherwise leaves the choice unbound so `transcribe` fails loud.
  - The orchestrator's `resolved_transcription_manager(&Config, channel_key)` adds the enabled gate and the single warn-and-continue failure path; every channel site (daemon and one-shot `build_channel_by_id`) goes through it.
  - Each channel keeps one storage setter, `with_transcription_manager`; `with_transcription(config)` becomes the compatibility/test path over a shared `manager_from_snapshot`, with identical semantics everywhere (config recorded only alongside a manager).
  - Matrix's helper delegates to the shared one; Telegram's two private builder methods (a typed-provider workaround and a hand-rolled `type.alias` truncation) are removed.
  - While this branch was parked, #10692 landed on master with a WhatsApp-only copy of the same fix (an orchestrator wrapper `configure_whatsapp_transcription` plus a by-value `with_transcription_manager` on the channel). Both are folded into the shared path here: the wrapper is gone, WhatsApp uses the same `Option<Arc<..>>` setter as every other channel, and #10692's regression test is kept and now asserts the bound provider through the shared resolver.
- **Scope boundary:** No change to the transcription providers themselves, to `TranscriptionManager`'s public API, or to Voice Wake's factory shape (it now calls the shared builder). No change to which config keys exist. Other channel slop (HTTP status handling, proxy-client bypasses, backoff loops, dedup policies, `collect_configured_channels`) is deliberately left for follow-up PRs.
- **Blast radius:** `crates/zeroclaw-channels` only: `transcription.rs`, `orchestrator/mod.rs`, and the eight channel modules (discord, lark, line, matrix, mattermost, qq, slack, telegram, whatsapp_web). Behavior changes are all in the direction of the four fixes (see Compatibility).
- **Linked issue(s):** Related #9153, #10032, #10487, #10494 (the serial fixes this consolidates); #10692 (WhatsApp's copy of the fix, consolidated here).
- **Labels:** `channel`, `refactor`, `risk:medium`, `size:M` (maintainers to confirm).

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes` — for one of the six channels that never bound a provider before (e.g. Slack).
- **Interface(s) exercised:** `channel` (slack / mattermost / whatsapp / lark / line / qq).
- **Setup / preconditions:** a config with `[transcription] enabled = true` and a Groq `api_key`, an agent owning `slack.<alias>` with `transcription_provider = "groq.default"`.
- **Steps to run:** start the daemon; send a voice/audio attachment to the Slack channel.
- **Expected on this branch (after):** the attachment is transcribed via Groq; `plugin`-independent — no errors about a missing provider.
- **Prior behavior on `master` (before):** Slack stored a manager with no bound provider, so every audio attachment failed with "Agent has no transcription_provider configured".

### How I tested

- **CI checks relied on and why they cover this change:** `Test` (channels crate under `channels-full`), `Lint` (clippy + comment hygiene), the no-default-features / single-feature build matrix (the new helpers are `cfg`-gated on the union of transcribing channel features).
- **Known CI coverage gap, if any:** none identified.
- **Commands run and tail output:**

```text
# rebased onto upstream/master c18478e6f7 (post v0.8.5); branch head b1e9188bc4
cargo fmt --all -- --check -> clean
scripts/ci/comment_hygiene_gate.sh -> Comment hygiene gate passed.

cargo clippy -p zeroclaw-channels --features channels-full --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.49s

cargo clippy -p zeroclaw-channels --no-default-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.41s

cargo clippy -p zeroclaw-channels --no-default-features --features whatsapp-web --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 36s

cargo test --locked -p zeroclaw-channels --features channels-full --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 56.38s
    test result: ok. 2636 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 35.45s

# CI-shape workspace check on the same head
cargo check --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 17s   (no errors, no warnings)
```

- **Beyond CI, what did you manually verify?** That every orchestrator site (10 daemon/one-shot `with_transcription` sites + Discord's `configure_discord_transcription` + the Voice Wake factory, and the WhatsApp wrapper #10692 added on master) now routes through the shared builder, and that each channel's existing `with_transcription_*` tests keep passing under the shared snapshot path. I did NOT run a live-daemon audio transcription.
- **Visual interface changed?** `N/A`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`.
- New external network calls? `No` — the same providers are called; six channels can now reach a configured provider they previously could not bind.
- Secrets / tokens / credentials handling changed? `No`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- Prompt injection or untrusted model-visible text introduced/changed? `No`.

## Compatibility (required)

- Backward compatible? **Mostly.** Existing config keys are unchanged. Behavior changes, all toward the four fixes' rule: Slack, Mattermost, WhatsApp Web, Lark, LINE and QQ now bind the owning agent's provider (and see typed providers); LINE no longer picks a provider by a hard-coded precedence when several are configured (it stays unbound like every other channel, and the agent's preference is used instead); Lark no longer records a transcription config without a manager; the one-shot Discord path is routed through the same resolver as the daemon path.
- Config / env / CLI surface changed? `No`.
- Rust/MSRV/toolchain floor changed? `No`.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-squash-sha>`; no data or config migration.
- **Feature flags or config toggles:** none.
- **Observable failure symptoms:** a channel logging `transcription manager init failed` at startup, or `transcription: provider not configured` on an audio message — both name the channel key and the configured providers.
