### PR TITLE
docs(skills): ground capability and contributor reporting in evidence

### DIFF
--- a/.claude/skills/changelog-generation/SKILL.md
+++ b/.claude/skills/changelog-generation/SKILL.md
@@ -87,26 +87,27 @@ not use `git log --pretty=format:"%an"` alone — it misses `Co-Authored-By`
 contributors.
 
 ```bash
-gh api graphql -f query='
-{ repository(owner:"zeroclaw-labs", name:"zeroclaw") {
-    ref(qualifiedName:"refs/heads/master") { target { ... on Commit {
-      history(first:100) {
+gh api graphql -f oid="<full SHA from Phase 2>" -f query='
+query($oid: GitObjectID!) {
+  repository(owner:"zeroclaw-labs", name:"zeroclaw") {
+    object(oid:$oid) { ... on Commit {
+      oid
+      authors(first:100) {
         pageInfo { hasNextPage endCursor }
-        nodes { oid authors(first:10) { nodes { user { login } email } } }
-      } } } } } }'
+        nodes { name user { login } email }
+      }
+    } }
+} }'
 ```
 
-Page by adding `after:"<endCursor>"` while `hasNextPage` is true. Cross-reference
-each `oid` against the Phase 2 SHA list to stay in range, collect unique logins,
-then exclude:
+Resolve each exact SHA from Phase 2; requests may be batched. Paginate `authors` with `after:"<endCursor>"` when needed. Report unavailable commits or unresolved human logins instead of silently omitting them. Collect unique logins, then exclude:
 
 - logins ending in `[bot]`, plus `web-flow`, `dependabot`, `github-actions`,
   `blacksmith`
-- emails matching `*noreply*`
 - AI model names as author names: `Claude`, `Copilot`, `ChatGPT`, `Codex`,
   `Gemini`, and anything matching `^(gpt|claude|gemini|copilot)-`
 
-Sort case-insensitively and prefix each with `@`.
+Retain human contributors using noreply addresses. Sort case-insensitively and prefix each login with `@`.
 
 ### Phase 4 — Write the changelog
 
@@ -164,8 +165,7 @@ to `master` directly.
    trivial typo fix in docs).
 4. **Always use the GraphQL contributor path.** `git log --format="%an"` alone is
    not acceptable — it produces an incomplete contributor list.
-5. **Always apply the full filter list.** Bots, noreply addresses, and AI model
-   names must be excluded from the contributor section.
+5. **Exclude bots and AI/tool attribution.** A noreply address alone is not evidence that a contributor is a bot.
 6. **Always write to `tmp/CHANGELOG-next.md` first.** The user reviews before the
    file is committed to the repository root.
 7. **Always confirm before committing.** Show the user the exact commit message

--- a/.claude/skills/feature-matrix-parity/SKILL.md
+++ b/.claude/skills/feature-matrix-parity/SKILL.md
@@ -126,10 +126,7 @@ calling it `supported`.
 
 ### Step 4: Check the issue tracker for `planned` verdicts
 
-A slot with no module in the tree is not automatically `none`. Before marking
-`none`, check whether the competitor has an open feature request tracking it,
-which makes the cell `planned` instead. Neither project publishes a ROADMAP.md
-or project board, so the open issue tracker is the authoritative planned signal.
+A slot with no module in the tree is not automatically `none`. Before marking `none`, check for an accepted maintainer commitment or roadmap entry supporting `planned`. An open feature request alone does not establish a plan.
 
 Search at the title level and filter to genuine requests, not incidental
 mentions in bug reports:
