### PR TITLE
fix(release): order versioned dev dependencies before publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Test release tool installer mappings
         run: bash scripts/ci/install_release_tool.test.sh
 
+      - name: Test crates.io publish ordering and preflight
+        run: python3 scripts/release/publish_crates_test.py
+
       - name: Test apt install timeout and retry behavior
         run: bash scripts/ci/apt_install.test.sh
 

--- a/scripts/release/publish-crates.sh
+++ b/scripts/release/publish-crates.sh
@@ -101,6 +101,15 @@ fi
 
 META="$(cargo metadata --format-version 1 --no-deps)"
 
+# Resolve the entire graph before registry queries, even during a tokenless dry
+# run or a resume. Versioned dev-dependencies survive Cargo packaging and must
+# already exist when their consumer uploads. Stream metadata: the full workspace
+# exceeds the platform limit for a single argv entry.
+ORDER="$(python3 "$REPO_ROOT/scripts/release/publish_order.py" "$VERSION" <<<"$META")" || {
+  echo "error: could not compute publish order." >&2
+  exit 1
+}
+
 # `publish` is null when unrestricted (publishable) and [] when publish = false.
 # Only packages at the coordinated workspace version belong to this release;
 # independent-version workspace members are reported but never uploaded merely
@@ -138,27 +147,6 @@ echo "  publishable:  ${#PUBLISHABLE[@]} crates"
 echo "  private:      ${#PRIVATE[@]} crates (${PRIVATE[*]})"
 echo "  independent:  ${#INDEPENDENT[@]} crates (${INDEPENDENT[*]})"
 echo
-
-# ── Preflight 1: no release crate depends on a private one ─────────────────
-# cargo only reports this once it reaches the offending crate, which can be
-# after several irreversible uploads have already succeeded.
-leaks="$(jq -r --arg version "$VERSION" \
-  --argjson priv "$(printf '%s\n' "${PRIVATE[@]}" | jq -R . | jq -s .)" '
-  [ .packages[]
-    | select(.publish == null and .version == $version) as $p
-    | $p.dependencies[]
-    | select(.kind == null or .kind == "build")
-    | select(.name as $n | $priv | index($n))
-    | "\($p.name) -> \(.name)"
-  ] | unique | .[]' <<<"$META")"
-if [[ -n "$leaks" ]]; then
-  echo "error: publishable crates depend on unpublishable workspace crates:" >&2
-  while IFS= read -r leak; do
-    echo "       $leak" >&2
-  done <<<"$leaks"
-  echo "       Either publish the dependency or drop the edge." >&2
-  exit 1
-fi
 
 # ── Preflight 2: what is already on crates.io, and what would be created ────
 # Two distinct questions, and the difference decides how fast the loop may run:
@@ -263,49 +251,6 @@ if [[ $EXECUTE -eq 1 && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
   echo "       subsequent version bumps need 'publish-update'." >&2
   exit 1
 fi
-
-# Topological order over the publishable set, so each crate's dependencies are
-# already on the registry when it uploads. Compute this during the dry run too:
-# the tokenless preflight must exercise every operation needed before the first
-# irreversible upload. Cargo metadata is too large for one argv entry on the
-# full workspace, so pass it on a dedicated file descriptor instead.
-ORDER="$(python3 - "$VERSION" 3<<<"$META" <<'PY'
-import json
-import os
-import sys
-
-with os.fdopen(3) as metadata:
-    meta = json.load(metadata)
-version = sys.argv[1]
-pkgs = {p["name"]: p for p in meta["packages"]}
-pub = {
-    n for n, p in pkgs.items()
-    if p["publish"] is None and p["version"] == version
-}
-deps = {
-    n: sorted({d["name"] for d in p["dependencies"]
-               if d["name"] in pub and d["kind"] in (None, "build")})
-    for n, p in pkgs.items()
-}
-order, state = [], {}
-def visit(n, trail=()):
-    if state.get(n) == "done":
-        return
-    if state.get(n) == "visiting":
-        sys.exit("dependency cycle: " + " -> ".join(trail + (n,)))
-    state[n] = "visiting"
-    for d in deps[n]:
-        visit(d, trail + (n,))
-    state[n] = "done"
-    order.append(n)
-for n in sorted(pub):
-    visit(n)
-print("\n".join(order))
-PY
-)" || {
-  echo "error: could not compute publish order." >&2
-  exit 1
-}
 
 if [[ $EXECUTE -eq 0 ]]; then
   echo "── Dry run: packaging and verifying every crate (no upload) ──"

