### PR TITLE
fix(release): check Apple notarization before compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Test translation release submodule handling
         run: scripts/release/refresh-translations.test.sh
 
+      - name: Test early Apple release credential validation
+        run: python3 scripts/release/apple_preflight_test.py
+
       - name: Test monthly outdated result classification
         run: bash scripts/ci/monthly_outdated_result.test.sh
 

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -401,6 +401,23 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Validate before either architecture compiles. Absent credential groups
+      # retain optional signing/notarization; partial or rejected groups fail.
+      # Signing requires a certificate and identity; its PKCS#12 password may
+      # be empty and is forwarded unchanged to Tauri below.
+      # Certificate import, signing identity and bundle acceptance are still
+      # checked by Tauri. Export credentials only at the bundling step below.
+      - name: Validate Apple notarization credentials
+        timeout-minutes: 5
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: python3 scripts/release/apple_preflight.py
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: web-dist
@@ -499,10 +516,9 @@ jobs:
             exit 1
           fi
 
-      # Code-signing + notarization are optional: when the APPLE_* secrets are
-      # configured the Tauri bundler picks them up from the environment and
-      # signs/notarizes the app; when absent the build stays unsigned (ad-hoc),
-      # exactly as before. Secrets never gate the build itself.
+      # The preflight checked completeness and notarization authentication.
+      # Keep credentials out of earlier build steps; Tauri now imports the
+      # certificate, validates the signing identity and notarizes the bundle.
       - name: Enable macOS signing (when secrets are configured)
         shell: bash
         env:
@@ -560,7 +576,7 @@ jobs:
       # validates online (Gatekeeper must reach Apple on first open). Notarize
       # the .dmg too and staple the ticket into it so the downloaded installer
       # validates fully offline. Guarded on APPLE_ID so unsigned builds skip
-      # cleanly — secrets never gate the build.
+      # cleanly when notarization credentials are absent.
       - name: Notarize and staple the .dmg (offline-valid installer)
         if: ${{ env.APPLE_ID != '' }}
         shell: bash

