### PR TITLE
fix(zerocode): reload notification-lag sessions without cancelling running turns

### DIFF
--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -451,6 +451,7 @@ zc-chat-reconnect-interrupted = The connection was rebuilt and queued messages w
 zc-chat-resyncing = Some live updates were missed. Reloading this session before sending queued messages…
 zc-chat-resynced = Live updates were missed, so the durable transcript was reloaded. Any in-progress approval or question was cancelled.
 zc-chat-resynced-turn-running = Live updates were missed, so the durable transcript was reloaded. The in-progress turn is still running; the transcript will be reloaded once more when it finishes.
+zc-chat-resynced-turn-finished = The in-progress turn finished, so the durable transcript was reloaded once more.
 zc-chat-resync-failed = Live updates were missed and the session could not be reloaded: { $error }
 zc-chat-session-restart-error = Failed to start a new session: { $error }
 zc-chat-code-cwd-unavailable = Cannot determine the directory zerocode was launched from: { $error }. A local Code session must start in that project, so it was not created.

--- a/apps/zerocode/locales/en/zerocode.ftl
+++ b/apps/zerocode/locales/en/zerocode.ftl
@@ -450,6 +450,7 @@ zc-chat-resume-dropped = { $count } prior session(s) could not be re-attached an
 zc-chat-reconnect-interrupted = The connection was rebuilt and queued messages were preserved. Waiting for the prior turn to stop before reloading the durable transcript.
 zc-chat-resyncing = Some live updates were missed. Reloading this session before sending queued messages…
 zc-chat-resynced = Live updates were missed, so the durable transcript was reloaded. Any in-progress approval or question was cancelled.
+zc-chat-resynced-turn-running = Live updates were missed, so the durable transcript was reloaded. The in-progress turn is still running; the transcript will be reloaded once more when it finishes.
 zc-chat-resync-failed = Live updates were missed and the session could not be reloaded: { $error }
 zc-chat-session-restart-error = Failed to start a new session: { $error }
 zc-chat-code-cwd-unavailable = Cannot determine the directory zerocode was launched from: { $error }. A local Code session must start in that project, so it was not created.

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -413,6 +413,7 @@ zc-chat-resume-dropped = No se pudieron reconectar { $count } sesión(es) anteri
 zc-chat-reconnect-interrupted = Se restableció la conexión y se conservaron los mensajes en cola. Esperando a que termine el turno anterior antes de recargar la conversación persistente.
 zc-chat-resyncing = Se perdieron algunas actualizaciones en vivo. Recargando esta sesión antes de enviar mensajes en cola…
 zc-chat-resynced = Se perdieron actualizaciones en vivo, por lo que se recargó la conversación persistente. Se canceló cualquier aprobación o pregunta en curso.
+zc-chat-resynced-turn-running = Se perdieron actualizaciones en vivo, por lo que se recargó la conversación persistente. El turno en curso sigue ejecutándose; la conversación se volverá a recargar cuando termine.
 zc-chat-resync-failed = Se perdieron actualizaciones en vivo y no se pudo recargar la sesión: { $error }
 zc-chat-session-restart-error = No se pudo iniciar una nueva sesión: { $error }
 zc-chat-code-cwd-unavailable = No se puede determinar el directorio desde el que se inició zerocode: { $error }. Una sesión local de Code debe comenzar en ese proyecto, por lo que no se creó.

--- a/apps/zerocode/locales/es/zerocode.ftl
+++ b/apps/zerocode/locales/es/zerocode.ftl
@@ -414,6 +414,7 @@ zc-chat-reconnect-interrupted = Se restableció la conexión y se conservaron lo
 zc-chat-resyncing = Se perdieron algunas actualizaciones en vivo. Recargando esta sesión antes de enviar mensajes en cola…
 zc-chat-resynced = Se perdieron actualizaciones en vivo, por lo que se recargó la conversación persistente. Se canceló cualquier aprobación o pregunta en curso.
 zc-chat-resynced-turn-running = Se perdieron actualizaciones en vivo, por lo que se recargó la conversación persistente. El turno en curso sigue ejecutándose; la conversación se volverá a recargar cuando termine.
+zc-chat-resynced-turn-finished = El turno en curso terminó, por lo que la conversación persistente se volvió a recargar una vez más.
 zc-chat-resync-failed = Se perdieron actualizaciones en vivo y no se pudo recargar la sesión: { $error }
 zc-chat-session-restart-error = No se pudo iniciar una nueva sesión: { $error }
 zc-chat-code-cwd-unavailable = No se puede determinar el directorio desde el que se inició zerocode: { $error }. Una sesión local de Code debe comenzar en ese proyecto, por lo que no se creó.

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -414,6 +414,7 @@ zc-chat-reconnect-interrupted = La connexion a été rétablie et les messages e
 zc-chat-resyncing = Des mises à jour en direct ont été manquées. Rechargement de cette session avant l’envoi des messages en file…
 zc-chat-resynced = Des mises à jour en direct ont été manquées ; la conversation persistante a donc été rechargée. Toute approbation ou question en cours a été annulée.
 zc-chat-resynced-turn-running = Des mises à jour en direct ont été manquées ; la conversation persistante a donc été rechargée. Le tour en cours s'exécute toujours ; la conversation sera rechargée une fois de plus à sa fin.
+zc-chat-resynced-turn-finished = Le tour en cours s'est terminé, la conversation persistante a donc été rechargée une fois de plus.
 zc-chat-resync-failed = Des mises à jour en direct ont été manquées et la session n’a pas pu être rechargée : { $error }
 zc-chat-session-restart-error = Échec du démarrage d'une nouvelle session : { $error }
 zc-chat-code-cwd-unavailable = Impossible de déterminer le répertoire depuis lequel zerocode a été lancé : { $error }. Une session Code locale doit démarrer dans ce projet, elle n'a donc pas été créée.

--- a/apps/zerocode/locales/fr/zerocode.ftl
+++ b/apps/zerocode/locales/fr/zerocode.ftl
@@ -413,6 +413,7 @@ zc-chat-resume-dropped = { $count } session(s) précédente(s) n'ont pas pu êtr
 zc-chat-reconnect-interrupted = La connexion a été rétablie et les messages en file ont été conservés. Attente de l'arrêt du tour précédent avant de recharger la conversation persistante.
 zc-chat-resyncing = Des mises à jour en direct ont été manquées. Rechargement de cette session avant l’envoi des messages en file…
 zc-chat-resynced = Des mises à jour en direct ont été manquées ; la conversation persistante a donc été rechargée. Toute approbation ou question en cours a été annulée.
+zc-chat-resynced-turn-running = Des mises à jour en direct ont été manquées ; la conversation persistante a donc été rechargée. Le tour en cours s'exécute toujours ; la conversation sera rechargée une fois de plus à sa fin.
 zc-chat-resync-failed = Des mises à jour en direct ont été manquées et la session n’a pas pu être rechargée : { $error }
 zc-chat-session-restart-error = Échec du démarrage d'une nouvelle session : { $error }
 zc-chat-code-cwd-unavailable = Impossible de déterminer le répertoire depuis lequel zerocode a été lancé : { $error }. Une session Code locale doit démarrer dans ce projet, elle n'a donc pas été créée.

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -414,6 +414,7 @@ zc-chat-reconnect-interrupted = 接続を再構築し、キュー内のメッセ
 zc-chat-resyncing = 一部のライブ更新を受信できませんでした。キュー内のメッセージを送信する前に、このセッションを再読み込みしています…
 zc-chat-resynced = ライブ更新を受信できなかったため、永続化された会話を再読み込みしました。進行中の承認や質問はキャンセルされました。
 zc-chat-resynced-turn-running = ライブ更新を受信できなかったため、永続化された会話を再読み込みしました。実行中のターンはそのまま継続し、終了時に会話を再度読み込みます。
+zc-chat-resynced-turn-finished = 実行中のターンが終了したため、永続化された会話をもう一度再読み込みしました。
 zc-chat-resync-failed = ライブ更新を受信できず、セッションを再読み込みできませんでした: { $error }
 zc-chat-session-restart-error = 新しいセッションを開始できませんでした: { $error }
 zc-chat-code-cwd-unavailable = zerocode を起動したディレクトリを特定できません: { $error }。ローカルの Code セッションはそのプロジェクトで開始する必要があるため、作成されませんでした。

--- a/apps/zerocode/locales/ja/zerocode.ftl
+++ b/apps/zerocode/locales/ja/zerocode.ftl
@@ -413,6 +413,7 @@ zc-chat-resume-dropped = 以前のセッション { $count } 件を再接続で�
 zc-chat-reconnect-interrupted = 接続を再構築し、キュー内のメッセージを保持しました。以前のターンが停止してから永続化された会話を再読み込みします。
 zc-chat-resyncing = 一部のライブ更新を受信できませんでした。キュー内のメッセージを送信する前に、このセッションを再読み込みしています…
 zc-chat-resynced = ライブ更新を受信できなかったため、永続化された会話を再読み込みしました。進行中の承認や質問はキャンセルされました。
+zc-chat-resynced-turn-running = ライブ更新を受信できなかったため、永続化された会話を再読み込みしました。実行中のターンはそのまま継続し、終了時に会話を再度読み込みます。
 zc-chat-resync-failed = ライブ更新を受信できず、セッションを再読み込みできませんでした: { $error }
 zc-chat-session-restart-error = 新しいセッションを開始できませんでした: { $error }
 zc-chat-code-cwd-unavailable = zerocode を起動したディレクトリを特定できません: { $error }。ローカルの Code セッションはそのプロジェクトで開始する必要があるため、作成されませんでした。

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -414,6 +414,7 @@ zc-chat-reconnect-interrupted = 连接已重建，排队消息已保留。正在
 zc-chat-resyncing = 部分实时更新丢失。正在重新加载此会话，然后再发送排队消息…
 zc-chat-resynced = 实时更新丢失，因此已重新加载持久化对话。任何进行中的审批或提问均已取消。
 zc-chat-resynced-turn-running = 实时更新丢失，因此已重新加载持久化对话。进行中的回合仍在运行；回合结束后将再次重新加载对话。
+zc-chat-resynced-turn-finished = 进行中的回合已结束，因此再次重新加载了一次持久化对话。
 zc-chat-resync-failed = 实时更新丢失，且无法重新加载会话：{ $error }
 zc-chat-session-restart-error = 无法启动新会话：{ $error }
 zc-chat-code-cwd-unavailable = 无法确定启动 zerocode 的目录：{ $error }。本地 Code 会话必须在该项目中启动，因此未创建会话。

