### PR TITLE
fix(tools): expand only a leading tilde in knowledge.db_path

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -8732,7 +8732,8 @@ pub struct KnowledgeConfig {
     /// Enable the knowledge graph tool. Default: false.
     #[serde(default)]
     pub enabled: bool,
-    /// Path to the knowledge graph SQLite database.
+    /// Path to the knowledge graph SQLite database. A leading `~` is expanded
+    /// at use time via [`KnowledgeConfig::resolved_db_path`].
     #[serde(default = "default_knowledge_db_path")]
     pub db_path: String,
     /// Maximum number of knowledge nodes. Default: 100000.
@@ -8763,6 +8764,20 @@ impl Default for KnowledgeConfig {
             auto_capture: false,
             suggest_on_query: true,
         }
+    }
+}
+
+impl KnowledgeConfig {
+    /// Resolve `db_path` to a filesystem path, expanding only a leading `~`
+    /// or `~/` as the home directory.
+    ///
+    /// A `~` anywhere else in the path is left intact, so Windows 8.3 short
+    /// names such as `ADMINI~1` survive resolution. This is the single source
+    /// of truth for the knowledge database location. Pure — performs no
+    /// filesystem I/O.
+    #[must_use]
+    pub fn resolved_db_path(&self) -> PathBuf {
+        expand_tilde_path(&self.db_path)
     }
 }
 
@@ -25965,6 +25980,46 @@ mod tests {
         if std::env::var("HOME").is_ok() {
             assert!(!resolved.to_string_lossy().starts_with('~'));
             assert!(resolved.ends_with(".zeroclaw/plugins"));
+        }
+    }
+
+    // ── Knowledge db path resolution ──────────────────────────
+
+    #[test]
+    async fn resolved_db_path_passes_absolute_path_through() {
+        let cfg = KnowledgeConfig {
+            db_path: "/srv/zeroclaw/knowledge.db".to_string(),
+            ..KnowledgeConfig::default()
+        };
+        assert_eq!(
+            cfg.resolved_db_path(),
+            PathBuf::from("/srv/zeroclaw/knowledge.db")
+        );
+    }
+
+    #[test]
+    async fn resolved_db_path_preserves_non_prefix_tilde() {
+        // Windows 8.3 short names contain a `~` that is not a home shortcut.
+        let cfg = KnowledgeConfig {
+            db_path: "/tmp/ADMINI~1/knowledge.db".to_string(),
+            ..KnowledgeConfig::default()
+        };
+        assert_eq!(
+            cfg.resolved_db_path(),
+            PathBuf::from("/tmp/ADMINI~1/knowledge.db")
+        );
+    }
+
+    #[test]
+    async fn resolved_db_path_expands_leading_tilde() {
+        let cfg = KnowledgeConfig {
+            db_path: "~/.zeroclaw/knowledge.db".to_string(),
+            ..KnowledgeConfig::default()
+        };
+        let resolved = cfg.resolved_db_path();
+        if std::env::var("HOME").is_ok() {
+            assert!(!resolved.to_string_lossy().starts_with('~'));
+            assert!(resolved.ends_with(".zeroclaw/knowledge.db"));
         }
     }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -1719,13 +1719,7 @@ pub fn all_tools_with_runtime(
 
     // Knowledge graph tool
     if root_config.knowledge.enabled {
-        let db_path_str = root_config.knowledge.db_path.replace(
-            '~',
-            &directories::UserDirs::new()
-                .map(|u| u.home_dir().to_string_lossy().to_string())
-                .unwrap_or_else(|| ".".to_string()),
-        );
-        let db_path = std::path::PathBuf::from(&db_path_str);
+        let db_path = root_config.knowledge.resolved_db_path();
         match zeroclaw_memory::knowledge_graph::KnowledgeGraph::new(
             &db_path,
             root_config.knowledge.max_nodes,
@@ -1735,11 +1729,14 @@ pub fn all_tools_with_runtime(
             }
             Err(e) => {
                 ::zeroclaw_log::record!(
-                    WARN,
-                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note)
-                        .with_outcome(::zeroclaw_log::EventOutcome::Unknown)
-                        .with_attrs(::serde_json::json!({"error": format!("{}", e)})),
-                    "knowledge graph disabled due to init error"
+                    ERROR,
+                    ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Fail)
+                        .with_outcome(::zeroclaw_log::EventOutcome::Failure)
+                        .with_attrs(::serde_json::json!({
+                            "error": format!("{}", e),
+                            "db_path": db_path.display().to_string(),
+                        })),
+                    "knowledge: failed to initialize tool"
                 );
             }
         }