--- a/scripts/release/publish_crates_test.py
+++ b/scripts/release/publish_crates_test.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Exercise the publisher process with local Cargo/registry doubles; never upload."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+RELEASE = Path(__file__).resolve().parent
+VERSION = "1.2.3"
+
+
+def dependency(name, kind=None, req="^1.2.3", **fields):
+    return {"name": name, "kind": kind, "req": req, "rename": None,
+            "target": None, **fields}
+
+
+def package(name, dependencies=(), publish=None, version=VERSION):
+    return {"name": name, "version": version, "publish": publish,
+            "dependencies": list(dependencies)}
+
+
+DOUBLE = r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+root = Path(os.environ["PUBLISH_TEST_ROOT"])
+tool = Path(sys.argv[0]).name
+args = sys.argv[1:]
+if tool == "cargo" and args[0] == "metadata":
+    sys.stdout.write((root / "metadata.json").read_text())
+elif tool == "cargo" and args[0] == "publish":
+    with (root / "publishes.jsonl").open("a") as log:
+        log.write(json.dumps(args) + "\n")
+    if "--dry-run" not in args:
+        name = args[args.index("-p") + 1]
+        (root / "registry" / name).touch()
+elif tool == "curl":
+    with (root / "queries.jsonl").open("a") as log:
+        log.write(json.dumps(args) + "\n")
+    suffix = args[-1].split("/api/v1/crates/")[1].split("/")
+    # Existing crate names, but only recorded versions have been uploaded.
+    print("200" if len(suffix) == 1 or (root / "registry" / suffix[0]).exists() else "404")
+elif tool == "git" and args[0] in ("diff", "ls-files"):
+    pass
+else:
+    sys.exit("unexpected external command: " + tool + " " + repr(args))
+'''
+
+
+class PublishCratesTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="publish-crates-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        script_dir = self.root / "scripts/release"
+        script_dir.mkdir(parents=True)
+        for filename in ("publish-crates.sh", "publish_order.py"):
+            source = RELEASE / filename
+            if source.exists():
+                shutil.copyfile(source, script_dir / filename)
+        (self.root / "Cargo.toml").write_text(
+            '[workspace.package]\nversion = "1.2.3"\n'
+        )
+        (self.root / "web/dist").mkdir(parents=True)
+        (self.root / "web/dist/index.html").write_text("fixture")
+        (self.root / "registry").mkdir()
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        for tool in ("cargo", "curl", "git"):
+            path = bin_dir / tool
+            path.write_text(DOUBLE)
+            path.chmod(0o755)
+        self.env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "PUBLISH_TEST_ROOT": str(self.root), "PUBLISH_DELAY_SECONDS": "0"}
+        self.env.pop("CARGO_REGISTRY_TOKEN", None)
+
+    def run_publisher(self, packages=None, *, raw=None, execute=False, token=True):
+        # Match the real workspace's private and independent members. Bash 3.2
+        # cannot expand empty arrays under nounset in the existing summary.
+        metadata = raw if raw is not None else json.dumps({"packages": [
+            *packages, package("fixture-private", publish=[]),
+            package("fixture-independent", version="0.1.0")
+        ]})
+        (self.root / "metadata.json").write_text(metadata)
+        env = self.env.copy()
+        if execute and token:
+            env["CARGO_REGISTRY_TOKEN"] = "fixture-not-a-credential"
+        args = ["bash", str(self.root / "scripts/release/publish-crates.sh")]
+        if execute:
+            args.append("--execute")
+        return subprocess.run(args, env=env, text=True, capture_output=True, timeout=15)
+
+    def calls(self, filename):
+        path = self.root / filename
+        return [json.loads(line) for line in path.read_text().splitlines()] if path.exists() else []
+
+    def uploads(self):
+        return [args[args.index("-p") + 1] for args in self.calls("publishes.jsonl")
+                if "--dry-run" not in args]
+
+    def assert_preflight_failure(self, result, message):
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn(message, result.stderr)
+        self.assertEqual(self.calls("publishes.jsonl"), [])
+        self.assertEqual(self.calls("queries.jsonl"), [])
+
+    def test_versioned_dev_dependency_uploads_before_consumer(self):
+        result = self.run_publisher([
+            package("a-runtime", [dependency("z-relay", "dev")]), package("z-relay")
+        ], execute=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.uploads(), ["z-relay", "a-runtime"])
+
+    def test_normal_build_target_and_renamed_edges_are_ordered(self):
+        result = self.run_publisher([
+            package("a-app", [dependency("z-normal"), dependency("z-build", "build"),
+                              dependency("z-target", "dev", target="cfg(windows)", rename="alias")]),
+            package("z-target"), package("z-build"), package("z-normal")
+        ], execute=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.uploads(), ["z-build", "z-normal", "z-target", "a-app"])
+
+    def test_cycle_fails_before_registry_queries_in_both_modes(self):
+        packages = [package("a", [dependency("b", "dev")]),
+                    package("b", [dependency("a")])]
+        for execute in (False, True):
+            with self.subTest(execute=execute):
+                result = self.run_publisher(packages, execute=execute)
+                self.assert_preflight_failure(result, "dependency cycle: a -> b -> a")
+
+    def test_private_versioned_dev_dependency_fails_before_registry_queries(self):
+        for version in (VERSION, "0.1.0"):
+            with self.subTest(version=version):
+                result = self.run_publisher([
+                    package("a", [dependency("private", "dev")]),
+                    package("private", publish=[], version=version)
+                ], execute=True)
+                self.assert_preflight_failure(result, "a -> private")
+
+    def test_private_normal_dependency_fails_before_registry_queries(self):
+        result = self.run_publisher([
+            package("a", [dependency("private")]), package("private", publish=[])
+        ], execute=True)
+        self.assert_preflight_failure(result, "a -> private")
+
+    def test_malformed_metadata_fails_before_registry_queries(self):
+        for metadata in ("{broken", '{"packages": [{}]}',
+                         json.dumps({"packages": [package("a", [{"name": "b"}])]}),
+                         json.dumps({"packages": [package("a", [dependency("b", "unknown")])]}),
+                         json.dumps({"packages": [package("a", [dependency("b", req=123)])]})):
+            with self.subTest(metadata=metadata):
+                self.assert_preflight_failure(
+                    self.run_publisher(raw=metadata, execute=True), "could not compute publish order"
+                )
+
+    def test_large_metadata_crosses_real_process_boundary(self):
+        large = json.dumps({"packages": [package("a"), package("fixture-private", publish=[]),
+                                          package("fixture-independent", version="0.1.0")],
+                            "padding": "x" * 262144})
+        self.assertGreater(len(large.encode()), 214753)
+        result = self.run_publisher(raw=large)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(self.calls("publishes.jsonl")), 1)
+        self.assertIn("--dry-run", self.calls("publishes.jsonl")[0])
+
+    def test_tokenless_dry_run_excludes_private_and_independent_packages(self):
+        result = self.run_publisher([package("a"), package("private", publish=[]),
+                                     package("independent", version="0.1.0")])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls("publishes.jsonl"), [
+            ["publish", "--dry-run", "--locked", "--allow-dirty", "-p", "a"]
+        ])
+
+    def test_execute_requires_token(self):
+        result = self.run_publisher([package("a")], execute=True, token=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CARGO_REGISTRY_TOKEN is required", result.stderr)
+        self.assertEqual(self.calls("publishes.jsonl"), [])
+
+    def test_execute_resumes_and_skips_existing_dependency(self):
+        (self.root / "registry/z-relay").touch()
+        result = self.run_publisher([
+            package("a-runtime", [dependency("z-relay", "dev")]), package("z-relay")
+        ], execute=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.uploads(), ["a-runtime"])
+        self.assertIn("skipped 1 already present", result.stdout)
+        self.assertEqual(self.calls("publishes.jsonl")[0],
+                         ["publish", "-p", "a-runtime", "--locked", "--no-verify", "--allow-dirty"])
+
+    def test_path_only_dev_cycle_is_stripped_but_explicit_version_cycle_is_rejected(self):
+        # Both declarations produce req="*" in cargo metadata. Use real Cargo
+        # here so a synthetic fixture cannot hide that loss of information.
+        cargo = shutil.which("cargo")
+        (self.root / "Cargo.toml").write_text(
+            '[workspace]\nmembers = ["a", "b"]\nresolver = "2"\n'
+            '[workspace.package]\nversion = "1.2.3"\n'
+        )
+        for name in ("a", "b"):
+            (self.root / name / "src").mkdir(parents=True)
+            (self.root / name / "src/lib.rs").write_text("")
+        (self.root / "b/Cargo.toml").write_text(
+            '[package]\nname = "b"\nversion.workspace = true\nedition = "2021"\n'
+            '[dependencies]\na = { path = "../a", version = "1.2.3" }\n'
+        )
+        for explicit, inherited in ((False, False), (True, False), (False, True), (True, True)):
+            with self.subTest(explicit=explicit, inherited=inherited):
+                (self.root / "Cargo.toml").write_text(
+                    '[workspace]\nmembers = ["a", "b"]\nresolver = "2"\n'
+                    '[workspace.package]\nversion = "1.2.3"\n'
+                    '[workspace.dependencies]\nalias = { package = "b", path = "b"'
+                    + (', version = "*"' if explicit else '') + ' }\n'
+                )
+                (self.root / "a/Cargo.toml").write_text(
+                    '[package]\nname = "a"\nversion.workspace = true\nedition = "2021"\n'
+                    '[target.\'cfg(windows)\'.dev-dependencies]\n'
+                    + ('alias = { workspace = true }\n' if inherited else
+                       'alias = { package = "b", path = "../b"'
+                       + (', version = "*"' if explicit else '') + ' }\n')
+                )
+                metadata = subprocess.run(
+                    [cargo, "metadata", "--format-version", "1", "--no-deps", "--offline"],
+                    cwd=self.root, text=True, capture_output=True, check=True, timeout=15
+                )
+                packages = json.loads(metadata.stdout)["packages"]
+                self.assertEqual(packages[0]["dependencies"][0]["req"], "*")
+                for log in ("publishes.jsonl", "queries.jsonl"):
+                    (self.root / log).unlink(missing_ok=True)
+                result = self.run_publisher(packages)
+                if explicit:
+                    self.assert_preflight_failure(result, "dependency cycle: a -> b -> a")
+                else:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/publish_order.py
+++ b/scripts/release/publish_order.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Read cargo metadata on stdin; emit the complete release order or fail closed."""
+
+import json
+from pathlib import Path
+import sys
+
+
+def registry_visible(package, dependency):
+    if dependency["kind"] != "dev" or dependency["req"] != "*":
+        return True
+
+    # Cargo retains versioned dev-dependencies, but metadata represents both an
+    # omitted version and an explicit version="*" as req="*". Resolve that one
+    # ambiguity from the manifest, including target tables and workspace aliases.
+    import tomllib
+
+    with open(package["manifest_path"], "rb") as source:
+        manifest = tomllib.load(source)
+    target = dependency["target"]
+    table = manifest if target is None else manifest["target"][target]
+    key = dependency["rename"] or dependency["name"]
+    spec = table["dev-dependencies"][key]
+    if isinstance(spec, dict) and spec.get("workspace") is True:
+        with Path("Cargo.toml").open("rb") as source:
+            spec = tomllib.load(source)["workspace"]["dependencies"][key]
+    return isinstance(spec, str) or "version" in spec
+
+
+def publish_order(meta, version):
+    packages = {p["name"]: p for p in meta["packages"]}
+    publishable = {
+        name for name, package in packages.items()
+        if package["publish"] is None and package["version"] == version
+    }
+    deps = {}
+    for name in sorted(publishable):
+        deps[name] = set()
+        for dependency in packages[name]["dependencies"]:
+            # Require the fields used to classify an edge even for external
+            # dependencies; incomplete metadata must not silently drop edges.
+            target = dependency["name"]
+            kind, requirement = dependency["kind"], dependency["req"]
+            if kind not in (None, "build", "dev") or not isinstance(requirement, str):
+                raise ValueError(f"invalid dependency metadata: {name} -> {target}")
+            if target not in packages or not registry_visible(packages[name], dependency):
+                continue
+            if packages[target]["publish"] is not None:
+                raise ValueError(f"unpublishable workspace dependency: {name} -> {target}")
+            if target in publishable:
+                deps[name].add(target)
+
+    order, state = [], {}
+
+    def visit(name, trail=()):
+        if state.get(name) == "done":
+            return
+        if state.get(name) == "visiting":
+            raise ValueError("dependency cycle: " + " -> ".join(trail + (name,)))
+        state[name] = "visiting"
+        for dependency in sorted(deps[name]):
+            visit(dependency, trail + (name,))
+        state[name] = "done"
+        order.append(name)
+
+    for name in sorted(publishable):
+        visit(name)
+    return order
+
+
+if __name__ == "__main__":
+    try:
+        order = publish_order(json.load(sys.stdin), sys.argv[1])
+    except (ValueError, KeyError, TypeError, OSError, ImportError) as error:
+        sys.exit(f"error: invalid publish graph: {error}")
+    print("\n".join(order))

--- a/tests/architecture/publish_contract.rs
+++ b/tests/architecture/publish_contract.rs
@@ -121,8 +121,8 @@ fn release_crates(crates: &[Crate]) -> BTreeSet<&str> {
         .collect()
 }
 
-/// Internal dependency edges that affect publish order. Dev-dependencies are
-/// excluded: cargo strips them when packaging, so a dev-only cycle is legal.
+/// The root's normal/build dependency closure. Versioned dev-dependencies also
+/// affect publishing; scripts/release/publish_order.py owns that full graph.
 fn internal_deps(krate: &Crate, workspace_names: &BTreeSet<String>) -> BTreeSet<String> {
     ["dependencies", "build-dependencies"]
         .iter()
@@ -394,7 +394,7 @@ fn publish_order_is_streamed_and_exercised_by_preflight() {
     );
 
     let order = script
-        .find("ORDER=\"$(python3 - \"$VERSION\" 3<<<\"$META\"")
+        .find("ORDER=\"$(python3 \"$REPO_ROOT/scripts/release/publish_order.py\" \"$VERSION\" <<<\"$META\"")
         .expect("publisher streams metadata into its order helper");
     let dry_run = script
         .find("if [[ $EXECUTE -eq 0 ]]")


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Cargo validates versioned development dependencies when publishing, so a package can require a workspace crate that the old normal/build-only ordering had not published yet.
  - Read metadata from stdin, include retained dev dependencies in the order, and reject invalid publication graphs before registry access. Keep path-only dev dependencies excluded, matching Cargo's packaged manifests.
  - Exercise the actual shell publisher with local command doubles, including resume and large-metadata cases; run these tests in CI.
- **Scope boundary:** No package-content changes, registry writes, token changes, parallel uploads, or replacement of the existing #9381 work.
- **Blast radius:** The manually invoked workspace crates.io publisher and its ordering helper; application runtime code is unchanged.
- **Linked issue(s):** Related #10814 (R1). Related #9381; this does not close its remaining packaging work.
- **Labels:** `ci`, `tests`, `scripts`, `risk:high`, `size:M`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — focused repeatable tests below cover the changed orchestration. Live release actions are intentionally not requested as an ad-hoc PR test.

### How I tested

- **CI checks relied on and why they cover this change:** Local tests and lint provide the evidence below. This PR adds its focused Python suite to CI; hosted results are pending and are not claimed as passed.
- **Known CI coverage gap, if any:** No real registry publication was attempted. Test doubles cover the publisher process, and one temporary real Cargo workspace checks manifest normalization. The full Rust workspace was not rebuilt because the production changes are Python/shell; the changed Rust file contains architecture assertions.
- **Commands run and tail output:**

```text
python3 scripts/release/publish_crates_test.py -v
# Ran 11 tests ... OK
bash -n scripts/release/publish-crates.sh
shellcheck scripts/release/publish-crates.sh
rustfmt --check tests/architecture/publish_contract.rs
actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml
git diff --check
# All exited 0
```

- **Beyond CI, what did you manually verify?** Checked the real workspace metadata: 23 packages, with zerorelay ordered before zeroclaw-runtime. An isolated offline Rust harness also ran the 10 existing publication-contract tests; that is not a full workspace Cargo run. Removing the dev-edge behavior made its regression fail, then the helper was restored.
- **Visual interface changed?** N/A — release automation, not application rendering.
- **If any command was intentionally skipped, why:** Live publishing/deployment and a full application rebuild were not run; this draft changes orchestration, and the bounded tests isolate its failure paths without external writes. No production timing improvement is claimed yet.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- **Risk and mitigation:** Existing sequential upload and token checks are retained. New local parsing rejects cycles and private dependencies before attempting registry calls.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? Yes.
- Rust/MSRV/toolchain floor changed? No.
- **Upgrade steps:** The publisher invokes a new sibling Python helper. Use a complete checkout and Python 3.11+ when it must inspect a dev dependency manifest through tomllib; hosted release runners already provide it. No Rust/MSRV change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's merge commit before the next publisher invocation; reverting cannot undo already published crate versions.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Ordering errors are reported before registry calls, including dependency cycles, private dependencies, malformed metadata, and an unsuccessful helper exit.
