### PR TITLE
feat(channels): deliver one-off sends and cron output to QQ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,7 @@ jobs:
       # `qq::` module reaches the real auth endpoint and spends the four-attempt
       # backoff, which would put the network in the job.
       - name: Run QQ channel lib unit tests
-        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check one_off_send_resolves_dotted_qq_alias deliver_announcement_routes_qq_to_qq_arm compiled_channel_keys_have_intentional_announcement_delivery_registration compiled_channel_keys_have_intentional_one_shot_builder_support"
+        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check one_off_send_resolves_dotted_qq_alias deliver_announcement_routes_qq_to_qq_arm deliver_announcement_rejects_disabled_qq_alias compiled_channel_keys_have_intentional_announcement_delivery_registration compiled_channel_keys_have_intentional_one_shot_builder_support"
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,10 +704,15 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # `channel-qq` is outside `default-channels`, so the workspace run above
-      # does not execute QQ's feature-gated library regressions. This step is
-      # what actually executes the health probe's tests.
+      # executes neither QQ's feature-gated channel tests nor the disposition
+      # guards over its one-off and announcement arms (the guards skip any
+      # channel the build did not compile, so QQ reads as absent there). This
+      # step runs the health probe's tests and both arms against a build that
+      # has `channel-qq`. The filter names only those tests: the rest of the
+      # `qq::` module reaches the real auth endpoint and spends the four-attempt
+      # backoff, which would put the network in the job.
       - name: Run QQ channel lib unit tests
-        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check"
+        run: "cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib qq::tests::health_check one_off_send_resolves_dotted_qq_alias deliver_announcement_routes_qq_to_qq_arm compiled_channel_keys_have_intentional_announcement_delivery_registration compiled_channel_keys_have_intentional_one_shot_builder_support"
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -13366,6 +13366,21 @@ pub async fn deliver_announcement(
         #[cfg(feature = "channel-qq")]
         "qq" => {
             let qq = config.channels.qq.get(alias).ok_or_else(not_configured)?;
+            // The listener collector skips a disabled alias, but cron and
+            // one-off delivery reach this arm without a live instance, so the
+            // off switch has to be honored here before the transport is built.
+            if !qq.enabled {
+                let message =
+                    format!("[channels.qq.{alias}] is disabled; set enabled = true to deliver");
+                ::zeroclaw_log::record!(
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Reject)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({"channel": format!("qq.{alias}")})),
+                    &message
+                );
+                anyhow::bail!("{message}");
+            }
             let peers = config.channel_external_peers("qq", alias);
             let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
                 Arc::new(move || peers.clone());