@@ -3782,6 +3779,59 @@ permissions = ["http_client"]
         assert!(names.contains(&"model_routing_config"));
         assert!(names.contains(&"pushover"));
         assert!(names.contains(&"proxy_config"));
+    }
+
+    #[test]
+    fn all_tools_registers_knowledge_when_db_path_contains_non_prefix_tilde() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(zeroclaw_memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+        let browser = BrowserConfig {
+            enabled: false,
+            ..BrowserConfig::default()
+        };
+        let http = zeroclaw_config::schema::HttpRequestConfig::default();
+
+        // A `~` that is not a home shortcut, as in a Windows 8.3 short name.
+        let mut cfg = test_config(&tmp);
+        cfg.knowledge.enabled = true;
+        cfg.knowledge.db_path = tmp
+            .path()
+            .join("zc~1probe")
+            .join("knowledge.db")
+            .to_string_lossy()
+            .to_string();
+
+        let tools = all_tools(
+            Arc::new(Config::default()),
+            &security,
+            &zeroclaw_config::schema::RiskProfileConfig::default(),
+            "test-agent",
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &zeroclaw_config::schema::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+            None,
+            false,
+            None,
+        )
+        .tools;
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"knowledge"));
+        // `KnowledgeGraph::new` runs `create_dir_all` on the parent of the path it
+        // was handed, so this directory exists only if the `~` survived resolution.
+        assert!(tmp.path().join("zc~1probe").is_dir());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `all_tools_with_runtime` expanded `~` in `knowledge.db_path` with `String::replace('~', home)` over the **whole** string, so a path containing a non-prefix `~` could be rewritten into an invalid Windows path or the wrong valid Unix path. On Windows this needs no one to type a `~`: 8.3 short names such as `ADMINI~1` / `RUNNER~1` carry one, and the default `db_path` derives from `ZEROCLAW_CONFIG_DIR`/HOME. `KnowledgeGraph::new` then failed on the mangled parent, the error was swallowed into a WARN, and the `knowledge` tool silently never registered. This was the only `replace('~'` in the workspace.
  - Add `KnowledgeConfig::resolved_db_path()`, a two-line accessor mirroring the existing `PluginsConfig::resolved_plugins_dir()`, so the runtime resolves the path through the config crate's existing `expand_tilde_path`. A mid-string `~` survives; leading-tilde resolution follows that shared helper. The runtime call site shrinks from seven lines to one.
  - Align the init-failure log with the shape this file already uses for a real failure (`ERROR` / `Action::Fail` / `EventOutcome::Failure`, as the `microsoft365` arm does) instead of the "intentional skip" shape it used, and record the resolved `db_path` in the attrs so an operator can see what was actually opened.
