### PR TITLE
docs(skills): preserve approved GitHub publication text

### DIFF
--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -132,22 +132,16 @@ For checkbox fields, render each option as:
 
 Show the final constructed issue (title + labels + full body) for one last confirmation. If the selected template has no labels, show `Labels: none` and omit `--label` from the create command.
 
-Then submit using a HEREDOC for the body to preserve formatting:
+Save the final body to `tmp/issue-body.md`, preview that file, and submit it unchanged:
 
 ```bash
-gh issue create --title "<title prefix><user title>" --label "<label1>,<label2>" --body "$(cat <<'ISSUE_EOF'
-<body content>
-ISSUE_EOF
-)"
+gh issue create --title "<title prefix><user title>" --label "<label1>,<label2>" --body-file tmp/issue-body.md
 ```
 
 When the selected template has no labels:
 
 ```bash
-gh issue create --title "<title prefix><user title>" --body "$(cat <<'ISSUE_EOF'
-<body content>
-ISSUE_EOF
-)"
+gh issue create --title "<title prefix><user title>" --body-file tmp/issue-body.md
 ```
 
 Return the resulting issue URL to the user.

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -187,7 +187,7 @@ gh pr checks "$NUMBER" --repo zeroclaw-labs/zeroclaw \
 | `skipping` for any required check | Stop — report the skipped required check names and ask whether the skip is expected before proceeding |
 | No required checks are configured or returned | Warn and ask user whether to proceed |
 
-Do not merge on red CI unless the user explicitly overrides after seeing the failure list.
+Failed or cancelled required checks must be resolved before merging.
 
 ### Step 1c: Establish the Freshness Basis
 
@@ -253,8 +253,7 @@ If `origin/${HEAD_REF}` doesn't exist (contributor's branch is on their own fork
 **Single-commit PRs:** If `$COMMITS` is exactly one line, use the full commit body instead of the bullet list. Get it with:
 
 ```bash
-SHA=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json commits --jq '.commits[-1].oid')
-COMMITS=$(git log -1 --format="%b" "$SHA")
+COMMITS=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json commits --jq '.commits[0].messageBody')
 ```
 
 Leave `$COMMITS` empty if there is no commit body. A one-item bullet list adds no information.
@@ -276,6 +275,13 @@ printf '%s\n' "$COMMITS" | rg -i '(^[[:space:]]*(Co-authored-by|Co-Authored-By):
 If this prints anything, stop and strip the remaining bot attribution or
 generated footer before continuing.
 
+Save the sanitized body before confirmation and show that file's contents with the merge command. Submit the same file unchanged:
+
+```bash
+BODY_FILE="tmp/merge-body-${NUMBER}.md"
+printf '%s' "$COMMITS" > "$BODY_FILE"
+```
+
 ```bash
 PR_TITLE=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json title --jq '.title')
 SUBJECT="${PR_TITLE} (#${NUMBER})"
@@ -287,9 +293,7 @@ The title should follow conventional commit format, e.g. `feat(scope): descripti
 
 **This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit.
 
-Present the following to the user with `$NUMBER`, `$HEAD_SHA`, `$SUBJECT`,
-`$COMMITS`, `$FRESHNESS_BASIS`, and `$RELEASE_LINE_DISPOSITION` substituted with
-their actual values — never show variable names or placeholder text:
+Present the following to the user with `$NUMBER`, `$HEAD_SHA`, `$SUBJECT`, `$BODY_FILE`, `$COMMITS`, `$FRESHNESS_BASIS`, and `$RELEASE_LINE_DISPOSITION` substituted with their actual values. Never show variable names or placeholder text:
 
 ---
 
@@ -298,7 +302,7 @@ their actual values — never show variable names or placeholder text:
 gh pr merge $NUMBER --repo zeroclaw-labs/zeroclaw --squash \
   --match-head-commit "$HEAD_SHA" \
   --subject "$SUBJECT" \
-  --body "$COMMITS"
+  --body-file "$BODY_FILE"
 ```
 
 **Effect:**
@@ -358,7 +362,7 @@ Only then run the merge command:
 gh pr merge "$NUMBER" --repo zeroclaw-labs/zeroclaw --squash \
   --match-head-commit "$HEAD_SHA" \
   --subject "$SUBJECT" \
-  --body "$COMMITS"
+  --body-file "$BODY_FILE"
 ```
 
 If the command exits non-zero, stop and report the full error output verbatim. Do not retry or attempt to work around failures.
@@ -408,12 +412,12 @@ leaving a known public tracker stale.
 
 - **Require a PR number or explicit squash-merge context before triggering** — do not invoke on vague phrases without a clear target.
 - **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push produces "Closed" not "Merged", breaks issue auto-close, and loses PR association.
