### PR TITLE
refactor(channels): share one status check for the copy-pasted vendor error shape

### DIFF
--- a/crates/zeroclaw-channels/src/dingtalk.rs
+++ b/crates/zeroclaw-channels/src/dingtalk.rs
@@ -124,11 +124,7 @@ impl DingTalkChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("gateway registration failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "gateway registration").await?;
 
         let gw: GatewayResponse = resp.json().await?;
         Ok(gw)
@@ -188,11 +184,7 @@ impl Channel for DingTalkChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("webhook reply failed ({status}): {err}");
-        }
+        crate::util::ensure_success(resp, "webhook reply").await?;
 
         Ok(())
     }

--- a/crates/zeroclaw-channels/src/discord/interaction.rs
+++ b/crates/zeroclaw-channels/src/discord/interaction.rs
@@ -42,11 +42,7 @@ pub(crate) async fn discord_defer_interaction(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("interaction defer failed ({status}): {err}");
-    }
+    crate::util::ensure_success(resp, "interaction defer").await?;
     Ok(())
 }
 
@@ -75,11 +71,7 @@ pub(crate) async fn discord_open_modal(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("modal open failed ({status}): {err}");
-    }
+    crate::util::ensure_success(resp, "modal open").await?;
     Ok(())
 }
 
@@ -106,11 +98,7 @@ pub(crate) async fn discord_answer_autocomplete(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("interaction autocomplete answer failed ({status}): {err}");
-    }
+    crate::util::ensure_success(resp, "interaction autocomplete answer").await?;
     Ok(())
 }
 
@@ -157,11 +145,7 @@ pub(crate) async fn discord_reject_interaction(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("interaction reject failed ({status}): {err}");
-    }
+    crate::util::ensure_success(resp, "interaction reject").await?;
     Ok(())
 }
 
@@ -192,11 +176,7 @@ pub(crate) async fn discord_edit_interaction_response(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("interaction followup edit failed ({status}): {err}");
-    }
+    crate::util::ensure_success(resp, "interaction followup edit").await?;
     Ok(())
 }
 
@@ -217,11 +197,7 @@ pub(crate) async fn discord_post_interaction_followup(
         .send()
         .await
         .map_err(reqwest::Error::without_url)?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("interaction followup post failed ({status}): {err}");
-    }
+    crate::util::ensure_success(resp, "interaction followup post").await?;
     Ok(())
 }
 

--- a/crates/zeroclaw-channels/src/line.rs
+++ b/crates/zeroclaw-channels/src/line.rs
@@ -1038,11 +1038,7 @@ impl LineChannel {
                 .send()
                 .await?;
 
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let err = resp.text().await.unwrap_or_default();
-                anyhow::bail!("Reply API failed ({status}): {err}");
-            }
+            crate::util::ensure_success(resp, "Reply API").await?;
         }
         Ok(())
     }
@@ -1078,11 +1074,7 @@ impl LineChannel {
                 .send()
                 .await?;
 
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let err = resp.text().await.unwrap_or_default();
-                anyhow::bail!("Push API failed ({status}): {err}");
-            }
+            crate::util::ensure_success(resp, "Push API").await?;
         }
         Ok(())
     }

--- a/crates/zeroclaw-channels/src/mochat.rs
+++ b/crates/zeroclaw-channels/src/mochat.rs
@@ -115,11 +115,7 @@ impl Channel for MochatChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Mochat send message failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "Mochat send message").await?;
 
         let result: serde_json::Value = resp.json().await?;
         let code = result.get("code").and_then(|v| v.as_i64()).unwrap_or(-1);

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -424,11 +424,7 @@ impl QQChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ token request failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "QQ token request").await?;
 
         let data: serde_json::Value = resp.json().await?;
         let token = data
@@ -540,11 +536,7 @@ impl QQChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ gateway request failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "QQ gateway request").await?;
 
         let data: serde_json::Value = resp.json().await?;
         let url = data
@@ -847,11 +839,7 @@ impl QQChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ upload media failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "QQ upload media").await?;
 
         let upload_resp: QQUploadResponse = resp.json().await?;
         Ok((upload_resp.file_info, upload_resp.ttl))
