### PR TITLE
fix(infra): persist projected ACP message count for session/list-acp

### DIFF
--- a/crates/zeroclaw-api/src/model_provider.rs
+++ b/crates/zeroclaw-api/src/model_provider.rs
@@ -284,6 +284,46 @@ pub enum ConversationMessage {
     ToolResults(Vec<ToolResultMessage>),
 }
 
+/// Count the conversation entries a transcript projects into, without
+/// materializing them. One entry per chat message; an assistant tool-call
+/// message contributes its non-empty text plus one entry per call; a tool
+/// result folds into the entry of a call still awaiting a result (FIFO by
+/// `tool_call_id`) and otherwise counts as its own orphan entry.
+///
+/// The ACP session store maintains a persisted per-session counter with the
+/// same semantics. Runtime projection (`conversation_message_entries`) and
+/// this function are two expressions of one counting rule and must agree on
+/// every input.
+pub fn projected_entry_count(messages: &[ConversationMessage]) -> usize {
+    let mut count = 0usize;
+    let mut open_calls = std::collections::HashMap::<&str, usize>::new();
+    for message in messages {
+        match message {
+            ConversationMessage::Chat(_) => count += 1,
+            ConversationMessage::AssistantToolCalls {
+                text, tool_calls, ..
+            } => {
+                if text.as_deref().is_some_and(|text| !text.is_empty()) {
+                    count += 1;
+                }
+                count += tool_calls.len();
+                for call in tool_calls {
+                    *open_calls.entry(call.id.as_str()).or_insert(0) += 1;
+                }
+            }
+            ConversationMessage::ToolResults(results) => {
+                for result in results {
+                    match open_calls.get_mut(result.tool_call_id.as_str()) {
+                        Some(open) if *open > 0 => *open -= 1,
+                        _ => count += 1,
+                    }
+                }
+            }
+        }
+    }
+    count
+}
+
 /// A chunk of content from a streaming response.
 #[derive(Debug, Clone)]
 pub struct StreamChunk {
@@ -1193,6 +1233,64 @@ mod turn_order_tests {
         let mut msgs: Vec<ChatMessage> = vec![];
         ChatMessage::sanitize_leading_turn_order(&mut msgs);
         assert!(msgs.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod projected_entry_count_tests {
+    use super::projected_entry_count;
+    use super::{ChatMessage, ConversationMessage, ToolCall, ToolResultMessage};
+
+    fn call(id: &str, name: &str) -> ToolCall {
+        ToolCall {
+            id: id.into(),
+            name: name.into(),
+            arguments: "{}".into(),
+            extra_content: None,
+        }
+    }
+
+    fn result(id: &str) -> ToolResultMessage {
+        ToolResultMessage {
+            tool_call_id: id.into(),
+            content: "out".into(),
+            tool_name: "shell".into(),
+        }
+    }
+
+    fn batch(text: Option<&str>, calls: Vec<ToolCall>) -> ConversationMessage {
+        ConversationMessage::AssistantToolCalls {
+            text: text.map(str::to_string),
+            tool_calls: calls,
+            reasoning_content: None,
+        }
+    }
+
+    #[test]
+    fn counts_chat_and_call_batches_by_their_parts() {
+        let count = projected_entry_count(&[
+            ConversationMessage::Chat(ChatMessage::user("hi")),
+            batch(Some("working"), vec![call("a", "shell"), call("b", "read")]),
+            batch(Some(""), vec![call("c", "read")]),
+            batch(None, vec![]),
+        ]);
+        // 1 chat + (text + 2 calls) + (empty text, 1 call) + (nothing).
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn results_fold_into_open_calls_and_count_orphans() {
+        let count = projected_entry_count(&[
+            batch(None, vec![call("dup", "shell"), call("dup", "shell")]),
+            ConversationMessage::ToolResults(vec![
+                result("dup"),
+                result("dup"),
+                result("dup"), // one more result than calls
+                result("never-issued"),
+            ]),
+        ]);
+        // 2 calls, second batch's extra results are orphans.
+        assert_eq!(count, 4);
     }
 }
 

--- a/crates/zeroclaw-infra/src/acp_session_store.rs
+++ b/crates/zeroclaw-infra/src/acp_session_store.rs
@@ -139,6 +139,9 @@ impl AcpSessionStore {
         Self::ensure_interaction_surface_column(&conn)
             .context("Failed to migrate ACP session interaction surface")?;
 
+        Self::ensure_projected_message_count_column(&conn)
+            .context("Failed to migrate ACP session projected message count")?;
+
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -248,6 +251,98 @@ impl AcpSessionStore {
             }
             Err(e) => Err(e).context("Failed to add ACP session interaction surface"),
         }
+    }
+
+    /// One-statement backfill for `projected_message_count`, applied exactly
+    /// once when the column is added. Per session it counts the same entries
+    /// the runtime projection produces:
+    ///   - chat rows plus tool-call batch rows whose text is non-empty,
+    ///   - one entry per `event_kind = 'in'` tool-call row,
+    ///   - one orphan entry per `event_kind = 'out'` row that finds no
+    ///     unconsumed `'in'` row for its `tool_call_id` at its position.
+    const BACKFILL_PROJECTED_MESSAGE_COUNT_SQL: &str = "
+        WITH tool_rows AS (
+            SELECT m.session_id  AS sid,
+                   tc.event_kind AS ev,
+                   SUM(CASE WHEN tc.event_kind = 'in' THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY tc.tool_call_id ORDER BY tc.id
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+                     AS ins_before,
+                   SUM(CASE WHEN tc.event_kind = 'out' THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY tc.tool_call_id ORDER BY tc.id
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+                     AS outs_before
+            FROM acp_tool_calls tc
+            JOIN acp_messages m ON m.id = tc.message_id
+        )
+        UPDATE acp_sessions
+           SET projected_message_count =
+                 (SELECT COUNT(*)
+                    FROM acp_messages m
+                   WHERE m.session_id = acp_sessions.id
+                     AND NOT (m.content = ''
+                              AND EXISTS (SELECT 1
+                                            FROM acp_tool_calls tc
+                                           WHERE tc.message_id = m.id
+                                             AND tc.event_kind = 'in')))
+               + (SELECT COUNT(*)
+                    FROM acp_tool_calls tc
+                    JOIN acp_messages m ON m.id = tc.message_id
+                   WHERE m.session_id = acp_sessions.id
+                     AND tc.event_kind = 'in')
+               + (SELECT COUNT(*)
+                    FROM tool_rows tr
+                   WHERE tr.sid = acp_sessions.id
+                     AND tr.ev = 'out'
+                     AND COALESCE(tr.ins_before, 0) <= COALESCE(tr.outs_before, 0))";
+
+    /// Idempotent migration adding the persisted projected conversation-entry
+    /// count the session picker reports. `session/list-acp` must show the same
+    /// number `turn_end` reports for the same session, and deriving that
+    /// number from the message rows at read time is too expensive to run
+    /// under the store's connection mutex, so the count is stored on
+    /// `acp_sessions` and maintained by `append_turn`. Existing databases are
+    /// backfilled from the message rows exactly once, when the column is
+    /// added.
+    fn ensure_projected_message_count_column(conn: &Connection) -> Result<()> {
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(acp_sessions)")
+            .context("Failed to inspect ACP session schema")?;
+        let mut rows = stmt
+            .query([])
+            .context("Failed to read ACP session schema")?;
+        while let Some(row) = rows
+            .next()
+            .context("Failed to read ACP session schema row")?
+        {
+            let column: String = row
+                .get(1)
+                .context("Failed to read ACP session column name")?;
+            if column == "projected_message_count" {
+                return Ok(());
+            }
+        }
+        drop(rows);
+        drop(stmt);
+
+        match conn.execute(
+            "ALTER TABLE acp_sessions ADD COLUMN projected_message_count INTEGER NOT NULL DEFAULT 0",
+            [],
+        ) {
+            Ok(_) => {}
+            Err(rusqlite::Error::SqliteFailure(_, Some(ref msg)))
+                if msg.contains("duplicate column name") =>
+            {
+                return Ok(());
+            }
+            Err(e) => return Err(e).context("Failed to add ACP session projected message count"),
+        }
+
+        // Only reached when the column was just added; re-opening an already
+        // migrated database must not rewrite live counters.
+        conn.execute(Self::BACKFILL_PROJECTED_MESSAGE_COUNT_SQL, [])
+            .context("Failed to backfill ACP session projected message count")?;
+        Ok(())
     }
 
     /// Record a new session. Returns the integer `id` assigned by SQLite.
@@ -436,7 +531,7 @@ impl AcpSessionStore {
                         s.token_count,
                         s.created_at,
                         s.last_activity,
-                        (SELECT COUNT(*) FROM acp_messages m WHERE m.session_id = s.id) AS message_count
+                        s.projected_message_count AS message_count
                  FROM acp_sessions s
                  WHERE s.killed_at IS NULL
                  ORDER BY s.last_activity DESC",
@@ -619,6 +714,10 @@ impl AcpSessionStore {
         // Track the most recent assistant message_id so a following
         // ToolResults variant can attach its 'out' rows back to it.
         let mut last_assistant_msg_id: Option<i64> = None;
+        // Persisted counter mirroring the runtime's projected conversation
+        // length: one entry per chat message, non-empty assistant text plus
+        // one per tool call, results folding into the call awaiting them.
+        let mut projected_increment: i64 = 0;
 
         for msg in messages {
             match msg {
@@ -630,6 +729,7 @@ impl AcpSessionStore {
                         params![session_id, chat.role, chat.content, now],
                     )
                     .context("Failed to insert chat message")?;
+                    projected_increment += 1;
                     if chat.role == "assistant" {
                         last_assistant_msg_id = Some(tx.last_insert_rowid());
                     }
@@ -639,6 +739,10 @@ impl AcpSessionStore {
                     tool_calls,
                     reasoning_content,
                 } => {
+                    if text.as_deref().is_some_and(|text| !text.is_empty()) {
+                        projected_increment += 1;
+                    }
+                    projected_increment += tool_calls.len() as i64;
                     tx.execute(
                         "INSERT INTO acp_messages
                            (session_id, role, content, reasoning_content, created_at)
@@ -703,6 +807,26 @@ impl AcpSessionStore {
                                 |row| row.get(0),
                             )
                             .unwrap_or_else(|_| String::from("unknown"));
+                        // A result folds into its call (no entry) while an
+                        // 'in' row for this tool_call_id is still unconsumed;
+                        // beyond that it is an orphan entry. The transaction
+                        // sees this turn's earlier 'out' rows, so duplicates
+                        // within and across turns fold correctly.
+                        let (in_rows, out_rows): (i64, i64) = tx
+                            .query_row(
+                                "SELECT
+                                    COALESCE(SUM(CASE WHEN tc.event_kind = 'in' THEN 1 ELSE 0 END), 0),
+                                    COALESCE(SUM(CASE WHEN tc.event_kind = 'out' THEN 1 ELSE 0 END), 0)
+                                 FROM acp_tool_calls tc
+                                 JOIN acp_messages m ON m.id = tc.message_id
+                                 WHERE m.session_id = ?1 AND tc.tool_call_id = ?2",
+                                params![session_id, result.tool_call_id],
+                                |row| Ok((row.get(0)?, row.get(1)?)),
+                            )
+                            .context("Failed to look up tool call availability")?;
+                        if in_rows <= out_rows {
+                            projected_increment += 1;
+                        }
                         tx.execute(
                             "INSERT INTO acp_tool_calls
                                (message_id, tool_call_id, tool_name, event_kind, payload, outcome, created_at)
@@ -724,8 +848,11 @@ impl AcpSessionStore {
         }
 
         tx.execute(
-            "UPDATE acp_sessions SET last_activity = ?1 WHERE id = ?2",
-            params![now, session_id],
+            "UPDATE acp_sessions
+                SET last_activity = ?1,
+                    projected_message_count = projected_message_count + ?2
+              WHERE id = ?3",
+            params![now, projected_increment, session_id],
         )
         .context("Failed to update last_activity")?;
 
@@ -861,7 +988,7 @@ impl AcpSessionStore {
                         s.token_count,
                         s.created_at,
                         s.last_activity,
-                        (SELECT COUNT(*) FROM acp_messages m WHERE m.session_id = s.id) AS message_count
+                        s.projected_message_count AS message_count
                  FROM acp_sessions s
                  WHERE s.agent_alias = ?1
                  ORDER BY s.last_activity DESC",
@@ -904,6 +1031,24 @@ impl AcpSessionStore {
             });
         }
         Ok(out)
+    }
+
+    /// Persisted projected conversation-entry count for the session, the
+    /// same number the session picker lists and `turn_end` reports. Reading
+    /// it avoids hydrating the full message history that `load_session`
+    /// performs just to re-derive the count. `None` when the session UUID is
+    /// unknown.
+    pub fn projected_message_count(&self, session_uuid: &str) -> Result<Option<usize>> {
+        let conn = self.conn.lock();
+        let count: Option<i64> = conn
+            .query_row(
+                "SELECT projected_message_count FROM acp_sessions WHERE session_uuid = ?1",
+                params![session_uuid],
+                |row| row.get(0),
+            )
+            .optional()
+            .context("Failed to query projected_message_count")?;
+        Ok(count.map(|n| n.max(0) as usize))
     }
 
     /// Delete every ACP session (live or killed) for `agent_alias`, returning the
@@ -1004,7 +1149,9 @@ fn parse_ts(s: &str, field: &'static str, session_uuid: &str) -> DateTime<Utc> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
-    use zeroclaw_api::model_provider::{ChatMessage, ToolCall, ToolResultMessage};
+    use zeroclaw_api::model_provider::{
+        ChatMessage, ToolCall, ToolResultMessage, projected_entry_count,
+    };
 
     fn open_store() -> (TempDir, AcpSessionStore) {
         let tmp = TempDir::new().unwrap();
@@ -1553,6 +1700,288 @@ mod tests {
         let list = store.list_sessions().unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].session_uuid, "sess-live");
+    }
+
+    fn tool_call(id: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: "shell".into(),
+            arguments: "{}".into(),
+            extra_content: None,
+        }
+    }
+
+    fn tool_result(id: &str) -> ToolResultMessage {
+        ToolResultMessage {
+            tool_call_id: id.to_string(),
+            content: "out".into(),
+            tool_name: "shell".into(),
+        }
+    }
+
+    fn assert_list_matches_projection(
+        store: &AcpSessionStore,
+        session_uuid: &str,
+        expected: usize,
+    ) {
+        let summary = &store
+            .list_sessions()
+            .unwrap()
+            .into_iter()
+            .find(|s| s.session_uuid == session_uuid)
+            .unwrap_or_else(|| panic!("session {session_uuid} should be listed"));
+        let data = store.load_session(session_uuid).unwrap().unwrap();
+        assert_eq!(summary.message_count, expected, "session {session_uuid}");
+        assert_eq!(
+            summary.message_count,
+            projected_entry_count(&data.messages),
+            "session {session_uuid} persisted count must match the projection"
+        );
+    }
+
+    #[test]
+    fn list_sessions_message_count_matches_projection_after_mixed_writes() {
+        let (_tmp, store) = open_store();
+        store
+            .create_session("sess-mixed", "alpha", "/tmp/mixed")
+            .unwrap();
+
+        // Chat only.
+        store
+            .append_turn(
+                "sess-mixed",
+                &[ConversationMessage::Chat(ChatMessage::user("hi"))],
+            )
+            .unwrap();
+        assert_list_matches_projection(&store, "sess-mixed", 1);
+
+        // One batch of 3 calls with text: text + 3 calls = +4. Results come
+        // in a later turn so the cross-turn fold is exercised there.
+        store
+            .append_turn(
+                "sess-mixed",
+                &[ConversationMessage::AssistantToolCalls {
+                    text: Some("inspecting".into()),
+                    tool_calls: vec![tool_call("a"), tool_call("b"), tool_call("c")],
+                    reasoning_content: None,
+                }],
+            )
+            .unwrap();
+        assert_list_matches_projection(&store, "sess-mixed", 5);
+
+        // One batch of 2 calls with empty text: calls only = +2.
+        store
+            .append_turn(
+                "sess-mixed",
+                &[ConversationMessage::AssistantToolCalls {
+                    text: Some(String::new()),
+                    tool_calls: vec![tool_call("d"), tool_call("e")],
+                    reasoning_content: None,
+                }],
+            )
+            .unwrap();
+        assert_list_matches_projection(&store, "sess-mixed", 7);
+
+        // Results folding into the same-turn call ("f") and into calls
+        // written in PREVIOUS append_turns ("a", "b", "c"): only the new
+        // call adds an entry.
+        store
+            .append_turn(
+                "sess-mixed",
+                &[
+                    ConversationMessage::AssistantToolCalls {
+                        text: None,
+                        tool_calls: vec![tool_call("f")],
+                        reasoning_content: None,
+                    },
+                    ConversationMessage::ToolResults(vec![
+                        tool_result("f"),
+                        tool_result("a"),
+                        tool_result("b"),
+                        tool_result("c"),
+                    ]),
+                ],
+            )
+            .unwrap();
+        assert_list_matches_projection(&store, "sess-mixed", 8);
+
+        // An orphan result (no call was ever written for it) counts as its
+        // own entry on top of the same-turn call; the unconsumed previous
+        // turn's call ("d") still folds.
+        store
+            .append_turn(
+                "sess-mixed",
+                &[
+                    ConversationMessage::AssistantToolCalls {
+                        text: None,
+                        tool_calls: vec![tool_call("g")],
+                        reasoning_content: None,
+                    },
+                    ConversationMessage::ToolResults(vec![
+                        tool_result("g"),
+                        tool_result("d"),
+                        tool_result("orphan"),
+                    ]),
+                ],
+            )
+            .unwrap();
+        assert_list_matches_projection(&store, "sess-mixed", 10);
+    }
+
+    #[test]
+    fn migration_backfills_projected_message_count_from_existing_rows() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("sessions").join("acp-sessions.db");
+        std::fs::create_dir_all(tmp.path().join("sessions")).unwrap();
+
+        // A pre-migration database: current tables, no projected counter.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE acp_sessions (
+                 id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                 session_uuid  TEXT NOT NULL UNIQUE,
+                 agent_alias   TEXT NOT NULL,
+                 workspace_dir TEXT NOT NULL,
+                 interaction_surface TEXT,
+                 token_count   INTEGER NOT NULL DEFAULT 0,
+                 killed_at     TEXT,
+                 created_at    TEXT NOT NULL,
+                 last_activity TEXT NOT NULL
+             );
+             CREATE TABLE acp_messages (
+                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                 session_id  INTEGER NOT NULL REFERENCES acp_sessions(id) ON DELETE CASCADE,
+                 role        TEXT NOT NULL,
+                 content     TEXT NOT NULL,
+                 reasoning_content TEXT,
+                 created_at  TEXT NOT NULL
+             );
+             CREATE TABLE acp_tool_calls (
+                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                 message_id   INTEGER NOT NULL REFERENCES acp_messages(id) ON DELETE CASCADE,
+                 tool_call_id TEXT NOT NULL,
+                 tool_name    TEXT NOT NULL,
+                 event_kind   TEXT NOT NULL,
+                 payload      TEXT NOT NULL,
+                 outcome      TEXT,
+                 created_at   TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+
+        // Session 1: chat (1), batch with text + 2 calls (3), results fold.
+        conn.execute(
+            "INSERT INTO acp_sessions
+               (session_uuid, agent_alias, workspace_dir, token_count, created_at, last_activity)
+             VALUES ('old-full', 'alpha', '/tmp/a', 0, 't', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_messages (session_id, role, content, created_at)
+             VALUES (1, 'user', 'hi', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_messages (session_id, role, content, created_at)
+             VALUES (1, 'assistant', 'working', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, created_at)
+             VALUES (2, 'x', 'shell', 'in', '{}', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, created_at)
+             VALUES (2, 'y', 'read', 'in', '{}', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, outcome, created_at)
+             VALUES (2, 'x', 'shell', 'out', '/tmp', 'unknown', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, outcome, created_at)
+             VALUES (2, 'y', 'read', 'out', 'data', 'unknown', 't')",
+            [],
+        )
+        .unwrap();
+
+        // Session 2: empty-text batch (0 text entries), one call whose
+        // result folds, and one orphan 'out' row for a call never issued.
+        conn.execute(
+            "INSERT INTO acp_sessions
+               (session_uuid, agent_alias, workspace_dir, token_count, created_at, last_activity)
+             VALUES ('old-orphan', 'alpha', '/tmp/b', 0, 't', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_messages (session_id, role, content, created_at)
+             VALUES (2, 'assistant', '', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, created_at)
+             VALUES (3, 'z', 'shell', 'in', '{}', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, outcome, created_at)
+             VALUES (3, 'z', 'shell', 'out', 'ok', 'unknown', 't')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO acp_tool_calls (message_id, tool_call_id, tool_name, event_kind, payload, outcome, created_at)
+             VALUES (3, 'ghost', 'shell', 'out', 'lost', 'unknown', 't')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        // Opening the store migrates and backfills once.
+        let store = AcpSessionStore::new(tmp.path()).unwrap();
+        assert_list_matches_projection(&store, "old-full", 4);
+        assert_list_matches_projection(&store, "old-orphan", 2);
+
+        // A post-migration append keeps incrementing from the backfilled base.
+        store
+            .append_turn(
+                "old-full",
+                &[ConversationMessage::Chat(ChatMessage::user("again"))],
+            )
+            .unwrap();
+        assert_list_matches_projection(&store, "old-full", 5);
+        drop(store);
+
+        // Reopening an already-migrated database must not re-run the
+        // backfill: plant a sentinel and expect it to survive.
+        let store = AcpSessionStore::new(tmp.path()).unwrap();
+        {
+            let conn = store.conn.lock();
+            conn.execute(
+                "UPDATE acp_sessions SET projected_message_count = 99 WHERE session_uuid = 'old-full'",
+                [],
+            )
+            .unwrap();
+        }
+        drop(store);
+        let store = AcpSessionStore::new(tmp.path()).unwrap();
+        let count = store
+            .projected_message_count("old-full")
+            .unwrap()
+            .unwrap_or_else(|| panic!("old-full should report a count"));
+        assert_eq!(count, 99, "backfill must run only when the column is added");
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -2681,14 +2681,18 @@ impl RpcDispatcher {
 
         // Keep the terminal count aligned with session/new and session/messages:
         // it is the durable projected conversation length, not the number of
-        // visible TUI bubbles or local user turns.
+        // visible TUI bubbles or local user turns. The store maintains this
+        // counter as turns are appended, so reading it here avoids hydrating
+        // the whole history on every turn end.
         let message_count = match chat_mode {
-            crate::rpc::types::ChatMode::Acp => self
-                .ctx
-                .acp_session_store
-                .as_ref()
-                .and_then(|store| store.load_session(&req.session_id).ok().flatten())
-                .map(|data| conversation_message_entries(&data.messages).len()),
+            crate::rpc::types::ChatMode::Acp => {
+                self.ctx.acp_session_store.as_ref().and_then(|store| {
+                    store
+                        .projected_message_count(&req.session_id)
+                        .ok()
+                        .flatten()
+                })
+            }
             crate::rpc::types::ChatMode::Chat => self
                 .ctx
                 .session_backend
@@ -10522,7 +10526,10 @@ mod tests {
             ]),
         ];
 
-        assert_eq!(projected_entry_count(&msgs), conversation_message_entries(&msgs).len());
+        assert_eq!(
+            projected_entry_count(&msgs),
+            conversation_message_entries(&msgs).len()
+        );
         // 1 chat + (text + 2 calls) + folded result + empty-text-batch call
         // + 2 folded results + 1 orphan result.
         assert_eq!(projected_entry_count(&msgs), 6);

--- a/crates/zeroclaw-runtime/src/rpc/dispatch.rs
+++ b/crates/zeroclaw-runtime/src/rpc/dispatch.rs
@@ -10459,6 +10459,76 @@ mod tests {
     }
 
     #[test]
+    fn projected_entry_count_matches_conversation_message_entries() {
+        use zeroclaw_api::model_provider::projected_entry_count;
+        use zeroclaw_api::model_provider::{ToolCall, ToolResultMessage};
+
+        let msgs = vec![
+            ConversationMessage::Chat(ChatMessage::user("plain chat")),
+            ConversationMessage::AssistantToolCalls {
+                text: Some("batch with text".into()),
+                tool_calls: vec![
+                    ToolCall {
+                        id: "shared".into(),
+                        name: "shell".into(),
+                        arguments: r#"{"command":"pwd"}"#.into(),
+                        extra_content: None,
+                    },
+                    ToolCall {
+                        id: "solo".into(),
+                        name: "read".into(),
+                        arguments: "{}".into(),
+                        extra_content: None,
+                    },
+                ],
+                reasoning_content: None,
+            },
+            ConversationMessage::ToolResults(vec![ToolResultMessage {
+                tool_call_id: "shared".into(),
+                content: "/tmp".into(),
+                tool_name: "shell".into(),
+            }]),
+            ConversationMessage::AssistantToolCalls {
+                text: Some(String::new()),
+                tool_calls: vec![ToolCall {
+                    id: "shared".into(),
+                    name: "shell".into(),
+                    arguments: r#"{"command":"ls"}"#.into(),
+                    extra_content: None,
+                }],
+                reasoning_content: None,
+            },
+            ConversationMessage::AssistantToolCalls {
+                text: None,
+                tool_calls: vec![],
+                reasoning_content: None,
+            },
+            ConversationMessage::ToolResults(vec![
+                ToolResultMessage {
+                    tool_call_id: "solo".into(),
+                    content: "contents".into(),
+                    tool_name: "read".into(),
+                },
+                ToolResultMessage {
+                    tool_call_id: "shared".into(),
+                    content: "second fold".into(),
+                    tool_name: "shell".into(),
+                },
+                ToolResultMessage {
+                    tool_call_id: "orphan".into(),
+                    content: "late result".into(),
+                    tool_name: "shell".into(),
+                },
+            ]),
+        ];
+
+        assert_eq!(projected_entry_count(&msgs), conversation_message_entries(&msgs).len());
+        // 1 chat + (text + 2 calls) + folded result + empty-text-batch call
+        // + 2 folded results + 1 orphan result.
+        assert_eq!(projected_entry_count(&msgs), 6);
+    }
+
+    #[test]
     fn conversation_message_entries_pairs_duplicate_tool_ids_in_order() {
         use zeroclaw_api::model_provider::{ToolCall, ToolResultMessage};
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `session/list-acp` and `turn_end` report different `message_count` values for the same session. `turn_end` reports the projected conversation length (`conversation_message_entries(...).len()`: one entry per chat message, one per tool call, tool results folding into their call). `session/list-acp` relays `AcpSessionStore::list_sessions().message_count`, which is `SELECT COUNT(*) FROM acp_messages`: one row per chat message and one per `AssistantToolCalls` batch regardless of how many calls it carries. Every assistant message batching N tool calls makes the picker undercount by N-1 (N when its text is empty, since the empty-text row is counted by SQL but produces no projection entry). Observed on a real store: 162 vs 164, 214 vs 219.
  - The projected count is now stored on `acp_sessions` instead of derived at read time.
  - `zeroclaw-api`: `projected_entry_count(&[ConversationMessage]) -> usize` next to the type, the single counting rule both sides share (infra already depends on zeroclaw-api; no new crate edge). Runtime's `conversation_message_entries` is asserted equal to it in a dispatch test on a fixture covering plain chat, batches with text / empty text / no text, duplicate tool ids across batches, and an orphan result.
  - `zeroclaw-infra`: `projected_message_count INTEGER NOT NULL DEFAULT 0` on `acp_sessions`, added with the existing `PRAGMA table_info`/`ALTER TABLE` pattern and backfilled once in the same migration step by a single SQL statement (chat rows plus non-empty batch text, one entry per `'in'` tool row, plus `'out'` rows with no unconsumed `'in'` row at their position). `append_turn` increments the counter inside its transaction; a result folds into its call while an `'in'` row for that `tool_call_id` is unconsumed, and the transaction sees the same turn's earlier `'out'` rows, so duplicates within and across turns fold correctly. `list_sessions` and `list_sessions_by_agent` read the column (ordering/filtering unchanged); `append_turn` remains the only writer of `acp_messages`, so no other path needs coverage.
  - `zeroclaw-runtime`: `turn_end` reads the persisted count via a small store getter instead of `load_session` + projection, dropping a full-history hydration per turn end.
- **Scope boundary:** `session/new` and `session/messages` still project from loaded history (they need the history anyway). No change to what counts as an entry; the rule is the existing `conversation_message_entries` projection, now shared. No CHANGELOG-next entry (maintainers generate it from PRs at release time per the release runbook).
- **Blast radius:** `zeroclaw-api` (one additive function), `zeroclaw-infra` ACP session store (schema column + migration + write path + two list queries), `zeroclaw-runtime` `turn_end` (one expression). The backfill runs once per store at first open after upgrade and is O(total tool rows); not measured on a real 182-session store.
- **Linked issue(s):** Closes #10802.
- **Labels:** to be snapshotted after labeler runs.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** Optional.
- **Interface(s) exercised:** `surface: zerocode` (switch-session picker) and `surface: rpc` (`session/list-acp`, `turn_end`).
- **Setup / preconditions:** A daemon with at least one ACP session whose history contains an assistant message issuing two or more tool calls in one batch.
- **Steps to run:** Open ZeroCode's switch-session picker and compare the listed count with the `message_count` in the last `turn_end` notification for that session (or `zeroclaw sessions` / the RPC directly).
- **Expected on this branch (after):** The two numbers agree, including on stores created before this change (backfilled at first open).
- **Prior behavior on `master` (before):** The picker number is smaller by the number of extra tool calls in each batch.

### How I tested

- **CI checks relied on and why they cover this change:** required Rust CI (fmt, clippy, tests) covers all three touched crates.
- **Known CI coverage gap, if any:** no RPC-level test asserts `turn_end`'s `message_count` (none existed before either), so the getter swap is covered by compile + store-level tests only. Full runtime suite not run locally (compile exceeded the validation shell timeout); the mandated filters pass.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check                                                            clean
cargo clippy -p zeroclaw-infra -p zeroclaw-runtime -p zeroclaw-api --all-targets -- -D warnings   clean
cargo test -p zeroclaw-infra acp_session_store            27 -> 29 passed; 0 failed
cargo test -p zeroclaw-runtime conversation_message_entries   2 -> 3 passed; 0 failed
cargo test -p zeroclaw-api projected_entry_count            2 passed; 0 failed (new module)
```

New tests:

- infra: parity after mixed writes (chat; 3-call batch with text; empty-text batch; results folding into same-turn and previous-turn calls; orphan result), asserting the persisted count equals `projected_entry_count(load_session(...).messages)` after every append.
- infra: migration backfill on a hand-built pre-column schema (seeded chat, batch-with-text, empty-text batch, folding and orphan `'out'` rows), one-shot verification via a sentinel value, and post-migration increment.
- runtime: `projected_entry_count(&msgs) == conversation_message_entries(&msgs).len()` on the mixed fixture.
- api: the counting rule on its own.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No
- Prompt injection or untrusted model-visible text introduced/changed? No

## Compatibility (required)

- Backward compatible? Yes. Existing stores gain the column and backfill on first open; the migration is idempotent (`PRAGMA table_info` check) and runs inside the existing schema-setup path. Older binaries opening a newer store ignore the extra column.
- Config / env / CLI surface changed? No
- Rust/MSRV/toolchain floor changed? No

## Rollback (required for medium/high-risk PRs)

Low risk: `git revert <sha>`. The added column is harmless to the previous code, which never reads it.