--- a/apps/zerocode/locales/zh-CN/zerocode.ftl
+++ b/apps/zerocode/locales/zh-CN/zerocode.ftl
@@ -413,6 +413,7 @@ zc-chat-resume-dropped = 有 { $count } 个先前会话无法重新连接，已�
 zc-chat-reconnect-interrupted = 连接已重建，排队消息已保留。正在等待先前轮次停止，然后重新加载持久化对话。
 zc-chat-resyncing = 部分实时更新丢失。正在重新加载此会话，然后再发送排队消息…
 zc-chat-resynced = 实时更新丢失，因此已重新加载持久化对话。任何进行中的审批或提问均已取消。
+zc-chat-resynced-turn-running = 实时更新丢失，因此已重新加载持久化对话。进行中的回合仍在运行；回合结束后将再次重新加载对话。
 zc-chat-resync-failed = 实时更新丢失，且无法重新加载会话：{ $error }
 zc-chat-session-restart-error = 无法启动新会话：{ $error }
 zc-chat-code-cwd-unavailable = 无法确定启动 zerocode 的目录：{ $error }。本地 Code 会话必须在该项目中启动，因此未创建会话。

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -244,6 +244,20 @@ enum SessionError {
     ResyncFailed,
 }
 
+/// Classify a failed turn's daemon error text for `SessionError`. Single
+/// source of the daemon's session-loss sentinel string (`session_not_found`,
+/// see `handle_session_prompt`): the session must be re-attached before the
+/// next prompt can run; any other failure text is an ordinary turn failure.
+/// Used by `apply_update`'s `TurnComplete` arm and by the terminal-follow-up
+/// outcome carrier in `replace_history_after_notification_resync`.
+fn classify_turn_failure(content: &str) -> SessionError {
+    if content.ends_with("session_not_found") {
+        SessionError::SessionLost
+    } else {
+        SessionError::TurnFailed
+    }
+}
+
 /// Upper bound on sessions one chat-like pane tracks (focused + background).
 /// Two panes keep the TUI comfortably under the daemon's 64-session cap.
 const MAX_TRACKED_SESSIONS_PER_PANE: usize = 8;
@@ -374,10 +388,32 @@ struct SessionResyncResult {
 ///   `session/cancel`, then poll `session/state` to terminal) and only then
 ///   reloads. Kept for reconnect/resume recovery, where the caller needs a
 ///   known-idle session before proceeding.
+/// - [`SessionResyncMode::ReattachTerminal`] reconciles exactly like
+///   `Reattach` but marks the reload as the terminal follow-up for a
+///   kept-running turn (begun from `drain_notifications`), so the reloaded
+///   transcript opens with the turn-finished notice instead of the
+///   cancelled-input one.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SessionResyncMode {
     Reattach,
+    ReattachTerminal,
     Cancel,
+}
+
+/// Which resync notice a reloaded transcript opens with. Decided in
+/// `apply_session_resync_result` from the snapshot's `turn_running` plus the
+/// resync mode; the in-flight map (`session_resync_in_flight`, keyed by
+/// session id) is the single source of truth for "this reload is the
+/// terminal follow-up".
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResyncNotice {
+    /// Reloaded while idle: the generic cancelled-input notice.
+    Idle,
+    /// The turn survived: the pane re-attaches to the live stream.
+    TurnRunning,
+    /// Terminal follow-up after a kept-running turn finished: nothing was
+    /// cancelled, the transcript was reloaded once more.
+    TurnFinished,
 }
 
 /// Canonical daemon state recovered after notification loss. Transcript and
