### PR TITLE
fix(release): fail closed during version preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Test translation release submodule handling
         run: scripts/release/refresh-translations.test.sh
 
+      - name: Test release version preparation failures
+        run: python3 scripts/release/bump-version.test.py
+
       - name: Test monthly outdated result classification
         run: bash scripts/ci/monthly_outdated_result.test.sh
 

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -54,7 +54,7 @@ Bump `workspace.package.version` in the workspace `Cargo.toml`, then run the two
 #### sh
 
 ```sh
-./scripts/release/bump-version.sh    # version from Cargo.toml
+./scripts/release/bump-version.sh --release    # version from Cargo.toml
 ```
 
 </div>
@@ -73,6 +73,13 @@ in step automatically, so never hand-edit a generated region. Live release
 availability remains hand-authored and is not inferred by the generator. This
 script also refreshes the Nix git dependency hashes (`nix/hashes.json`) via
 `scripts/dev/refresh-nix-hashes.sh`.
+
+Release mode requires `cargo`, `jq`, `nix-prefetch-git`, `perl`, `sha256sum`,
+the lockfile, and the Nix refresh script before it edits files. It stops if
+lockfile resolution, Nix hashes, or installer generation fails. A failure can
+leave earlier edits in the worktree: inspect them and rerun after fixing the
+reported prerequisite. Do not commit an incomplete bump. Without `--release`,
+the script retains its best-effort behavior for local preparation.
 
 ### Refresh and pin translations
 

--- a/scripts/release/bump-version.sh
+++ b/scripts/release/bump-version.sh
@@ -6,15 +6,30 @@ set -euo pipefail
 # Usage:
 #   scripts/release/bump-version.sh           # reads version from Cargo.toml
 #   scripts/release/bump-version.sh 0.7.0     # explicit version
+#   scripts/release/bump-version.sh --release 0.7.0 # require every generator
 #
-# This script is called automatically by the version-sync workflow
-# whenever Cargo.toml changes on master. It can also be run locally.
+# Run locally when preparing a version-bump PR. Release mode checks prerequisites
+# before editing and stops on generation failures; it does not roll back edits.
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
-if [[ $# -ge 1 ]]; then
-  VERSION="$1"
-else
+RELEASE_MODE=0
+VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --release) RELEASE_MODE=1 ;;
+    -h|--help) sed -n '3,12p' "$0"; exit 0 ;;
+    -*) echo "error: unknown option: $arg" >&2; exit 2 ;;
+    *)
+      if [[ -n "$VERSION" ]]; then
+        echo "error: supply at most one version" >&2
+        exit 2
+      fi
+      VERSION="$arg"
+      ;;
+  esac
+done
+if [[ -z "$VERSION" ]]; then
   VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$REPO_ROOT/Cargo.toml" | head -1)"
 fi
 