@@ -36277,6 +36292,40 @@ Done."#;
         assert!(
             msg.contains("[channels.qq.qq] not configured"),
             "qq.qq must report the real config table; got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "channel-qq")]
+    async fn deliver_announcement_rejects_disabled_qq_alias() {
+        // Disabling an alias keeps its credentials, and the cron scheduler
+        // reaches this arm without consulting the listener collector, so the
+        // refusal has to come from the dispatcher itself.
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.channels.qq.insert(
+            "work".to_string(),
+            zeroclaw_config::schema::QQConfig {
+                enabled: false,
+                app_id: "test-app-id".to_string(),
+                app_secret: "test-app-secret".to_string(),
+                // If the guard regresses, the send attempt lands on a refused
+                // loopback port instead of Tencent's API.
+                proxy_url: Some("http://127.0.0.1:1".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let err = deliver_announcement(&config, "qq.work", "user:OPENID", None, "hi")
+            .await
+            .expect_err("a disabled qq alias must not be delivered to");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("[channels.qq.work] is disabled"),
+            "disabled alias must report the off switch; got: {msg}"
+        );
+        assert!(
+            !msg.contains("unsupported delivery channel"),
+            "disabled alias must reach the QQ arm; got: {msg}"
         );
     }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -13363,6 +13363,25 @@ pub async fn deliver_announcement(
         "wechat" => {
             anyhow::bail!("WeChat channel requires the `channel-wechat` feature");
         }
+        #[cfg(feature = "channel-qq")]
+        "qq" => {
+            let qq = config.channels.qq.get(alias).ok_or_else(not_configured)?;
+            let peers = config.channel_external_peers("qq", alias);
+            let peer_resolver: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+                Arc::new(move || peers.clone());
+            let ch = QQChannel::new(
+                qq.app_id.clone(),
+                qq.app_secret.clone(),
+                alias,
+                peer_resolver,
+            )
+            .with_proxy_url(qq.proxy_url.clone());
+            zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
+        }
+        #[cfg(not(feature = "channel-qq"))]
+        "qq" => {
+            anyhow::bail!("QQ channel requires the `channel-qq` feature");
+        }
         #[cfg(feature = "channel-lark")]
         "lark" | "feishu" => {
             // [channels.lark.<alias>] is the single source of truth for both
@@ -36042,6 +36061,29 @@ Done."#;
     }
 
     #[tokio::test]
+    #[cfg(feature = "channel-qq")]
+    async fn one_off_send_resolves_dotted_qq_alias() {
+        // The QQ instance alias is the channel type in practice
+        // (`[channels.qq.qq]`), and a bare id only ever resolves a
+        // `default` alias, so the dotted form is the one operators use.
+        // It must reach the QQ arm rather than the dispatcher's reject path.
+        let config = zeroclaw_config::schema::Config::default();
+
+        let err = send_channel_message(&config, "qq.qq", "user:OPENID", "test message")
+            .await
+            .expect_err("unconfigured alias should fail after dotted ref resolution");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("[channels.qq.qq] not configured"),
+            "dotted qq id should reach named channel resolution; got: {message}"
+        );
+        assert!(
+            !message.contains("unsupported delivery channel"),
+            "dotted qq id must not be reported as an unsupported delivery channel; got: {message}"
+        );
+    }
+
+    #[tokio::test]
     #[cfg(feature = "channel-linq")]
     async fn one_off_send_keeps_dotted_linq_alias_on_builder() {
         // `linq.<alias>` predates the announcement delegation and is resolved by
@@ -36093,7 +36135,6 @@ Done."#;
             "wecom",
             "wecom_ws",
             "wecom-ws",
-            "qq",
             "nostr",
             "clawdtalk",
             "reddit",
@@ -36217,6 +36258,25 @@ Done."#;
         assert!(
             msg.contains("[channels.email.default] not configured"),
             "email.default must report the real config table; got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "channel-qq")]
+    async fn deliver_announcement_routes_qq_to_qq_arm() {
+        let config = zeroclaw_config::schema::Config::default();
+
+        let err = deliver_announcement(&config, "qq.qq", "user:OPENID", None, "hi")
+            .await
+            .expect_err("expected qq.qq to bail because channel is not configured");
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.contains("unsupported delivery channel"),
+            "qq.qq must route to the QQ arm, not fall through; got: {msg}"
+        );
+        assert!(
+            msg.contains("[channels.qq.qq] not configured"),
+            "qq.qq must report the real config table; got: {msg}"
         );
     }
 

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -93,9 +93,9 @@ Build with `channel-lark` for either Lark or Feishu. The root `channel-feishu` f
 
 Tencent's consumer messenger. Bot API access requires developer registration; `[channels.qq.<alias>]` takes the console's `app_id` and `app_secret`.
 
-Inbound senders are the platform's opaque IDs — `user_openid` on single-chat messages, `member_openid` on group `@`-messages. Authorize them through a [peer group](./peer-groups.md) (`external_peers`); an empty peer set denies everyone, so a connected bot that never answers usually has no peer-group entry for the sender.
+Inbound senders are the platform's opaque IDs: `user_openid` on single-chat messages, `member_openid` on group `@`-messages. Authorize them through a [peer group](./peer-groups.md) (`external_peers`); an empty peer set denies everyone, so a connected bot that never answers usually has no peer-group entry for the sender.
 
-Replies to an inbound message are passive (the triggering `msg_id` is echoed), so they need no extra permission. Sends that are not a reply — cron delivery, `zeroclaw channel send` — are active messages and draw on the bot's active-message quota. Address the instance explicitly as `qq.<alias>`; a bare `--channel-id qq` resolves a `default` alias only.
+Replies to an inbound message are passive (the triggering `msg_id` is echoed), so they need no extra permission. Sends that are not a reply (cron delivery, `zeroclaw channel send`) are active messages and draw on the bot's active-message quota. Address the instance as `qq.<alias>` and the destination as `user:<user_openid>` for a single chat or `group:<group_openid>` for a group, where the group ID comes from the message's `group_openid` rather than the sender's `member_openid`. A bare `--channel-id qq` resolves a `default` alias only.
 
 `zeroclaw channel doctor` probes the bot's own identity (`GET /users/@me`) with the channel's credentials, so a healthy verdict means the API accepts the same token the send and listen paths use, not merely that the app secret still mints one. The probe cannot vet a recipient: the platform exposes no lookup for single-chat peer IDs, so an unusable address surfaces only when a send is attempted.
 

--- a/docs/book/src/channels/chat-others.md
+++ b/docs/book/src/channels/chat-others.md
@@ -91,7 +91,11 @@ Build with `channel-lark` for either Lark or Feishu. The root `channel-feishu` f
 
 ## QQ
 
-Tencent's consumer messenger. Bot API access requires developer registration.
+Tencent's consumer messenger. Bot API access requires developer registration; `[channels.qq.<alias>]` takes the console's `app_id` and `app_secret`.
+
+Inbound senders are the platform's opaque IDs — `user_openid` on single-chat messages, `member_openid` on group `@`-messages. Authorize them through a [peer group](./peer-groups.md) (`external_peers`); an empty peer set denies everyone, so a connected bot that never answers usually has no peer-group entry for the sender.
+
+Replies to an inbound message are passive (the triggering `msg_id` is echoed), so they need no extra permission. Sends that are not a reply — cron delivery, `zeroclaw channel send` — are active messages and draw on the bot's active-message quota. Address the instance explicitly as `qq.<alias>`; a bare `--channel-id qq` resolves a `default` alias only.
 
 `zeroclaw channel doctor` probes the bot's own identity (`GET /users/@me`) with the channel's credentials, so a healthy verdict means the API accepts the same token the send and listen paths use, not merely that the app secret still mints one. The probe cannot vet a recipient: the platform exposes no lookup for single-chat peer IDs, so an unusable address surfaces only when a send is attempted.
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `deliver_announcement` had no `qq` arm, so the two delivery paths that
    have no live channel instance failed before any I/O: `zeroclaw channel
    send --channel-id qq.<alias>` reported `unsupported delivery channel:
    qq`, and cron announce jobs targeting `qq.<alias>` never delivered. QQ
    was reachable only as a reply to an inbound message, through the live
    registry. This adds the missing arm, built from the canonical
    `[channels.qq.<alias>]` block with its peer resolver and per-channel
    proxy, the same way the neighbouring per-alias arms are built.
  - The arm refuses an alias whose `enabled` flag is off before it builds the
    transport, logging `[channels.qq.<alias>] is disabled; set enabled = true
    to deliver` with `Action::Reject`. The listener collector skips a disabled
    alias, but cron announce jobs and one-off sends reach this arm without a
    live instance, so the off switch has to be honored in the dispatcher. A
    disabled alias keeps its credentials, so the switch cannot be a matter of
    deleting the section.
  - `qq` leaves the announcement-delivery set pinned as intentionally
    unsupported. Both surface guards read the dispatcher from source, so
    they see the new arm.
  - The tests are gated on `channel-qq`, which no job executes: the
    Test job's workspace run compiles the default channel surface, and its
    per-channel steps cover WeChat, Lark, and Matrix. Clippy compiles the
    same tests through `ci-all` but never runs them, and a disposition guard
    skips channels the build did not compile, so QQ read as absent in the
    only run that executed the guards. A Test-job step now runs master's QQ
    health tests plus this PR's routing tests, the disabled-alias refusal,
    and both disposition guards against a `channel-qq` build.
  - Docs: the QQ section of the chat-platforms page records the sender-ID
    shapes, the peer-group inbound gate, the passive/active split, and the
    send target forms. Two prose em-dashes in that section also trip the
    docs style gate, which scans the whole changed file rather than added
    lines, so they are rewritten.
- **Scope boundary:** Does not touch `qq.rs` (the health-probe change is a
  separate branch). Does not change the reply path: an in-flight instance is
  still preferred through the live registry, so replies stay passive with the
  triggering `msg_id` echoed. Does not change bare `--channel-id qq`, which
  still resolves a `default` alias only; that is now documented rather than
  changed. Honors `enabled` for this arm only; no sibling arm is changed. No
  new config keys, flags, or cargo features.
- **Blast radius:** `deliver_announcement` is the shared dispatcher for
  one-off sends and cron announce delivery across every channel; a `qq`-typed
  ref on a `channel-qq` build now reaches a real send instead of erroring.
  Configured `qq.<alias>` cron jobs that were failing closed will start
  posting, except an alias with `enabled = false`, which fails fast with
  `[channels.qq.<alias>] is disabled; set enabled = true to deliver`.
  Non-QQ arms and the live-registry fast path are untouched.
- **Linked issue(s):** None. No tracking issue was identified for this
  report; add `Related #` here if one exists.
- **Labels:** `channel`, `channel:core`, `ci`, `docs`, `enhancement`, `risk:medium`, `size:S`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `cli` (the `zeroclaw channel send` subcommand),
  and `channel` for outbound QQ delivery. No `web`/`tui` surface involved.
- **Setup / preconditions:** None for the A/B below; it needs no QQ
  credentials because both revisions fail before any network I/O. The
  credentialed smoke test at the end needs a real `app_id`/`app_secret`.
- **Steps to run:** drop this throwaway test at
  `crates/zeroclaw-channels/tests/qq_dispatch_probe.rs` and run
  `cargo nextest run --locked -p zeroclaw-channels --features channel-qq --test qq_dispatch_probe --no-capture`
  on both revisions:

  ```rust
  #[tokio::test]
  async fn qq_dispatch_probe() {
      use zeroclaw_channels::orchestrator::{deliver_announcement, send_channel_message};
      let config = zeroclaw_config::schema::Config::default();
      let one_off = send_channel_message(&config, "qq.qq", "user:OPENID", "hi")
          .await.expect_err("unconfigured alias must fail");
      println!("ONE-OFF qq.qq  => {:#}", one_off);
      let bare = send_channel_message(&config, "qq", "user:OPENID", "hi")
          .await.expect_err("unconfigured alias must fail");
      println!("ONE-OFF qq     => {:#}", bare);
      let announce = deliver_announcement(&config, "qq.qq", "user:OPENID", None, "hi")
          .await.expect_err("unconfigured alias must fail");
      println!("ANNOUNCE qq.qq => {:#}", announce);

      let mut disabled = zeroclaw_config::schema::Config::default();
      disabled.channels.qq.insert(
          "work".to_string(),
          zeroclaw_config::schema::QQConfig {
              enabled: false,
              app_id: "probe-app-id".to_string(),
              app_secret: "probe-app-secret".to_string(),
              proxy_url: Some("http://127.0.0.1:1".to_string()),
              ..Default::default()
          },
      );
      let off = deliver_announcement(&disabled, "qq.work", "user:OPENID", None, "hi")
          .await.expect_err("a disabled alias must fail");
      println!("ANNOUNCE qq.work (enabled = false) => {:#}", off);
  }
  ```

  If you share one `CARGO_TARGET_DIR` across worktrees, `touch` the channel
  sources first. Cargo's mtime fingerprint treats an older checkout as fresh,
  and the run silently reuses the other tree's artifact.
- **Expected on this branch (after):**
  `ONE-OFF qq.qq => ... [channels.qq.qq] not configured` and
  `ANNOUNCE qq.qq => [channels.qq.qq] not configured`: both dotted refs reach
  the QQ arm and report the real config table.
  `ANNOUNCE qq.work (enabled = false) => [channels.qq.work] is disabled; set
  enabled = true to deliver`, with no request leaving the machine (the probe
  proxy points at a refused loopback port).
- **Prior behavior on `master` (before):** the same command prints
  `unsupported delivery channel: qq` for both dotted refs; the dispatcher
  rejects the type before it reads config. The disabled alias prints the same
  `unsupported delivery channel: qq`, which is a rejection for the wrong
  reason, not the off switch.
  Bare `qq` prints `QQ channel is not configured` on both revisions, which is
  the documented `default`-alias rule, not a regression.
- **Optional credentialed smoke:** with `[channels.qq.<alias>]` configured
  and a peer-group entry for the recipient,
  `zeroclaw channel send --channel-id qq.<alias> --to user:<user_openid> --message hi`
  should post, and a cron announce job pointed at `qq.<alias>` should deliver.

### How I tested

The changed surface is channel dispatch plus the CI step that pins it, so the
evidence is the dispatcher A/B, the new step's own command, the two source
guards, the disabled-alias refusal and its mutation check, and the docs gates.

- **Commands run and tail output:**

  ```
  # the exact command this PR adds to the Test job
  $ cargo nextest run --locked -p zeroclaw-channels --features channel-qq --lib \
      qq::tests::health_check one_off_send_resolves_dotted_qq_alias \
      deliver_announcement_routes_qq_to_qq_arm deliver_announcement_rejects_disabled_qq_alias \
      compiled_channel_keys_have_intentional_announcement_delivery_registration \
      compiled_channel_keys_have_intentional_one_shot_builder_support
  PASS (1/7) compiled_channel_keys_have_intentional_one_shot_builder_support
  PASS (2/7) compiled_channel_keys_have_intentional_announcement_delivery_registration
  PASS (3/7) deliver_announcement_routes_qq_to_qq_arm
  PASS (4/7) one_off_send_resolves_dotted_qq_alias
  PASS (5/7) deliver_announcement_rejects_disabled_qq_alias
  PASS (6/7) qq::tests::health_check_reports_a_rejected_token
  PASS (7/7) qq::tests::health_check_accepts_a_live_token
  Summary [0.371s] 7 tests run: 7 passed, 1631 skipped

  # the step is a live pin, not a re-run: removing the arm's send fails the guard
  $ # (arm body replaced with `anyhow::bail!`)
  FAIL compiled_channel_keys_have_intentional_announcement_delivery_registration
    assertion `left == right` failed: compiled channel key `qq` changed
    announcement delivery support without an explicit registration disposition
      left: false
     right: true

  # the refusal test is live too, and stays offline when the guard regresses
  $ # (guard removed, test run alone)
  FAIL deliver_announcement_rejects_disabled_qq_alias
    disabled alias must report the off switch; got: error sending request for url
    (https://bots.qq.com/app/getAppAccessToken): client error (Connect): tunnel
    error: failed to create underlying connection: tcp connect error:
    由于目标计算机积极拒绝，无法连接。 (os error 10061)
  # os error 10061 is WSAECONNREFUSED; the OS text is localized on a zh-CN host

  # A/B on the dispatcher, master vs this branch (probe above)
  master:
  ONE-OFF qq.qq  => Failed to send message via qq.qq: unsupported delivery channel: qq
  ANNOUNCE qq.qq => unsupported delivery channel: qq
  this branch:
  ONE-OFF qq.qq  => Failed to send message via qq.qq: [channels.qq.qq] not configured
  ANNOUNCE qq.qq => [channels.qq.qq] not configured
  ANNOUNCE qq.work (enabled = false) => [channels.qq.work] is disabled; set enabled = true to deliver

  # docs gates over the changed Markdown
  $ BASE_SHA=... DOCS_FILES=docs/book/src/channels/chat-others.md bash scripts/ci/docs_quality_gate.sh
  No prose em-dashes in changed docs files.
  markdownlint-cli2 v0.20.0: Summary: 0 error(s)
  $ ... bash scripts/ci/docs_links_gate.sh
  Checked 1 local docs link target(s). Ran 6 tests in 0.190s  OK

  # hygiene and lint
  $ cargo fmt --all -- --check                           # clean
  $ cargo clippy -p zeroclaw-channels --features channel-qq --all-targets  # exit 0
  $ python scripts/ci/comment_hygiene_gate.py <file list> # Comment hygiene gate passed.
  ```

- **Beyond CI, what did you manually verify?** The dispatcher A/B above, on a
  `channel-qq` build, with a real rebuild forced on each side so the two
  results are not the same artifact. Also that both edits are load-bearing:
  mutating the arm back to a non-delivering body fails the announcement guard
  at `--features channel-qq`, and dropping the `enabled` guard fails the
  refusal test on a refused loopback connection rather than a Tencent request.
  Both are exactly the runs the new step provides.
- **What I did NOT verify:** delivery against a live QQ bot. That needs
  console-issued credentials, so the end-to-end post is reviewer/manual
  territory. A disabled alias is covered offline (refusal happens before the
  transport is built) but not against a live endpoint; neither is the
  `enabled = true` path.
- **Known CI coverage gap, if any:** No gap for the surface this PR changes;
  the new Test-job step is what closes it, and it is part of this diff (7
  tests: both health probes, both routing tests, the disabled-alias refusal,
  both disposition guards). The other 55 `qq::` tests still never execute,
  deliberately: they reach the real auth endpoint and spend a four-attempt
  backoff, which would put the network in the Test job. No live-platform
  coverage exists for QQ in CI.
- **CI checks relied on and why they cover this change:** `Test` (the new QQ
  step runs the routing tests, the refusal, both guards, and master's health
  probes), `Lint` (clippy at `--features ci-all` compiles the gated arm and
  the new step's targets), `Docs Style` (covers the changed Markdown and the
  em-dash rule), `CI Required Gate`.
- **If any command was intentionally skipped, why:** No full workspace
  `cargo test` run; the changed surface is one dispatcher arm plus its guards,
  which the focused run above exercises directly, and the workspace run does
  not compile the gated code at all.
- **Visual interface changed?** N/A (no rendered text, layout, or state).

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `Yes`. The dispatcher now performs real sends to `api.sgroup.qq.com` for `qq.<alias>` refs where it previously errored before any I/O. The arm requires an alias present in `[channels.qq.<alias>]` with credentials, and refuses an alias with `enabled = false` before the transport is built, so the off switch does not leave a network path open. The `channel_external_peers` resolver governs inbound access, not these outbound sends. Outbound text still passes `redact_channel_outbound_leaks` and `ensure_nonempty_channel_reply` before the send, unchanged.
- Secrets / tokens / credentials handling changed? `No`. The arm reads the
  same `app_id`/`app_secret` fields the other QQ construction sites read, and
  mints a token through the existing auth path; nothing new is logged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs?
  `No`. The tests use placeholder IDs (`user:OPENID`) and placeholder
  credentials on an unconfigured `Config::default()`.
- Prompt injection or untrusted model-visible text introduced/changed? `No`.
- If any `Yes`, describe the risk and mitigation: covered inline above.

## Compatibility (required)

- Backward compatible? `Yes`. The change turns a hard failure into the
  documented behavior; no capability is removed. An alias with
  `enabled = false` still fails instead of delivering, now naming the switch
  (`[channels.qq.<alias>] is disabled; set enabled = true to deliver`) rather
  than reporting `unsupported delivery channel: qq`.
- Config / env / CLI surface changed? `No`. No new keys, flags, or features;
  an existing `qq.<alias>` ref now resolves instead of erroring.
- Rust/MSRV/toolchain floor changed? `No`.
- If backward compatibility is `No` or either surface/floor question is
  `Yes`: exact upgrade steps for existing users: N/A.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert <squash-sha>`. This PR squash-
  merges to one commit, and reverting it restores `qq` to the announcement
  set pinned as unsupported and removes the arm, the step, and the docs
  paragraph together.
- **Feature flags or config toggles:** None new. An operator stops delivery by
  setting `enabled = false` on the alias (this arm honors it) or by removing
  the `[channels.qq.<alias>]` block.
- **Observable failure symptoms:** after a rollback, cron announce jobs and
  `zeroclaw channel send --channel-id qq.<alias>` log
  `unsupported delivery channel: qq`; the announcement guard would also fail
  at `--features channel-qq` if only the arm were reverted. A retained but
  disabled alias logs `[channels.qq.<alias>] is disabled; set enabled = true
  to deliver`.