- **Scope boundary:** No change to `expand_tilde_path` itself or to any other tilde-handling site; no change to `KnowledgeGraph`; no doctor check, validation warning, or tool-registry error channel (the maintainer's triage note asked for the log-surface fix only if it stayed out of broader error-handling territory, and it does).
- **Blast radius:** Knowledge tool registration only. Paths with no `~` resolve identically to before. Every other consumer of `expand_tilde_path` is untouched.
- **Linked issue(s):** Closes #10721. Related #10391 (its advisory Windows job exposed the bug; it deliberately does not fix it). Related #9647 (same subsystem, different axis).
- **Labels:** `config`, `runtime`, `risk:medium`, `size:S`

## Testing (required)

### How you can test (when useful)

- **Reviewer testing requested?** `N/A` — the unit-level regression below reproduces the issue's observable deterministically.

### How I tested

- **CI checks relied on and why they cover this change:**
  - `Format` (`cargo fmt --all -- --check`) and `Lint` (`cargo clippy --all-targets -- -D warnings`) — the accessor copies the `#[must_use]` precedent exactly.
  - `Test` (`cargo nextest run --locked --workspace --exclude zeroclaw-desktop`) — runs the new `tools::tests::all_tools_registers_knowledge_when_db_path_contains_non_prefix_tilde` and the three new `schema.rs` tests (`resolved_db_path_*`).
  - `Advisory Windows nextest` — the platform where the bug was observed. Advisory, but the strongest evidence: the runner's own TEMP can carry an 8.3 component.
- **Known CI coverage gap, if any:** No local cargo on the authoring machine — compile, fmt, clippy, and tests are CI-only for this PR.
- **Commands run and tail output:** None locally (see gap above). CI results for head `fe40bce5` (run `34731539618`): `Format` passed first try (no round-trip was needed), `Lint` passed, all three `Check` variants passed, `CI Required Gate` passed. From the `Test` job log:

```text
PASS [ 0.008s] ( 4262/15858) zeroclaw-config schema::tests::resolved_db_path_expands_leading_tilde
PASS [ 0.007s] ( 4263/15858) zeroclaw-config schema::tests::resolved_db_path_passes_absolute_path_through
PASS [ 0.009s] ( 4265/15858) zeroclaw-config schema::tests::resolved_db_path_preserves_non_prefix_tilde
PASS [ 0.027s] (12083/15858) zeroclaw-runtime tools::tests::all_tools_registers_knowledge_when_db_path_contains_non_prefix_tilde
     Summary [ 204.887s] 15858 tests run: 15858 passed (1 slow, 2 leaky), 23 skipped
```
- **Beyond CI, what did you manually verify?**
  - Read `expand_tilde_path` (`schema.rs`) end to end: `shellexpand::tilde` touches only a *leading* `~`, and the `UserDirs` fallback is gated on `starts_with('~')`, so a mid-string `~` passes through unchanged by construction.
  - Read `KnowledgeGraph::new` (`knowledge_graph.rs`): it calls `create_dir_all(parent)` before `Connection::open`. The registration test asserts that `zc~1probe/` exists afterwards, which is only true if the `~` survived. That second assertion matters: **on Unix the mangled path is still a valid path** (`…/zc/home/<user>1probe/…`), so the tool would register at the wrong location and a presence check alone would pass on master. On Windows the mangled path is invalid, `create_dir_all` fails, and the tool is dropped. The two assertions together make the test red on master on every platform — and explain why the issue only surfaced on the Windows job.
  - Confirmed `KnowledgeTool::name()` returns `"knowledge"`, and that nothing else in `all_tools_with_runtime` reads `knowledge.*`, so enabling it in the test triggers only the branch under test.
  - Confirmed `use tokio::test;` is module-scoped in `schema.rs`'s `mod tests`, so the new tests follow that module's `#[test] async fn` convention.
  - What I did NOT verify: any of this by execution.
- **Visual interface changed?** `N/A`

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- Prompt injection or untrusted model-visible text introduced/changed? `No`

## Compatibility (required)

- Backward compatible? Paths without `~` are unchanged. Embedded tildes are preserved, fixing invalid Windows paths and wrong-location Unix paths. Leading-tilde inputs now follow the existing config helper: ordinary `~` and `~/...` expand to the home directory when available; its fallback also handles other leading forms such as `~name` and leaves the literal path when no home can be resolved. This is not a guarantee that every leading-tilde edge case resolves identically to the former global replacement.
- Config / env / CLI surface changed? `No` — `resolved_db_path` is an accessor, not a new key.
- Rust/MSRV/toolchain floor changed? `No`

## Rollback (required for medium/high-risk PRs)

Revert the landed squash commit to restore the previous path resolution and logging behavior.