--- a/scripts/release/apple_preflight.py
+++ b/scripts/release/apple_preflight.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check optional Apple credential groups before expensive release compilation.
+
+The workflow's APPLE_* environment is the source of truth. This checks group
+completeness and read-only notarization authentication, not certificate import,
+signing identity validity, or whether Apple will accept the finished bundle.
+Those remain Tauri's checks. No keychain, credential profile, temporary secret
+file, or GITHUB_ENV entry is created; the workflow exports secrets at bundling.
+Signing requires a certificate and identity; an empty PKCS#12 password is valid
+configuration and is forwarded unchanged to Tauri by the workflow.
+"""
+
+import os
+import re
+import subprocess
+import time
+
+
+SIGNING = ("APPLE_CERTIFICATE", "APPLE_CERTIFICATE_PASSWORD", "APPLE_SIGNING_IDENTITY")
+NOTARY = ("APPLE_ID", "APPLE_PASSWORD", "APPLE_TEAM_ID")
+
+
+def authenticate(credentials):
+    command = [
+        "xcrun", "notarytool", "history",
+        "--apple-id", credentials["APPLE_ID"],
+        "--password", credentials["APPLE_PASSWORD"],
+        "--team-id", credentials["APPLE_TEAM_ID"],
+    ]
+    for attempt in range(3):
+        try:
+            result = subprocess.run(
+                command, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            reason = "request timed out"
+            transient = True
+        except OSError:
+            print("::error::Cannot run notarytool. Check the runner's Xcode installation.")
+            return False
+        else:
+            if result.returncode == 0:
+                print("Apple notarization authentication passed (read-only history request).")
+                return True
+            # Tool output can include credentials and account history. Only
+            # report a recognized HTTP status, never the output or command.
+            match = re.search(rb"HTTP status code:\s*(\d{3})\b", result.stdout)
+            status = int(match.group(1)) if match else None
+            reason = f"HTTP {status}" if status else "unclassified notarytool failure"
+            transient = status in (429, 500, 502, 503, 504)
+        if not transient or attempt == 2:
+            print(
+                f"::error::Apple notarization preflight failed: {reason}. "
+                "Check APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID and Apple's service status. "
+                "Raw tool output is suppressed to protect credentials."
+            )
+            return False
+        delay = 5 * (attempt + 1)
+        print(f"Apple notarization preflight: {reason}; retrying in {delay}s ({attempt + 2}/3).")
+        time.sleep(delay)
+    return False
+
+
+def main():
+    credentials = {name: os.environ.get(name, "") for name in SIGNING + NOTARY}
+    for name, value in credentials.items():
+        # The later GITHUB_ENV handoff uses one line per value.
+        if value and (not value.strip() or "\n" in value or "\r" in value):
+            print(f"::error::{name} must be a nonblank, single-line value.")
+            return 1
+    for group in (SIGNING, NOTARY):
+        present = [name for name in group if credentials[name]]
+        # Tauri passes the PKCS#12 password verbatim to `security import -P`,
+        # including an empty password. Password-only configuration still
+        # activates this group and must have its certificate and identity.
+        missing = [name for name in group if name != "APPLE_CERTIFICATE_PASSWORD" and not credentials[name]]
+        if present and missing:
+            print(f"::error::Incomplete Apple credential group; missing {', '.join(missing)}.")
+            return 1
+    if credentials["APPLE_ID"] and not authenticate(credentials):
+        return 1
+    if credentials["APPLE_CERTIFICATE"]:
+        print("Signing group complete; certificate import and signing identity are not checked until Tauri bundling.")
+    else:
+        print("Apple signing credentials absent; retaining the unsigned (ad-hoc) build.")
+    if not credentials["APPLE_ID"]:
+        print("Apple notarization credentials absent; retaining the build without notarization.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/apple_preflight_test.py
+++ b/scripts/release/apple_preflight_test.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Hermetic checks for the early Apple release authentication boundary."""
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/release/apple_preflight.py"
+SIGNING = ("APPLE_CERTIFICATE", "APPLE_CERTIFICATE_PASSWORD", "APPLE_SIGNING_IDENTITY")
+NOTARY = ("APPLE_ID", "APPLE_PASSWORD", "APPLE_TEAM_ID")
+
+
+def desktop_steps():
+    workflow = (ROOT / ".github/workflows/release-stable-manual.yml").read_text()
+    job = re.search(
+        r"^  build-desktop:\n.*?(?=^  [a-zA-Z0-9_-]+:|\Z)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    ).group(0)
+    return re.findall(r"^      - .*?(?=^      - |\Z)", job, re.MULTILINE | re.DOTALL)
+
+
+class WorkflowTest(unittest.TestCase):
+    def test_authentication_precedes_build_and_secret_export(self):
+        steps = desktop_steps()
+        preflight = [i for i, step in enumerate(steps) if "apple_preflight.py" in step]
+        self.assertEqual(len(preflight), 1, "missing early Apple credential validation")
+        index = preflight[0]
+        self.assertLess(index, next(i for i, s in enumerate(steps) if "prepare-kernel.sh" in s))
+        self.assertLess(index, next(i for i, s in enumerate(steps) if "GITHUB_ENV" in s))
+        step = steps[index]
+        self.assertIn("timeout-minutes: 5", step)
+        self.assertNotIn("continue-on-error:", step)
+        self.assertNotRegex(step, r"(?m)^        if:")
+        for name in SIGNING + NOTARY:
+            self.assertIn(name + ": ${{ secrets." + name + " }}", step)
+        self.assertRegex(step, r"(?m)^        run: python3 scripts/release/apple_preflight.py$")
+
+
+class PreflightTest(unittest.TestCase):
+    def setUp(self):
+        spec = importlib.util.spec_from_file_location("apple_preflight", SCRIPT)
+        self.helper = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.helper)
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.calls = self.root / "calls"
+        self.export = self.root / "github-env"
+        self.export.write_text("EXISTING=value\n")
+        # Runtime-generated opaque values: no actual credentials or identities.
+        self.credentials = {key: secrets.token_hex(24) for key in SIGNING + NOTARY}
+        self.env = {
+            "PATH": str(self.bin),
+            "GITHUB_ENV": str(self.export),
+            "PREFLIGHT_TEST_CALLS": str(self.calls),
+            "PREFLIGHT_TEST_RESPONSES": "[0]",
+        }
+        stub = self.bin / "xcrun"
+        stub.write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, pathlib, sys\n"
+            "assert sys.argv[1:3] == ['notarytool', 'history']\n"
+            "args = dict(zip(sys.argv[3::2], sys.argv[4::2]))\n"
+            "assert args == {'--apple-id': os.environ['APPLE_ID'], "
+            "'--password': os.environ['APPLE_PASSWORD'], "
+            "'--team-id': os.environ['APPLE_TEAM_ID']}\n"
+            "path = pathlib.Path(os.environ['PREFLIGHT_TEST_CALLS'])\n"
+            "calls = path.read_text().splitlines() if path.exists() else []\n"
+            "with path.open('a') as output: output.write('history\\n')\n"
+            "statuses = json.loads(os.environ['PREFLIGHT_TEST_RESPONSES'])\n"
+            "status = statuses[min(len(calls), len(statuses) - 1)]\n"
+            "for key, value in os.environ.items():\n"
+            "    if key.startswith('APPLE_'): print(value, file=sys.stderr)\n"
+            "if status: print('HTTP status code: ' + str(status), file=sys.stderr)\n"
+            "sys.exit(bool(status))\n"
+        )
+        stub.chmod(0o700)
+
+    def run_preflight(self, credentials=None, responses=(0,)):
+        values = self.credentials if credentials is None else credentials
+        env = self.env | values | {"PREFLIGHT_TEST_RESPONSES": json.dumps(responses)}
+        output = io.StringIO()
+        # Clear inherited credentials and all other Apple/Tauri configuration.
+        with mock.patch.dict(os.environ, env, clear=True), contextlib.redirect_stdout(output), \
+                contextlib.redirect_stderr(output), mock.patch.object(self.helper.time, "sleep") as sleep:
+            code = self.helper.main()
+        log = output.getvalue()
+        for value in values.values():
+            if value.strip():
+                self.assertNotIn(value, log)
+        self.assertEqual(self.export.read_text(), "EXISTING=value\n")
+        self.assertEqual(set(self.root.iterdir()), {self.bin, self.export} | ({self.calls} if self.calls.exists() else set()))
+        return code, log, sleep
+
+    def count_calls(self):
+        return len(self.calls.read_text().splitlines()) if self.calls.exists() else 0
+
+    def test_absent_credentials_keep_unsigned_build(self):
+        code, log, sleep = self.run_preflight({})
+        self.assertEqual(code, 0)
+        self.assertIn("unsigned", log)
+        self.assertEqual(self.count_calls(), 0)
+        sleep.assert_not_called()
+
+    def test_signing_only_does_not_require_notarization(self):
+        code, log, _ = self.run_preflight({key: self.credentials[key] for key in SIGNING})
+        self.assertEqual(code, 0)
+        self.assertIn("not checked", log)
+        self.assertEqual(self.count_calls(), 0)
+
+    def test_signing_accepts_empty_or_absent_certificate_password(self):
+        for password in ({"APPLE_CERTIFICATE_PASSWORD": ""}, {}):
+            with self.subTest(password_present=bool(password)):
+                signing = {key: self.credentials[key] for key in SIGNING if key != "APPLE_CERTIFICATE_PASSWORD"}
+                code, log, _ = self.run_preflight(signing | password)
+                self.assertEqual(code, 0)
+                self.assertIn("Signing group complete", log)
+                self.assertEqual(self.count_calls(), 0)
+
+    def test_workflow_exports_empty_certificate_password_for_tauri(self):
+        values = {key: self.credentials[key] for key in SIGNING} | {"APPLE_CERTIFICATE_PASSWORD": ""}
+        code, _, _ = self.run_preflight(values)
+        self.assertEqual(code, 0)
+        export_step = next(step for step in desktop_steps() if "GITHUB_ENV" in step)
+        command = re.search(r"        run: \|\n(.*)", export_step, re.DOTALL).group(1)
+        result = subprocess.run(
+            ["/bin/bash", "-e", "-c", command],
+            cwd=ROOT, env=self.env | values | dict.fromkeys(NOTARY, ""),
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+        exported = dict(line.split("=", 1) for line in self.export.read_text().splitlines())
+        self.assertEqual(exported, {"EXISTING": "value"} | values)
+        for value in values.values():
+            if value:
+                self.assertNotIn(value, result.stdout)
+
+    def test_notarization_only_preserves_independent_group(self):
+        code, _, _ = self.run_preflight({key: self.credentials[key] for key in NOTARY})
+        self.assertEqual(code, 0)
+        self.assertEqual(self.count_calls(), 1)
+
+    def test_success_does_not_log_or_export_credentials(self):
+        code, log, sleep = self.run_preflight()
+        self.assertEqual(code, 0)
+        self.assertIn("authentication passed", log)
+        self.assertEqual(self.count_calls(), 1)
+        sleep.assert_not_called()
+
+    def test_each_missing_required_group_member_fails_before_authentication(self):
+        for missing in ("APPLE_CERTIFICATE", "APPLE_SIGNING_IDENTITY") + NOTARY:
+            with self.subTest(missing=missing):
+                values = {key: value for key, value in self.credentials.items() if key != missing}
+                code, log, _ = self.run_preflight(values)
+                self.assertEqual(code, 1)
+                self.assertIn(missing, log)
+                self.assertEqual(self.count_calls(), 0)
+
+    def test_each_lone_group_member_fails_before_authentication(self):
+        for present in SIGNING + NOTARY:
+            with self.subTest(present=present):
+                code, _, _ = self.run_preflight({present: self.credentials[present]})
+                self.assertEqual(code, 1)
+                self.assertEqual(self.count_calls(), 0)
+
+    def test_blank_or_multiline_credentials_fail_before_authentication(self):
+        for key in SIGNING + NOTARY:
+            for value in (" ", "\t", self.credentials[key] + "\n", self.credentials[key] + "\r"):
+                with self.subTest(key=key, kind=repr(value[-1])):
+                    code, log, _ = self.run_preflight(self.credentials | {key: value})
+                    self.assertEqual(code, 1)
+                    self.assertIn(key, log)
+                    self.assertEqual(self.count_calls(), 0)
+
+    def test_authentication_rejection_is_not_retried(self):
+        for status in (401, 403):
+            with self.subTest(status=status):
+                before = self.count_calls()
+                code, log, sleep = self.run_preflight(responses=(status,))
+                self.assertEqual(code, 1)
+                self.assertIn(str(status), log)
+                self.assertEqual(self.count_calls() - before, 1)
+                sleep.assert_not_called()
+
+    def test_known_transient_failures_retry_then_succeed(self):
+        for status in (429, 500, 502, 503, 504):
+            with self.subTest(status=status):
+                if self.calls.exists():
+                    self.calls.unlink()
+                code, _, sleep = self.run_preflight(responses=(status, 0))
+                self.assertEqual(code, 0)
+                self.assertEqual(self.count_calls(), 2)
+                sleep.assert_called_once_with(5)
+
+    def test_transient_failure_stops_after_three_attempts(self):
+        code, _, sleep = self.run_preflight(responses=(503,))
+        self.assertEqual(code, 1)
+        self.assertEqual(self.count_calls(), 3)
+        self.assertEqual(sleep.call_args_list, [mock.call(5), mock.call(10)])
+
+    def test_unknown_failure_is_not_retried(self):
+        for status, reason in ((418, "418"), ("offline", "unclassified")):
+            with self.subTest(status=status):
+                before = self.count_calls()
+                code, log, sleep = self.run_preflight(responses=(status,))
+                self.assertEqual(code, 1)
+                self.assertIn(reason, log)
+                self.assertEqual(self.count_calls() - before, 1)
+                sleep.assert_not_called()
+
+    def test_missing_tool_fails_without_traceback_or_retry(self):
+        (self.bin / "xcrun").unlink()
+        code, log, sleep = self.run_preflight()
+        self.assertEqual(code, 1)
+        self.assertNotIn("Traceback", log)
+        self.assertIn("Xcode", log)
+        sleep.assert_not_called()
+
+    def test_timed_out_request_has_a_bounded_retry_budget(self):
+        with mock.patch.object(self.helper.subprocess, "run", side_effect=subprocess.TimeoutExpired("hidden", 60)) as run:
+            code, log, sleep = self.run_preflight()
+        self.assertEqual(code, 1)
+        self.assertIn("timed out", log)
+        self.assertEqual(run.call_count, 3)
+        self.assertTrue(all(call.kwargs["timeout"] == 60 for call in run.call_args_list))
+        self.assertEqual(sleep.call_args_list, [mock.call(5), mock.call(10)])
+
+    def test_workflow_stops_before_build_and_export_on_auth_failure(self):
+        steps = desktop_steps()
+        check = next(step for step in steps if "apple_preflight.py" in step)
+        command = re.search(r"^        run: (.+)$", check, re.MULTILINE).group(1)
+        build = self.bin / "build-marker"
+        build.write_text(f"#!{sys.executable}\nimport pathlib\npathlib.Path({str(self.root / 'built')!r}).touch()\n")
+        build.chmod(0o700)
+        (self.bin / "python3").symlink_to(sys.executable)
+        export_step = next(step for step in steps if "GITHUB_ENV" in step)
+        export_command = re.search(r"        run: \|\n(.*)", export_step, re.DOTALL).group(1)
+        result = subprocess.run(
+            ["/bin/bash", "-e", "-c", command + "\nbuild-marker\n" + export_command],
+            cwd=ROOT, env=self.env | self.credentials | {"PREFLIGHT_TEST_RESPONSES": "[401]"},
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("401", result.stdout)
+        self.assertFalse((self.root / "built").exists())
+        self.assertEqual(self.export.read_text(), "EXISTING=value\n")
+        for value in self.credentials.values():
+            self.assertNotIn(value, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - A rejected notarization login should be discovered before either macOS architecture spends time compiling.
  - Check optional credential-group completeness and use a bounded, read-only notarytool history request for configured notarization credentials. Retry only timeouts and recognized transient HTTP failures.
  - Preserve optional signing/notarization and valid empty PKCS#12 passwords. Suppress subprocess output and keep the existing late credential export for bundling.
- **Scope boundary:** This is not certificate import, identity validation, bundle acceptance, or a change to Apple signing policy. Those checks remain in Tauri and the existing notarization steps.
- **Blast radius:** The macOS desktop release matrix; unsigned builds remain supported. Other platform builds are unchanged.
- **Linked issue(s):** Related #10814 (R2).
- **Labels:** `ci`, `scripts`, `risk:high`, `size:M`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — focused repeatable tests below cover the changed orchestration. Live release actions are intentionally not requested as an ad-hoc PR test.

### How I tested

- **CI checks relied on and why they cover this change:** Local tests and lint provide the evidence below. This PR adds its focused Python suite to CI; hosted results are pending and are not claimed as passed.
- **Known CI coverage gap, if any:** No live Apple account authentication, certificate import, keychain mutation, signing, or notarization was run. Full actionlint reports the same six pre-existing shellcheck warnings as master (SC2086, SC2016, SC2094); the new helper introduces none.
- **Commands run and tail output:**

```text
python3 scripts/release/apple_preflight_test.py
# Ran 17 tests ... OK
python3 scripts/ci/release_attestation_contract_test.py
# Existing attestation suite: 11 tests passed
actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml .github/workflows/release-stable-manual.yml
git diff --check
# Workflow lint and diff check exited 0
```

- **Beyond CI, what did you manually verify?** The tests cover absent/partial groups, empty or omitted certificate passwords, permanent failures, bounded transient retries, and suppression of account/credential output. The empty-password regression failed before the compatibility correction. The workflow's late signing export remains unchanged.
- **Visual interface changed?** N/A — release automation, not application rendering.
- **If any command was intentionally skipped, why:** Live publishing/deployment and a full application rebuild were not run; this draft changes orchestration, and the bounded tests isolate its failure paths without external writes. No production timing improvement is claimed yet.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? Yes.
- Secrets / tokens / credentials handling changed? Yes.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- **Risk and mitigation:** The preflight makes a read-only request to Apple's notarization service using the same configured credentials as bundling. Credentials are scoped to the check step; captured tool output, account history, and command arguments are not logged. It creates no keychain profile or credential file. The subprocess still necessarily receives credentials as arguments, as notarytool requires.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? No.
- Rust/MSRV/toolchain floor changed? No.
- **Upgrade steps:** No new configuration. Incomplete configured groups now fail early; signing requires a certificate and identity, but its password may be empty. Completely absent groups remain optional. No Rust/MSRV change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's merge commit to restore the previous late-only checks.
- **Feature flags or config toggles:** No new flag; existing absent credential groups retain unsigned/non-notarized builds.
- **Observable failure symptoms:** Look for 'Incomplete Apple credential group', 'Cannot run notarytool', or 'Apple notarization preflight failed' in the early macOS job.
