### PR TITLE
fix(channels/qq): probe the bot identity in the health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,6 +703,14 @@ jobs:
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      # `channel-qq` is outside `default-channels`, so the workspace run above
+      # does not execute QQ's feature-gated library regressions. This step is
+      # what actually executes the health probe's tests.
+      - name: Run QQ channel lib unit tests
+        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check"
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
   windows-test-scope:
     name: Advisory Windows test selection

--- a/crates/zeroclaw-channels/src/qq.rs
+++ b/crates/zeroclaw-channels/src/qq.rs
@@ -556,6 +556,74 @@ impl QQChannel {
         Ok(url)
     }
 
+    /// [`Channel::health_check`] against an explicit API base.
+    ///
+    /// Split out so a test can drive the whole check — the request shape it
+    /// issues and the verdict it reaches — against a stub server without
+    /// reaching the real API; production passes [`QQ_API_BASE`].
+    ///
+    /// The check has two steps because minting a token is not evidence the
+    /// credential works. `getAppAccessToken` succeeds for a bot the
+    /// platform has since disabled and for a token revoked before its
+    /// expiry, while every send and the gateway handshake then fail, so
+    /// the minted token is followed by `GET /users/@me` with the same
+    /// `QQBot <token>` header the send and listen paths use.
+    ///
+    /// A cached token is reused when one is live, rather than re-minting:
+    /// the probe is what establishes it still works, and re-minting would
+    /// spend the auth retry budget (four attempts with backoff) inside the
+    /// caller's own 10s timeout. QQ exposes no endpoint that validates a
+    /// *recipient*, so the check stops at the bot's identity by design —
+    /// an unusable peer ID surfaces only at send time.
+    async fn health_check_at(&self, api_base: &str) -> bool {
+        let token = match self.get_token().await {
+            Ok(token) => token,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "phase": "getAppAccessToken",
+                            "error": format!("{}", e),
+                        })),
+                    "qq: health check could not obtain an access token"
+                );
+                return false;
+            }
+        };
+
+        let probe = match self
+            .http_client()
+            .get(format!("{api_base}/users/@me"))
+            .header("Authorization", format!("QQBot {token}"))
+            .send()
+            .await
+        {
+            Err(e) => Err(anyhow::Error::from(e)),
+            Ok(resp) => crate::util::ensure_success(resp, "QQ health probe (/users/@me)")
+                .await
+                .map(|_| ()),
+        };
+
+        match probe {
+            Ok(()) => true,
+            Err(e) => {
+                ::zeroclaw_log::record!(
+                    WARN,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "phase": "probeBotIdentity",
+                            "error": format!("{}", e),
+                        })),
+                    "qq: health check rejected by the API"
+                );
+                false
+            }
+        }
+    }
+
     async fn record_dedup_key(&self, key: String) -> bool {
         let mut dedup = self.dedup.write().await;
 
@@ -1807,8 +1875,11 @@ impl Channel for QQChannel {
         }
     }
 
+    /// Probe the configured credentials against the live API. See
+    /// `health_check_at` for what the probe establishes and what it
+    /// deliberately cannot.
     async fn health_check(&self) -> bool {
-        self.fetch_access_token_with_retry().await.is_ok()
+        self.health_check_at(QQ_API_BASE).await
     }
 
     async fn start_typing(&self, _recipient: &str) -> anyhow::Result<()> {
@@ -2779,6 +2850,79 @@ allowed_users = ["user1"]
         assert!(
             result.is_err(),
             "should fail when token expired and no server available"
+        );
+    }
+
+    // --- Health probe tests ---
+    //
+    // Every case seeds the token cache with a live-expiry token so the
+    // check exercises the probe rather than the auth endpoint: no network
+    // beyond the stub, and a failure can only come from the probe itself.
+
+    #[tokio::test]
+    async fn health_check_accepts_a_live_token() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/@me"))
+            // The API accepts the credential only in this exact scheme; a
+            // mismatch would 401 in production and report the channel down.
+            .and(header("Authorization", "QQBot tok_abc"))
+            // The probe reads only the verdict, so this body is a shape
+            // placeholder, not a captured response.
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "zeroclaw_bot",
+                "username": "ZEROCLAW",
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let ch = QQChannel::new(
+            "id".into(),
+            "secret".into(),
+            "qq_test_alias",
+            Arc::new(Vec::new),
+        );
+        *ch.token_cache.write().await = Some(("tok_abc".to_string(), now_secs() + 3600));
+
+        assert!(
+            ch.health_check_at(&mock_server.uri()).await,
+            "an accepted identity response must report the channel healthy"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_reports_a_rejected_token() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/@me"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "message": "invalid or expired access token",
+                "code": 11244,
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let ch = QQChannel::new(
+            "id".into(),
+            "secret".into(),
+            "qq_test_alias",
+            Arc::new(Vec::new),
+        );
+        // Minting succeeded, so the app secret is fine; only the token is
+        // rejected. That is the case the auth-only check used to report
+        // healthy.
+        *ch.token_cache.write().await = Some(("revoked".to_string(), now_secs() + 3600));
+
+        assert!(
+            !ch.health_check_at(&mock_server.uri()).await,
+            "a rejected token must report the channel unhealthy"
         );
     }
 

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -93,6 +93,8 @@ Build with `channel-lark` for either Lark or Feishu. The root `channel-feishu` f
 
 Tencent's consumer messenger. Bot API access requires developer registration.
 