@@ -37,6 +52,28 @@ if [[ ! "$MSRV" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+generation_failure() {
+  if [[ "$RELEASE_MODE" -eq 1 ]]; then
+    echo "error: $*; release preparation is incomplete. Review local edits before retrying." >&2
+    exit 1
+  fi
+  echo "  warn: $*"
+}
+
+if [[ "$RELEASE_MODE" -eq 1 ]]; then
+  for tool in cargo jq nix-prefetch-git perl sha256sum; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "error: release preparation requires $tool; no files changed" >&2
+      exit 1
+    fi
+  done
+  if [[ ! -f "$REPO_ROOT/Cargo.lock" ]] || [[ ! -x "$REPO_ROOT/scripts/dev/refresh-nix-hashes.sh" ]]; then
+    echo "error: release preparation requires Cargo.lock and executable scripts/dev/refresh-nix-hashes.sh; no files changed" >&2
+    exit 1
+  fi
+fi
+
+cd "$REPO_ROOT"
 echo "Syncing all version references to $VERSION ..."
 
 changed=0
@@ -68,8 +105,11 @@ echo "Tauri config..."
 TAURI_CONF="$REPO_ROOT/apps/tauri/tauri.conf.json"
 if [[ -f "$TAURI_CONF" ]]; then
   if command -v jq >/dev/null 2>&1; then
-    jq --arg v "$VERSION" '.version = $v' "$TAURI_CONF" > "$TAURI_CONF.tmp" \
-      && mv "$TAURI_CONF.tmp" "$TAURI_CONF"
+    if ! jq --arg v "$VERSION" '.version = $v' "$TAURI_CONF" > "$TAURI_CONF.tmp"; then
+      generation_failure "Tauri version update failed"
+    else
+      mv "$TAURI_CONF.tmp" "$TAURI_CONF"
+    fi
   else
     sed -i '' -E "s|\"version\": \"[^\"]+\"|\"version\": \"$VERSION\"|" "$TAURI_CONF" 2>/dev/null \
       || sed -i -E "s|\"version\": \"[^\"]+\"|\"version\": \"$VERSION\"|" "$TAURI_CONF"
@@ -128,7 +168,7 @@ if [[ -f "$ROOT_LOCK" ]] && command -v cargo >/dev/null 2>&1; then
   before="$(sha256sum "$ROOT_LOCK" | awk '{print $1}')"
   ( cd "$REPO_ROOT" && cargo update --workspace --offline >/dev/null 2>&1 ) \
     || ( cd "$REPO_ROOT" && cargo update --workspace >/dev/null 2>&1 ) \
-    || echo "  warn: cargo update --workspace failed; review Cargo.lock manually"
+    || generation_failure "cargo update --workspace failed; review Cargo.lock manually"
   after="$(sha256sum "$ROOT_LOCK" | awk '{print $1}')"
   if [[ "$before" != "$after" ]]; then
     echo "  updated: Cargo.lock"
@@ -220,15 +260,17 @@ fi
 
 # ── Nix git-dep hashes ──────────────────────────────────────────
 # Refresh NAR hashes for git-sourced dependencies so the flake can
-# resolve them.  Skips gracefully if the script or its prerequisites
-# (nix-prefetch-git, jq) are missing.
+# resolve them. Release mode requires this generator and its prerequisites;
+# ordinary local use retains best-effort behavior.
 echo "Nix git-dep hashes..."
 REFRESH_SCRIPT="$REPO_ROOT/scripts/dev/refresh-nix-hashes.sh"
 if [[ -x "$REFRESH_SCRIPT" ]]; then
   if command -v nix-prefetch-git >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-    ( cd "$REPO_ROOT" && bash "$REFRESH_SCRIPT" ) \
-      && echo "  refreshed nix/hashes.json" \
-      || echo "  warn: refresh-nix-hashes.sh failed; nix/hashes.json may be stale"
+    if ( cd "$REPO_ROOT" && bash "$REFRESH_SCRIPT" ); then
+      echo "  refreshed nix/hashes.json"
+    else
+      generation_failure "refresh-nix-hashes.sh failed; nix/hashes.json may be stale"
+    fi
   else
     echo "  skip: nix-prefetch-git or jq not on PATH"
   fi
@@ -245,9 +287,12 @@ fi
 # Drift gate fails if this is skipped.
 echo "Generated install surfaces (cargo generate installers)..."
 if command -v cargo >/dev/null 2>&1; then
-  ( cd "$REPO_ROOT" && cargo generate installers ) \
-    && { echo "  regenerated install surfaces"; changed=$((changed + 1)); } \
-    || echo "  warn: cargo generate installers failed; run it manually and commit the result"
+  if ( cd "$REPO_ROOT" && cargo generate installers ); then
+    echo "  regenerated install surfaces"
+    changed=$((changed + 1))
+  else
+    generation_failure "cargo generate installers failed; run it manually and commit the result"
+  fi
 else
   echo "  skip: cargo not on PATH; run 'cargo generate installers' before committing"
 fi

--- a/scripts/release/bump-version.test.py
+++ b/scripts/release/bump-version.test.py
@@ -1,0 +1,156 @@
+"""Exercise release-mode failures through the actual version-bump script."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("bump-version.sh")
+
+
+class ReleaseBumpTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name) / "repo"
+        self.bin = Path(self.temp.name) / "bin"
+        self.bin.mkdir()
+        (self.root / "scripts/release").mkdir(parents=True)
+        (self.root / "scripts/dev").mkdir()
+        (self.root / "docs/book/src").mkdir(parents=True)
+        (self.root / "docs/book/src/intro.md").write_text("# Test release documentation\n")
+        shutil.copyfile(SCRIPT, self.root / "scripts/release/bump-version.sh")
+        (self.root / "Cargo.toml").write_text(
+            '[workspace.package]\nversion = "0.8.5"\nrust-version = "1.96.0"\n'
+        )
+        (self.root / "Cargo.lock").write_text("# fixture lock\n")
+        (self.root / "README.md").write_text(
+            '<img src="version-v0.8.5-blue" alt="Version v0.8.5">\n'
+        )
+        self.calls = Path(self.temp.name) / "calls"
+        self.env = {**os.environ, "PATH": str(self.bin), "BUMP_TEST_CALLS": str(self.calls)}
+        # A closed PATH makes missing prerequisites deterministic even on hosts
+        # with a complete release toolchain. Only generators are mocked.
+        for name in ("dirname", "sed", "head", "awk", "grep", "perl", "sha256sum", "find", "cat", "mv"):
+            executable = shutil.which(name)
+            self.assertIsNotNone(executable, f"test needs {name}")
+            (self.bin / name).symlink_to(executable)
+        self.stub("jq", "exit 0")
+        self.stub("nix-prefetch-git", "exit 0")
+        self.stub("cargo", """
+echo "$*" >> "$BUMP_TEST_CALLS"
+case "$*" in
+  'update --workspace --offline') exit "${BUMP_TEST_OFFLINE:-0}" ;;
+  'update --workspace') exit "${BUMP_TEST_ONLINE:-0}" ;;
+  'generate installers') exit "${BUMP_TEST_INSTALLERS:-0}" ;;
+  *) exit 90 ;;
+esac
+""")
+        self.refresh = self.root / "scripts/dev/refresh-nix-hashes.sh"
+        self.refresh.write_text('#!/bin/sh\necho nix >> "$BUMP_TEST_CALLS"\nexit "${BUMP_TEST_NIX:-0}"\n')
+        self.refresh.chmod(0o700)
+        # The real script invokes its refresh helper via bash.
+        (self.bin / "bash").symlink_to(shutil.which("bash"))
+
+    def stub(self, name, body):
+        path = self.bin / name
+        path.write_text("#!/bin/sh\n" + body + "\n")
+        path.chmod(0o700)
+
+    def run_bump(self, *args, **env):
+        return subprocess.run(
+            ["/bin/bash", str(self.root / "scripts/release/bump-version.sh"), *args],
+            cwd=self.temp.name, env={**self.env, **env}, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=15,
+        )
+
+    def assert_incomplete(self, result, message):
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn(message, result.stdout)
+        self.assertNotIn("Done.", result.stdout)
+
+    def test_release_success_runs_all_generators_from_repo(self):
+        result = self.run_bump("--release", "0.8.6")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.calls.read_text().splitlines(), ["update --workspace --offline", "nix", "generate installers"])
+        self.assertIn('version = "0.8.6"', (self.root / "Cargo.toml").read_text())
+        self.assertIn("version-v0.8.6-blue", (self.root / "README.md").read_text())
+
+    def test_missing_tools_fail_before_mutation(self):
+        for name in ("cargo", "jq", "nix-prefetch-git"):
+            with self.subTest(name=name):
+                path = self.bin / name
+                saved = path.read_bytes()
+                path.unlink()
+                before = (self.root / "Cargo.toml").read_bytes()
+                result = self.run_bump("--release", "0.8.6")
+                self.assert_incomplete(result, f"requires {name}")
+                self.assertEqual(before, (self.root / "Cargo.toml").read_bytes())
+                self.assertFalse(self.calls.exists())
+                path.write_bytes(saved)
+                path.chmod(0o700)
+
+    def test_missing_lock_fails_before_mutation(self):
+        (self.root / "Cargo.lock").unlink()
+        result = self.run_bump("--release", "0.8.6")
+        self.assert_incomplete(result, "requires Cargo.lock")
+        self.assertIn('version = "0.8.5"', (self.root / "Cargo.toml").read_text())
+
+    def test_missing_refresh_helper_fails_before_mutation(self):
+        self.refresh.unlink()
+        result = self.run_bump("--release", "0.8.6")
+        self.assert_incomplete(result, "requires Cargo.lock and executable")
+        self.assertFalse(self.calls.exists())
+
+    def test_failed_lock_refresh_prevents_later_generators(self):
+        result = self.run_bump("--release", "0.8.6", BUMP_TEST_OFFLINE="1", BUMP_TEST_ONLINE="1")
+        self.assert_incomplete(result, "cargo update --workspace failed")
+        self.assertEqual(self.calls.read_text().splitlines(), ["update --workspace --offline", "update --workspace"])
+
+    def test_online_fallback_is_retained(self):
+        result = self.run_bump("--release", "0.8.6", BUMP_TEST_OFFLINE="1")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("update --workspace\n", self.calls.read_text())
+
+    def test_nix_failure_prevents_installer_generation(self):
+        result = self.run_bump("--release", "0.8.6", BUMP_TEST_NIX="1")
+        self.assert_incomplete(result, "refresh-nix-hashes.sh failed")
+        self.assertNotIn("generate installers", self.calls.read_text())
+
+    def test_installer_failure_is_not_success(self):
+        result = self.run_bump("--release", "0.8.6", BUMP_TEST_INSTALLERS="1")
+        self.assert_incomplete(result, "cargo generate installers failed")
+
+    def test_regular_local_mode_remains_best_effort(self):
+        result = self.run_bump("0.8.6", BUMP_TEST_INSTALLERS="1")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("warn: cargo generate installers failed", result.stdout)
+
+    def test_unknown_and_extra_arguments_fail_before_mutation(self):
+        for args in (("--typo",), ("0.8.6", "0.8.7")):
+            result = self.run_bump(*args)
+            self.assert_incomplete(result, "error:")
+            self.assertFalse(self.calls.exists())
+
+    def test_release_defaults_to_canonical_version(self):
+        result = self.run_bump("--release")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Done.", result.stdout)
+        self.assertEqual((self.root / "docs/book/stable-version.txt").read_text(), "v0.8.5\n")
+
+    def test_tauri_generation_error_is_fatal_in_release_mode(self):
+        config = self.root / "apps/tauri/tauri.conf.json"
+        config.parent.mkdir(parents=True)
+        config.write_text('{"version":"0.8.5"}\n')
+        self.stub("jq", "exit 1")
+        result = self.run_bump("--release", "0.8.6")
+        self.assert_incomplete(result, "Tauri version update failed")
+        self.assertEqual(config.read_text(), '{"version":"0.8.5"}\n')
+        self.assertFalse(self.calls.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The version-bump script can currently report success after required lockfile, Nix-hash, or installer generation fails, leaving a release cut incomplete.
  - Add an opt-in --release mode that checks its tools and required inputs before edits and returns an error for any required generation failure.
  - Document strict mode as the maintainer release command, while retaining the current best-effort behavior for existing no-flag callers.
- **Scope boundary:** No version bump is performed by this PR. No generated install surfaces are hand-edited, no dependencies are upgraded, and no release is dispatched.
- **Blast radius:** The maintainer's local release-preparation script and the runbook invocation; existing non-strict callers keep their behavior.
- **Linked issue(s):** Related #10814 (R4).
- **Labels:** `ci`, `docs`, `scripts`, `risk:high`, `size:S`, `type:ci`.

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — focused repeatable tests below cover the changed orchestration. Live release actions are intentionally not requested as an ad-hoc PR test.

### How I tested

- **CI checks relied on and why they cover this change:** Local tests and lint provide the evidence below. This PR adds its focused Python suite to CI; hosted results are pending and are not claimed as passed.
- **Known CI coverage gap, if any:** No real release version, dependency resolution, Nix network fetch, or generated installer content was changed. These tests prove orchestration and failure propagation; the existing installer drift gate still validates actual generated content when a version-cut PR runs.
- **Commands run and tail output:**

```text
python3 scripts/release/bump-version.test.py
# Ran 12 tests ... OK
bash -n scripts/release/bump-version.sh
shellcheck scripts/release/bump-version.sh
actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml
# Exited 0
BASE_SHA=ae8fc3ab18657e2e7fb547941b1143828107dd1d \
  DOCS_FILES=docs/book/src/maintainers/release-runbook.md \
  bash scripts/ci/docs_quality_gate.sh
# No blocking markdown issues on changed lines.
# One pre-existing MD028 warning outside changed lines.
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false \
  BASE_SHA=ae8fc3ab18657e2e7fb547941b1143828107dd1d \
  DOCS_FILES=docs/book/src/maintainers/release-runbook.md \
  bash scripts/ci/docs_links_gate.sh
# Ran 6 tests ... OK; no added links detected.
git diff --check
# Exited 0
```

- **Beyond CI, what did you manually verify?** Tests invoke the real shell entry point in temporary repositories with closed-PATH tool doubles. They cover missing prerequisites before edits, offline-to-online Cargo fallback, lockfile/Nix/installer failures, failed Tauri JSON generation, canonical-version fallback, argument validation, and unchanged best-effort behavior.
- **Visual interface changed?** N/A — release automation, not application rendering.
- **If any command was intentionally skipped, why:** Live publishing/deployment and a full application rebuild were not run; this draft changes orchestration, and the bounded tests isolate its failure paths without external writes. No production timing improvement is claimed yet.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- **Risk and mitigation:** Strict mode changes failure handling, not external endpoints or credentials. A late generation failure can leave partial working-tree edits; the script does not roll them back automatically, and the runbook explicitly requires inspection before committing.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? Yes.
- Rust/MSRV/toolchain floor changed? No.
- **Upgrade steps:** Release maintainers should run ./scripts/release/bump-version.sh --release X.Y.Z and install the listed prerequisites first. Existing invocations without --release remain best-effort. No Rust/MSRV change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's merge commit. For a failed preparation attempt, inspect the working-tree diff and rerun after repairing prerequisites; do not commit a partially generated release cut.
- **Feature flags or config toggles:** Omit --release for legacy best-effort behavior; the runbook uses strict mode for actual releases.
- **Observable failure symptoms:** Strict preparation exits nonzero for missing prerequisites or reports a required generation failure, stopping subsequent generators.