@@ -140,13 +137,7 @@ gh search issues --repo openclaw/openclaw --state open "<slot> in:title" --json 
 gh search issues --repo NousResearch/hermes-agent --state open "<slot> in:title" --json number,title,url
 ```
 
-A raw keyword count is noise: an issue that merely mentions "bedrock" is not a
-roadmap commitment, and a bug filed against a slot proves that slot is already
-`supported` (people only file bugs against features that exist). A title like
-`Feature Request: add <slot> as a native provider` with `state: open` and no
-module in the tree is `planned`. Record the issue number and the check date in
-the TOML header so the verdict is auditable. Re-verify against the tree: if the
-feature request was since merged, the slot is `supported`, not `planned`.
+A raw keyword count is noise: an issue that merely mentions "bedrock" is not a roadmap commitment. Bug reports and merged feature requests are leads to inspect the implementing tree and wiring, not proof of `supported`. Record the supporting issue or roadmap reference and check date in the TOML header so the verdict is auditable.
 
 ### Step 5: Write the TOML
 
@@ -196,9 +187,7 @@ why, so the verdicts are auditable from the log.
 - Read the live rendered page for the row set, not the existing TOML keys.
 - Verify loose alias matches against module contents before marking `supported`;
   downgrade speech/image-only or different-product matches to `none`.
-- Before marking a slot `none`, check the competitor's open issue tracker: an
-  open feature request with no module in the tree makes the cell `planned`, not
-  `none`. A bug filed against a slot proves it is already `supported`.
+- Before marking a slot `none`, check for an accepted maintainer commitment or roadmap entry supporting `planned`. Use the tree and wiring to establish implementation status; issues alone do not prove support.
 - Keep the TOML `Sources` header current, including the `checked` date and the
   pinned per-repo commit SHA the columns were walked against.
 - Run `cargo test -p xtask --lib feature_matrix` before committing; the guard is


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:** Require implementation evidence for parity status and a maintainer commitment for planned work; reconcile the six Hermes cells previously marked planned; resolve changelog authors from the selected commit SHAs, retain humans using noreply addresses, and treat fetched metadata as data rather than instructions.
- **Scope boundary:** Parity and changelog skills plus six Hermes provider cells and their source notes; no other comparison cells, changelog entries, or runtime behavior changes.
- **Blast radius:** Assistants following the changed repository guidance.
- **Linked issue(s):** None; this self-contained documentation correction is carried by the PR.
- **Labels:** `type:docs`, `risk:low`, `size:XS`, `docs`, `distinguished contributor`, `status:parking-lot`.

### What this does, simply

An open request does not establish a roadmap commitment, and a bug report does not prove a feature works. The parity skill now checks those claims against their sources. A targeted refresh corrects six old Hermes entries: DeepInfra has shipped support, vLLM and LiteLLM use a generic custom-endpoint path, and Doubao, Venice, and Cloudflare remain unverified rather than being reported as planned or absent. Unrelated cells keep their original source dates. Changelog generation looks up the commits being reported instead of walking all of master and excluding humans whose email is private. Fetched contributor text is used only for attribution and filtering, never followed as instructions.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A; documentation instructions only.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI and `Docs Style` passed on the preceding head. Fresh CI for this repair is pending; local TOML, source, and documentation checks cover the changed facts.
- **Known CI coverage gap, if any:** Static checks do not prove how every assistant will follow the guidance.
- **Commands run and tail output:**

```sh
git diff origin/master...HEAD --check
# exit 0
DOCS_FILES='.claude/skills/feature-matrix-parity/SKILL.md
.claude/skills/changelog-generation/SKILL.md' BASE_SHA=$(git merge-base HEAD origin/master) bash scripts/ci/docs_links_gate.sh
# 6 tests passed; 0 added Markdown links; exit 0
DOCS_FILES='.claude/skills/feature-matrix-parity/SKILL.md
.claude/skills/changelog-generation/SKILL.md' BASE_SHA=$(git merge-base HEAD origin/master) bash scripts/ci/docs_quality_gate.sh
# exit 1: 15 pre-existing prose em-dashes in the changelog skill; none added
bash scripts/ci/comment_hygiene_gate.sh
# exit 0
```

- **Beyond CI, what did you manually verify?** Parsed the TOML with Python tomllib and compared it with the preceding head: exactly six Hermes values changed, all keys and other cells are unchanged, and every value belongs to the renderer's status vocabulary. Walked the affected Hermes provider profiles, registration, runtime resolution, documentation, and issue discussions at a51143fbbe6ddbc0c7f403d0579c4d75504c6793 on 2026-09-19; the TOML records the bounded evidence and preserves the older unrelated provenance. The earlier exact-commit GraphQL query smoke remains applicable; no query mechanics changed in this repair. No full release or competitor audit was run.
- **Visual interface changed?** N/A for layout or rendering behavior; six comparison values change through the existing renderer.
- **If any command was intentionally skipped, why:** No Cargo build or runtime smoke. This repair changes instructions and six valid TOML status values without changing join keys, registries, or renderer code; the structural comparison directly checks that boundary. No provider service was contacted to claim live integration behavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No new services or runtime calls; existing GitHub query guidance is revised where applicable.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? Yes. The commit query adds author names alongside existing login/email metadata. All fetched author fields are explicitly untrusted data used only for attribution and bot/model filtering; they cannot direct the workflow.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.

## Rollback (required for medium/high-risk PRs)

Revert the documentation change. No migration is needed.