+`zeroclaw channel doctor` probes the bot's own identity (`GET /users/@me`) with the channel's credentials, so a healthy verdict means the API accepts the same token the send and listen paths use, not merely that the app secret still mints one. The probe cannot vet a recipient: the platform exposes no lookup for single-chat peer IDs, so an unusable address surfaces only when a send is attempted.
+
 ## IRC
 
 Classic IRC. Supports SASL, NickServ auth, and multiple channels.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `QQChannel::health_check` only minted an access token, so `zeroclaw channel doctor` reported QQ healthy whenever the app secret was still accepted. That mint succeeds for a bot the platform has since disabled and for a token revoked before its expiry, while every send and the gateway handshake then fail, so the verdict described nothing the message path would hit. The check now follows the minted token with `GET users/@me`, issued with the same `QQBot <token>` header the send and listen paths use, and reports healthy only when the API accepts it. Both steps log the phase and error at WARN, so a failure says whether the credentials were rejected at mint time or the token was refused afterwards.
  - A live cached token is reused instead of re-minting: the probe is what establishes it still works, and re-minting spends the auth retry budget (four attempts with backoff) inside the doctor's own 10s timeout.
  - `channel-qq` sits outside `default-channels`, so the workspace nextest run would never execute the new tests; a dedicated Test-job step now does, matching the existing WeChat, Lark, and Matrix steps for the same reason. The filter is deliberately narrower than those steps: the rest of the `qq::` module reaches the real auth endpoint and spends the four-attempt backoff, which would add a network dependency to that job.
  - The check takes an explicit API base through a private entry point so tests drive it against a stub server rather than the real API. That entry point stays private, so the trait method's docs name it as plain code text instead of linking it, because the repository denies rustdoc warnings and a docs build enabling `channel-qq` failed on the private-item link.
- **Scope boundary:** No change to the auth, send, listen, or gateway paths; `get_token`, `fetch_access_token_with_retry`, `ensure_success`, and `QQ_API_BASE` are untouched. No new config key, CLI flag, or log field. The check deliberately stops at the bot's own identity: the platform exposes no endpoint that validates a *recipient*, so an unusable peer ID still surfaces only at send time. The `channel doctor` output format and exit behavior are unchanged.
- **Blast radius:** `Channel::health_check` for QQ only. Its sole production caller is `orchestrator::doctor_channels`, reached from `zeroclaw channel doctor`; the daemon and gateway paths do not call it (the gateway hits are test doubles). An operator running doctor against QQ now reaches the vendor twice per channel (mint then probe) instead of once, through the existing `channel.qq` proxy-configured client. The CI change adds one feature combination (`--features channel-qq`) to the Test job's build, consistent with the WeChat, Lark, and Matrix steps already there.
- **Linked issue(s):** None.
- **Labels:** `bug`, `ci`, `docs`, `channel`, `channel:qq`, `risk:medium`, `size:S`, `cli`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes, for the focused test path; the CLI A/B needs a QQ bot you control.
- **Interface(s) exercised:** `surface` = `cli` (`zeroclaw channel doctor`); `channel` = `qq.<alias>` (composite: type `qq`, configured alias).
- **Setup / preconditions:** For the A/B command below, none beyond the repo. For the CLI check, a configured QQ channel whose credentials still mint a token but whose token the API now refuses (for example, an app disabled after the secret was issued).
- **Steps to run:**

  ```sh
  # Test-level A/B: same command, both revisions.
  git checkout master
  cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check

  git checkout feat/qq-health-probe
  cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check

  # Optional CLI-level A/B, with the preconditions above:
  zeroclaw channel doctor
  ```

- **Expected on this branch (after):** 2 tests run, 2 passed. With the CLI precondition, QQ reports `❌ ... unhealthy` and the log carries `"phase": "probeBotIdentity"` with the API's status, for example `QQ health probe (users/@me) failed (401): ...`.
- **Prior behavior on `master` (before):** 0 tests run (the probe cases do not exist). With the CLI precondition, QQ reports `✅ ... healthy` while every send and the gateway handshake fail.

### How I tested

Focused tests, the two gates this branch had to satisfy, the CI rustdoc command run verbatim, and a rustdoc build with this channel enabled:

```text
# The new Test-job step, reproduced exactly (current HEAD)
$ cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check
        PASS [   0.336s] (1/2) zeroclaw-channels qq::tests::health_check_reports_a_rejected_token
        PASS [   0.336s] (2/2) zeroclaw-channels qq::tests::health_check_accepts_a_live_token
     Summary [   0.338s] 2 tests run: 2 passed, 1619 skipped

# Docs Style gate on the changed docs file
$ BASE_SHA=$(git merge-base origin/master HEAD) DOCS_FILES=docs/book/src/channels/chat-others.md bash scripts/ci/docs_quality_gate.sh
No prose em-dashes in changed docs files.
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Summary: 0 error(s)

# Docs link gate
$ bash scripts/ci/docs_links_gate.sh
Ran 6 tests in 0.226s
OK
Collected 0 added link(s) from 1 docs file(s).

# rustdoc with this channel enabled (the surface the CI gate misses)
$ cargo doc -p zeroclaw-channels --no-deps --features channel-qq
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.32s

# The CI rustdoc step, verbatim
$ cargo doc --no-deps --workspace --exclude zeroclaw-desktop
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.12s

$ cargo fmt -p zeroclaw-channels -- --check          # clean
$ python scripts/ci/comment_hygiene_gate.py <qq.rs>  # Comment hygiene gate passed.
```

- **CI checks relied on and why they cover this change:** `Docs Style` covers the changed Markdown lines (em-dash and markdownlint, both run on this file) and the added-link gate. `Test` reaches the new probe cases through the step added in this PR. `Lint` covers the QQ source and its tests through `--features ci-all --all-targets`, since `ci-all` pulls `channels-full`, which includes `channel-qq`. `Check (all features)` compiles the same surface.
- **Known CI coverage gap, if any:** The rustdoc warnings gate builds with default features, where `channel-qq` is absent, so it does not cover this file; that gap is why the private-item link was found and closed with an explicit `--features channel-qq` build instead. Separately, no job exercises the probe against the live API.
- **Commands run and tail output:** as pasted above.
- **Beyond CI, what did I manually verify?** The endpoint and auth scheme against the vendor's own documentation ("接口调用与鉴权": `Authorization: QQBot ACCESS_TOKEN`) and the official botpy SDK, where the current-user call is `Route("GET", "users/@me")` and the default domain is `api.sgroup.qq.com`, matching `QQ_API_BASE`. A call-site audit confirming that `orchestrator::doctor_channels` is the only production caller of `Channel::health_check` and that `fetch_access_token_with_retry` remains reachable through `get_token` (no dead code). A privacy pass over the new fixtures. A structure check that the added `ci.yml` step parses and lands inside the `test` job.

  **Not verified:** no live call was made against the QQ API. The probe's happy path is exercised only against a wiremock stub, so the claim that `users/@me` accepts the minted token rests on the vendor documentation and the SDK rather than an end-to-end run; no QQ bot credentials were available here. Locally, clippy never reached this file either; see the skipped-command note below.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why?** `cargo clippy --all-targets -- -D warnings` was not completed locally: this machine carries a nightly toolchain (1.100) while the repo pins 1.98, and `zeroclaw-tools` fails to compile under the newer nightly on an unrelated deprecation (`Atomic::fetch_update`), so the run never reached `zeroclaw-channels`. CI's Lint job supplies that evidence through `--features ci-all --all-targets`. No live-API probe was run, for want of QQ credentials; see the note above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`Yes`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- Prompt injection or untrusted model-visible text introduced/changed? (`No`)
- If any `Yes`, describe the risk and mitigation: `zeroclaw channel doctor` now issues one additional request per QQ channel, `GET https://api.sgroup.qq.com (bot identity endpoint)`, using the channel's existing proxy-configured client and the same `QQBot <token>` header the send and listen paths already send. No new host, credential, or secret enters the process, and the request goes to the origin the message path already talks to; the only new cost is one extra vendor round trip during a doctor run. The token itself is read from the existing cache through `get_token`, so storage, refresh, and logging behavior are unchanged.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- Rust/MSRV/toolchain floor changed? (`No`)
- If backward compatibility is `No` or either surface/floor question is `Yes`: exact upgrade steps for existing users: N/A. The verdict is intentionally stricter, so an operator whose QQ bot was actually broken now sees `unhealthy` where `healthy` was reported before, which is the point of the change; no configuration needs to move.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-merge-sha>`, which restores the auth-only check. The change is one commit after squash-merge, with no migration or persisted state.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `zeroclaw channel doctor` reporting QQ `unhealthy` immediately after a successful `getAppAccessToken`; the WARN log carries `"phase": "probeBotIdentity"` alongside the API's status and body, for example `QQ health probe (users/@me) failed (401): {"message":"invalid or expired access token","code":11244}`. If the API is temporarily refusing `users/@me` while sends still work, that verdict is the symptom to look for.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A: this PR uses no `Supersedes #`.
