### PR TITLE
perf(docs): promote stable metadata without rebuilding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Test CLI and hardware path-label ownership
         run: bash scripts/ci/path_labeler_matrix.test.sh
 
+      - name: Test docs stable metadata promotion
+        run: python3 scripts/docs/promote_stable_test.py
+
   relay-container-smoke-changes:
     name: Detect Relay Container Smoke changes
     needs: [fmt]

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -30,8 +30,13 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Build docs, or promote an already deployed release without rebuilding."
+        type: choice
+        options: [build, promote-stable]
+        default: build
       tag:
-        description: "The version tag to deploy (e.g. v0.7.5, master). If omitted, builds 'master'."
+        description: "Version to build (default master), or exact final tag to promote (e.g. v0.8.5)."
         required: false
         default: "master"
 
@@ -44,6 +49,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.event_name != 'workflow_dispatch' || inputs.mode == 'build'
     runs-on: ubuntu-24.04-arm
     steps:
       # A push to master may flip the stable pointer (docs/book/stable-version.txt).
@@ -267,6 +273,9 @@ jobs:
             mkdir -p "$TAG_SRC"
             rsync -a "$BUILD_ROOT/" "$TAG_SRC/"
           fi
+          # Receipt travels with the built version, including retries. Promotion
+          # compares this exact checkout commit with the current release tag.
+          git rev-parse HEAD > "$TAG_SRC/.docs-source-commit"
 
           pushd "$CLONE_DIR" > /dev/null
 
@@ -417,3 +426,45 @@ jobs:
             apply_run_slice
           done
           popd > /dev/null
+
+  promote-stable:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'promote-stable'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Promote deployed stable docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          # This job shares the workflow-wide gh-pages lock with normal builds.
+          # A missing gh-pages branch is an error: promotion never bootstraps it.
+          PAGES_DIR=$(mktemp -d)
+          git fetch --depth=1 origin refs/heads/gh-pages
+          git worktree add --detach "$PAGES_DIR" FETCH_HEAD
+          PAGES_SHA=$(git -C "$PAGES_DIR" rev-parse HEAD)
+          PROMOTE=(python3 scripts/docs/promote_stable.py
+            --pages "$PAGES_DIR" --repo "$GITHUB_REPOSITORY"
+            --master-sha "$GITHUB_SHA" --tag "$TAG" --minimum "$DOCS_MIN_VERSION")
+          "${PROMOTE[@]}"
+          if git -C "$PAGES_DIR" diff --quiet; then
+            echo "Stable docs already point to $TAG."
+            exit 0
+          fi
+          # Preserve the one-commit artifact branch. The lease rejects another
+          # writer instead of replacing a site that was not validated here.
+          git -C "$PAGES_DIR" checkout --orphan ghp-promotion
+          git -C "$PAGES_DIR" add --all
+          git -C "$PAGES_DIR" -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -m "docs: promote $TAG to stable (from $GITHUB_SHA)"
+          # Recheck live master, Latest, tag identity and locales before publish.
+          "${PROMOTE[@]}" --check-only
+          git -C "$PAGES_DIR" push --force-with-lease=refs/heads/gh-pages:"$PAGES_SHA" \
+            origin HEAD:refs/heads/gh-pages

--- a/docs/book/src/maintainers/release-runbook.md
+++ b/docs/book/src/maintainers/release-runbook.md
@@ -469,11 +469,42 @@ recreate `gh-pages` or change the supported-version window.
 ### What happens automatically
 
 - The `deploy-docs` job dispatches a build that lands in `/vX.Y.Z/`.