@@ -926,11 +914,7 @@ impl QQChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ send media message failed ({status}): {err}");
-        }
+        crate::util::ensure_success(resp, "QQ send media message").await?;
 
         Ok(())
     }
@@ -1279,11 +1263,7 @@ impl QQChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ send message failed ({status}): {err}");
-        }
+        crate::util::ensure_success(resp, "QQ send message").await?;
 
         Ok(())
     }

--- a/crates/zeroclaw-channels/src/twitter.rs
+++ b/crates/zeroclaw-channels/src/twitter.rs
@@ -86,11 +86,7 @@ impl TwitterChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Twitter users/me failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "Twitter users/me").await?;
 
         let data: serde_json::Value = resp.json().await?;
         let user_id = data
@@ -131,11 +127,7 @@ impl TwitterChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Twitter create tweet failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "Twitter create tweet").await?;
 
         let data: serde_json::Value = resp.json().await?;
         let tweet_id = data
@@ -164,11 +156,7 @@ impl TwitterChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Twitter DM send failed ({status}): {err}");
-        }
+        crate::util::ensure_success(resp, "Twitter DM send").await?;
 
         Ok(())
     }

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -613,9 +613,68 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
     }
 }
 
+/// Fail with the vendor's status and body when an HTTP response is not a
+/// success, otherwise hand the response back so the caller can read it.
+///
+/// This is the one shape twenty-nine hand-written checks shared: a status
+/// test, the status captured, the body read best-effort, and
+/// `"<what> failed (<status>): <body>"`. Keeping the message byte-identical
+/// means callers migrate without changing what an operator sees in a log.
+/// Sites that need something else, such as a typed error, a sanitized body, a
+/// status-specific retry, or a body that must stay unread so it can be
+/// streamed — keep their own check on purpose.
+#[cfg(any(
+    feature = "channel-dingtalk",
+    feature = "channel-discord",
+    feature = "channel-line",
+    feature = "channel-mochat",
+    feature = "channel-qq",
+    feature = "channel-twitter",
+    feature = "channel-wechat",
+    feature = "channel-wecom"
+))]
+pub(crate) async fn ensure_success(
+    resp: reqwest::Response,
+    what: &str,
+) -> anyhow::Result<reqwest::Response> {
+    if resp.status().is_success() {
+        return Ok(resp);
+    }
+    let status = resp.status();
+    let err = resp.text().await.unwrap_or_default();
+    anyhow::bail!("{what} failed ({status}): {err}");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "channel-qq")]
+    #[tokio::test]
+    async fn ensure_success_passes_a_success_through_and_reports_status_and_body_otherwise() {
+        let (url, server) = spawn_raw_http_response(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok".to_vec(),
+            false,
+        )
+        .await;
+        let resp = reqwest::get(&url).await.unwrap();
+        let resp = ensure_success(resp, "QQ sendMessage").await.unwrap();
+        assert_eq!(resp.text().await.unwrap(), "ok");
+        server.await.unwrap();
+
+        let (url, server) = spawn_raw_http_response(
+            b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 5\r\n\r\nboom!".to_vec(),
+            false,
+        )
+        .await;
+        let resp = reqwest::get(&url).await.unwrap();
+        let err = ensure_success(resp, "QQ sendMessage").await.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "QQ sendMessage failed (500 Internal Server Error): boom!"
+        );
+        server.await.unwrap();
+    }
 
     /// Verifies the exported compatibility wrapper retains the legacy UTF-8 boundary contract.
     #[allow(deprecated)]

--- a/crates/zeroclaw-channels/src/wechat.rs
+++ b/crates/zeroclaw-channels/src/wechat.rs
@@ -1982,11 +1982,7 @@ impl WeChatChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("sendMessage failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "sendMessage").await?;
 
         // The API reports failures as HTTP 200 with a non-zero ret/errcode
         // in the body; a status check alone silently drops the message.

--- a/crates/zeroclaw-channels/src/wecom.rs
+++ b/crates/zeroclaw-channels/src/wecom.rs
@@ -88,11 +88,7 @@ impl Channel for WeComChannel {
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("WeCom webhook send failed ({status}): {err}");
-        }
+        let resp = crate::util::ensure_success(resp, "WeCom webhook send").await?;
 
         // WeCom returns {"errcode":0,"errmsg":"ok"} on success.
         let result: serde_json::Value = resp.json().await?;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions).
