### PR TITLE
docs(skills): correct configuration and security guidance

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -90,7 +90,7 @@ Using the parsed template structure and gathered context, draft a complete PR bo
 
 - For each `## ` section from the template, fill in the bullet points and fields based on context from the commits, diff, and changed files.
 - Use the field descriptions and placeholder text in the template as guidance for what each field expects.
-- For Yes/No fields, infer from the diff (e.g., if no files in `src/security/` changed, security impact is likely all No).
+- For Yes/No fields, infer from the diff (e.g., if files in `src/security/` changed, security impact is likely).
 - For required sections, always provide a substantive answer. For optional sections, fill if there's enough context, otherwise leave the template prompts in place.
 - Draft a conventional commit-style PR title based on the changes (e.g., `feat(provider): add retry budget override`, `fix(channel): handle disconnect gracefully`, `chore(ci): update workflow targets`).
 - Apply the shared authorship-hygiene check before showing or submitting the PR

--- a/.claude/skills/zeroclaw/SKILL.md
+++ b/.claude/skills/zeroclaw/SKILL.md
@@ -204,7 +204,7 @@ Confirm with the user before running any estop command — these are disruptive.
 
 ### Channels
 
-Channel availability depends on the installed build's feature set. Use `zeroclaw channels list` to inspect configured channels and `zeroclaw channels doctor` to check their health. Consult the current channel guide and generated config reference before configuring a channel; do not infer config keys from a fixed channel inventory.
+Channel availability depends on the installed build's feature set. Use `zeroclaw channels list` to inspect configured channels and `zeroclaw channel doctor` to check their health. Consult the current channel guide and generated config reference before configuring a channel; do not infer config keys from a fixed channel inventory.
 
 ### Pairing (Authentication Setup)
 
@@ -227,7 +227,7 @@ Here are multi-step sequences you're likely to need:
 1. Inspect the relevant channel's configuration fields without printing credentials.
 2. Configure the channel with `zeroclaw config set channels.<name>.<field> <value>`; omit secret values to use the masked input prompt.
 3. Restart: `zeroclaw service restart` (or restart daemon manually)
-4. Verify: `zeroclaw channels doctor`
+4. Verify: `zeroclaw channel doctor`
 
 **"Switch to a different model"**
 1. Check available: `zeroclaw models list`
@@ -270,6 +270,6 @@ Only load these when you need precise details beyond what's in this file — for
 
 **Memory not persisting** — Check `[memory]` config. If `backend = "none"`, nothing is stored. Switch to `"sqlite"` or `"markdown"`. Also verify `auto_save = true`.
 
-**Channel not responding** — Run `zeroclaw channels doctor` for the specific channel. Common issues: expired bot token, wrong allowed_users list, channel not enabled in `[channels]`.
+**Channel not responding**: Run `zeroclaw channel doctor` and inspect the affected channel's result. Common issues: expired bot token, wrong allowed_users list, channel not enabled in `[channels]`.
 
 Report errors to the user with context appropriate to their expertise level. For beginners, explain what went wrong and suggest the fix. For experts, just show the error and the fix.

--- a/.claude/skills/zeroclaw/SKILL.md
+++ b/.claude/skills/zeroclaw/SKILL.md
@@ -21,7 +21,7 @@ Default to a middle ground — brief explanation of what you're about to do, the
 
 ## Discovery — Before You Act
 
-Before running any ZeroClaw operation, make sure you know where things are:
+Before running any ZeroClaw operation, make sure you know where things are. When inspecting configuration, read only the fields needed for the operation and keep credential values out of tool output.
 
 1. **Find the binary.** Search in this order:
    - `which zeroclaw` (PATH)
@@ -55,7 +55,7 @@ If the user hasn't set up ZeroClaw yet (no `~/.zeroclaw/config.toml` exists), gu
 ```bash
 zeroclaw quickstart                                              # Interactive — picks a provider + agent
 zeroclaw quickstart --model-provider ollama --model qwen2.5:7b   # Non-interactive
-zeroclaw config set channels.<name>.<field>=<value>              # Configure a channel after quickstart
+zeroclaw config set channels.<name>.<field> <value>             # Configure a channel after quickstart
 ```
 
 After quickstart, verify everything works:
@@ -64,7 +64,7 @@ zeroclaw status
 zeroclaw doctor
 ```
 
-If they already have a config but a channel is broken, edit just that channel's fields with `zeroclaw config set channels.<name>.<field>=<value>` rather than re-running quickstart (quickstart leaves an existing config alone).
+If they already have a config but a channel is broken, edit just that channel's fields with `zeroclaw config set channels.<name>.<field> <value>` rather than re-running quickstart (quickstart leaves an existing config alone).
 
 ## Building from Source
 
@@ -157,7 +157,7 @@ To see what's available: `GET /api/tools` (REST) lists all registered tools with
 
 ### Configuration
 
-Edit `~/.zeroclaw/config.toml` directly, use `zeroclaw config set <key>=<value>` for one field at a time, or delete `~/.zeroclaw/` and re-run `zeroclaw quickstart` for a fresh setup.
+Use `zeroclaw config set <path> <value>` to update configuration fields. For secret fields, omit the value and use the masked input prompt. Change only the affected fields, preserving unrelated settings and stored data.
 
 **REST:**
 - `GET /api/config`: compatibility whole-config read (secrets masked as `***MASKED***`)
@@ -204,7 +204,7 @@ Confirm with the user before running any estop command — these are disruptive.
 
 ### Channels
 
-Channel availability depends on the installed build's feature set. Use `zeroclaw channels list` to inspect configured channels and `zeroclaw channels doctor` to check their health. Consult the current channel guide and generated config reference before editing `~/.zeroclaw/config.toml`; do not infer config keys from a fixed channel inventory.
+Channel availability depends on the installed build's feature set. Use `zeroclaw channels list` to inspect configured channels and `zeroclaw channels doctor` to check their health. Consult the current channel guide and generated config reference before configuring a channel; do not infer config keys from a fixed channel inventory.
 
 ### Pairing (Authentication Setup)
 
@@ -224,8 +224,8 @@ Here are multi-step sequences you're likely to need:
 3. If gateway needed: `curl -sf http://127.0.0.1:42617/health`
 
 **"Set up a new channel"**