-- **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message omits the PR number and uses inconsistent formatting.
+- **Always supply `--subject` and `--body-file` with `gh pr merge --squash`.** The auto-generated message omits the PR number and uses inconsistent formatting.
 - **Never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks.
 - **Always strip bot/AI attribution from the squash body** before confirmation.
   Preserve intentional human co-author trailers only under the superseding and
   privacy rules.
-- **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
+- **Keep the subject in a shell variable and submit the unchanged checked body file.** Never interpolate untrusted content into shell command text.
 - **Always run pre-flight checks** (merge conflicts, review decision, labels, milestone, release-line placement, and CI status) before confirming — do not skip them even if the user says "just merge it."
 - **Always record a freshness basis before confirming** — refreshed official checks, exact queued/merge-result checks, exact merge-result smoke, or explicit stale-risk acceptance. Do not treat old green branch checks as merge readiness when current `master` could invalidate them.
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:** Submit saved issue and squash bodies with --body-file from private, uniquely created scratch directories; retrieve single-commit bodies through GitHub; remove the sentence allowing failed required CI to be overridden; align the maintainer guide's merge flag.
- **Scope boundary:** Issue-filing and squash-merge skills plus their maintainer guide; no GitHub automation or runtime changes.
- **Blast radius:** Assistants following the changed repository guidance.
- **Linked issue(s):** None; this self-contained documentation correction is carried by the PR.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`, `distinguished contributor`, `status:parking-lot`.

### What this does, simply

Issue and merge instructions now submit the same saved text the user checked. The file lives in a private temporary directory outside the checkout, so a predictable checkout symlink cannot redirect the write. The instructions require a fresh check before submission and renewed confirmation if the text changes; they do not claim protection from a malicious process running as the same user. A squash merge can read its single commit's body even when that commit is absent locally. Required CI failures follow the existing stop rule consistently.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; documentation instructions only.

### How I tested

- **CI checks relied on and why they cover this change:** [Required CI](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35404759566/job/105796252113) and [Docs Style](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35404759566/job/105792192142) passed on `f8aa3a940e1d`; the optional advisory Windows nextest job failed. Follow-up `d6fe0b7cb59e` adds the explicit issue-body write. Its CI is pending; the unmodified recipe smoke and focused issue-skill documentation checks pass locally.
- **Known CI coverage gap, if any:** Static checks do not prove how every assistant will follow the guidance.
- **Commands run and tail output:**

```sh
git diff origin/master...HEAD --check
# exit 0
DOCS_FILES='.claude/skills/github-issue/SKILL.md
.claude/skills/squash-merge/SKILL.md
docs/book/src/maintainers/skills.md' BASE_SHA=$(git merge-base HEAD origin/master) bash scripts/ci/docs_links_gate.sh
# 6 tests passed; 0 added links; exit 0
DOCS_FILES='.claude/skills/github-issue/SKILL.md
.claude/skills/squash-merge/SKILL.md
docs/book/src/maintainers/skills.md' BASE_SHA=$(git merge-base HEAD origin/master) bash scripts/ci/docs_quality_gate.sh
# exit 1: 32 pre-existing prose em-dashes in the squash skill; none added
DOCS_FILES='docs/book/src/maintainers/skills.md' BASE_SHA=$(git merge-base HEAD origin/master) bash scripts/ci/docs_quality_gate.sh
# 0 errors; exit 0
```

- **Beyond CI, what did you manually verify?** On `d6fe0b7cb59e`, executed both documented scratch recipes without supplementing their write steps, using empty and multiline bodies, quotes and literal shell-looking text, pre-existing checkout symlinks, and a failing temporary-directory allocator. Both flows preserved exact bytes, used directory/file modes 0700/0600, left symlink targets unchanged, and stopped on allocation failure. A local CLI double confirmed --body-file handed off the same bytes; no public issue or merge was executed. The earlier smoke had supplied the issue write itself, so its claim to exercise that recipe unchanged was inaccurate. The corrected smoke now checks the documented write directly. The earlier read-only single-commit messageBody query remains applicable.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** No Cargo or runtime smoke; these are instruction-only changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? Yes. The documented scratch write moves outside the checkout to a uniquely created private system temporary directory. It avoids checkout-controlled symlinks, retains failed-submission files for inspection, and removes only the body and empty directory after success.
- New external network calls? No new services or runtime calls; existing GitHub query guidance is revised where applicable.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No new untrusted input source. Existing fetched-content rules still apply.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.

## Rollback (required for medium/high-risk PRs)

Revert the documentation change. No migration is needed.
