### PR TITLE
fix(channels): route every outbound HTTP client through the runtime proxy

### DIFF
--- a/crates/zeroclaw-channels/src/clawdtalk.rs
+++ b/crates/zeroclaw-channels/src/clawdtalk.rs
@@ -36,10 +36,12 @@ impl ClawdTalkChannel {
             from_number: config.from_number,
             allowed_destinations: config.allowed_destinations,
             alias: alias.into(),
-            client: Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
-                .build()
-                .unwrap_or_else(|_| Client::new()),
+            client: zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+                Client::builder().timeout(std::time::Duration::from_secs(30)),
+                "channel.clawdtalk",
+            )
+            .build()
+            .unwrap_or_else(|_| Client::new()),
         }
     }
 

--- a/crates/zeroclaw-channels/src/gmail_push.rs
+++ b/crates/zeroclaw-channels/src/gmail_push.rs
@@ -166,10 +166,12 @@ impl GmailPushChannel {
         alias: impl Into<String>,
         peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     ) -> Self {
-        let http = Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .expect("failed to build HTTP client");
+        let http = zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+            Client::builder().timeout(Duration::from_secs(30)),
+            "channel.gmail_push",
+        )
+        .build()
+        .expect("failed to build HTTP client");
         Self {
             config,
             alias: alias.into(),

--- a/crates/zeroclaw-channels/src/link_enricher.rs
+++ b/crates/zeroclaw-channels/src/link_enricher.rs
@@ -77,11 +77,17 @@ fn redirect_policy() -> reqwest::redirect::Policy {
 }
 
 fn http_client_builder(timeout_secs: u64) -> reqwest::ClientBuilder {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
-        .connect_timeout(Duration::from_secs(5))
-        .redirect(redirect_policy())
-        .user_agent("ZeroClaw/0.1 (link-enricher)")
+    // The SSRF redirect policy and identity stay as they are; only the
+    // deployment's runtime proxy is applied on top, like every other
+    // outbound client in this crate.
+    zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(timeout_secs))
+            .connect_timeout(Duration::from_secs(5))
+            .redirect(redirect_policy())
+            .user_agent("ZeroClaw/0.1 (link-enricher)"),
+        "channel.link_enricher",
+    )
 }
 
 fn http_client(timeout_secs: u64) -> reqwest::Result<reqwest::Client> {

--- a/crates/zeroclaw-channels/src/linq.rs
+++ b/crates/zeroclaw-channels/src/linq.rs
@@ -29,7 +29,7 @@ impl LinqChannel {
             from_phone,
             alias: alias.into(),
             peer_resolver,
-            client: reqwest::Client::new(),
+            client: zeroclaw_config::schema::build_runtime_proxy_client("channel.linq"),
         }
     }
 

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1715,15 +1715,17 @@ mod client {
             .as_deref()
             .context("matrix: whoami requires access_token")?;
         let url = matrix_client_api_url(homeserver, WHOAMI_ENDPOINT);
-        let response = reqwest::Client::builder()
-            .timeout(WHOAMI_TIMEOUT)
-            .build()
-            .context("matrix: build whoami HTTP client")?
-            .get(url)
-            .bearer_auth(access_token)
-            .send()
-            .await
-            .context("matrix: whoami request failed")?;
+        let response = zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+            reqwest::Client::builder().timeout(WHOAMI_TIMEOUT),
+            "channel.matrix",
+        )
+        .build()
+        .context("matrix: build whoami HTTP client")?
+        .get(url)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .context("matrix: whoami request failed")?;
         let status = response.status();
 
         if !status.is_success() {
@@ -3388,12 +3390,15 @@ mod outbound {
                 }
                 attempt.follow()
             });
-            reqwest::Client::builder()
-                .timeout(MARKER_HTTP_TIMEOUT)
-                .redirect(redirect_policy)
-                .user_agent("zeroclaw-matrix/1.0")
-                .build()
-                .expect("default reqwest client config never fails to build")
+            zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+                reqwest::Client::builder()
+                    .timeout(MARKER_HTTP_TIMEOUT)
+                    .redirect(redirect_policy)
+                    .user_agent("zeroclaw-matrix/1.0"),
+                "channel.matrix",
+            )
+            .build()
+            .expect("default reqwest client config never fails to build")
         })
     }
 

--- a/crates/zeroclaw-channels/src/notion.rs
+++ b/crates/zeroclaw-channels/src/notion.rs
@@ -55,7 +55,7 @@ impl NotionChannel {
             alias: alias.into(),
             status_type: Arc::new(RwLock::new("select".to_string())),
             inflight: Arc::new(RwLock::new(HashSet::new())),
-            http: reqwest::Client::new(),
+            http: zeroclaw_config::schema::build_runtime_proxy_client("channel.notion"),
             recover_stale,
         }
     }

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -553,7 +553,6 @@ impl SlackChannel {
         self
     }
 
