### PR TITLE
fix(zerocode): restore macOS Control shortcut aliases

### DIFF
--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -15320,6 +15320,9 @@ mod tests {
         );
     }
 
+    // This test intentionally holds the process-global keymap test guard while
+    // async dispatch runs so override-mutating tests cannot race it.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn rtg_9739_composer_enter_and_modifier_enter_dispatch_without_approval() {
         use crossterm::event::{KeyCode, KeyModifiers};

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -15341,11 +15341,12 @@ mod tests {
                     "inject",
                 ),
             ];
-            #[cfg(target_os = "macos")]
-            cases.push((
-                KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
-                "control inject",
-            ));
+            if cfg!(target_os = "macos") {
+                cases.push((
+                    KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
+                    "control inject",
+                ));
+            }
 
             for (key, prompt) in cases {
                 let (tx, mut rx) = mpsc::channel::<String>(16);

--- a/apps/zerocode/src/chat.rs
+++ b/apps/zerocode/src/chat.rs
@@ -15321,11 +15321,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rtg_9739_composer_enter_and_primary_enter_dispatch_without_approval() {
+    async fn rtg_9739_composer_enter_and_modifier_enter_dispatch_without_approval() {
         use crossterm::event::{KeyCode, KeyModifiers};
 
+        let _guard = crate::keymap::overrides::TEST_GUARD
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        crate::keymap::overrides::reset();
+
         for kind in [PaneKind::Chat, PaneKind::Acp] {
-            for (key, prompt) in [
+            let mut cases = vec![
                 (KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), "submit"),
                 (
                     KeyEvent::new(
@@ -15335,7 +15340,14 @@ mod tests {
                     ),
                     "inject",
                 ),
-            ] {
+            ];
+            #[cfg(target_os = "macos")]
+            cases.push((
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
+                "control inject",
+            ));
+
+            for (key, prompt) in cases {
                 let (tx, mut rx) = mpsc::channel::<String>(16);
                 let outbound = Arc::new(RpcOutbound::new(tx));
                 let client = Arc::new(RpcClient::with_rpc(Arc::clone(&outbound)));

--- a/apps/zerocode/src/keymap/actions.rs
+++ b/apps/zerocode/src/keymap/actions.rs
@@ -4,6 +4,19 @@ use serde::{Deserialize, Serialize};
 
 use super::chord::Chord;
 
+fn distinct_effective_chords(chords: Vec<Chord>) -> Vec<Chord> {
+    let mut distinct = Vec::with_capacity(chords.len());
+    for chord in chords {
+        if !distinct
+            .iter()
+            .any(|existing: &Chord| existing.same_key(&chord))
+        {
+            distinct.push(chord);
+        }
+    }
+    distinct
+}
+
 macro_rules! keyactions {
     (
         $vis:vis enum $name:ident ( $tag:literal ) {
@@ -50,14 +63,19 @@ macro_rules! keyactions {
 
             /// Compile-time default chords for this variant.
             pub fn default_chords(&self) -> Vec<Chord> {
-                match self {
+                let chords = match self {
                     $( $name::$variant => vec![ $( $chord ),* ] ),*
-                }
+                };
+                distinct_effective_chords(chords)
             }
 
             pub fn bindings() -> Vec<(Chord, $name)> {
                 let mut out: Vec<(Chord, $name)> = Vec::new();
-                $( for c in [ $( $chord ),* ] { out.push((c, $name::$variant)); } )*
+                for action in Self::variants() {
+                    for chord in action.default_chords() {
+                        out.push((chord, *action));
+                    }
+                }
                 out
             }
 
@@ -146,7 +164,7 @@ keyactions! {
         ]                                                              => "help",
         PaneNavLeft  [Chord::with(KeyCode::Left, KeyModifiers::ALT), Chord::with(KeyCode::Char('b'), KeyModifiers::ALT)]  => "prev pane",
         PaneNavRight [Chord::with(KeyCode::Right, KeyModifiers::ALT), Chord::with(KeyCode::Char('f'), KeyModifiers::ALT)] => "next pane",
-        ReloadDaemon [Chord::primary('r')]                              => "reload daemon",
+        ReloadDaemon [Chord::primary('r'), Chord::ctrl('r')]            => "reload daemon",
         ToggleSidebar [Chord::ctrl('b')]                                => "toggle sidebar",
         ConfirmYes   []                                                 => "confirm",
         ConfirmNo    []                                                 => "cancel",
@@ -174,8 +192,8 @@ keyactions! {
         BrowseDownVim           [Chord::char('j')] => "browse next (vim)",
         BrowseSelectExtend      [Chord::shift(KeyCode::Up)] => "extend selection up",
         BrowseSelectExtendDown  [Chord::shift(KeyCode::Down)] => "extend selection down",
-        FastScrollUp            [Chord::with_primary(KeyCode::Up, KeyModifiers::SHIFT)] => "fast scroll up",
-        FastScrollDown          [Chord::with_primary(KeyCode::Down, KeyModifiers::SHIFT)] => "fast scroll down",
+        FastScrollUp            [Chord::with_primary(KeyCode::Up, KeyModifiers::SHIFT), Chord::with(KeyCode::Up, KeyModifiers::CONTROL.union(KeyModifiers::SHIFT))] => "fast scroll up",
+        FastScrollDown          [Chord::with_primary(KeyCode::Down, KeyModifiers::SHIFT), Chord::with(KeyCode::Down, KeyModifiers::CONTROL.union(KeyModifiers::SHIFT))] => "fast scroll down",
         BrowseExitSelection     [Chord::key(KeyCode::Esc)] => "exit selection",
         CopySelection           [
             Chord::char('y'),
@@ -183,11 +201,11 @@ keyactions! {
         ] => "copy selection",
         CopyAllVisible          [Chord::with(KeyCode::Char('C'), KeyModifiers::CONTROL.union(KeyModifiers::SHIFT))] => "copy all visible",
         ToggleThoughts          [Chord::char('t')] => "toggle thoughts",
-        TodoToggle              [Chord::primary('p')] => "toggle todo tracker",
+        TodoToggle              [Chord::primary('p'), Chord::ctrl('p')] => "toggle todo tracker",
         NewSession              [Chord::ctrl('n')] => "new session",
         SwitchSession           [Chord::ctrl('s')] => "switch session",
         DeleteSession           [] => "delete session",
-        CancelTurn              [Chord::primary('d')] => "cancel turn",
+        CancelTurn              [Chord::primary('d'), Chord::ctrl('d')] => "cancel turn",
         ApprovalApprove         [Chord::key(KeyCode::Enter)] => "approve",
         ApprovalDeny            [] => "deny",
         ApprovalApproveAll      [Chord::char('a')] => "approve all",
@@ -348,20 +366,20 @@ keyactions! {
 keyactions! {
     pub enum InputBarAction ("input_bar") {
         Submit             [Chord::key(KeyCode::Enter)] => "send",
-        Inject             [Chord::with_primary(KeyCode::Enter, KeyModifiers::NONE)] => "send now",
+        Inject             [Chord::with_primary(KeyCode::Enter, KeyModifiers::NONE), Chord::with(KeyCode::Enter, KeyModifiers::CONTROL)] => "send now",
         NewLine            [Chord::shift(KeyCode::Enter)] => "new line",
         CursorLeft         [Chord::key(KeyCode::Left)] => "cursor left",
         CursorRight        [Chord::key(KeyCode::Right)] => "cursor right",
         CursorWordLeft     [Chord::with(KeyCode::Left, KeyModifiers::ALT), Chord::with(KeyCode::Char('b'), KeyModifiers::ALT)] => "word left",
         CursorWordRight    [Chord::with(KeyCode::Right, KeyModifiers::ALT), Chord::with(KeyCode::Char('f'), KeyModifiers::ALT)] => "word right",
         CursorStart        [Chord::key(KeyCode::Home)] => "line start",
-        CursorEnd          [Chord::key(KeyCode::End), Chord::primary('e')] => "line end",
-        OpenFileBrowser    [Chord::primary('a')] => "browse files",
+        CursorEnd          [Chord::key(KeyCode::End), Chord::primary('e'), Chord::ctrl('e')] => "line end",
+        OpenFileBrowser    [Chord::primary('a'), Chord::ctrl('a')] => "browse files",
         Backspace          [Chord::key(KeyCode::Backspace)] => "backspace",
-        DeletePreviousWord [Chord::primary('w'), Chord::with(KeyCode::Backspace, KeyModifiers::ALT)] => "delete previous word",
-        ClearInput         [Chord::primary('u')] => "clear input",
+        DeletePreviousWord [Chord::primary('w'), Chord::ctrl('w'), Chord::with(KeyCode::Backspace, KeyModifiers::ALT)] => "delete previous word",
+        ClearInput         [Chord::primary('u'), Chord::ctrl('u')] => "clear input",
         SelectAll          [] => "select all",
-        Paste              [Chord::primary('v')] => "paste",
+        Paste              [Chord::primary('v'), Chord::ctrl('v')] => "paste",
         HistoryPrev        [Chord::key(KeyCode::Up)] => "history prev",
         HistoryNext        [Chord::key(KeyCode::Down)] => "history next",
         AutocompleteNext   [] => "autocomplete next",
@@ -444,6 +462,104 @@ keyactions! {
 mod tests {
     use super::*;
     use crossterm::event::KeyEvent;
+
+    fn assert_distinct_defaults<A: crate::keymap::RebindableActions>() {
+        for action in A::all() {
+            let defaults = action.defaults();
+            for (index, chord) in defaults.iter().enumerate() {
+                assert!(
+                    defaults[..index]
+                        .iter()
+                        .all(|existing| !existing.same_key(chord)),
+                    "{} advertises the effective chord {} more than once",
+                    action.key(),
+                    chord.wire()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn default_tables_do_not_duplicate_effective_chords() {
+        assert_distinct_defaults::<GlobalAction>();
+        assert_distinct_defaults::<ChatTabAction>();
+        assert_distinct_defaults::<InputBarAction>();
+    }
+
+    #[cfg(target_os = "macos")]
+    fn assert_macos_primary_and_control<A: std::fmt::Debug + Eq + Copy>(
+        code: KeyCode,
+        extra: KeyModifiers,
+        resolve: impl Fn(&KeyEvent) -> Option<A>,
+        expected: A,
+    ) {
+        assert_eq!(
+            resolve(&KeyEvent::new(code, KeyModifiers::SUPER.union(extra))),
+            Some(expected),
+            "platform-primary event must remain accepted"
+        );
+        assert_eq!(
+            resolve(&KeyEvent::new(code, KeyModifiers::CONTROL.union(extra))),
+            Some(expected),
+            "literal-Control compatibility event must be restored"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn primary_defaults_retain_their_pre_10479_control_events_on_macos() {
+        let _guard = crate::keymap::overrides::TEST_GUARD
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        crate::keymap::overrides::reset();
+
+        assert_macos_primary_and_control(
+            KeyCode::Char('r'),
+            KeyModifiers::NONE,
+            GlobalAction::from_chord,
+            GlobalAction::ReloadDaemon,
+        );
+        assert_macos_primary_and_control(
+            KeyCode::Up,
+            KeyModifiers::SHIFT,
+            ChatTabAction::from_chord,
+            ChatTabAction::FastScrollUp,
+        );
+        assert_macos_primary_and_control(
+            KeyCode::Down,
+            KeyModifiers::SHIFT,
+            ChatTabAction::from_chord,
+            ChatTabAction::FastScrollDown,
+        );
+        assert_macos_primary_and_control(
+            KeyCode::Char('p'),
+            KeyModifiers::NONE,
+            ChatTabAction::from_chord,
+            ChatTabAction::TodoToggle,
+        );
+        assert_macos_primary_and_control(
+            KeyCode::Char('d'),
+            KeyModifiers::NONE,
+            ChatTabAction::from_chord,
+            ChatTabAction::CancelTurn,
+        );
+
+        for (code, expected) in [
+            (KeyCode::Enter, InputBarAction::Inject),
+            (KeyCode::Char('e'), InputBarAction::CursorEnd),
+            (KeyCode::Char('a'), InputBarAction::OpenFileBrowser),
+            (KeyCode::Char('w'), InputBarAction::DeletePreviousWord),
+            (KeyCode::Char('u'), InputBarAction::ClearInput),
+            (KeyCode::Char('v'), InputBarAction::Paste),
+        ] {
+            assert_macos_primary_and_control(
+                code,
+                KeyModifiers::NONE,
+                InputBarAction::from_chord,
+                expected,
+            );
+        }
+    }
 
     #[test]
     fn copy_selection_resolves_from_super_c_and_terminal_fallback() {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Restore literal Control aliases beside the platform-primary defaults that #10479 changed to Command on macOS. Deduplicate equivalent defaults on platforms where primary already means Control so Help and binding tables do not advertise the same chord twice.
- **Scope boundary:** This does not change configured `control` or `primary` modifiers, sparse override replacement, action ownership, or non-macOS shortcut behavior.
- **Blast radius:** ZeroCode's built-in keymap defaults for eleven actions across the global, chat-tab, and input-bar action families.
- **Linked issue(s):** Related #10479
- **Labels:** `bug`, `distinguished contributor`, `risk:medium`, `zerocode`, `size:S`, `topic:zerocode`

### What this does, simply

#10479 made shortcut intent explicit so macOS defaults could use Command where other platforms use Control. That correctly added native Command shortcuts, but it also removed the literal Control forms that existing macOS users could previously press.

This PR keeps the Command shortcuts and restores those earlier Control aliases. It also prevents duplicate Help entries on platforms where the two modifier names resolve to the same physical key. User-configured keybindings continue to replace defaults exactly as before.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Yes
- **Interface(s) exercised:** TUI
- **Setup / preconditions:** Run ZeroCode on macOS with the default keymap and open a Chat or ACP session.
- **Steps to run:** Enter text and press `Control+Enter`, then repeat with `Command+Enter`. Check another restored pair such as `Control+E` and `Command+E` in the composer.
- **Expected on this branch (after):** Both physical modifier forms resolve to the same action; `Control+Enter` and `Command+Enter` both use send-now, and both `Control+E` and `Command+E` move to line end.
- **Prior behavior on `master` (before):** The Command forms work on macOS, but the literal Control aliases no longer resolve to these defaults.

### How I tested

- **CI checks relied on and why they cover this change:** Required CI will provide the normal repository build and test coverage on the published head.
- **Known CI coverage gap, if any:** Hosted CI does not establish both physical macOS modifier events through the affected keymap defaults, so focused macOS regressions cover that distinction.
- **Commands run and tail output:**

```sh
cargo test --locked -p zerocode primary_defaults_retain_their_pre_10479_control_events_on_macos
# 2 passed across the lib and bin test targets; 0 failed

cargo test --locked -p zerocode rtg_9739_composer_enter_and_modifier_enter_dispatch_without_approval
# 1 passed through the real Chat/ACP SESSION_PROMPT dispatch regression; 0 failed

cargo test --locked -p zerocode default_tables_do_not_duplicate_effective_chords
# 2 passed across the lib and bin test targets; 0 failed

rustfmt --edition 2024 --check apps/zerocode/src/keymap/actions.rs apps/zerocode/src/chat.rs
git diff --check
# passed
```

- **Beyond CI, what did you manually verify?** Source inspection confirmed that every default converted from literal Control to platform-primary by #10479 retains both forms on macOS, while effective defaults remain unique elsewhere. I tested the restored macOS shortcuts in my combined dogfood build; the smoke passed. Control+E moved to line end.
- **Visual interface changed?** Yes. On macOS, Help and keybinding displays include the restored Control aliases alongside the platform-primary shortcuts. The recorded smoke covers shortcut behavior, not Help layout or wrapping at narrow terminal widths; no screenshot evidence for those displays is claimed.
- **If any command was intentionally skipped, why:** No broad local suite was run because the focused tests cover the changed keymap and dispatch contracts; required CI remains the broader published-head check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No
- If any Yes, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No
- If backward compatibility is No or either surface/floor question is Yes: N/A

## Rollback

Low risk: revert the PR merge commit to restore the #10479-only default table.
