### PR TITLE
perf(runtime): share one config snapshot across the tool registry build

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -853,6 +853,10 @@ pub fn all_tools_with_runtime(
     // Independent agentic delegates use it later to build the target-owned tool
     // registry; bounded delegates continue to use the parent `tool_arcs`
     // snapshot below.
+    // The `root_config`-derived tools below share ONE snapshot `Arc` instead
+    // of each taking a full `Config` clone: registry construction (per agent
+    // build and per channel-message turn) previously paid three deep copies.
+    let root_config_shared = Arc::new(root_config.clone());
     let mut tool_arcs: Vec<Arc<dyn Tool>> = vec![
         Arc::new(RateLimitedTool::new(
             shell_tool
@@ -930,16 +934,20 @@ pub fn all_tools_with_runtime(
         Arc::new(MemoryPurgeTool::new(memory.clone(), security.clone())),
         Arc::new(ScheduleTool::new_with_runtime(
             security.clone(),
-            root_config.clone(),
+            Arc::clone(&root_config_shared),
             agent_alias,
             runtime.clone(),
         )),
         Arc::new(
-            SpawnSubagentTool::new(Arc::new(root_config.clone()), agent_alias, security.clone())
-                .with_subagent_caller(is_subagent_caller),
+            SpawnSubagentTool::new(
+                Arc::clone(&root_config_shared),
+                agent_alias,
+                security.clone(),
+            )
+            .with_subagent_caller(is_subagent_caller),
         ),
         Arc::new(SendMessageToPeerTool::new(
-            Arc::new(root_config.clone()),
+            Arc::clone(&root_config_shared),
             agent_alias,
         )),
         Arc::new(ModelRoutingConfigTool::new(

--- a/crates/zeroclaw-runtime/src/tools/schedule.rs
+++ b/crates/zeroclaw-runtime/src/tools/schedule.rs
@@ -12,16 +12,20 @@ use zeroclaw_config::schema::Config;
 /// Tool that lets the agent manage recurring and one-shot scheduled tasks.
 pub struct ScheduleTool {
     security: Arc<SecurityPolicy>,
-    config: Config,
+    config: Arc<Config>,
     runtime: Arc<dyn RuntimeAdapter>,
     /// Owning agent — risk profile gate for shell command validation.
     agent_alias: String,
 }
 
 impl ScheduleTool {
+    /// `config` is a shared snapshot: every constructor site in
+    /// `all_tools_with_runtime` wraps the same `Arc`, so building the tool
+    /// registry costs one full `Config` copy per build instead of one per
+    /// `root_config`-derived tool.
     pub fn new_with_runtime(
         security: Arc<SecurityPolicy>,
-        config: Config,
+        config: Arc<Config>,
         agent_alias: impl Into<String>,
         runtime: Arc<dyn RuntimeAdapter>,
     ) -> Self {
@@ -43,7 +47,7 @@ impl ScheduleTool {
             crate::platform::create_runtime(&config.runtime)
                 .expect("test config must construct its runtime"),
         );
-        Self::new_with_runtime(security, config, agent_alias, runtime)
+        Self::new_with_runtime(security, Arc::new(config), agent_alias, runtime)
     }
 }
 
@@ -960,7 +964,7 @@ mod tests {
         let security = Arc::new(SecurityPolicy::for_agent(&config, TEST_AGENT).unwrap());
         let runtime: Arc<dyn RuntimeAdapter> =
             Arc::new(crate::platform::NativeRuntime::with_shell("pwsh".into()));
-        let tool = ScheduleTool::new_with_runtime(security, config, TEST_AGENT, runtime);
+        let tool = ScheduleTool::new_with_runtime(security, Arc::new(config), TEST_AGENT, runtime);
 
         let result = tool
             .execute(json!({

--- a/tests/architecture/publish_contract.rs
+++ b/tests/architecture/publish_contract.rs
@@ -691,6 +691,19 @@ const ESCAPE_EXCEPTIONS: &[(&str, &str)] = &[(
     "../../web/dist",
 )];
 
+fn slash_separated_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[test]
+fn repository_relative_paths_use_slash_separators() {
+    let windows_path = PathBuf::from(r"crates\zeroclaw-gateway\src\static_files.rs");
+    assert_eq!(
+        slash_separated_path(&windows_path),
+        "crates/zeroclaw-gateway/src/static_files.rs"
+    );
+}
+
 #[test]
 fn published_crates_never_include_files_outside_their_own_directory() {
     let mut violations = Vec::new();
@@ -733,11 +746,11 @@ fn published_crates_never_include_files_outside_their_own_directory() {
                         .to_path_buf()
                 };
                 let resolved = normalize(&base, &include.path);
-                let rel = source_path
-                    .strip_prefix(repo_root())
-                    .unwrap_or(&source_path)
-                    .to_string_lossy()
-                    .into_owned();
+                let rel = slash_separated_path(
+                    source_path
+                        .strip_prefix(repo_root())
+                        .unwrap_or(&source_path),
+                );
                 let excepted = ESCAPE_EXCEPTIONS
                     .iter()
                     .any(|(f, p)| *f == rel && *p == include.path);


### PR DESCRIPTION
## Summary

`all_tools_with_runtime` cloned the full `Config` three times per build for the `root_config`-derived tools:

- `ScheduleTool::new_with_runtime` takes a `Config` by value (`root_config.clone()`),
- `SpawnSubagentTool::new` and `SendMessageToPeerTool::new` each received `Arc::new(root_config.clone())` — a full copy immediately wrapped in an `Arc`.

These three deep copies occurred on every registry build. `process_message` rebuilds the registry per invocation, including gateway chat and detached peer turns; the channel daemon can reuse a registry built at agent startup.

The three sites now share **one** `Arc<Config>` snapshot materialized once per build, and `ScheduleTool`'s constructor takes `Arc<Config>` (field access is unchanged via `Deref`; its test-only convenience constructor still accepts an owned `Config` and wraps it, with the direct runtime-constructor test updated for the new argument). The other `config.clone()` matches in the build were already cheap `Arc` clones — every other constructor already takes `Arc<Config>` — and are untouched.

Related to #9535: that PR moves the registry build off the RPC caller's stack onto a dedicated thread; this PR removes two full `Config` copies within the build. No latency or peak-stack reduction is measured here. The two changes are independent and can land in either order.

The architecture test also normalizes repository-relative path separators before matching its existing include exception, fixing Windows matching without adding an exception or changing containment checks.

## Testing (required)

- **Commands run and tail output:**

```sh
$ cargo fmt --all -- --check
# (no output; exit 0)

$ cargo clippy --locked -p zeroclaw-runtime --all-targets --no-deps -- -D warnings
# (no diagnostics)

$ ZEROCLAW_CONFIG_DIR=/tmp/zeroclaw-9535-tierb cargo test --locked -p zeroclaw-runtime --lib
test result: ok. 4246 passed; 0 failed; 5 ignored

$ ZEROCLAW_CONFIG_DIR=/tmp/zeroclaw-9535-tierb cargo test --locked -p zeroclaw-runtime --lib -- schedule:: tools::tests::
test result: ok. 33 passed; 0 failed   # schedule
test result: ok. 32 passed; 0 failed   # tools
```

- **CI checks relied on and why they cover this change:** the required GitHub Actions matrix (Lint, Test, Parallel Runtime Test, cross-platform checks) compiles and tests every crate this diff touches; the registry-build behavior is covered by the `tools::tests` suite, which passes unchanged.
- **Regression coverage added/updated:** the direct `ScheduleTool::new_with_runtime` test call is updated for `Arc<Config>`, and a Windows-form path regression covers separator normalization. Existing `tools::tests` exercise registry registration and the shared data path with divergent root and incoming configuration; they do not separately assert the configuration held by all three changed tools.

## Security & Privacy Impact (required)

None. No new inputs, network paths, or permission surfaces; the shared snapshot is read-only config data already available to every tool constructor at that call site.

## Compatibility (required)

- `all_tools_with_runtime`'s public signature is unchanged.
- `ScheduleTool::new_with_runtime` is publicly reachable Rust API and now takes `Arc<Config>`. All repository call sites are updated; downstream callers passing an owned `Config` must wrap it in `Arc::new(config)`. The runtime crate is Experimental and carries no stability guarantee.
- No wire, config-schema, or storage changes.

## Rollback

Single commit, construction-internal; revert cleanly restores the three per-build clones.