-    /// Set a per-channel proxy URL that overrides the global proxy config.
     /// Enable the newer `markdown` block type for richer formatting.
     /// Only use this if your Slack workspace supports it.
     pub fn with_markdown_blocks(mut self, enabled: bool) -> Self {
@@ -561,6 +560,7 @@ impl SlackChannel {
         self
     }
 
+    /// Set a per-channel proxy URL that overrides the global proxy config.
     pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
         self.proxy_url = proxy_url;
         self

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -611,7 +611,6 @@ pub struct TelegramChannel {
     peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     persist: Option<Arc<RwLock<Config>>>,
     pairing: Option<PairingGuard>,
-    client: reqwest::Client,
     typing_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     stream_mode: StreamMode,
     draft_update_interval_ms: u64,
@@ -896,7 +895,6 @@ impl TelegramChannel {
             peer_resolver,
             persist: None,
             pairing,
-            client: reqwest::Client::new(),
             stream_mode: StreamMode::Off,
             draft_update_interval_ms: TELEGRAM_DRAFT_UPDATE_INTERVAL_MS,
             last_draft_edit: Mutex::new(std::collections::HashMap::new()),
@@ -1438,6 +1436,7 @@ impl TelegramChannel {
             // Finalize path: text is already the final answer — no debounce.
             let text = content.to_string();
             let recipient = recipient.to_string();
+            let proxy_url = self.proxy_url.clone();
             zeroclaw_spawn::spawn!(async move {
                 let is_config_voice_peer = voice_peer_resolver().contains(&recipient);
                 if !is_config_voice_peer && let Ok(mut vc) = voice_chats.lock() {
@@ -1446,6 +1445,7 @@ impl TelegramChannel {
                 match Self::synthesize_and_send_voice(
                     &api_base,
                     &bot_token,
+                    proxy_url.as_deref(),
                     &chat_id,
                     thread_id.as_deref(),
                     &text,
@@ -1490,6 +1490,7 @@ impl TelegramChannel {
 
         let pending = self.pending_voice.clone();
         let recipient = recipient.to_string();
+        let proxy_url = self.proxy_url.clone();
         zeroclaw_spawn::spawn!(async move {
             // Wait 10 seconds — long enough for the agent to finish its
             // full tool chain and send the final answer.
@@ -1513,6 +1514,7 @@ impl TelegramChannel {
                 match Self::synthesize_and_send_voice(
                     &api_base,
                     &bot_token,
+                    proxy_url.as_deref(),
                     &chat_id,
                     thread_id.as_deref(),
                     &text,
@@ -1551,6 +1553,7 @@ impl TelegramChannel {
     async fn synthesize_and_send_voice(
         api_base: &str,
         bot_token: &str,
+        proxy_url: Option<&str>,
         chat_id: &str,
         thread_id: Option<&str>,
         text: &str,
@@ -1573,7 +1576,10 @@ impl TelegramChannel {
         let (method, field, filename, mime) = telegram_audio_send_spec("opus")?;
 
         let url = format!("{api_base}/bot{bot_token}/{method}");
-        let client = zeroclaw_config::schema::build_runtime_proxy_client("channel.telegram");
+        // The same per-channel proxy every other Telegram request uses; the
+        // global proxy alone dropped a configured `proxy_url` for voice uploads.
+        let client =
+            zeroclaw_config::schema::build_channel_proxy_client("channel.telegram", proxy_url);
 
         let mut form = reqwest::multipart::Form::new()
             .text("chat_id", chat_id.to_string())
@@ -4213,7 +4219,7 @@ impl Channel for TelegramChannel {
         }
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("sendMessage"))
             .json(&body)
             .send()
@@ -4295,7 +4301,7 @@ impl Channel for TelegramChannel {
         });
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("editMessageText"))
             .json(&body)
             .send()
@@ -4351,7 +4357,7 @@ impl Channel for TelegramChannel {
         if !suppress_voice && self.is_voice_peer(recipient) {
             if let Ok(id) = message_id.parse::<i64>() {
                 let _ = self
-                    .client
+                    .http_client()
                     .post(self.api_url("deleteMessage"))
                     .json(&serde_json::json!({
                         "chat_id": chat_id,
@@ -4389,7 +4395,7 @@ impl Channel for TelegramChannel {
             // Delete the draft message
             if let Some(id) = msg_id {
                 let _ = self
-                    .client
+                    .http_client()
                     .post(self.api_url("deleteMessage"))
                     .json(&serde_json::json!({
                         "chat_id": chat_id,
@@ -4418,7 +4424,7 @@ impl Channel for TelegramChannel {
         if text.len() > TELEGRAM_MAX_MESSAGE_LENGTH {
             if let Some(id) = msg_id {
                 let _ = self
-                    .client
+                    .http_client()
                     .post(self.api_url("deleteMessage"))
                     .json(&serde_json::json!({
                         "chat_id": chat_id,
@@ -4449,7 +4455,7 @@ impl Channel for TelegramChannel {
         });
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("editMessageText"))
             .json(&body)
             .send()
@@ -4475,7 +4481,7 @@ impl Channel for TelegramChannel {
         });
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("editMessageText"))
             .json(&plain_body)
             .send()
@@ -4495,7 +4501,7 @@ impl Channel for TelegramChannel {
         }
 
         let delete_resp = self
-            .client
+            .http_client()
             .post(self.api_url("deleteMessage"))
             .json(&serde_json::json!({
                 "chat_id": chat_id,
@@ -4552,7 +4558,7 @@ impl Channel for TelegramChannel {
         };
 
         let response = self
-            .client
+            .http_client()
             .post(self.api_url("deleteMessage"))
             .json(&serde_json::json!({
                 "chat_id": chat_id,

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -98,10 +98,12 @@ impl OpenAiTtsProvider {
                 .clone()
                 .filter(|f| !f.trim().is_empty())
                 .unwrap_or_else(|| "opus".to_string()),
-            client: reqwest::Client::builder()
-                .timeout(TTS_HTTP_TIMEOUT)
-                .build()
-                .context("Failed to build HTTP client for OpenAI TTS")?,
+            client: zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+                reqwest::Client::builder().timeout(TTS_HTTP_TIMEOUT),
+                "channel.tts.openai",
+            )
+            .build()
+            .context("Failed to build HTTP client for OpenAI TTS")?,
         })
     }
 }
@@ -206,10 +208,12 @@ impl ElevenLabsTtsProvider {
                 .unwrap_or_else(|| "eleven_monolingual_v1".to_string()),
             stability: config.stability.unwrap_or(0.5),
             similarity_boost: config.similarity_boost.unwrap_or(0.5),
-            client: reqwest::Client::builder()
-                .timeout(TTS_HTTP_TIMEOUT)
-                .build()
-                .context("Failed to build HTTP client for ElevenLabs TTS")?,
+            client: zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+                reqwest::Client::builder().timeout(TTS_HTTP_TIMEOUT),
+                "channel.tts.elevenlabs",
+            )
+            .build()
+            .context("Failed to build HTTP client for ElevenLabs TTS")?,
         })
     }
 
@@ -333,10 +337,12 @@ impl GoogleTtsProvider {
                 .clone()
                 .filter(|c| !c.trim().is_empty())
                 .unwrap_or_else(|| "en-US".to_string()),
-            client: reqwest::Client::builder()
-                .timeout(TTS_HTTP_TIMEOUT)
-                .build()
-                .context("Failed to build HTTP client for Google TTS")?,
+            client: zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+                reqwest::Client::builder().timeout(TTS_HTTP_TIMEOUT),
+                "channel.tts.google",
+            )
+            .build()
+            .context("Failed to build HTTP client for Google TTS")?,
         })
     }
 
@@ -869,10 +875,12 @@ impl PiperTtsProvider {
             .unwrap_or_else(|| "http://127.0.0.1:5000/v1/audio/speech".to_string());
         Self {
             alias: alias.to_string(),
-            client: reqwest::Client::builder()
-                .timeout(TTS_HTTP_TIMEOUT)
-                .build()
-                .expect("Failed to build HTTP client for Piper TTS"),
+            client: zeroclaw_config::schema::apply_runtime_proxy_to_builder(
+                reqwest::Client::builder().timeout(TTS_HTTP_TIMEOUT),
+                "channel.tts.piper",
+            )
+            .build()
+            .expect("Failed to build HTTP client for Piper TTS"),
             api_url,
         }
     }

--- a/crates/zeroclaw-channels/src/voice_call.rs
+++ b/crates/zeroclaw-channels/src/voice_call.rs
@@ -105,7 +105,7 @@ impl VoiceCallChannel {
             config,
             alias: alias.into(),
             active_calls: Arc::new(Mutex::new(HashMap::new())),
-            client: reqwest::Client::new(),
+            client: zeroclaw_config::schema::build_runtime_proxy_client("channel.voice_call"),
         }
     }
 

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -774,7 +774,7 @@ impl WeChatChannel {
             peer_resolver,
             persist: None,
             pairing,
-            client: reqwest::Client::new(),
+            client: zeroclaw_config::schema::build_runtime_proxy_client("channel.wechat"),
             context_tokens: Mutex::new(HashMap::new()),
             typing_tickets: Mutex::new(HashMap::new()),
             cursor: Mutex::new(String::new()),


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions).
- **What changed and why:** The channels crate has one way to build an outbound HTTP client that honours the deployment's proxy policy (`build_channel_proxy_client` / `apply_runtime_proxy_to_builder`), and most channels use it. A census found eleven construction sites that did not — and one that mattered:
  - **Telegram kept a second, bare `reqwest::Client`** next to its proxied `http_client()`, and the whole streaming-draft path (`send_draft`, `update_draft`, `finalize_draft`, `cancel_draft`, nine call sites) used the bare one: a Telegram deployment behind a proxy streamed its replies direct. Its voice upload used the global proxy only, dropping a configured per-channel `proxy_url`. Both fixed; the bare field is gone.
  - WeChat, Notion, LINQ, Voice Call, ClawdTalk, Gmail Push, Matrix's whoami/read-marker calls, the four TTS providers, and the link enricher honoured no proxy at all. Each now builds through the shared helpers, keeping its own timeouts, redirect policy (the link enricher's and Matrix's SSRF policies are untouched) and user agent, under service keys in the supported `channel.*` selector family so operators can scope proxy rules to them.
  - Slack's `with_proxy_url` doc comment had drifted onto `with_markdown_blocks`; moved back.
- **Scope boundary:** No change to proxy configuration keys or the helpers themselves. Not touched: the Matrix SDK client (not a reqwest builder), WhatsApp Web (ureq) and Nostr (relay client) — each needs its own follow-up. The nine trivial `with_proxy_url` setters are left as they are; LINE's eager-rebuild variant is noted, not changed.
- **Blast radius:** `crates/zeroclaw-channels` only: telegram, tts, link_enricher, matrix, gmail_push, clawdtalk, voice_call, linq, notion, wechat, slack. Behavior change: with a runtime proxy configured, these clients now use it (previously they silently bypassed it).
- **Linked issue(s):** none (found by a deslop census; related to the proxy plumbing that introduced `build_channel_proxy_client`).
- **Labels:** `channel`, `bug`, `risk:medium`, `size:M` (maintainers to confirm).

## Testing (required)

### How you can test

- **Reviewer testing requested?** `Yes` — Telegram streaming behind a proxy is the user-visible fix.
- **Interface(s) exercised:** `channel` (telegram).
- **Setup / preconditions:** a runtime proxy (`[proxy] all_proxy = "http://127.0.0.1:8888"` pointed at a local mitm/logging proxy) and a Telegram channel with streaming drafts enabled.
- **Steps to run:** send a message that produces a multi-chunk streamed reply; watch the proxy log.
- **Expected on this branch (after):** the `sendMessage`/`editMessageText` draft calls appear in the proxy log like every other Telegram call.
- **Prior behavior on `master` (before):** the initial send and edits of the streamed draft never touch the proxy (they use the bare client), while non-streamed replies do.

### How I tested

- **CI checks relied on and why they cover this change:** `Test` (channels crate under `channels-full`), `Lint` (clippy + comment hygiene), no-default-features build.
- **Known CI coverage gap, if any:** no automated test observes proxy application end to end (the helpers' own tests live in `zeroclaw-config`); this PR is wiring only.
- **Commands run and tail output:**

```text
# rebased onto upstream/master c18478e6f7 (post v0.8.5); branch head fa4ac94bce
cargo fmt --all -- --check -> clean
scripts/ci/comment_hygiene_gate.sh -> Comment hygiene gate passed.

cargo clippy -p zeroclaw-channels --features channels-full --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 18s

cargo clippy -p zeroclaw-channels --no-default-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 46s

cargo test --locked -p zeroclaw-channels --features channels-full --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3m 31s
    test result: ok. 2628 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 27.94s

# CI-shape workspace check on the same head
cargo check --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 40s   (no errors, no warnings)
```

- **Beyond CI, what did you manually verify?** That the nine bare-client reads in Telegram's draft path are the only readers of the removed field (the field is gone, so the compiler proves it), that each rewritten builder keeps its original options, and that every new service key sits under the supported `channel.*` selector prefix. I did NOT run a live proxied Telegram session.
- **Visual interface changed?** `N/A`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`.
- New external network calls? `No` — the same calls, now routed through the configured proxy when one is set.
- Secrets / tokens / credentials handling changed? `No`.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- Prompt injection or untrusted model-visible text introduced/changed? `No`.

## Compatibility (required)

- Backward compatible? `Yes` for deployments without a proxy (no behavior change). With a runtime proxy configured, the listed clients now honour it; an operator who relied on any of them bypassing the proxy can exclude them with a `[proxy]` service selector (each new key is under `channel.*`).
- Config / env / CLI surface changed? `No`.
- Rust/MSRV/toolchain floor changed? `No`.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-squash-sha>`.
- **Feature flags or config toggles:** `[proxy]` service selectors can exclude any of the newly keyed services.
- **Observable failure symptoms:** a `Failed to build proxied client` warning at startup naming the service key; Telegram draft edits failing where plain sends succeed.