- **What changed and why:** Twenty-one call sites across eight channels carried the same four lines by hand: test the status, capture it, read the body best-effort, bail with `"<what> failed (<status>): <body>"`. Every copy was a place for the shape to drift, and none was tested. This PR adds one crate-private helper, `util::ensure_success(resp, what)`, which fails with exactly that message and otherwise hands the response back, and routes the twenty-one byte-identical sites through it: DingTalk (2), Discord interactions (6), LINE (2), MoChat (1), QQ (5), Twitter (3), WeChat (1), WeCom (1). Sites that read the response afterwards rebind it; the twelve that only needed the check no longer bind anything. A unit test pins both branches against a raw HTTP response.
- **Scope boundary:** Pure refactor. The error text is unchanged at every site, so operator logs and any string matching on them are unaffected. Left alone on purpose, because each is a behaviour choice rather than a copy: Telegram's checks propagate the body-read error and use a different message; one QQ download check reports the URL without reading the body; Telegram's draft path logs instead of failing; Slack's `ok` checks exist in two non-equivalent spellings.
- **Blast radius:** `crates/zeroclaw-channels` only; the helper is `pub(crate)` and gated on the features of the channels that use it, so no public API and no change to any feature shape.
- **Linked issue(s):** none closed; in the spirit of the anti-slop tracker #10118 (found by a deslop census of the channels crate).
- **Labels:** `channel`,`distinguished contributor`,`channel:discord`,`channel:dingtalk`,`channel:mochat`,`channel:qq`,`channel:twitter`,`channel:wecom`,`channel:line`,`risk:low`,`size:S`,`type:refactor`,`channel:wechat`.

## Testing (required)

### How you can test

- **Reviewer testing requested?** `No` — mechanical refactor with the message text pinned by a unit test.
- **Interface(s) exercised:** `channel` (error path only).
- **Setup / preconditions:** N/A.
- **Steps to run:** `cargo test -p zeroclaw-channels --features channels-full --lib ensure_success`.
- **Expected on this branch (after):** the new test passes and asserts `QQ sendMessage failed (500 Internal Server Error): boom!` verbatim.
- **Prior behavior on `master` (before):** same message produced by each hand-written copy; no test.

### How I tested

- **CI checks relied on and why they cover this change:** `Test` (channels crate under `channels-full`), `Lint` (clippy + comment hygiene), no-default-features build (the helper is feature-gated, so this is the shape that would catch a dead-code slip).
- **Known CI coverage gap, if any:** none.
- **Commands run and tail output:**

```text
# rebased onto upstream/master c18478e6f7 (post v0.8.5); branch head eb1bf95b0d
cargo fmt --all -- --check -> clean
scripts/ci/comment_hygiene_gate.sh -> Comment hygiene gate passed.

cargo clippy -p zeroclaw-channels --features channels-full --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 48s

cargo clippy -p zeroclaw-channels --no-default-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 17s

cargo test --locked -p zeroclaw-channels --features channels-full --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 06s
    test result: ok. 2629 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 35.96s

# CI-shape workspace check on the same head
cargo check --locked --workspace --exclude zeroclaw-desktop --all-targets --features ci-all
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 28s   (no errors, no warnings)
```

- **Beyond CI, what did you manually verify?** That every rewritten site had the exact four-line shape (the rewrite is a strict regex over the whole block, so any variant was skipped, not approximated), and that the compiler proves the binding decisions in both directions: a site that drops the binding but later used the response would fail with use-after-move, and a site that rebinds without a later use would fail clippy's unused-variable lint under `-D warnings`.
- **Visual interface changed?** `N/A`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`.
- New external network calls? `No`.
- Secrets / tokens / credentials handling changed? `No` — the same vendor error body is surfaced as before, no more and no less.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- Prompt injection or untrusted model-visible text introduced/changed? `No`.

## Compatibility (required)

- Backward compatible? `Yes` — identical messages, identical control flow.
- Config / env / CLI surface changed? `No`.
- Rust/MSRV/toolchain floor changed? `No`.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <merged-squash-sha>`.
- **Feature flags or config toggles:** none.
- **Observable failure symptoms:** none expected; a compile failure under an unusual feature combination would be the only signature.

