### PR TITLE
docs(security): state the actual supported release line

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,8 @@ branches, and earlier minor versions do not receive backported fixes.
 | Latest released minor line | :white_check_mark: |
 | Earlier minor lines        | :x:                |
 
+For example, if the latest release is `0.8.6`, the supported minor line is `0.8.x`; `0.7.x` and older lines are unsupported.
+
 Upgrade to the latest release before reporting. If the issue still reproduces
 there, report it as described below.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,10 @@
 Security fixes ship on the latest release line only. There are no maintenance
 branches, and earlier minor versions do not receive backported fixes.
 
-| Version                                              | Supported          |
-| ---------------------------------------------------- | ------------------ |
-| Latest release (`0.8.x` at the time of writing)      | :white_check_mark: |
-| Earlier minor versions (`0.7.x` and older)           | :x:                |
+| Version                    | Supported          |
+| -------------------------- | ------------------ |
+| Latest released minor line | :white_check_mark: |
+| Earlier minor lines        | :x:                |
 
 Upgrade to the latest release before reporting. If the issue still reproduces
 there, report it as described below.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,16 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+Security fixes ship on the latest release line only. There are no maintenance
+branches, and earlier minor versions do not receive backported fixes.
+
+| Version                                              | Supported          |
+| ---------------------------------------------------- | ------------------ |
+| Latest release (`0.8.x` at the time of writing)      | :white_check_mark: |
+| Earlier minor versions (`0.7.x` and older)           | :x:                |
+
+Upgrade to the latest release before reporting. If the issue still reproduces
+there, report it as described below.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** `SECURITY.md` still told reporters that `0.1.x` is the only supported version. The project is on 0.8.5. The table now names the latest release line as supported and earlier minors as unsupported, with one sentence on why: patch releases only ever land on the latest minor and there are no maintenance branches (see the release history: 0.7.5 on 2026-05-08, then 0.8.0 through 0.8.5, nothing on 0.7 after). It also asks reporters to reproduce on the latest release before filing.
- **Scope boundary:** Only the Supported Versions section. The reporting process, response timeline, architecture and container sections are untouched. No code, no docs/book pages.
- **Blast radius:** Reader-facing policy text only. GitHub renders `SECURITY.md` on the Security tab, so the stale line was the first thing a reporter saw.
- **Linked issue(s):** None.
- **Labels:** `docs`, `risk:low`, `size:XS`, `type:docs`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A, docs-only text change.

### How I tested

- **CI checks relied on and why they cover this change:** None cover it. `scripts/ci/docs_quality_gate.sh` only auto-selects `docs/book/src/**`, so root-level `SECURITY.md` is never linted in CI. Ran the same gate and linter locally instead (below).
- **Known CI coverage gap, if any:** Root-level Markdown is outside the docs gate. Locally the gate flags nine pre-existing prose em-dashes (lines 43 to 52 and 79) and markdownlint flags three pre-existing MD022 blank-line errors (lines 42, 47, 54). All are outside this diff (lines 5 to 14) and left as they were to keep the PR to the supported-versions change. Happy to fix them here if a maintainer prefers.
- **Commands run and tail output:**

```sh
DOCS_FILES="SECURITY.md" bash scripts/ci/docs_quality_gate.sh
  SECURITY.md:43: - **ReadOnly** — Agent can only read, no shell or write access
  ... (nine pre-existing lines, none in this diff)
Blocking prose em-dashes: 9

npx --yes markdownlint-cli2@0.20.0 SECURITY.md
Summary: 3 error(s)
SECURITY.md:42 error MD022/blanks-around-headings ... [Context: "### Autonomy Levels"]
SECURITY.md:47 error MD022/blanks-around-headings ... [Context: "### Sandboxing Layers"]
SECURITY.md:54 error MD022/blanks-around-headings ... [Context: "### What We Protect Against"]
(no findings on lines 5 to 14, the lines this PR touches)

bash scripts/ci/docs_links_gate.sh
OK
Collected 0 added link(s) from 1 docs file(s).
No added links detected in changed docs lines.
```

- **Beyond CI, what did you manually verify?** Checked `gh release list` for the release cadence claim (only the latest minor receives patch releases) and `gh api repos/zeroclaw-labs/zeroclaw/branches` for maintenance branches (none). Did not verify anything else; nothing else changed.
- **Visual interface changed?** N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk PR: `git revert <sha>`.