-1. Read the current config: `cat ~/.zeroclaw/config.toml`
-2. Add the channel config (edit the TOML)
+1. Inspect the relevant channel's configuration fields without printing credentials.
+2. Configure the channel with `zeroclaw config set channels.<name>.<field> <value>`; omit secret values to use the masked input prompt.
 3. Restart: `zeroclaw service restart` (or restart daemon manually)
 4. Verify: `zeroclaw channels doctor`
 
@@ -266,7 +266,7 @@ Only load these when you need precise details beyond what's in this file — for
 
 **"Too many requests" (429)** — You're hitting ZeroClaw's rate limit. Back off — the response includes `retry_after` with the number of seconds to wait.
 
-**Agent not using tools / acting limited** — Check autonomy settings in config.toml under `[autonomy]`. `level = "read_only"` disables most tools. Try `level = "supervised"` or `level = "full"`.
+**Agent not using tools / acting limited**: Inspect the affected agent's effective tool policy and the failing operation. Check whether a denied permission explains the failure and whether the restriction is intentional. If broader access is needed, explain and confirm the smallest policy change; do not use full autonomy as a generic fix.
 
 **Memory not persisting** — Check `[memory]` config. If `backend = "none"`, nothing is stored. Switch to `"sqlite"` or `"markdown"`. Also verify `auto_save = true`.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:** Use targeted configuration inspection and supported config commands, diagnose tool restrictions before changing access, and correct the PR template's security-impact example.
- **Scope boundary:** Two skill files and their CLI reference; no runtime, schema, or permission changes.
- **Blast radius:** Assistants following the changed repository guidance.
- **Linked issue(s):** None; this self-contained documentation correction is carried by the PR.
- **Labels:** `docs`, `distinguished contributor`, `risk:low`, `size:XS`, `type:docs`.

### What this does, simply

The operations skill could tell an assistant to print credentials, delete configuration, or broaden autonomy while troubleshooting. It now uses targeted commands and diagnosis. The PR-writing skill also stops suggesting that changes outside the security directory imply no security impact.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; documentation instructions only.

### How I tested

- **CI checks relied on and why they cover this change:** The required CI gate passed on `dc682b163f31ca1daf3978757f273e73ee07506c`. The non-required Advisory Windows nextest job failed; it does not exercise these instruction-only changes. CI's Docs Style job skips these `.claude` files. Explicit local checks below cover the documentation; broad runtime CI is not treated as proof of the instructions.
- **Known CI coverage gap, if any:** Static checks do not prove how every assistant will follow the guidance. Full-file style checks still report existing violations.
- **Commands run and tail output:** On `dc682b163f31`, with all three changed documentation files explicitly selected:

```bash
export BASE_SHA=46479bdca74bedb5c71e30afab657ccaac77dab4
export DOCS_FILES='.claude/skills/github-pr/SKILL.md
.claude/skills/zeroclaw/SKILL.md
.claude/skills/zeroclaw/references/cli-reference.md'
git diff --check "$BASE_SHA"...HEAD
# exit 0
bash scripts/ci/docs_links_gate.sh
# 6 tests passed; 1 added link collected; 1 local target checked; exit 0
bash scripts/ci/docs_quality_gate.sh
# exit 1: 81 pre-existing prose em-dash violations
```

- **Beyond CI, what did you manually verify?** Compared positional `config set <path> <value>`, masked secret input, the alias-keyed channel path, and singular `channel doctor` with the CLI definitions and configuration regression tests. Re-walked the operations skill and references: no plural `channels doctor` or equals-form `config set` remains. Every one of the 81 style diagnostics matches a line already present at the merge base; none is introduced by this PR. No broader formatting cleanup was made.
- **Visual interface evidence:** N/A; instruction-only documentation.
- **Tested revision, interface, and evidence path:** `dc682b163f31`; the three documentation files above, compared with `src/main.rs`, `src/lib.rs`, and `src/alias_cli/mod.rs`. No live configuration was changed.
- **Screenshot or exact-output evidence:** N/A; no rendered interface changed.
- **Action or changed state and observed result:** The main skill and its linked reference now agree on channel command spelling, separate path/value arguments, and the required type/alias/field path.
- **If any command was intentionally skipped, why:** No Cargo or runtime smoke; these are instruction-only corrections to existing CLI behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No new services or runtime calls; existing GitHub query guidance is revised where applicable.
- Secrets / tokens / credentials handling changed? Yes, guidance only: avoid printing credentials and use the existing masked input prompt.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No new untrusted input source. Existing fetched-content rules still apply.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.

## Rollback (required for medium/high-risk PRs)

Revert the documentation change. No migration is needed.
