### PR TITLE
test(rpc): calibrate the dispatch constrained-stack guard to 1.5 MiB

### DIFF
--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -13086,11 +13086,20 @@ mod tests {
         (dispatcher, rx)
     }
 
+    /// Calibrated stack budget for the constrained-stack regression below.
+    /// Tokio worker threads default to 2 MiB; on macOS/aarch64, debug builds
+    /// need ~1.1 MB of execution stack for a `session/new` dispatch now that
+    /// the largest dispatch branches are heap-pinned, and needed ~2.0 MB
+    /// before that. 1.5 MiB sits between the two: a new inline branch pushing
+    /// the requirement back toward the old level fails this test, while the
+    /// current shape passes with margin.
+    const CONSTRAINED_STACK_BYTES: usize = 1536 * 1024;
+
     #[test]
-    fn process_line_session_new_creates_session_on_two_megabyte_stack() {
+    fn process_line_session_new_creates_session_on_constrained_stack() {
         std::thread::Builder::new()
             .name("rpc-session-new-stack-regression".into())
-            .stack_size(2 * 1024 * 1024)
+            .stack_size(CONSTRAINED_STACK_BYTES)
             .spawn(|| {
                 let runtime = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
@@ -13122,7 +13131,7 @@ mod tests {
             })
             .expect("stack regression thread should spawn")
             .join()
-            .expect("session/new should not exhaust a two-megabyte stack");
+            .expect("session/new should not exhaust the constrained stack");
     }
 
     /// `process_line`'s exhaustive `match` sizes its generated state machine
@@ -13136,7 +13145,7 @@ mod tests {
     /// bound: the intent is to catch a new multi-hundred-KB branch, not to
     /// force every incidental size change through this test.
     #[test]
-    fn process_line_future_stays_small_enough_for_a_two_megabyte_stack() {
+    fn process_line_future_stays_small_enough_for_a_constrained_stack() {
         let tmp = tempfile::TempDir::new().expect("temporary test directory");
         let config = make_acp_test_config(&tmp);
         let (mut dispatcher, _sessions, _rx) = make_acp_test_dispatcher_with_receiver(config);
@@ -13147,7 +13156,7 @@ mod tests {
             "process_line's future grew to {size} bytes; a new or changed handler is now \
              inlined into this match without Box::pin, which can overflow the 2MB Windows \
              thread stack this exists to protect (see \
-             process_line_session_new_creates_session_on_two_megabyte_stack). Box::pin the \
+             process_line_session_new_creates_session_on_constrained_stack). Box::pin the \
              large new branch the same way ConfigSet, QuickstartApply, and the other handlers \
              above are"
         );


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `process_line_session_new_creates_session_on_two_megabyte_stack` runs a `session/new` dispatch on a reduced thread stack and fails when the dispatcher overflows it. Before #10735 it was calibrated within 2% of its limit: a 2 MiB guard against a measured 2004 KB debug requirement. At that margin real growth is indistinguishable from frame-layout noise, which is why the advisory Windows job flipped from pass to abort across two bases whose measured difference was under 64 KB (#10734).
  - After #10735's branch heap-pinning the debug requirement dropped to ~1075 KB on macOS/aarch64. This PR adds `CONSTRAINED_STACK_BYTES = 1536 * 1024` next to the test, with a doc comment stating the calibration, and spawns the regression thread at that size: the current shape passes with ~30% margin, and a new inline branch that pushes the requirement back toward the pre-pinning level fails.
  - Both tests renamed from `..._two_megabyte_stack` to `..._constrained_stack` so the names stop encoding a number that is no longer the guard. The `size_of_val` test's threshold and logic are unchanged; only its name and the cross-reference in its assert message moved.
- **Scope boundary:** Test module only. No change to `process_line`, any handler, the `size_of_val` threshold, or any production code. No platform-specific thresholds and no env-var override for the stack size.
- **Blast radius:** Two unit tests in `zeroclaw-runtime::rpc::dispatch::tests`. The Windows advisory nextest job runs the renamed test; nothing gates on the old name (`git grep two_megabyte_stack` is empty after the change; the only prior hits were the three in this file).
- **Linked issue(s):** Related #10734, #10735
- **Labels:** `runtime`, `distinguished contributor`, `risk:low`, `size:XS`, `type:test`

### Why 1536 KB

Measured smallest passing stack (macOS 26.6 / aarch64, Rust 1.96.1, 4 KB resolution):

| head | debug | release |
|---|---|---|
| master before #10735 | 2004 KB | 356 KB |
| #10735 (a2bfa0c76d) | 1075 KB | 308 KB |

- Not 1024 KB: fails on the current shape (verified, see below).
- Not 2048 KB: the old value; its 2% margin is the calibration problem.
- 1536 KB trips on the multi-hundred-KB inline handler the issue identified as the risk, and on nothing smaller.

Platform caveat: Windows MSVC debug frames are larger, so absolute numbers do not transfer. The advisory Windows job remains the instrument for that platform; this change is what lets it report something other than noise.

`size_of_val` guards the struct size of the dispatch future; this test guards execution-stack usage, which the size check cannot see (debug builds stage the future on the stack before moving it into a `Box::pin`). Both stay.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A. The two targeted tests are the whole change; the guard-bites check below is reproducible by editing one constant.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI passed on `748ccec9123c`. Both renamed tests also passed in the [advisory Windows job](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/35408175517/job/105802299013).
- **Known CI coverage gap, if any:** The advisory Windows job failed overall on two unrelated Arduino-upload tests: `failed_preflight_does_not_compile_or_upload` and `fake_cli_success_runs_all_stages_and_cleans_workspace`. Both changed RPC tests passed.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
# clean

cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
# clean (2m42s)

cargo test -p zeroclaw-runtime --lib rpc::dispatch::tests::process_line_session_new_creates_session_on_constrained_stack -- --exact
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4302 filtered out; finished in 0.04s

cargo test -p zeroclaw-runtime --lib rpc::dispatch::tests::process_line_future_stays_small_enough_for_a_constrained_stack -- --exact
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4302 filtered out; finished in 0.00s

# Guard-bites check: CONSTRAINED_STACK_BYTES temporarily set to 1024 * 1024
cargo test -p zeroclaw-runtime --lib rpc::dispatch::tests::process_line_session_new_creates_session_on_constrained_stack -- --exact
# thread 'rpc-session-new-stack-regression' has overflowed its stack
# error: test failed ... signal: 6, SIGABRT: process abort signal
# (constant restored to 1536 * 1024; re-run: 1 passed)
```

- **Beyond CI, what did you manually verify?** That the guard fails at 1024 KB and passes at 1536 KB on the same base, so the new value sits inside the measured window rather than above it. Local checks were on macOS/aarch64; the current-head advisory Windows job subsequently passed both changed tests.
- **Visual interface changed?** N/A
- **If any command was intentionally skipped, why:** Full `zeroclaw-runtime` suite not run locally; the diff touches only these two tests and clippy `--all-targets` compiled the whole test module.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low-risk: `git revert <sha>`.