@@ -2154,7 +2190,35 @@ impl Chat {
                                     state.turn_generation,
                                 )
                             {
+                                // Apply first: the frame still records the
+                                // outcome (error/sentinel classification,
+                                // terminal system message, turn settle) before
+                                // the reload rebuilds `entries` wholesale. The
+                                // outcome and its text are carried across the
+                                // reload by `resync_carried_outcome` and
+                                // re-applied in
+                                // `replace_history_after_notification_resync`.
+                                let terminal = match &update {
+                                    SessionUpdate::TurnComplete {
+                                        outcome, content, ..
+                                    } => Some((*outcome, content.clone())),
+                                    _ => None,
+                                };
+                                state.apply_update(update);
                                 state.resync_terminal_reload_pending = false;
+                                // Carry the just-recorded terminal outcome
+                                // across the upcoming wholesale reload: the
+                                // failure/sentinel text and the `last_error`
+                                // classification would otherwise be lost from
+                                // the transcript view. A completed frame carries
+                                // nothing — the reload transcript is the whole
+                                // story for a clean turn.
+                                if let Some((outcome, content)) = terminal
+                                    && outcome != crate::client::TurnEndOutcome::Completed
+                                {
+                                    state.resync_carried_outcome =
+                                        Some((outcome, Arc::<str>::from(content.as_str())));
+                                }
                                 terminal_reconcile = true;
                             } else {
                                 state.apply_update(update);
@@ -2174,7 +2238,7 @@ impl Chat {
             }
         }
         for sid in reconciles {
-            self.begin_session_resync(sid, SessionResyncMode::Reattach);
+            self.begin_session_resync(sid, SessionResyncMode::ReattachTerminal);
         }
         if applied {
             self.pump_all_queues();
@@ -2307,7 +2371,9 @@ impl Chat {
     ) -> Result<SessionResyncSnapshot, String> {
         match mode {
             SessionResyncMode::Cancel => Self::cancel_confirm_and_reload(rpc, session_id).await,
-            SessionResyncMode::Reattach => Self::reattach_confirm_and_reload(rpc, session_id).await,
+            SessionResyncMode::Reattach | SessionResyncMode::ReattachTerminal => {
+                Self::reattach_confirm_and_reload(rpc, session_id).await
+            }
         }
     }
 
@@ -2410,14 +2476,28 @@ impl Chat {
         match update.result {
             Ok(snapshot) => {
                 let strip_runtime_enrichment = self.pane_kind == PaneKind::Acp;
+                // Read the in-flight mode before taking the state borrow
+                // (`state_for_session_mut` holds `&mut self`).
+                let terminal_followup = self.session_resync_in_flight.get(&update.session_id)
+                    == Some(&SessionResyncMode::ReattachTerminal);
                 let Some(state) = self.state_for_session_mut(&update.session_id) else {
                     self.session_resync_in_flight.remove(&update.session_id);
                     return;
                 };
+                // Mode + snapshot decide the notice: a Reattach-mode resync
+                // whose turn survived shows the still-running notice; the
+                // terminal follow-up (turn now idle in the snapshot) shows
+                // the turn-finished one; everything else gets the generic
+                // cancelled-input notice.
+                let notice = match (terminal_followup, snapshot.turn_running) {
+                    (true, false) => ResyncNotice::TurnFinished,
+                    (_, true) => ResyncNotice::TurnRunning,
+                    (_, false) => ResyncNotice::Idle,
+                };
                 state.replace_history_after_notification_resync(
                     snapshot.messages,
                     strip_runtime_enrichment,
-                    snapshot.turn_running,
+                    notice,
                 );
                 state.message_count = snapshot.message_count;
                 if let Some(plan) = snapshot.plan {
@@ -7562,6 +7642,14 @@ pub struct ChatState {
     /// turn's terminal frame must trigger one more transcript reload
     /// instead of being trusted alone.
     resync_terminal_reload_pending: bool,
+    /// Owner: the terminal-follow-up reload (begun in `drain_notifications`
+    /// with `SessionResyncMode::ReattachTerminal`). `apply_update` records
+    /// the terminal outcome there, then the follow-up reload rebuilds
+    /// `entries` wholesale and would drop the failure text; this carries the
+    /// outcome across that one reload so `last_error` and the failure text
+    /// survive. Set on the intercept, consumed (and cleared) by
+    /// `replace_history_after_notification_resync`.
+    resync_carried_outcome: Option<(crate::client::TurnEndOutcome, Arc<str>)>,
     show_thoughts: bool,
     /// Browse mode cursor (most-recently moved position).
     browse_cursor: Option<usize>,
@@ -7717,6 +7805,7 @@ impl ChatState {
             turn_status: TurnStatus::Idle,
             turn_started_at: Instant::now(),
             resync_terminal_reload_pending: false,
+            resync_carried_outcome: None,
             show_thoughts: true,
             browse_cursor: None,
             browse_anchor: None,
@@ -8992,14 +9081,7 @@ impl ChatState {
                     }
                     TurnEndOutcome::Cancelled | TurnEndOutcome::Failed => {
                         if outcome == TurnEndOutcome::Failed {
-                            // The daemon's session-loss sentinel (see
-                            // `handle_session_prompt`) means the session must be
-                            // re-attached before the next prompt can run.
-                            self.last_error = Some(if content.ends_with("session_not_found") {
-                                SessionError::SessionLost
-                            } else {
-                                SessionError::TurnFailed
-                            });
+                            self.last_error = Some(classify_turn_failure(&content));
                         }
                         self.entries
                             .push(ChatEntry::SystemMessage(Arc::<str>::from(content.as_str())));
@@ -9666,7 +9748,7 @@ impl ChatState {
         &mut self,
         messages: Vec<crate::client::MessageEntry>,
         strip_runtime_enrichment: bool,
-        turn_kept_running: bool,
+        notice: ResyncNotice,
     ) {
         self.entries.clear();
         self.first_message = None;
@@ -9680,16 +9762,35 @@ impl ChatState {
         self.cached_total_rows = 0;
         self.clear_transcript_selection();
         self.load_history(messages, strip_runtime_enrichment);
-        let notice = if turn_kept_running {
-            crate::i18n::t("zc-chat-resynced-turn-running")
-        } else {
-            crate::i18n::t("zc-chat-resynced")
+        let notice_text = match notice {
+            ResyncNotice::TurnRunning => crate::i18n::t("zc-chat-resynced-turn-running"),
+            ResyncNotice::TurnFinished => crate::i18n::t("zc-chat-resynced-turn-finished"),
+            ResyncNotice::Idle => crate::i18n::t("zc-chat-resynced"),
         };
         self.entries
-            .push(ChatEntry::SystemMessage(Arc::<str>::from(notice)));
+            .push(ChatEntry::SystemMessage(Arc::<str>::from(notice_text)));
         self.info_message = None;
+        // The reload clears `last_error` unconditionally: a stale `ResyncFailed`
+        // from this very resync must not stick once the snapshot proves the
+        // transcript is readable again. The carrier below then re-applies
+        // `SessionLost`/`TurnFailed` if the finished turn itself failed.
         self.last_error = None;
-        if turn_kept_running {
+        // Consume the outcome captured by the terminal-follow-up intercept
+        // (`drain_notifications`). Owner: that one reload; nothing else may
+        // set this.
+        if let Some((outcome, text)) = self.resync_carried_outcome.take() {
+            match outcome {
+                crate::client::TurnEndOutcome::Failed => {
+                    self.last_error = Some(classify_turn_failure(&text));
+                    self.entries.push(ChatEntry::SystemMessage(text.clone()));
+                }
+                crate::client::TurnEndOutcome::Cancelled => {
+                    self.entries.push(ChatEntry::SystemMessage(text));
+                }
+                crate::client::TurnEndOutcome::Completed => {}
+            }
+        }
+        if matches!(notice, ResyncNotice::TurnRunning) {
             // The daemon still reports this turn live: re-attach instead of
             // settling. Live updates resume once the resync gate drops (see
             // `apply_session_resync_result`); `Working` is the neutral anchor
@@ -13464,11 +13565,16 @@ mod tests {
         assert!(state.entries.iter().any(|entry| matches!(
             entry,
             ChatEntry::SystemMessage(message)
-                if message.as_ref() == crate::i18n::t("zc-chat-resynced")
+                if message.as_ref() == crate::i18n::t("zc-chat-resynced-turn-finished")
         )));
         // The terminal reload replaced the transcript wholesale, so only the
         // settled outcome's notice remains (the kept-running one was asserted
-        // between the two applies above).
+        // between the two applies above). Nothing was cancelled by the
+        // terminal follow-up, so the cancelled-input notice must not appear.
+        assert!(state.entries.iter().all(|entry| !matches!(
+            entry,
+            ChatEntry::SystemMessage(text) if text.as_ref() == crate::i18n::t("zc-chat-resynced")
+        )));
 
         // The correlation fence still holds: a late frame from the original
         // turn must not settle the post-recovery prompt (generation 2 now).
@@ -13630,6 +13736,420 @@ mod tests {
         };
         assert_eq!(running.turn_status, TurnStatus::Responding);
         assert!(running.streaming_text.contains("post-resync delta"));
+    }
+
+    /// A kept-running turn whose terminal frame reports failure with the
+    /// daemon's session-loss sentinel: the intercepted TurnComplete must
+    /// still record `SessionLost` (re-attach before the next prompt) and
+    /// the failure text must survive the terminal transcript reload.
+    #[tokio::test]
+    async fn terminal_reload_after_lag_resync_preserves_session_lost_outcome() {
+        let (tx, mut writer_rx) = mpsc::channel::<String>(32);
+        let outbound = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(outbound.clone()));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut running = state_for("sess-1", "myagent");
+        running.push_user_message(Some("kept running".to_string()), Vec::new());
+        chat.phase = ChatPhase::Active(Box::new(running));
+        chat.session_order = vec!["sess-1".to_string()];
+
+        // Overflow the 64-frame notification channel: the drain reports
+        // Lagged and re-syncs the session without cancelling its turn.
+        for _ in 0..65 {
+            chat.rpc
+                .push_notification_for_test("session/update", serde_json::Value::Null);
+        }
+        chat.drain_notifications();
+        assert!(chat.session_resync_in_flight.contains_key("sess-1"));
+
+        for _ in 0..3 {
+            let frame = next_rpc_request(&mut writer_rx, "resync reloads the session").await;
+            match frame.get("method").and_then(serde_json::Value::as_str) {
+                Some(method::SESSION_STATE) => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({ "session_id": "sess-1", "state": "running", "turn_id": "9" }),
+                ),
+                Some(method::SESSION_MESSAGES) => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({
+                        "messages": [{ "role": "user", "content": "kept running" }],
+                        "total": 1
+                    }),
+                ),
+                other => panic!("unexpected resync frame: {other:?}"),
+            }
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first resync should finish");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after recovery");
+        };
+        assert!(state.turn_in_flight, "the kept-running turn re-attaches");
+        assert!(state.resync_terminal_reload_pending);
+
+        // The surviving turn fails with the session-loss sentinel. Its
+        // terminal frame is intercepted for the terminal reload, but the
+        // outcome must still be recorded first.
+        chat.rpc.push_notification_for_test(
+            "session/update",
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "sess-1",
+                "outcome": "failed",
+                "content": "turn failed: session_not_found",
+                "client_turn_generation": 1,
+            }),
+        );
+        chat.tick_transport_events();
+
+        // Terminal follow-up: state / messages / state, nothing cancelled.
+        let idle = next_rpc_request(&mut writer_rx, "terminal frame triggers reload").await;
+        assert_eq!(idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+        let reconciled =
+            next_rpc_request(&mut writer_rx, "terminal reload fetches the transcript").await;
+        assert_eq!(reconciled["method"], method::SESSION_MESSAGES);
+        respond_ok(
+            &outbound,
+            &reconciled,
+            serde_json::json!({
+                "messages": [
+                    { "role": "user", "content": "kept running" },
+                    { "role": "assistant", "content": "durable tail" }
+                ]
+            }),
+        );
+        let confirm_idle =
+            next_rpc_request(&mut writer_rx, "terminal reload brackets the snapshot").await;
+        assert_eq!(confirm_idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &confirm_idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal reload should finish");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after the terminal reload");
+        };
+        assert_eq!(
+            state.last_error,
+            Some(SessionError::SessionLost),
+            "the sentinel must survive the terminal reload so the next prompt re-attaches"
+        );
+        assert!(
+            state
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::SystemMessage(text)
+                    if text.as_ref() == "turn failed: session_not_found")),
+            "the failure text must survive the wholesale transcript reload"
+        );
+        assert!(!state.turn_in_flight, "the failed turn settles");
+        // The re-attach fence still fires before a follow-up prompt.
+        chat.pump_all_queues();
+        assert!(
+            writer_rx.try_recv().is_err(),
+            "a session-lost turn must not dispatch a new prompt before re-attaching"
+        );
+    }
+
+    /// A kept-running turn that completes cleanly: the intercepted terminal
+    /// frame keeps `last_error` clear and exactly one terminal reload runs.
+    #[tokio::test]
+    async fn terminal_reload_after_lag_resync_keeps_clean_completion_clean() {
+        let (tx, mut writer_rx) = mpsc::channel::<String>(32);
+        let outbound = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(outbound.clone()));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut running = state_for("sess-1", "myagent");
+        running.push_user_message(Some("kept running".to_string()), Vec::new());
+        chat.phase = ChatPhase::Active(Box::new(running));
+        chat.session_order = vec!["sess-1".to_string()];
+
+        for _ in 0..65 {
+            chat.rpc
+                .push_notification_for_test("session/update", serde_json::Value::Null);
+        }
+        chat.drain_notifications();
+        assert!(chat.session_resync_in_flight.contains_key("sess-1"));
+
+        for _ in 0..3 {
+            let frame = next_rpc_request(&mut writer_rx, "resync reloads the session").await;
+            match frame.get("method").and_then(serde_json::Value::as_str) {
+                Some(method::SESSION_STATE) => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({ "session_id": "sess-1", "state": "running", "turn_id": "9" }),
+                ),
+                Some(method::SESSION_MESSAGES) => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({
+                        "messages": [{ "role": "user", "content": "kept running" }],
+                        "total": 1
+                    }),
+                ),
+                other => panic!("unexpected resync frame: {other:?}"),
+            }
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first resync should finish");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after recovery");
+        };
+        assert!(state.turn_in_flight, "the kept-running turn re-attaches");
+
+        // The surviving turn completes cleanly. The frame is intercepted,
+        // applied, and triggers exactly one terminal reload.
+        chat.rpc.push_notification_for_test(
+            "session/update",
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "sess-1",
+                "outcome": "completed",
+                "content": "final answer",
+                "client_turn_generation": 1,
+            }),
+        );
+        chat.tick_transport_events();
+
+        let idle = next_rpc_request(&mut writer_rx, "terminal frame triggers reload").await;
+        assert_eq!(idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+        let reconciled =
+            next_rpc_request(&mut writer_rx, "terminal reload fetches the transcript").await;
+        assert_eq!(reconciled["method"], method::SESSION_MESSAGES);
+        respond_ok(
+            &outbound,
+            &reconciled,
+            serde_json::json!({
+                "messages": [
+                    { "role": "user", "content": "kept running" },
+                    { "role": "assistant", "content": "durable final answer" }
+                ]
+            }),
+        );
+        let confirm_idle =
+            next_rpc_request(&mut writer_rx, "terminal reload brackets the snapshot").await;
+        assert_eq!(confirm_idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &confirm_idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal reload should finish");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after the terminal reload");
+        };
+        assert_eq!(state.last_error, None, "a clean turn stays clean");
+        assert!(!state.turn_in_flight, "the completed turn settles");
+        assert!(
+            state
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::AgentMessage(text)
+                    if text.as_ref() == "durable final answer")),
+            "the reloaded transcript shows the durable turn output"
+        );
+        assert!(
+            state
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::SystemMessage(text)
+                    if text.as_ref() == crate::i18n::t("zc-chat-resynced-turn-finished"))),
+            "the terminal reload announces the finished turn, not a cancellation"
+        );
+        assert!(
+            state.entries.iter().all(|entry| !matches!(entry,
+                ChatEntry::SystemMessage(text) if text.as_ref() == crate::i18n::t("zc-chat-resynced"))),
+            "the cancelled-input notice must not appear for the terminal follow-up"
+        );
+    }
+
+    /// A kept-running turn whose terminal frame reports `Cancelled`: the
+    /// intercepted frame carries no `last_error`, but its text must still
+    /// survive the terminal transcript reload.
+    #[tokio::test]
+    async fn terminal_reload_after_lag_resync_preserves_cancelled_outcome_text() {
+        let (tx, mut writer_rx) = mpsc::channel::<String>(32);
+        let outbound = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(outbound.clone()));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut running = state_for("sess-1", "myagent");
+        running.push_user_message(Some("kept running".to_string()), Vec::new());
+        chat.phase = ChatPhase::Active(Box::new(running));
+        chat.session_order = vec!["sess-1".to_string()];
+
+        for _ in 0..65 {
+            chat.rpc
+                .push_notification_for_test("session/update", serde_json::Value::Null);
+        }
+        chat.drain_notifications();
+        assert!(chat.session_resync_in_flight.contains_key("sess-1"));
+
+        for _ in 0..3 {
+            let frame = next_rpc_request(&mut writer_rx, "resync reloads the session").await;
+            match frame.get("method").and_then(serde_json::Value::as_str) {
+                Some(method::SESSION_STATE) => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({ "session_id": "sess-1", "state": "running", "turn_id": "9" }),
+                ),
+                Some(method::SESSION_MESSAGES) => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({
+                        "messages": [{ "role": "user", "content": "kept running" }],
+                        "total": 1
+                    }),
+                ),
+                other => panic!("unexpected resync frame: {other:?}"),
+            }
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first resync should finish");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after recovery");
+        };
+        assert!(state.turn_in_flight, "the kept-running turn re-attaches");
+
+        // The surviving turn is cancelled daemon-side. The frame is
+        // intercepted for the terminal reload; cancellation records no
+        // `last_error`, but its text must be carried across the reload.
+        chat.rpc.push_notification_for_test(
+            "session/update",
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "sess-1",
+                "outcome": "cancelled",
+                "content": "turn cancelled: budget stop",
+                "client_turn_generation": 1,
+            }),
+        );
+        chat.tick_transport_events();
+
+        let idle = next_rpc_request(&mut writer_rx, "terminal frame triggers reload").await;
+        assert_eq!(idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+        let reconciled =
+            next_rpc_request(&mut writer_rx, "terminal reload fetches the transcript").await;
+        assert_eq!(reconciled["method"], method::SESSION_MESSAGES);
+        respond_ok(
+            &outbound,
+            &reconciled,
+            serde_json::json!({
+                "messages": [
+                    { "role": "user", "content": "kept running" },
+                    { "role": "assistant", "content": "partial answer before cancel" }
+                ]
+            }),
+        );
+        let confirm_idle =
+            next_rpc_request(&mut writer_rx, "terminal reload brackets the snapshot").await;
+        assert_eq!(confirm_idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &confirm_idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal reload should finish");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after the terminal reload");
+        };
+        assert_eq!(
+            state.last_error, None,
+            "a cancelled turn records no session error"
+        );
+        assert!(!state.turn_in_flight, "the cancelled turn settles");
+        assert!(
+            state
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::SystemMessage(text)
+                if text.as_ref() == "turn cancelled: budget stop")),
+            "the cancellation text must survive the wholesale transcript reload"
+        );
+        assert!(
+            state
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::AgentMessage(text)
+                if text.as_ref() == "partial answer before cancel")),
+            "the reloaded transcript shows the durable partial output"
+        );
+        assert!(
+            state
+                .entries
+                .iter()
+                .any(|entry| matches!(entry, ChatEntry::SystemMessage(text)
+                if text.as_ref() == crate::i18n::t("zc-chat-resynced-turn-finished"))),
+            "the terminal reload announces the finished turn"
+        );
     }
 
     #[tokio::test]

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ops::Range;
 use std::sync::{
     Arc,
@@ -272,7 +272,7 @@ pub(crate) struct Chat {
     /// session but cannot leave while its live view is desynchronized.
     session_resync_tx: mpsc::Sender<SessionResyncResult>,
     session_resync_rx: mpsc::Receiver<SessionResyncResult>,
-    session_resync_in_flight: HashSet<String>,
+    session_resync_in_flight: HashMap<String, SessionResyncMode>,
     /// Request-form `session/prompt` completions. Terminal notifications remain
     /// transcript authority; this channel only prevents a lost terminal frame
     /// from leaving the matching local turn stuck in flight.
@@ -362,6 +362,24 @@ struct SessionResyncResult {
     result: Result<SessionResyncSnapshot, String>,
 }
 
+/// How a resync reconciles with the daemon before reloading the transcript.
+///
+/// Single source of truth for the two recovery behaviours:
+/// - [`SessionResyncMode::Reattach`] never cancels. It reads the daemon's
+///   authoritative `session/state`, snapshots the durable transcript, and
+///   reports whether the turn is still live so the pane can re-attach to the
+///   running stream. Used by notification-lag recovery: a client-side buffer
+///   overflow must not abort turns the daemon is running for this client.
+/// - [`SessionResyncMode::Cancel`] forces a terminal state first (best-effort
+///   `session/cancel`, then poll `session/state` to terminal) and only then
+///   reloads. Kept for reconnect/resume recovery, where the caller needs a
+///   known-idle session before proceeding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SessionResyncMode {
+    Reattach,
+    Cancel,
+}
+
 /// Canonical daemon state recovered after notification loss. Transcript and
 /// plan travel together so the UI cannot display a plan from the abandoned
 /// turn beside a newly reloaded transcript.
@@ -369,6 +387,11 @@ struct SessionResyncSnapshot {
     messages: Vec<crate::client::MessageEntry>,
     message_count: usize,
     plan: Option<Vec<crate::wire::PlanEntry>>,
+    /// `Reattach` only: the daemon still reported a live turn after the
+    /// transcript snapshot, so the pane must return to the in-flight state
+    /// and re-attach to the live stream. The cancel mode always ends
+    /// terminal, so it reports `false`.
+    turn_running: bool,
 }
 
 struct ChatEntryRetryResult {
@@ -538,7 +561,7 @@ impl Chat {
             session_reattach_in_flight: HashSet::new(),
             session_resync_tx,
             session_resync_rx,
-            session_resync_in_flight: HashSet::new(),
+            session_resync_in_flight: HashMap::new(),
             prompt_completion_tx,
             prompt_completion_rx,
             phase: ChatPhase::PickAgent {
@@ -622,7 +645,9 @@ impl Chat {
                     || state.pending_approval.is_some()
                     || state.pending_elicitation.is_some(),
                 recovery_required: state.last_error == Some(SessionError::ResyncFailed)
-                    || self.session_resync_in_flight.contains(&state.session_id),
+                    || self
+                        .session_resync_in_flight
+                        .contains_key(&state.session_id),
             });
         }
 
@@ -879,7 +904,10 @@ impl Chat {
                     }
                 }
                 if needs_terminal_recovery {
-                    self.begin_session_resync(resumed_id);
+                    // Reconnect resume needs a known-idle session: the
+                    // interrupted turn predates this pane incarnation, so its
+                    // terminal frames can no longer be matched by generation.
+                    self.begin_session_resync(resumed_id, SessionResyncMode::Cancel);
                 }
                 self.pump_all_queues();
                 true
@@ -1040,7 +1068,12 @@ impl Chat {
             .state_for_session(session_id)
             .is_some_and(|state| state.last_error == Some(SessionError::ResyncFailed))
         {
-            self.begin_session_resync(session_id.to_string());
+            // Retry of a failed reconciliation: still Cancel. The caller
+            // needs a known-terminal session before the session-lost
+            // re-attach or queue dispatch can proceed, and a turn that
+            // outlived a Cancel attempt belongs to a pre-resync pane
+            // incarnation whose terminal frames can no longer be matched.
+            self.begin_session_resync(session_id.to_string(), SessionResyncMode::Cancel);
             return;
         }
 
@@ -1559,8 +1592,11 @@ impl Chat {
                 *self = replacement;
                 self.entry_retry_preparing = false;
                 let pending_resync = std::mem::take(&mut self.session_resync_in_flight);
-                for session_id in pending_resync {
-                    self.begin_session_resync(session_id);
+                // Adoption re-begins exactly the resyncs that were gated when
+                // the pane was rebuilt; each keeps the mode it was started
+                // with instead of being re-classified here.
+                for (session_id, mode) in pending_resync {
+                    self.begin_session_resync(session_id, mode);
                 }
                 self.pump_all_queues();
             }
@@ -1773,7 +1809,7 @@ impl Chat {
                 }
                 self.phase = ChatPhase::Active(Box::new(state));
                 if needs_terminal_recovery {
-                    self.begin_session_resync(recovery_session_id);
+                    self.begin_session_resync(recovery_session_id, SessionResyncMode::Cancel);
                 }
             }
             Err(e) => {
@@ -1818,7 +1854,7 @@ impl Chat {
                         self.phase = ChatPhase::Active(Box::new(state));
                         retained.extend(entries);
                         if needs_terminal_recovery {
-                            self.begin_session_resync(session_id);
+                            self.begin_session_resync(session_id, SessionResyncMode::Cancel);
                         }
                         break;
                     }
@@ -1859,7 +1895,7 @@ impl Chat {
                         }
                         self.background.push(state);
                         if needs_terminal_recovery {
-                            self.begin_session_resync(session_id);
+                            self.begin_session_resync(session_id, SessionResyncMode::Cancel);
                         }
                     }
                     Err(_) => retained.push(entry),
@@ -2092,6 +2128,7 @@ impl Chat {
 
     fn drain_notifications(&mut self) {
         let mut applied = false;
+        let mut reconciles: Vec<String> = Vec::new();
         loop {
             match self.notif_rx.try_recv() {
                 Ok(notif) if notif.method == "session/update" => {
@@ -2100,12 +2137,32 @@ impl Chat {
                         // their stream too, so transcripts and status dots
                         // stay current while unfocused.
                         let sid = update.session_id().to_string();
-                        if !self.session_resync_in_flight.contains(&sid)
+                        let mut terminal_reconcile = false;
+                        if !self.session_resync_in_flight.contains_key(&sid)
                             && let Some(state) = self.state_for_session_mut(&sid)
                             && state.last_error != Some(SessionError::ResyncFailed)
                         {
-                            state.apply_update(update);
-                            applied = true;
+                            // A turn that survived a lag resync streamed entries
+                            // into the durable store while the resync gate was
+                            // closed; its terminal frame is the signal to reload
+                            // the transcript once more instead of trusting the
+                            // frame alone (`resync_terminal_reload_pending`).
+                            // Stale generations keep the regular ignore path.
+                            if state.resync_terminal_reload_pending
+                                && Self::turn_complete_matches_generation(
+                                    &update,
+                                    state.turn_generation,
+                                )
+                            {
+                                state.resync_terminal_reload_pending = false;
+                                terminal_reconcile = true;
+                            } else {
+                                state.apply_update(update);
+                                applied = true;
+                            }
+                        }
+                        if terminal_reconcile {
+                            reconciles.push(sid);
                         }
                     }
                 }
@@ -2116,8 +2173,23 @@ impl Chat {
                 _ => break,
             }
         }
+        for sid in reconciles {
+            self.begin_session_resync(sid, SessionResyncMode::Reattach);
+        }
         if applied {
             self.pump_all_queues();
+        }
+    }
+
+    /// Whether a `session/update` is this session's live terminal frame (the
+    /// daemon either echoes the client turn generation or omits it).
+    fn turn_complete_matches_generation(update: &SessionUpdate, generation: u64) -> bool {
+        match update {
+            SessionUpdate::TurnComplete {
+                client_turn_generation,
+                ..
+            } => client_turn_generation.is_none_or(|turn| turn == generation),
+            _ => false,
         }
     }
 
@@ -2125,6 +2197,12 @@ impl Chat {
     /// the missing frame may have been a terminal update. Gate queue dispatch,
     /// invalidate transport-bound interactions, and reload every tracked
     /// session from the daemon's durable transcript.
+    ///
+    /// Reloads use `Reattach`: the overflow is a client-side event and must
+    /// not cancel turns the daemon is running for this client, including
+    /// background sessions. Sessions the daemon reports idle reload exactly
+    /// as before; live turns keep running and the pane re-attaches to their
+    /// stream.
     fn begin_notification_resync(&mut self) {
         let session_ids = self
             .session_summaries()
@@ -2132,7 +2210,7 @@ impl Chat {
             .map(|summary| summary.session_id)
             .collect::<Vec<_>>();
         for session_id in session_ids {
-            self.begin_session_resync(session_id);
+            self.begin_session_resync(session_id, SessionResyncMode::Reattach);
         }
     }
 
@@ -2171,8 +2249,12 @@ impl Chat {
         }
     }
 
-    fn begin_session_resync(&mut self, session_id: String) {
-        if !self.session_resync_in_flight.insert(session_id.clone()) {
+    fn begin_session_resync(&mut self, session_id: String, mode: SessionResyncMode) {
+        if self
+            .session_resync_in_flight
+            .insert(session_id.clone(), mode)
+            .is_some()
+        {
             return;
         }
         if self.entry_retry_preparing {
@@ -2194,18 +2276,19 @@ impl Chat {
         }
 
         tokio::spawn(async move {
-            let result = Self::cancel_confirm_and_reload_with_retry(&rpc, &session_id).await;
+            let result = Self::confirm_and_reload_with_retry(&rpc, &session_id, mode).await;
             let _ = tx.send(SessionResyncResult { session_id, result }).await;
         });
     }
 
-    async fn cancel_confirm_and_reload_with_retry(
+    async fn confirm_and_reload_with_retry(
         rpc: &Arc<RpcClient>,
         session_id: &str,
+        mode: SessionResyncMode,
     ) -> Result<SessionResyncSnapshot, String> {
         let mut last_error = String::new();
         for attempt in 0..SESSION_RECOVERY_MAX_ATTEMPTS {
-            match Self::cancel_confirm_and_reload(rpc, session_id).await {
+            match Self::confirm_and_reload(rpc, session_id, mode).await {
                 Ok(messages) => return Ok(messages),
                 Err(error) => last_error = error,
             }
@@ -2215,6 +2298,17 @@ impl Chat {
             }
         }
         Err(last_error)
+    }
+
+    async fn confirm_and_reload(
+        rpc: &Arc<RpcClient>,
+        session_id: &str,
+        mode: SessionResyncMode,
+    ) -> Result<SessionResyncSnapshot, String> {
+        match mode {
+            SessionResyncMode::Cancel => Self::cancel_confirm_and_reload(rpc, session_id).await,
+            SessionResyncMode::Reattach => Self::reattach_confirm_and_reload(rpc, session_id).await,
+        }
     }
 
     async fn cancel_confirm_and_reload(
@@ -2250,9 +2344,66 @@ impl Chat {
                 message_count: messages.total,
                 messages: messages.messages,
                 plan,
+                turn_running: false,
             })
             .map_err(|error| format!("transcript reload failed: {error}"))?;
         Ok(messages)
+    }
+
+    /// Reattach-mode reconciliation: read the daemon's authoritative state,
+    /// snapshot the durable transcript, and report whether the turn survived.
+    /// No cancellation — a notification overflow is a client-side event, and
+    /// the turns the daemon is running for this client are unrelated to it.
+    ///
+    /// The daemon's `session/state` answers what the cancel cascade only
+    /// guessed at: whether a turn is actually live (`running` with a turn id)
+    /// or merely queued (`running` without one — daemon-side queued work,
+    /// which reloads and settles like idle here; the pane's own queue stays
+    /// client-owned either way).
+    ///
+    /// The two state reads bracket the transcript snapshot: a turn still live
+    /// across both reports `turn_running`, and one that ends inside the
+    /// bracket triggers a post-terminal re-fetch so the pane never settles
+    /// short of the turn's final durable entries.
+    async fn reattach_confirm_and_reload(
+        rpc: &Arc<RpcClient>,
+        session_id: &str,
+    ) -> Result<SessionResyncSnapshot, String> {
+        let state_before = rpc
+            .session_state(session_id)
+            .await
+            .map_err(|error| format!("session-state check failed: {error}"))?;
+        let turn_was_live = state_before.state == "running" && state_before.turn_id.is_some();
+        let messages = rpc
+            .session_messages(session_id)
+            .await
+            .map_err(|error| format!("transcript reload failed: {error}"))?;
+        // Bracket the snapshot with a second state read: a turn still live
+        // across both reports re-attaches (entries the snapshot raced are
+        // reconciled at its terminal frame), a turn that ended inside the
+        // bracket may have left the snapshot short of its final entries, so
+        // the reload runs once more after the terminal confirmation.
+        let state_after = rpc
+            .session_state(session_id)
+            .await
+            .map_err(|error| format!("session-state check failed: {error}"))?;
+        let turn_running =
+            turn_was_live && state_after.state == "running" && state_after.turn_id.is_some();
+        let (messages, message_count) = if turn_was_live && !turn_running {
+            let refreshed = rpc
+                .session_messages(session_id)
+                .await
+                .map_err(|error| format!("transcript reload failed: {error}"))?;
+            (refreshed.messages, refreshed.total)
+        } else {
+            (messages.messages, messages.total)
+        };
+        Ok(SessionResyncSnapshot {
+            message_count,
+            messages,
+            plan: state_after.plan,
+            turn_running,
+        })
     }
 
     fn apply_session_resync_result(&mut self, update: SessionResyncResult) {
@@ -2266,11 +2417,15 @@ impl Chat {
                 state.replace_history_after_notification_resync(
                     snapshot.messages,
                     strip_runtime_enrichment,
+                    snapshot.turn_running,
                 );
                 state.message_count = snapshot.message_count;
                 if let Some(plan) = snapshot.plan {
                     state.todo_tracker.set_plan(plan);
                 }
+                // Dropping the gate re-enables live `session/update` frames for
+                // this session; a kept-running turn streams onto the reloaded
+                // transcript from here.
                 self.session_resync_in_flight.remove(&update.session_id);
                 self.pump_all_queues();
             }
@@ -2541,7 +2696,10 @@ impl Chat {
             })
             .collect::<Vec<_>>();
         for session_id in retry_resyncs {
-            self.begin_session_resync(session_id);
+            // Queue-driven retry of a failed reconciliation: still Cancel,
+            // matching `ensure_session_alive` — the caller needs a
+            // known-terminal session before the queued input can dispatch.
+            self.begin_session_resync(session_id, SessionResyncMode::Cancel);
         }
     }
 
@@ -2591,12 +2749,12 @@ impl Chat {
         rpc: &Arc<RpcClient>,
         session_reattach_tx: &mpsc::Sender<SessionReattachResult>,
         session_reattach_in_flight: &mut HashSet<String>,
-        session_resync_in_flight: &HashSet<String>,
+        session_resync_in_flight: &HashMap<String, SessionResyncMode>,
         pane_kind: PaneKind,
         transport: crate::client::Transport,
         state: &mut ChatState,
     ) {
-        if session_resync_in_flight.contains(&state.session_id) {
+        if session_resync_in_flight.contains_key(&state.session_id) {
             return;
         }
         if state.last_error == Some(SessionError::ResyncFailed) {
@@ -7398,6 +7556,12 @@ pub struct ChatState {
     /// Anchor for the dots animation — reset each time a turn begins so
     /// the pulse starts from phase 0.
     turn_started_at: Instant,
+    /// Set when a lag resync re-attached to a still-running turn. The
+    /// transcript snapshot raced the live stream, so entries emitted while
+    /// the resync gate was closed exist only in the durable store: the
+    /// turn's terminal frame must trigger one more transcript reload
+    /// instead of being trusted alone.
+    resync_terminal_reload_pending: bool,
     show_thoughts: bool,
     /// Browse mode cursor (most-recently moved position).
     browse_cursor: Option<usize>,
@@ -7552,6 +7716,7 @@ impl ChatState {
             turn_had_tool_calls: false,
             turn_status: TurnStatus::Idle,
             turn_started_at: Instant::now(),
+            resync_terminal_reload_pending: false,
             show_thoughts: true,
             browse_cursor: None,
             browse_anchor: None,
@@ -9489,6 +9654,9 @@ impl ChatState {
         self.turn_status = TurnStatus::Idle;
         self.cancel_started_at = None;
         self.resume_override = false;
+        // A fresh resync supersedes any owed terminal reload; the new
+        // snapshot decides the outcome instead.
+        self.resync_terminal_reload_pending = false;
         let cleanup_report = self.cleanup_active_turn_attachments();
         self.surface_cleanup_report(cleanup_report);
         self.set_info_notice(crate::i18n::t("zc-chat-resyncing"));
@@ -9498,6 +9666,7 @@ impl ChatState {
         &mut self,
         messages: Vec<crate::client::MessageEntry>,
         strip_runtime_enrichment: bool,
+        turn_kept_running: bool,
     ) {
         self.entries.clear();
         self.first_message = None;
@@ -9511,12 +9680,28 @@ impl ChatState {
         self.cached_total_rows = 0;
         self.clear_transcript_selection();
         self.load_history(messages, strip_runtime_enrichment);
+        let notice = if turn_kept_running {
+            crate::i18n::t("zc-chat-resynced-turn-running")
+        } else {
+            crate::i18n::t("zc-chat-resynced")
+        };
         self.entries
-            .push(ChatEntry::SystemMessage(Arc::<str>::from(crate::i18n::t(
-                "zc-chat-resynced",
-            ))));
+            .push(ChatEntry::SystemMessage(Arc::<str>::from(notice)));
         self.info_message = None;
         self.last_error = None;
+        if turn_kept_running {
+            // The daemon still reports this turn live: re-attach instead of
+            // settling. Live updates resume once the resync gate drops (see
+            // `apply_session_resync_result`); `Working` is the neutral anchor
+            // until the first live chunk re-labels the status. The turn's
+            // client generation is untouched so the pending prompt response
+            // still settles it. Entries the snapshot raced are reconciled by
+            // one more reload at the turn's terminal frame.
+            self.turn_in_flight = true;
+            self.turn_status = TurnStatus::Working;
+            self.turn_started_at = Instant::now();
+            self.resync_terminal_reload_pending = true;
+        }
         self.mark_dirty_full();
     }
 
@@ -12952,7 +13137,8 @@ mod tests {
         let mut chat = Chat::new(client, PaneKind::Chat);
         chat.phase = ChatPhase::Active(Box::new(state()));
         chat.session_order.push("sess-1".to_string());
-        chat.session_resync_in_flight.insert("sess-1".to_string());
+        chat.session_resync_in_flight
+            .insert("sess-1".to_string(), SessionResyncMode::Cancel);
 
         let entries = chat.resume_entries();
         assert_eq!(entries.len(), 1);
@@ -13074,8 +13260,10 @@ mod tests {
         chat.session_order = vec!["sess-1".to_string()];
 
         // The test client's notification channel holds 64 frames. Put the
-        // terminal frame first, then overflow it so `try_recv` reports Lagged
-        // and the old implementation would have stranded `turn_in_flight`.
+        // terminal frame first, then overflow it with unparsable
+        // `session/update` frames so `try_recv` reports Lagged while the
+        // drain still consumes the backlog (a foreign method would stop the
+        // drain loop and strand later frames behind it).
         chat.rpc.push_notification_for_test(
             "session/update",
             serde_json::json!({
@@ -13087,33 +13275,25 @@ mod tests {
         );
         for _ in 0..64 {
             chat.rpc
-                .push_notification_for_test("test/noop", serde_json::Value::Null);
+                .push_notification_for_test("session/update", serde_json::Value::Null);
         }
         chat.drain_notifications();
 
         let ChatPhase::Active(state) = &chat.phase else {
             panic!("session remains active during recovery");
         };
-        assert!(!state.turn_in_flight, "lag resets terminal turn state");
-        assert_eq!(state.queue_len(), 1, "queued input remains client-owned");
+        assert!(chat.session_resync_in_flight.contains_key("sess-1"));
         assert!(state.pending_approval.is_none());
         assert!(state.pending_elicitation.is_none());
-        assert!(chat.session_resync_in_flight.contains("sess-1"));
 
-        let mut saw_cancel = false;
         let mut saw_approval = false;
         let mut saw_elicitation = false;
-        while !(saw_cancel && saw_approval && saw_elicitation) {
+        while !(saw_approval && saw_elicitation) {
             let frame =
-                next_rpc_request(&mut writer_rx, "resync should cancel and invalidate").await;
+                next_rpc_request(&mut writer_rx, "resync should invalidate stale input").await;
             match frame.get("method").and_then(serde_json::Value::as_str) {
                 Some(method::SESSION_CANCEL) => {
-                    saw_cancel = true;
-                    respond_ok(
-                        &outbound,
-                        &frame,
-                        serde_json::json!({ "session_id": "sess-1", "cancelled": true }),
-                    );
+                    panic!("lag recovery must not cancel the running turn");
                 }
                 Some(method::SESSION_APPROVE) => {
                     saw_approval = true;
@@ -13128,36 +13308,14 @@ mod tests {
             }
         }
 
-        let running = next_rpc_request(&mut writer_rx, "resync must confirm terminal state").await;
+        let running = next_rpc_request(&mut writer_rx, "resync checks daemon state").await;
         assert_eq!(running["method"], method::SESSION_STATE);
         respond_ok(
             &outbound,
             &running,
-            serde_json::json!({ "session_id": "sess-1", "state": "running" }),
+            serde_json::json!({ "session_id": "sess-1", "state": "running", "turn_id": "7" }),
         );
-        assert!(
-            writer_rx.try_recv().is_err(),
-            "overflow recovery must not reload or dispatch while the old turn is running"
-        );
-
-        let idle = next_rpc_request(&mut writer_rx, "resync should poll until terminal").await;
-        assert_eq!(idle["method"], method::SESSION_STATE);
-        respond_ok(
-            &outbound,
-            &idle,
-            serde_json::json!({
-                "session_id": "sess-1",
-                "state": "idle",
-                "plan": [{
-                    "content": "Authoritative recovery task",
-                    "status": "in_progress",
-                    "priority": "high",
-                    "activeForm": "Recovering task"
-                }]
-            }),
-        );
-
-        let messages = next_rpc_request(&mut writer_rx, "terminal resync reloads transcript").await;
+        let messages = next_rpc_request(&mut writer_rx, "resync reloads the transcript").await;
         assert_eq!(messages["method"], method::SESSION_MESSAGES);
         respond_ok(
             &outbound,
@@ -13169,9 +13327,23 @@ mod tests {
                 ]
             }),
         );
-        assert!(
-            writer_rx.try_recv().is_err(),
-            "queue dispatch stays gated until transcript reload completes"
+        let still_running =
+            next_rpc_request(&mut writer_rx, "resync confirms the turn survived").await;
+        assert_eq!(still_running["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &still_running,
+            serde_json::json!({
+                "session_id": "sess-1",
+                "state": "running",
+                "turn_id": "7",
+                "plan": [{
+                    "content": "Authoritative recovery task",
+                    "status": "in_progress",
+                    "priority": "high",
+                    "activeForm": "Recovering task"
+                }]
+            }),
         );
 
         tokio::time::timeout(Duration::from_secs(2), async {
@@ -13181,21 +13353,103 @@ mod tests {
         })
         .await
         .expect("session/messages should finish resync");
-        // The daemon's authoritative idle response is ordered after this old
-        // terminal notification on the same RPC stream. Exercise the real
-        // frame-tick order: the resync gate must discard the old completion
-        // before its result releases the queued follow-up.
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after recovery");
+        };
+        assert!(
+            state.turn_in_flight,
+            "the daemon kept the turn running, so the pane re-attaches"
+        );
+        assert_eq!(state.turn_status, TurnStatus::Working);
+        assert_eq!(state.queue_len(), 1, "queued input waits for the live turn");
+        assert!(state.entries.iter().any(|entry| matches!(
+            entry,
+            ChatEntry::SystemMessage(message)
+                if message.as_ref() == crate::i18n::t("zc-chat-resynced-turn-running")
+        )));
+        assert_eq!(state.todo_tracker.entries().len(), 1);
+        assert_eq!(
+            state.todo_tracker.entries()[0].content,
+            "Authoritative recovery task"
+        );
+
+        // Live updates resume once the gate drops: a fresh delta streams onto
+        // the reloaded transcript without a new resync.
+        chat.rpc.push_notification_for_test(
+            "session/update",
+            serde_json::json!({
+                "type": "agent_message_chunk",
+                "session_id": "sess-1",
+                "text": "live delta"
+            }),
+        );
+        chat.tick_transport_events();
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after recovery");
+        };
+        assert_eq!(state.turn_status, TurnStatus::Responding);
+
+        // The surviving turn's terminal frame carries durable entries the
+        // snapshot raced; it must trigger one authoritative reload instead of
+        // being trusted alone.
         chat.rpc.push_notification_for_test(
             "session/update",
             serde_json::json!({
                 "type": "turn_complete",
                 "session_id": "sess-1",
                 "outcome": "completed",
-                "content": "stale late completion",
+                "content": "final answer",
+                "client_turn_generation": 1,
             }),
         );
         chat.tick_transport_events();
-        let prompt = next_rpc_request(&mut writer_rx, "recovery should release queued input").await;
+
+        let idle =
+            next_rpc_request(&mut writer_rx, "terminal frame triggers one more reload").await;
+        assert_eq!(idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+        let reconciled = next_rpc_request(
+            &mut writer_rx,
+            "terminal reload fetches the full transcript",
+        )
+        .await;
+        assert_eq!(reconciled["method"], method::SESSION_MESSAGES);
+        respond_ok(
+            &outbound,
+            &reconciled,
+            serde_json::json!({
+                "messages": [
+                    { "role": "user", "content": "in flight" },
+                    { "role": "assistant", "content": "durable answer" },
+                    { "role": "assistant", "content": "reconciled tail" }
+                ]
+            }),
+        );
+        let confirm_idle =
+            next_rpc_request(&mut writer_rx, "terminal reload brackets the snapshot").await;
+        assert_eq!(confirm_idle["method"], method::SESSION_STATE);
+        respond_ok(
+            &outbound,
+            &confirm_idle,
+            serde_json::json!({ "session_id": "sess-1", "state": "idle" }),
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal reload should finish resync");
+        chat.tick_transport_events();
+
+        let prompt = next_rpc_request(&mut writer_rx, "settled pane releases queued input").await;
         assert_eq!(prompt["method"], method::SESSION_PROMPT);
         assert_eq!(prompt["params"]["prompt"], "send after recovery");
         let ChatPhase::Active(state) = &chat.phase else {
@@ -13203,24 +13457,154 @@ mod tests {
         };
         assert_eq!(state.queue_len(), 0);
         assert!(state.turn_in_flight, "queued follow-up is now in flight");
-        assert!(state.entries.iter().all(|entry| !matches!(
+        assert!(state.entries.iter().any(|entry| matches!(
             entry,
-            ChatEntry::AgentMessage(message) if message.as_ref() == "stale late completion"
+            ChatEntry::AgentMessage(message) if message.as_ref() == "reconciled tail"
         )));
-        assert!(matches!(
-            state.entries.get(1),
-            Some(ChatEntry::AgentMessage(message)) if message.as_ref() == "durable answer"
-        ));
-        assert_eq!(state.todo_tracker.entries().len(), 1);
-        assert_eq!(
-            state.todo_tracker.entries()[0].content,
-            "Authoritative recovery task"
-        );
         assert!(state.entries.iter().any(|entry| matches!(
             entry,
             ChatEntry::SystemMessage(message)
                 if message.as_ref() == crate::i18n::t("zc-chat-resynced")
         )));
+        // The terminal reload replaced the transcript wholesale, so only the
+        // settled outcome's notice remains (the kept-running one was asserted
+        // between the two applies above).
+    }
+
+    #[tokio::test]
+    async fn notification_lag_resync_reloads_running_and_idle_sessions_without_cancel() {
+        let (tx, mut writer_rx) = mpsc::channel::<String>(32);
+        let outbound = Arc::new(RpcOutbound::new(tx));
+        let client = Arc::new(RpcClient::with_rpc(outbound.clone()));
+        let mut chat = Chat::new(client, PaneKind::Chat);
+        let mut running = state_for("sess-running", "myagent");
+        running.push_user_message(Some("busy turn".to_string()), Vec::new());
+        let idle = state_for("sess-idle", "myagent");
+        chat.phase = ChatPhase::Active(Box::new(running));
+        chat.background.push(idle);
+        chat.session_order = vec!["sess-running".to_string(), "sess-idle".to_string()];
+
+        // Overflow the test client's 64-frame notification channel with
+        // unparsable `session/update` frames so the drain reports Lagged and
+        // re-syncs every tracked session while still consuming the backlog.
+        for _ in 0..65 {
+            chat.rpc
+                .push_notification_for_test("session/update", serde_json::Value::Null);
+        }
+        chat.drain_notifications();
+        assert!(chat.session_resync_in_flight.contains_key("sess-running"));
+        assert!(chat.session_resync_in_flight.contains_key("sess-idle"));
+
+        // Each resync task exchanges state/messages/state with the fake
+        // daemon; the running session stays live across the bracket, the
+        // idle one never leaves it. Interleaving between the two tasks is
+        // arbitrary, so route every frame by method and session.
+        for _ in 0..6 {
+            let frame = next_rpc_request(&mut writer_rx, "recovery reloads each session").await;
+            let method_name = frame
+                .get("method")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let sid = frame["params"]["session_id"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
+            match (method_name.as_str(), sid.as_str()) {
+                (method::SESSION_CANCEL, _) => {
+                    panic!("lag recovery must not cancel any session");
+                }
+                (method::SESSION_STATE, "sess-running") => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({ "session_id": "sess-running", "state": "running", "turn_id": "3" }),
+                ),
+                (method::SESSION_STATE, "sess-idle") => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({ "session_id": "sess-idle", "state": "idle" }),
+                ),
+                (method::SESSION_MESSAGES, "sess-running") => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({
+                        "messages": [{ "role": "user", "content": "busy turn" }],
+                        "total": 1
+                    }),
+                ),
+                (method::SESSION_MESSAGES, "sess-idle") => respond_ok(
+                    &outbound,
+                    &frame,
+                    serde_json::json!({
+                        "messages": [
+                            { "role": "user", "content": "old ask" },
+                            { "role": "assistant", "content": "old answer" }
+                        ],
+                        "total": 2
+                    }),
+                ),
+                other => panic!("unexpected recovery frame: {other:?}"),
+            }
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while chat.session_resync_rx.len() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both sessions should finish resync");
+        chat.tick_transport_events();
+
+        let ChatPhase::Active(running) = &chat.phase else {
+            panic!("focused session remains active after recovery");
+        };
+        assert!(
+            running.turn_in_flight,
+            "the daemon kept the focused turn running, so the pane re-attaches"
+        );
+        assert_eq!(running.turn_status, TurnStatus::Working);
+        assert!(running.entries.iter().any(|entry| matches!(
+            entry,
+            ChatEntry::UserMessage { text: Some(text), .. } if text.as_ref() == "busy turn"
+        )));
+        assert!(running.entries.iter().any(|entry| matches!(
+            entry,
+            ChatEntry::SystemMessage(message)
+                if message.as_ref() == crate::i18n::t("zc-chat-resynced-turn-running")
+        )));
+
+        let idle = chat
+            .background
+            .iter()
+            .find(|state| state.session_id == "sess-idle")
+            .expect("idle background session survives resync");
+        assert!(!idle.turn_in_flight, "an idle session reloads and settles");
+        assert!(idle.entries.iter().any(|entry| matches!(
+            entry,
+            ChatEntry::AgentMessage(message) if message.as_ref() == "old answer"
+        )));
+        assert!(idle.entries.iter().any(|entry| matches!(
+            entry,
+            ChatEntry::SystemMessage(message)
+                if message.as_ref() == crate::i18n::t("zc-chat-resynced")
+        )));
+
+        // The re-attached session applies subsequent live deltas normally.
+        chat.rpc.push_notification_for_test(
+            "session/update",
+            serde_json::json!({
+                "type": "agent_message_chunk",
+                "session_id": "sess-running",
+                "text": "post-resync delta"
+            }),
+        );
+        chat.tick_transport_events();
+        let ChatPhase::Active(running) = &chat.phase else {
+            panic!("focused session remains active");
+        };
+        assert_eq!(running.turn_status, TurnStatus::Responding);
+        assert!(running.streaming_text.contains("post-resync delta"));
     }
 
     #[tokio::test]
@@ -13237,7 +13621,7 @@ mod tests {
         chat.phase = ChatPhase::Active(Box::new(active));
         chat.session_order = vec!["sess-1".to_string()];
 
-        chat.begin_session_resync("sess-1".to_string());
+        chat.begin_session_resync("sess-1".to_string(), SessionResyncMode::Cancel);
         let cancel = next_rpc_request(&mut writer_rx, "first resync cancels the turn").await;
         assert_eq!(cancel["method"], method::SESSION_CANCEL);
         respond_ok(
@@ -13255,7 +13639,7 @@ mod tests {
             "transient state lookup failure",
         );
 
-        assert!(chat.session_resync_in_flight.contains("sess-1"));
+        assert!(chat.session_resync_in_flight.contains_key("sess-1"));
         let retry_cancel =
             next_rpc_request(&mut writer_rx, "resync must retry after a transient error").await;
         assert_eq!(retry_cancel["method"], method::SESSION_CANCEL);
@@ -13297,7 +13681,7 @@ mod tests {
         let prompt = next_rpc_request(&mut writer_rx, "retry releases queued input").await;
         assert_eq!(prompt["method"], method::SESSION_PROMPT);
         assert_eq!(prompt["params"]["prompt"], "send after retry");
-        assert!(!chat.session_resync_in_flight.contains("sess-1"));
+        assert!(!chat.session_resync_in_flight.contains_key("sess-1"));
     }
 
     #[tokio::test]
@@ -13319,7 +13703,7 @@ mod tests {
         chat.phase = ChatPhase::Active(Box::new(active));
         chat.session_order = vec!["sess-1".to_string()];
 
-        chat.begin_session_resync("sess-1".to_string());
+        chat.begin_session_resync("sess-1".to_string(), SessionResyncMode::Cancel);
         for _ in 0..SESSION_RECOVERY_MAX_ATTEMPTS {
             let cancel = next_rpc_request(&mut writer_rx, "each recovery attempt cancels").await;
             assert_eq!(cancel["method"], method::SESSION_CANCEL);
@@ -13358,7 +13742,7 @@ mod tests {
             "client-owned prompt must remain queued"
         );
         assert_eq!(state.todo_tracker.entries()[0].content, "stale plan");
-        assert!(!chat.session_resync_in_flight.contains("sess-1"));
+        assert!(!chat.session_resync_in_flight.contains_key("sess-1"));
         assert_eq!(chat.session_summaries()[0].status, SidebarStatus::Errored);
         chat.rpc.push_notification_for_test(
             "session/update",
@@ -13420,7 +13804,7 @@ mod tests {
         .await;
         assert_eq!(cancel["method"], method::SESSION_CANCEL);
         let mut chat = reconnect.await.unwrap();
-        assert!(chat.session_resync_in_flight.contains("sess-1"));
+        assert!(chat.session_resync_in_flight.contains_key("sess-1"));
         assert_eq!(
             chat.state_for_session("sess-1")
                 .expect("reattached session")
@@ -16584,7 +16968,7 @@ mod tests {
             .enqueue_message("after recovery".into(), Vec::new())
             .unwrap();
         worker.phase = ChatPhase::Active(Box::new(queued));
-        worker.begin_session_resync("sess-1".into());
+        worker.begin_session_resync("sess-1".into(), SessionResyncMode::Cancel);
         worker.pump_all_queues();
         assert!(
             tokio::time::timeout(Duration::from_millis(50), rx.recv())
@@ -16612,7 +16996,7 @@ mod tests {
         });
         pane.drain_entry_retry_results();
         assert!(!pane.entry_retry_preparing);
-        assert!(pane.session_resync_in_flight.contains("sess-1"));
+        assert!(pane.session_resync_in_flight.contains_key("sess-1"));
         assert_eq!(pane.state_for_session("sess-1").unwrap().queue_len(), 1);
         let request = next_rpc_request(&mut rx, "adoption starts deferred recovery").await;
         assert_eq!(request["method"], method::SESSION_CANCEL);

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -13469,6 +13469,31 @@ mod tests {
         // The terminal reload replaced the transcript wholesale, so only the
         // settled outcome's notice remains (the kept-running one was asserted
         // between the two applies above).
+
+        // The correlation fence still holds: a late frame from the original
+        // turn must not settle the post-recovery prompt (generation 2 now).
+        chat.rpc.push_notification_for_test(
+            "session/update",
+            serde_json::json!({
+                "type": "turn_complete",
+                "session_id": "sess-1",
+                "outcome": "completed",
+                "content": "stale late completion",
+                "client_turn_generation": 1,
+            }),
+        );
+        chat.tick_transport_events();
+        let ChatPhase::Active(state) = &chat.phase else {
+            panic!("session remains active after recovery");
+        };
+        assert!(state.entries.iter().all(|entry| !matches!(
+            entry,
+            ChatEntry::AgentMessage(message) if message.as_ref() == "stale late completion"
+        )));
+        assert!(
+            state.turn_in_flight,
+            "stale frame must not settle the new turn"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - A notification-channel overflow in ZeroCode (`TryRecvError::Lagged` on the daemon broadcast) used to run `begin_session_resync` for every tracked session, and that path called `session/cancel` before anything else. A client-side buffer overflow therefore aborted every turn the daemon was running for that client, including background sessions the user was not looking at. `begin_session_resync` now takes a `SessionResyncMode`: `Reattach` (never cancels; reads `session/state`, snapshots the durable transcript, and if the daemon still reports a live turn keeps the pane's displayed entries and in-flight state so live updates re-attach) and `Cancel` (the previous behaviour, force terminal then reload). Notification-lag recovery uses `Reattach` for every session.
  - The seven other `begin_session_resync` callers (reconnect/resume paths gated on `needs_terminal_recovery`, and the `ResyncFailed` retry paths) keep `Cancel`: those turns predate the current pane incarnation, so their terminal frames can no longer be matched by generation and the caller needs a known-idle session before it can proceed. The in-flight gate became `HashMap<String, SessionResyncMode>` so a resync deferred across pane adoption re-begins with the mode it was started with.
  - The daemon persists an ACP turn's messages only at its terminal frame (`persist_acp_turn` in `rpc/dispatch.rs` runs after `turn.await`), so for a running turn `session/messages` holds none of it — on a first turn the snapshot is empty. An earlier head of this PR reset the pane at `begin_session_resync` and replaced every displayed entry with that snapshot, which made the user's prompt, tool cards and streamed text disappear until the terminal reload, with new chunks appearing under the notice. Reattach now defers the reset to `apply_session_resync_result`, where the snapshot decides: a turn the daemon still runs keeps its entries, the streamed partial is committed as its own bubble, the still-running notice marks the missed interval so later chunks never splice onto it, and the pane re-attaches append-only (caches and reading position survive). Idle sessions and the Cancel mode reload wholesale exactly as before; a failed Reattach reload commits the partial and settles the turn so the `ResyncFailed` gate does not leave the pane in flight.
  - Entries a kept-running turn streams while the resync gate is closed exist only in the durable store. The transcript snapshot is bracketed by two `session/state` reads: a turn that ends inside the bracket triggers an immediate re-fetch, and a turn that survives sets `resync_terminal_reload_pending` so its terminal `session/update` triggers one more reload (`ReattachTerminal`). That terminal frame is applied first, so its outcome is recorded, and the outcome is carried across the wholesale reload (`resync_carried_outcome`): failed turns restore the `SessionLost`/`TurnFailed` classification via a single `classify_turn_failure` helper and re-push their text, cancelled turns re-push their text, completed turns carry nothing.
  - Notice text now matches what happened. `zc-chat-resynced` still says an in-progress approval or question was cancelled, which is true only for the idle reload; `zc-chat-resynced-turn-running` (turn kept running, output above kept, one more reload at its end) and `zc-chat-resynced-turn-finished` (that follow-up reload; nothing was cancelled) are added in en, es, fr, ja and zh-CN.
- **Scope boundary:** The broadcast channel capacity (`NOTIFICATION_CHANNEL_CAPACITY = 1024`), moving the drain off the draw loop, and delta coalescing are the issue's third bullet and are not touched here. The reconnect/resume recovery paths keep their cancel semantics on purpose; this PR removes the cascade, it does not re-audit every recovery path. No change outside `apps/zerocode/`.
- **Blast radius:** `apps/zerocode` only: `chat.rs` (resync plumbing, `ChatState` gains two fields) and the five `zerocode.ftl` locale files (two added keys each). No daemon or RPC protocol change; the client uses the existing `session/state`, `session/messages` and `session/update` shapes.
- **Linked issue(s):** Closes #10785. Related #10741 (adjacent missing-terminal-notification path), Related #10466 (lost prompt completion reconciliation, which this relies on as the backstop for pane-dispatched turns).
- **Labels:** to be snapshotted after the labeler runs.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** `tui` (zerocode), Chat and Code panes.
- **Setup / preconditions:** A daemon and zerocode built from the same revision (they share the wire with no compat). Two or more sessions in one zerocode instance on a chatty tool-looping model (any provider), at least one of them mid-turn in the background.
- **Steps to run:** With the turns streaming, stall the draw loop long enough to overflow the 1024-frame notification buffer: `kill -STOP <zerocode pid>`, wait ~3 s, `kill -CONT <pid>`; or resize the terminal rapidly for a few seconds.
- **Expected on this branch (after):** Each session shows a resync notice; sessions the daemon reported running keep the prompt, tool cards and streamed text already on screen, show the "turn is still running" notice beneath them, keep their working indicator, and continue streaming under the notice without the view jumping; when such a turn ends, the transcript reloads once more with the "turn finished" notice. No `session/cancel` in the daemon trace (`turn cancelled` records with `cancel_cause: client_rpc` do not appear).
- **Prior behavior on `master` (before):** Every running turn is cancelled within a millisecond of the lag (`dispatch.rs` logs `turn cancelled ... cancel_cause: client_rpc` for each session) and each pane shows "Live updates were missed, so the durable transcript was reloaded. Any in-progress approval or question was cancelled."

### How I tested

- **CI checks relied on and why they cover this change:** required Rust CI (fmt, clippy `-D warnings`, `cargo test -p zerocode`) covers the changed crate; the zerocode Fluent locale gate covers the five `.ftl` files.
- **Known CI coverage gap, if any:** no CI exercises a real notification overflow against a live daemon; that scenario is covered by the fake-RPC harness tests below and the manual steps above.
- **Commands run and tail output** (worktree, `cargo` via the shared SSD target dir, `-j 2`, `--locked`):

```text
cargo fmt --all -- --check                                      clean
cargo clippy -p zerocode --all-targets -- -D warnings           clean
cargo test -p zerocode                                          lib 306 passed; bin 1137 passed, 1 failed, 2 ignored
cargo test -p zerocode --bin zerocode -- chat::tests::          296 passed; 0 failed
```

The one bin failure at head `fdcb2d7` is `connection_tests::insecure_tls_prompt_preserves_default_sigint`, which fails whenever the parent process ignores SIGINT (the suite was run under `nohup`); the same test binary passes it in the foreground and fails it again under `trap '' INT`, so it is a harness artefact, not this change. At `6890d3f` the full suite ran foreground: 1422 passed; 0 failed; 2 ignored (master at the branch base: 1419; 0).

Tests added or rewritten in `apps/zerocode/src/chat.rs`:
- `notification_lag_resync_reloads_running_and_idle_sessions_without_cancel`: one running session with a streamed partial and one idle session, Lagged drain; the fake RPC panics on any `session/cancel` and answers `session/messages` for the running session with `[]` (the daemon's actual contract for a running first turn; the earlier fixture returned the prompt, which hid the disappearance). The running pane keeps `[user prompt, committed partial, still-running notice]` in that order, stays in flight with its pre-lag status label, and streams a subsequent delta into a fresh segment; the idle pane reloads and settles. Pointing the lag caller back at `Cancel` fails this test; so does the previous head `6890d3f` (entries collapse to the notice alone).
- `notification_lag_recovers_dropped_turn_complete_before_queue_dispatch` (rewritten): the stale-completion fence still holds after lag recovery: a late `TurnComplete` from the original turn does not settle the prompt the recovery released.
- `terminal_reload_after_lag_resync_preserves_session_lost_outcome`: kept-running turn ends with `outcome: failed` and a `session_not_found` sentinel; after the follow-up reload `last_error == SessionLost` and the failure text is in the transcript.
- `terminal_reload_after_lag_resync_keeps_clean_completion_clean`: same with `outcome: completed`; `last_error` stays `None`, exactly one follow-up reload.
- `terminal_reload_after_lag_resync_preserves_cancelled_outcome_text`: `outcome: cancelled`; text re-pushed, `last_error` stays `None`.
- `resume_snapshot_marks_inflight_resync_as_recovery_required` and the two existing resync retry tests updated for the keyed in-flight map; behaviour unchanged.

- **Beyond CI, what did you manually verify?** Dogfooding head `6890d3f` in ZeroCode Code: on a lag notice during a running turn the transcript above the notice went blank and new output appeared below it; the transcript returned at the terminal reload. That observation, traced to the persistence timing above, is what `fdcb2d7` fixes; the live-daemon run below was not repeated on the new head, the corrected fixture is the evidence for it. On head `6890d3f7ebff12dc29103673a2e8db08e12feade`, I ran the fixed branch against an isolated live daemon and a credential-free, protocol-compatible streaming mock provider. A 15,000-chunk burst exceeded ZeroCode's 1024-notification buffer, followed by 5,000 paced chunks so the turn remained active during recovery. ZeroCode detected the lag, reloaded the durable transcript, showed that the turn was still running, remained in the working state, continued streaming, and performed the terminal reload after successful completion. The daemon trace recorded the 12.003-second turn as successful and contained no `session/cancel`, `cancel_cause`, or `client_rpc` match. The pre-change cancel cascade was separately observed on a dogfood build (three ACP sessions, two running turns cancelled within 1 ms of a `Lagged` notice; trace excerpt in #10785). Not verified: `TurnComplete` echo semantics for turns started by other clients (the intercept treats a missing generation as matching, which is safe because the reload is idempotent).
- **Visual interface changed?** Only two new notice strings appear (the still-running one reworded at `fdcb2d7` to stop claiming a reload that no longer happens), in the same style and position as the existing `zc-chat-resynced` notice. No layout, spacing or colour change.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` skipped: the diff is confined to `apps/zerocode`, which depends on no `zeroclaw-*` crate.

### Known gaps

- `session/state` exposes no outstanding approval or elicitation (the client's `SessionStateResult` carries `state`, `turn_id` and `plan` only), so on lag recovery the pane still rejects its local copies of a pending approval/elicitation blind; a daemon-side approval may keep waiting until its own timeout. This is the issue's "invalidate transport-bound local state" boundary; re-rendering the daemon's pending request would need an RPC addition.
- The window between the second `session/state` read in `reattach_confirm_and_reload` (chat.rs:2438) and `apply_session_resync_result` (chat.rs:2461) is covered by `drain_prompt_completions` (chat.rs:2267) only for turns this pane dispatched. A turn started by another client (external ACP) whose `TurnComplete` lands inside that window has no backstop: the pane stays in-flight with the reload pending until the next resync. The gate the frames cannot cross meanwhile is the `session_resync_in_flight` check in `drain_notifications` (chat.rs:2163).
- A turn that fails inside the `session/state` bracket reloads as an idle transcript: `last_error` is cleared by the reload and, because `persist_acp_turn` skips `Err` outcomes, the store has no trace of the turn either. The daemon half is #10788; the client half (keep the intercepted failure across an idle reload) is not attempted here.
- A lag resync that exhausts its retries and is then retried through the queue/focus paths still cancels (those paths are `Cancel` by design, see caller decisions above).
- Daemon-side queued-only state (`running` without a `turn_id`) reloads and settles idle; if the daemon then dispatches the queued work, the pane shows the stream without the in-flight indicator. Pre-existing for turns this pane did not dispatch.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes. The client sends the same RPC methods; an older daemon behaves as before (`session/state` without `plan` already deserializes with `None`).
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert` of the five commits on this branch restores the cancel-first resync; no data migration.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** a pane stuck showing the working indicator after a lag notice with no further stream (the foreign-turn window above; recovers on the next resync or focus change); or, if the guard regressed, daemon trace lines `turn cancelled ... cancel_cause: client_rpc` for several sessions within the same millisecond right after a zerocode "Live updates were missed" notice.