-- "Stable" is a pointer, not a copy. The release tag deploy (e.g., `v0.8.0`) is what builds and publishes that version's docs directory. `bump-version.sh` writes the released version to `docs/book/stable-version.txt`; landing that change on master refreshes the stable metadata only. The master deploy does not rebuild or republish the release tag's docs; it copies `stable-version.txt` to the `gh-pages` root and regenerates the root `/` redirect and the version-selector's "Stable (latest release)" entry so both resolve to that release's already-published version dir. The deploy fails loudly if the named version dir is not present on `gh-pages`. There is no duplicate `/stable/` tree.
-- **Ordering matters:** the tag deploy must land `/vX.Y.Z/` on `gh-pages` *before* a master deploy can flip the stable pointer to it. In the normal release sequence the version-bump PR merges first (Step 2), so its `master` docs deploy typically runs *before* `Release Stable` creates and deploys the tag. That earlier master deploy finds `/vX.Y.Z/` absent and deliberately retains the previous pointer; the flip is deferred (see the deferred-flip logic in `docs-deploy.yml`). The `deploy-docs` job then creates `/vX.Y.Z/`, and the flip publishes on the *next* master deploy after the dir is live. Note that `deploy-docs` only dispatches the tag build and does not wait for it: a green `deploy-docs` job means the dispatch was accepted, not that the docs run finished. After `/vX.Y.Z/` is live, dispatch `docs-deploy.yml` with `tag=master` to publish the stable-pointer flip (and confirm the dispatched runs actually succeeded in the Actions tab).
-- `gh-pages` is ephemeral: every deploy force-pushes a single orphan commit (no accumulating history) and enforces retention via `DOCS_KEEP_VERSIONS` (master plus the newest N final releases; pre-releases and older finals are pruned). This keeps clone size bounded.
+- "Stable" is a pointer to the release's existing docs directory. `bump-version.sh` writes `docs/book/stable-version.txt`; only a master run publishes that pointer to `gh-pages` and refreshes the root redirect and version selector. A normal master deploy builds development docs and shared assets as well. There is no duplicate `/stable/` tree.
+- **Ordering matters:** the version-bump master deploy usually precedes the release tag deploy. It retains the previous live pointer until `/vX.Y.Z/` exists. The release's `deploy-docs` job only dispatches the tag build: a green dispatch job does not prove the docs build finished. Once that run succeeds, use the promotion mode below to publish the stable pointer without another full master build.
+- `gh-pages` is ephemeral: publication replaces it with a single orphan commit. Normal builds enforce retention via `DOCS_KEEP_VERSIONS` (master, the stable pointer target, and the newest N final releases). Promotion preserves all existing version directories.
 - The `_shared/` directory (containing UI CSS, JS, and favicons) is updated from the build so the theme cascades to all deployed versions.
 - Translated locales (`es`, `fr`, `ja`, `zh-CN`) render from the `docs/book/po` submodule, which the deploy resolves via `submodules: recursive` at whatever commit the deployed ref pins. That pin is set during the version bump; see [Step 2](#step-2-bump-and-merge-the-version-pr) for the refresh, tag, and pin procedure. English needs no submodule.
+
+### Promote an already deployed release
+
+Dispatch **Deploy mdBook docs to Pages** from branch **master**, set **mode** to
+`promote-stable`, and set **tag** to the exact final tag, for example `v0.8.5`.
+The default `build` mode retains the normal build behavior.
+
+Promotion updates only `stable-version.txt`, `index.html`, and `versions.json` at
+the site root. It installs no Rust or mdBook tools and preserves every locale,
+the API reference, shared chrome, and retention state. The workflow's existing
+`gh-pages` concurrency group serializes both modes; promotion also uses an exact
+push lease so it cannot replace a site changed by another writer.
+
+The helper requires the dispatch commit to remain protected master's current
+head, its committed pointer to match the requested tag, and GitHub Latest to name
+that same public final release. It resolves the tag to a commit and compares it
+with the deployed version's `.docs-source-commit` receipt. Every locale listed in
+that release's `locales.toml` must have a nonempty landing page. Missing or
+inconsistent metadata, API errors, prereleases, versions below the docs floor,
+and numeric version downgrades fail before publication. The live checks repeat
+immediately before the push. If master advances while the run waits, dispatch a
+fresh run. Repeating a successful promotion is safe.
+
+Deployments made before source receipts were introduced need one normal `build`
+dispatch for that release tag before promotion can verify their source. Do not
+create a receipt by hand. Promotion does not rewrite page-level canonical or
+language-alternate tags, or `sitemap.xml`; those SEO fields refresh on the next
+normal docs deploy. If an immediate SEO refresh is required, use a normal master
+build. A downgrade requires a separately reviewed manual rollback; this mode has
+no rollback override. Reverting the workflow change removes the manual mode but
+does not change the already published pointer.
 
 ### Bootstrapping `gh-pages`
 

--- a/scripts/docs/promote_stable.py
+++ b/scripts/docs/promote_stable.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Promote an existing release by changing exactly three gh-pages root files.
+
+Master's committed pointer is policy; GitHub Latest and the deployed source
+receipt prove eligibility. No builds, pruning, tag writes, or publication here.
+"""
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tomllib
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def final_version(tag):
+    require(re.fullmatch(r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", tag),
+            f"Expected a final vX.Y.Z tag, got {tag!r}")
+    return tuple(int(part) for part in tag[1:].split("."))
+
+
+def gh_json(repo, endpoint):
+    result = subprocess.run(["gh", "api", "--method", "GET", f"repos/{repo}/{endpoint}"],
+                            check=True, capture_output=True, text=True, timeout=60)
+    return json.loads(result.stdout)
+
+
+def github_file(repo, name, sha):
+    data = gh_json(repo, f"contents/{name}?ref={sha}")
+    require(data["encoding"] == "base64", "GitHub content was not base64 encoded")
+    return base64.b64decode(data["content"].replace("\n", ""), validate=True).decode("utf-8")
+
+
+def read_file(path):
+    require(path.is_file() and not path.is_symlink(), f"Expected a regular file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def promote(*, pages, repo, master_sha, tag, workflow_ref, minimum, check_only=False):
+    version = final_version(tag)
+    require(workflow_ref == "refs/heads/master", "Promotion must run on master")
+    require(version >= final_version(minimum), "Release is below the docs minimum version")
+    master = gh_json(repo, "branches/master")
+    require(master["protected"] is True, "Promotion requires protected master")
+    require(master["commit"]["sha"] == master_sha, "master advanced; dispatch a fresh promotion")
+    pointer = github_file(repo, "docs/book/stable-version.txt", master_sha).strip()
+    require(pointer == tag, "Requested tag does not match master's committed pointer")
+    release = gh_json(repo, "releases/latest")
+    require(release["tag_name"] == tag, "Requested tag is not GitHub Latest")
+    require(release.get("draft") is False and release.get("prerelease") is False
+            and bool(release.get("published_at")), "GitHub Latest must be a public final release")
+
+    # Resolve annotated as well as lightweight tags; target_commitish can be a
+    # mutable branch name and cannot establish release source identity.
+    obj = gh_json(repo, f"git/ref/tags/{tag}")["object"]
+    for _ in range(8):
+        if obj["type"] != "tag":
+            break
+        obj = gh_json(repo, f"git/tags/{obj['sha']}")["object"]
+    require(obj["type"] == "commit" and re.fullmatch(r"[0-9a-f]{40}", obj["sha"]),
+            "Could not resolve the release tag commit")
+    tag_sha = obj["sha"]
+    target = pages / tag
+    require(not target.is_symlink(), "Release directory must not be a symlink")
+    require(read_file(target / ".docs-source-commit").strip() == tag_sha,
+            "Release tag does not match deployed source; deploy that release first")
+
+    # The release's own locale registry defines its payload, even if master has
+    # added a language since that release. English is the root redirect target.
+    registry = tomllib.loads(github_file(repo, "locales.toml", tag_sha))
+    locales = [entry["code"] for entry in registry["locale"]]
+    require("en" in locales and len(set(locales)) == len(locales)
+            and all(re.fullmatch(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*", code) for code in locales),
+            "Invalid release locale registry")
+    for locale in locales:
+        require(not (target / locale).is_symlink(), "Locale directory must not be a symlink")
+        require(bool(read_file(target / locale / "index.html").strip()),
+                f"Release locale {locale} has an empty landing page")
+
+    current = read_file(pages / "stable-version.txt").strip()
+    require(version >= final_version(current),
+            "Refusing a stable downgrade; use a separately reviewed manual rollback")
+    metadata = json.loads(read_file(pages / "versions.json"))
+    require(metadata["stable"] == current, "Version metadata disagrees with the live pointer")
+    entries = metadata["versions"]
+    tags = [entry["tag"] for entry in entries]
+    require(tag in tags and current in tags and len(set(tags)) == len(tags),
+            "Missing or duplicate version entries; run a normal docs deploy first")
+    read_file(pages / "index.html")  # Check every output before writing any.
+    for entry in entries:
+        if entry["tag"] == current:
+            entry["label"] = current
+        if entry["tag"] == tag:
+            entry["label"] = "Stable (latest release)"
+    metadata["stable"] = tag
+    destination = f"./{tag}/en/"
+    # Same root redirect shape as xtask's gen-root-index; keep the existing
+    # version inventory/order instead of copying its discovery/retention logic.
+    index = ('<!doctype html>\n<meta charset="utf-8">\n'
+             f'<meta http-equiv="refresh" content="0; url={destination}">\n'
+             f'<link rel="canonical" href="{destination}">\n<title>ZeroClaw Docs</title>\n')
+    if not check_only:
+        (pages / "stable-version.txt").write_text(tag + "\n", encoding="utf-8")
+        (pages / "versions.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (pages / "index.html").write_text(index, encoding="utf-8")
+    print(f"{'Validated' if check_only else 'Promoted'} {tag} ({tag_sha}) from master {master_sha}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pages", type=Path, required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--master-sha", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--minimum", default="v0.7.5")
+    parser.add_argument("--check-only", action="store_true")
+    args = vars(parser.parse_args())
+    try:
+        promote(**args, workflow_ref=os.environ.get("GITHUB_REF", ""))
+    except (ValueError, OSError, KeyError, TypeError, subprocess.SubprocessError) as error:
+        print(f"::error::Stable promotion failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docs/promote_stable_test.py
+++ b/scripts/docs/promote_stable_test.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Hermetic stable promotion tests: real files, mocked GitHub transport only."""
+
+import base64
+import copy
+import importlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parents[2]
+MASTER_SHA = "a" * 40
+TAG_SHA = "b" * 40
+TAG = "v0.10.0"
+
+
+def content(text):
+    return {"encoding": "base64", "content": base64.b64encode(text.encode()).decode()}
+
+
+class WorkflowTest(unittest.TestCase):
+    def test_promotion_has_separate_job_without_build_tools(self):
+        workflow = (REPO / ".github/workflows/docs-deploy.yml").read_text()
+        self.assertIn("default: build", workflow)
+        self.assertIn("if: github.event_name != 'workflow_dispatch' || inputs.mode == 'build'", workflow)
+        promotion = workflow.split("  promote-stable:\n", 1)[1]
+        self.assertIn("inputs.mode == 'promote-stable'", promotion)
+        self.assertIn("ref: ${{ github.sha }}", promotion)
+        self.assertIn("--check-only", promotion)
+        self.assertIn("--force-with-lease=refs/heads/gh-pages:", promotion)
+        self.assertIn("group: gh-pages\n  cancel-in-progress: false", workflow)
+        for build_tool in ["cargo ", "rust-toolchain", "rust-cache", "apt-get", "mdbook build"]:
+            self.assertNotIn(build_tool, promotion)
+
+    def test_build_receipt_records_the_actual_checkout(self):
+        workflow = (REPO / ".github/workflows/docs-deploy.yml").read_text()
+        self.assertIn('git rev-parse HEAD > "$TAG_SRC/.docs-source-commit"', workflow)
+
+
+class PromotionTest(unittest.TestCase):
+    def setUp(self):
+        self.helper = importlib.import_module("promote_stable")
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.pages = Path(self.temp.name)
+        for tag in ["master", "v0.9.0", TAG]:
+            for locale in ["en", "fr"]:
+                self.write(f"{tag}/{locale}/index.html", f"<h1>{tag}/{locale}</h1>")
+                self.write(f"{tag}/{locale}/chapter.html", "existing locale payload")
+        for name in ["_shared/theme.js", "api/index.html", "sitemap.xml", "robots.txt", "CNAME", ".nojekyll"]:
+            self.write(name, f"preserve {name}")
+        self.write(f"{TAG}/.docs-source-commit", TAG_SHA + "\n")
+        self.write("stable-version.txt", "v0.9.0\n")
+        self.write("index.html", "old redirect")
+        self.metadata = {
+            "stable": "v0.9.0",
+            "versions": [
+                {"tag": "master", "label": "Development (master)"},
+                {"tag": TAG, "label": TAG},
+                {"tag": "v0.9.0", "label": "Stable (latest release)"},
+            ],
+        }
+        self.write_metadata()
+        self.responses = {
+            "branches/master": {"protected": True, "commit": {"sha": MASTER_SHA}},
+            f"contents/docs/book/stable-version.txt?ref={MASTER_SHA}": content(TAG + "\n"),
+            "releases/latest": {"tag_name": TAG, "draft": False, "prerelease": False, "published_at": "2026-09-12T00:00:00Z"},
+            f"git/ref/tags/{TAG}": {"object": {"type": "commit", "sha": TAG_SHA}},
+            f"contents/locales.toml?ref={TAG_SHA}": content('[[locale]]\ncode = "en"\n[[locale]]\ncode = "fr"\n'),
+        }
+        self.api = mock.patch.object(self.helper, "gh_json", side_effect=self.github).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def write(self, name, text):
+        target = self.pages / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text)
+
+    def write_metadata(self):
+        self.write("versions.json", json.dumps(self.metadata))
+
+    def github(self, repo, endpoint):
+        self.assertEqual(repo, "zeroclaw-labs/zeroclaw")
+        return copy.deepcopy(self.responses[endpoint])
+
+    def snapshot(self):
+        return {str(p.relative_to(self.pages)): p.read_bytes() for p in self.pages.rglob("*") if p.is_file()}
+
+    def promote(self, **overrides):
+        args = dict(pages=self.pages, repo="zeroclaw-labs/zeroclaw", master_sha=MASTER_SHA,
+                    tag=TAG, workflow_ref="refs/heads/master", minimum="v0.7.5", check_only=False)
+        args.update(overrides)
+        self.helper.promote(**args)
+
+    def rejected(self, error, **overrides):
+        before = self.snapshot()
+        with self.assertRaisesRegex((ValueError, OSError), error):
+            self.promote(**overrides)
+        self.assertEqual(self.snapshot(), before, "rejected promotion changed site files")
+
+    def test_promotes_ten_over_nine_and_preserves_payload_and_chrome(self):
+        before = self.snapshot()
+        self.promote()
+        after = self.snapshot()
+        changed = {name for name in before.keys() | after.keys() if before.get(name) != after.get(name)}
+        self.assertEqual(changed, {"stable-version.txt", "versions.json", "index.html"})
+        self.assertEqual(after["stable-version.txt"], b"v0.10.0\n")
+        self.assertEqual(after["index.html"].decode(),
+                         '<!doctype html>\n<meta charset="utf-8">\n'
+                         '<meta http-equiv="refresh" content="0; url=./v0.10.0/en/">\n'
+                         '<link rel="canonical" href="./v0.10.0/en/">\n<title>ZeroClaw Docs</title>\n')
+        metadata = json.loads(after["versions.json"])
+        self.assertEqual(metadata["stable"], TAG)
+        self.assertEqual(metadata["versions"], [
+            {"tag": "master", "label": "Development (master)"},
+            {"tag": TAG, "label": "Stable (latest release)"},
+            {"tag": "v0.9.0", "label": "v0.9.0"},
+        ])
+        self.promote()  # Retry is idempotent.
+        self.assertEqual(self.snapshot(), after)
+
+    def test_check_only_validates_without_writes(self):
+        before = self.snapshot()
+        self.promote(check_only=True)
+        self.assertEqual(self.snapshot(), before)
+
+    def test_final_tags_only(self):
+        for tag in ["v0.10.0-rc.1", "master", "v01.2.3", "v1.2.3+build", "../../bad"]:
+            with self.subTest(tag=tag):
+                self.rejected("final vX.Y.Z", tag=tag)
+
+    def test_workflow_must_run_on_master(self):
+        self.rejected("run on master", workflow_ref="refs/tags/v0.10.0")
+
+    def test_below_minimum_rejected(self):
+        self.rejected("minimum", minimum="v0.11.0")
+
+    def test_unprotected_master_rejected(self):
+        self.responses["branches/master"]["protected"] = False
+        self.rejected("protected master")
+
+    def test_stale_master_run_rejected(self):
+        self.responses["branches/master"]["commit"]["sha"] = "c" * 40
+        self.rejected("master advanced")
+
+    def test_committed_pointer_mismatch_rejected(self):
+        self.responses[f"contents/docs/book/stable-version.txt?ref={MASTER_SHA}"] = content("v0.9.0\n")
+        self.rejected("committed pointer")
+
+    def test_latest_release_mismatch_rejected(self):
+        self.responses["releases/latest"]["tag_name"] = "v0.11.0"
+        self.rejected("GitHub Latest")
+
+    def test_nonpublic_or_prerelease_latest_rejected(self):
+        for field, value in [("draft", True), ("prerelease", True), ("published_at", None), ("draft", None)]:
+            with self.subTest(field=field, value=value):
+                original = self.responses["releases/latest"][field]
+                self.responses["releases/latest"][field] = value
+                self.rejected("public final release")
+                self.responses["releases/latest"][field] = original
+
+    def test_annotated_tag_resolves_to_deployed_commit(self):
+        self.responses[f"git/ref/tags/{TAG}"]["object"] = {"type": "tag", "sha": "d" * 40}
+        self.responses[f"git/tags/{'d' * 40}"] = {"object": {"type": "commit", "sha": TAG_SHA}}
+        self.promote()
+
+    def test_invalid_tag_object_rejected(self):
+        for obj in [{"type": "tree", "sha": TAG_SHA}, {"type": "commit", "sha": "invalid"}]:
+            self.responses[f"git/ref/tags/{TAG}"]["object"] = obj
+            self.write(f"{TAG}/.docs-source-commit", obj["sha"])
+            self.responses[f"contents/locales.toml?ref={obj['sha']}"] = content('[[locale]]\ncode = "en"')
+            self.rejected("tag commit")
+
+    def test_recursive_annotated_tag_rejected(self):
+        obj = {"type": "tag", "sha": "d" * 40}
+        self.responses[f"git/ref/tags/{TAG}"]["object"] = obj
+        self.responses[f"git/tags/{'d' * 40}"] = {"object": obj}
+        self.rejected("tag commit")
+
+    def test_missing_deployed_source_receipt_rejected(self):
+        (self.pages / TAG / ".docs-source-commit").unlink()
+        self.rejected("regular file")
+
+    def test_wrong_deployed_source_rejected(self):
+        self.write(f"{TAG}/.docs-source-commit", "e" * 40)
+        self.rejected("deployed source")
+
+    def test_missing_target_rejected(self):
+        (self.pages / TAG).rename(self.pages / "unpublished")
+        self.rejected("regular file")
+
+    def test_symlinked_target_rejected(self):
+        (self.pages / TAG).rename(self.pages / "elsewhere")
+        (self.pages / TAG).symlink_to(self.pages / "elsewhere")
+        self.rejected("symlink")
+
+    def test_missing_locale_index_rejected(self):
+        (self.pages / TAG / "fr/index.html").unlink()
+        self.rejected("regular file")
+
+    def test_empty_locale_index_rejected(self):
+        self.write(f"{TAG}/fr/index.html", "")
+        self.rejected("empty landing page")
+
+    def test_invalid_locale_registry_rejected(self):
+        for data in ['locale = []', '[[locale]]\ncode = "../en"', '[[locale]]\ncode = "fr"', '[[locale]]\ncode = "en"\n[[locale]]\ncode = "en"']:
+            self.responses[f"contents/locales.toml?ref={TAG_SHA}"] = content(data)
+            self.rejected("locale registry")
+
+    def test_nine_cannot_replace_ten(self):
+        older = "v0.9.0"
+        self.write("stable-version.txt", TAG + "\n")
+        self.metadata["stable"] = TAG
+        self.write_metadata()
+        self.responses[f"contents/docs/book/stable-version.txt?ref={MASTER_SHA}"] = content(older)
+        self.responses["releases/latest"]["tag_name"] = older
+        self.responses[f"git/ref/tags/{older}"] = {"object": {"type": "commit", "sha": TAG_SHA}}
+        self.write(f"{older}/.docs-source-commit", TAG_SHA)
+        self.rejected("downgrade.*rollback", tag=older)
+
+    def test_patch_and_major_ordering(self):
+        self.assertGreater(self.helper.final_version("v1.0.0"), self.helper.final_version("v0.99.99"))
+        self.assertGreater(self.helper.final_version("v0.9.10"), self.helper.final_version("v0.9.9"))
+
+    def test_inconsistent_live_metadata_rejected(self):
+        self.metadata["stable"] = "v0.8.0"
+        self.write_metadata()
+        self.rejected("live pointer")
+
+    def test_target_missing_from_metadata_rejected(self):
+        self.metadata["versions"] = [v for v in self.metadata["versions"] if v["tag"] != TAG]
+        self.write_metadata()
+        self.rejected("version entries")
+
+    def test_current_missing_from_metadata_rejected(self):
+        self.metadata["versions"] = [v for v in self.metadata["versions"] if v["tag"] != "v0.9.0"]
+        self.write_metadata()
+        self.rejected("version entries")
+
+    def test_duplicate_version_entries_rejected(self):
+        self.metadata["versions"].append(self.metadata["versions"][1])
+        self.write_metadata()
+        self.rejected("version entries")
+
+    def test_symlinked_metadata_rejected(self):
+        (self.pages / "index.html").unlink()
+        (self.pages / "index.html").symlink_to(self.pages / "api/index.html")
+        self.rejected("regular file")
+
+    def test_symlinked_locale_rejected(self):
+        self.pages.joinpath(TAG, "fr").rename(self.pages / "locale-backup")
+        self.pages.joinpath(TAG, "fr").symlink_to(self.pages / "locale-backup")
+        self.rejected("symlink")
+
+    def test_github_error_prevents_any_write(self):
+        self.api.side_effect = OSError("GitHub unavailable")
+        self.rejected("GitHub unavailable")
+
+    def test_check_only_rechecks_latest_before_publication(self):
+        self.promote()
+        self.responses["releases/latest"]["tag_name"] = "v0.11.0"
+        self.rejected("GitHub Latest", check_only=True)
+
+    def test_unknown_content_encoding_rejected(self):
+        self.responses[f"contents/docs/book/stable-version.txt?ref={MASTER_SHA}"]["encoding"] = "none"
+        self.rejected("base64 encoded")
+
+    def test_malformed_base64_rejected(self):
+        self.responses[f"contents/docs/book/stable-version.txt?ref={MASTER_SHA}"]["content"] = "invalid?"
+        self.rejected("base64")
+
+    def test_malformed_metadata_prevents_any_write(self):
+        self.write("versions.json", "not json")
+        self.rejected("Expecting value")
+
+    def test_actual_workflow_publishes_only_metadata_to_local_git_remote(self):
+        # Run the workflow's actual shell and CLI against a disposable local
+        # remote. Only gh's HTTP boundary is replaced; no Pages deployment.
+        with tempfile.TemporaryDirectory() as workspace:
+            root = Path(workspace)
+            remote = root / "remote.git"
+            source = root / "source"
+            source.mkdir()
+            git_env = {**os.environ, "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.devnull}
+
+            def git(cwd, *args):
+                return subprocess.run(["git", *args], cwd=cwd, check=True,
+                                      env=git_env, capture_output=True, text=True).stdout.strip()
+
+            git(root, "init", "--bare", str(remote))
+            for checkout in [self.pages, source]:
+                git(checkout, "init", "-b", "master")
+                git(checkout, "config", "user.name", "Docs Test")
+                git(checkout, "config", "user.email", "docs-test@example.invalid")
+                git(checkout, "remote", "add", "origin", str(remote))
+            git(self.pages, "add", "--all")
+            git(self.pages, "commit", "-m", "existing site")
+            before_sha = git(self.pages, "rev-parse", "HEAD")
+            git(self.pages, "push", "origin", "HEAD:refs/heads/gh-pages")
+            helper_path = source / "scripts/docs/promote_stable.py"
+            helper_path.parent.mkdir(parents=True)
+            shutil.copyfile(REPO / "scripts/docs/promote_stable.py", helper_path)
+            git(source, "add", "--all")
+            git(source, "commit", "-m", "workflow source")
+            master_sha = git(source, "rev-parse", "HEAD")
+            self.responses["branches/master"]["commit"]["sha"] = master_sha
+            self.responses[f"contents/docs/book/stable-version.txt?ref={master_sha}"] = content(TAG)
+            fixtures = root / "api.json"
+            fixtures.write_text(json.dumps(self.responses))
+            executable_dir = root / "bin"
+            executable_dir.mkdir()
+            gh = executable_dir / "gh"
+            gh.write_text('#!/usr/bin/env python3\nimport json, os, sys\n'
+                          'with open(os.environ["DOCS_TEST_API"]) as f: data = json.load(f)\n'
+                          'endpoint = sys.argv[-1].removeprefix("repos/zeroclaw-labs/zeroclaw/")\n'
+                          'print(json.dumps(data[endpoint]))\n')
+            gh.chmod(0o755)
+            workflow = (REPO / ".github/workflows/docs-deploy.yml").read_text()
+            body = workflow.split("      - name: Promote deployed stable docs\n", 1)[1].split("        run: |\n", 1)[1]
+            script = "\n".join(line[10:] for line in body.splitlines())
+            env = {**git_env, "PATH": str(executable_dir) + os.pathsep + os.environ["PATH"],
+                   "DOCS_TEST_API": str(fixtures), "TMPDIR": str(root),
+                   "GITHUB_REPOSITORY": "zeroclaw-labs/zeroclaw", "GITHUB_SHA": master_sha,
+                   "GITHUB_REF": "refs/heads/master", "TAG": TAG, "DOCS_MIN_VERSION": "v0.7.5"}
+            result = subprocess.run(["bash", "-c", script], cwd=source, env=env,
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(git(remote, "rev-list", "--count", "gh-pages"), "1")
+            changed = git(remote, "diff", "--name-only", before_sha, "gh-pages").splitlines()
+            self.assertEqual(changed, ["index.html", "stable-version.txt", "versions.json"])
+            self.assertEqual(git(remote, "show", "gh-pages:stable-version.txt"), TAG)
+            self.assertEqual(git(source, "rev-parse", "HEAD"), master_sha)
+
+
+class TransportTest(unittest.TestCase):
+    def test_gh_failure_is_not_treated_as_missing_release(self):
+        helper = importlib.import_module("promote_stable")
+        with mock.patch.object(helper.subprocess, "run", side_effect=subprocess.CalledProcessError(1, ["gh"])):
+            with self.assertRaises(subprocess.CalledProcessError):
+                helper.gh_json("zeroclaw-labs/zeroclaw", "releases/latest")
+
+    def test_cli_errors_return_failure(self):
+        helper_path = REPO / "scripts/docs/promote_stable.py"
+        result = subprocess.run(["python3", str(helper_path), "--pages", "/nonexistent",
+                                 "--repo", "zeroclaw-labs/zeroclaw", "--master-sha", MASTER_SHA,
+                                 "--tag", "v0.10.0-rc.1"], capture_output=True, text=True,
+                                env={**os.environ, "GITHUB_REF": "refs/heads/master"})
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("final vX.Y.Z", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Once a tagged docs build is deployed, promoting it to stable only needs metadata changes; rebuilding all five locales repeats expensive work.
  - Add an explicit promote-stable dispatch mode. Validate the release and deployed source receipt, then update only the root redirect, stable-version.txt, and versions.json.
  - Keep the existing full build as the default. Recheck live inputs and use a compare-and-swap push within the shared Pages concurrency group.
- **Scope boundary:** No translation, page regeneration, pruning, chrome update, SEO/sitemap refresh, or production deployment in this PR. Existing tracker/target-registry work is not replaced.
- **Blast radius:** Only the optional stable-promotion route of docs-deploy.yml and its three root metadata files. Normal master/tag builds still follow the existing route.
- **Linked issue(s):** Related #10814 (R3). Related #7108 for the broader CI-performance effort.
- **Labels:** `risk:high`, `type:ci` (path and size automation is still queued at this snapshot).

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** N/A — focused repeatable tests below cover the changed orchestration. Live release actions are intentionally not requested as an ad-hoc PR test.

### How I tested

- **CI checks relied on and why they cover this change:** Local tests and lint provide the evidence below. This PR adds its focused Python suite to CI; hosted results are pending and are not claimed as passed.
- **Known CI coverage gap, if any:** No live Pages deployment or browser test was performed. The helper changes deployment routing/metadata rather than page rendering. Existing deployments lack the new receipt: they require one normal tag rebuild before this path can promote them. Page-level SEO/sitemap state remains unchanged until the next normal build.
- **Commands run and tail output:**

```text
python3 scripts/docs/promote_stable_test.py
# Ran 38 tests ... OK
actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml .github/workflows/docs-deploy.yml
# Exited 0
BASE_SHA=ae8fc3ab18657e2e7fb547941b1143828107dd1d \
  DOCS_FILES=docs/book/src/maintainers/release-runbook.md \
  bash scripts/ci/docs_quality_gate.sh
# No blocking markdown issues on changed lines.
# One pre-existing MD028 warning outside changed lines.
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false \
  BASE_SHA=ae8fc3ab18657e2e7fb547941b1143828107dd1d \
  DOCS_FILES=docs/book/src/maintainers/release-runbook.md \
  bash scripts/ci/docs_links_gate.sh
# Ran 6 tests ... OK; no added links detected.
git diff --check
# Exited 0
```

- **Beyond CI, what did you manually verify?** The workflow shell and helper CLI ran against a disposable local Git remote with only the GitHub API responses mocked. The successful path changed exactly three files and preserved the single-orphan-commit Pages layout. Negative cases cover stale master, wrong/missing receipt, incomplete locales, prereleases, downgrade attempts, and inconsistent metadata.
- **Visual interface changed?** N/A — release automation, not application rendering.
- **If any command was intentionally skipped, why:** Live publishing/deployment and a full application rebuild were not run; this draft changes orchestration, and the bounded tests isolate its failure paths without external writes. No production timing improvement is claimed yet.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? Yes.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- Prompt injection or untrusted model-visible text introduced/changed? No.
- **Risk and mitigation:** The new mode reads GitHub release/ref metadata and uses the existing Pages write permission. It accepts only the current master workflow revision and GitHub's latest final release with a matching deployed commit receipt and all five locale entry pages. An explicit lease prevents overwriting a concurrently changed gh-pages ref.

## Compatibility (required)

- Backward compatible? Yes.
- Config / env / CLI surface changed? Yes.
- Rust/MSRV/toolchain floor changed? No.
- **Upgrade steps:** The new workflow_dispatch mode defaults to build, preserving existing callers. After the tag docs build succeeds, maintainers can dispatch mode=promote-stable from master. Legacy deployed releases need one normal rebuild to add the source receipt. No Rust/MSRV change.

## Rollback (required for medium/high-risk PRs)

- **Fast rollback command/path:** Revert this PR's merge commit and use the existing normal master docs deployment. Intentional rollback to an older stable release remains a separately reviewed operation; the new path refuses downgrades.
- **Feature flags or config toggles:** Use mode=build (the default) to retain the existing full deployment path.
- **Observable failure symptoms:** Promotion exits before push on a stale workflow revision, missing/mismatched source receipt, incomplete locale tree, inconsistent versions metadata, or failed gh-pages lease.
