### PR TITLE
fix(tools): preserve Windows PowerShell analysis cache

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/shell_env.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell_env.rs
@@ -21,6 +21,8 @@ pub(crate) const SAFE_SHELL_ENV_VARS: &[&str] = &[
     "WINDIR",
     "COMSPEC",
     "PSModulePath",
+    // Preserve the host-selected analysis cache to avoid costly module rediscovery.
+    "PSModuleAnalysisCachePath",
     "TEMP",
     "TMP",
     "TERM",
@@ -56,5 +58,6 @@ mod tests {
     #[test]
     fn safe_shell_env_vars_preserve_powershell_module_discovery() {
         assert!(SAFE_SHELL_ENV_VARS.contains(&"PSModulePath"));
+        assert!(SAFE_SHELL_ENV_VARS.contains(&"PSModuleAnalysisCachePath"));
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`.
- **What changed and why:**
  - Preserve the inherited `PSModuleAnalysisCachePath` in the shared Windows shell-child environment so PowerShell can use the host-selected command-discovery cache.
  - Extend the existing module-discovery environment assertion. Both ShellTool and SkillShellTool already consume this shared list.
- **Scope boundary:** No timeout, command-policy, module-preload, dependency, or workflow changes. This does not address the separate control-plane recovery assertion.
- **Blast radius:** Windows shell children inherit one additional existing host setting. Non-Windows behavior is unchanged.
- **Linked issue(s):** Related #10793; this implements the cache-sensitive PowerShell portion, not the whole issue.
- **Labels:** `bug`, `risk:high`, `size:XS`, `runtime`.

### What this does, simply

ZeroClaw's shell tools clear the parent environment, then restore a small set of settings needed to run commands. That also removed PowerShell's setting for an existing command-discovery cache. In a controlled Windows reproduction, leaving it out made a small pipeline take 22–30 seconds; restoring just that setting brought it below one second.

This change preserves that one inherited setting for both shell tools. It avoids unnecessary rediscovery without increasing timeouts or changing which commands are allowed. It does not establish that every Windows timeout is fixed.

### Scope and maintenance tradeoff

The shared environment list already owns this behavior, so the repair adds one entry rather than changing both consumers or introducing cache management. PowerShell remains responsible for its cache. The production diff is three added lines in one file; the separate validation workflow is not included.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — the two existing Windows execution regressions were run against this exact source; the linked remove/add-back diagnostic supplies the mechanism comparison. Another sequential manual run would not establish loaded-suite behavior.

### How I tested

- **CI checks relied on and why they cover this change:** [Windows exact shell regressions](https://github.com/Audacity88/zeroclaw/actions/runs/34711176081/job/103600135209) checked out source `403ea39b779d865c8048f69fb9d6537cdd4e3fe0` from a separate validation-only workflow and passed all three selected tests on Windows with Rust 1.96.1 and runtime default features. The inherited cache setting was present and pointed to an existing file; its value and contents were not logged.
- **Known CI coverage gap:** These were separate exact tests, not a loaded full-workspace nextest run with plugin-host enabled. They do not prove that every timeout in #10793 is resolved. The control-plane recovery assertion was not tested or changed. Required upstream PR CI is not claimed by this focused run.
- **Commands run and tail output:**

```text
cargo fmt --all -- --check
exit 0

cargo test --locked -p zeroclaw-runtime --lib --no-run
Finished test profile in 8m 32s

cargo test --locked -p zeroclaw-runtime --lib tools::shell_env::tests::safe_shell_env_vars_preserve_powershell_module_discovery -- --exact
1 passed; 0 failed; 0 ignored; 4212 filtered out; 0.00s

cargo test --locked -p zeroclaw-runtime --lib tools::shell::tests::powershell_agent_shell_executes_safe_pipeline_and_rejects_dangerous_alias -- --exact
1 passed; 0 failed; 0 ignored; 4212 filtered out; 1.36s

cargo test --locked -p zeroclaw-runtime --lib tools::skill_tool::tests::skill_shell_tool_executes_powershell_safe_pipeline_with_sanitized_env -- --exact
1 passed; 0 failed; 0 ignored; 4212 filtered out; 0.32s
```

- **Beyond CI, what did you manually verify?** Source inspection confirms both consumers retain the exact inherited value through their existing environment-copy logic, with existing ShellTool overlays unchanged. Tests verify execution and output, not the child variable's value. The earlier [remove/add-back diagnostic](https://github.com/Audacity88/zeroclaw/actions/runs/34709678260) measured sanitized runs at 30.203s and 22.375s, versus 0.313s and 0.296s when only the analysis-cache setting was restored. This refines the issue's initial startup-slowness hypothesis to a demonstrated cache-sensitive discovery cost in that reproduction.
- **Visual interface changed?** N/A.
- **If any command was intentionally skipped, why:** No full workspace suite or additional local compilation was run; selected Windows tests exercise the affected paths directly. Loaded-suite performance remains an explicit limit.

## Security & Privacy Impact (required)

- **New permissions, capabilities, or file system access scope?** Yes — default child-environment forwarding expands by one code-influencing host setting. No OS permission or sandbox file-access rule is added.
- **New external network calls?** No.
- **Secrets / tokens / credentials handling changed?** No.
- **PII, real identities, or personal data in diff, tests, fixtures, or docs?** No.
- **Prompt injection or untrusted model-visible text introduced/changed?** No.
- **Risk and mitigation:** The host environment and selected cache must be trusted, as with inherited command-search settings. PowerShell may read and refresh that cache under its existing OS authority. ZeroClaw preserves only the inherited value; it does not construct a path, validate or create the cache, or accept a new model-supplied value. Command authorization, timeouts, and existing environment overrides are unchanged.

## Compatibility (required)

- **Backward compatible?** Yes, with the intentional Windows inherited-environment change described above.
- **Config / env / CLI surface changed?** Yes — `PSModuleAnalysisCachePath` joins the Windows baseline. An absent setting remains absent; a present empty value retains the existing copy semantics.
- **Rust/MSRV/toolchain floor changed?** No.
- **Exact upgrade steps for existing users:** None. Existing host configuration is reused; no setting or cache file needs to be created for this change. Hosts without the setting retain their prior behavior.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** `git revert 403ea39b779d865c8048f69fb9d6537cdd4e3fe0` on this branch; after a squash merge, revert the resulting squash commit.
- **Feature flags or config toggles:** None dedicated to this entry.
- **Observable failure symptoms:** Unexpected PowerShell module-discovery/cache errors, changed command lookup, or renewed pipeline latency/timeouts. Reverting restores omission of this setting from the default shell-child environment.

